### PR TITLE
feat: add docs generation pipeline

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,47 @@
+name: Update docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "scripts/**"
+      - "cfn-schema-cache/**"
+  workflow_dispatch:
+
+jobs:
+  update-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Generate markdown docs
+        run: ./scripts/generate-docs.sh
+
+      - uses: actions/checkout@v4
+        with:
+          repository: carina-rs/carina
+          token: ${{ secrets.DOCS_PR_TOKEN }}
+          path: carina-main
+
+      - name: Copy generated docs
+        run: |
+          rm -rf carina-main/docs/src/content/docs/reference/providers/awscc/
+          mkdir -p carina-main/docs/src/content/docs/reference/providers/awscc/
+          cp -r generated-docs/awscc/* carina-main/docs/src/content/docs/reference/providers/awscc/
+
+      - name: Create PR
+        uses: peter-evans/create-pull-request@v7
+        with:
+          path: carina-main
+          token: ${{ secrets.DOCS_PR_TOKEN }}
+          branch: docs/update-awscc-reference
+          title: "docs: update awscc provider reference"
+          body: |
+            Auto-generated from carina-provider-awscc.
+
+            Triggered by ${{ github.event.head_commit.url }}
+          commit-message: "docs: update awscc provider reference"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 Cargo.lock
 cfn-schema-cache/
+generated-docs/

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Generate awscc provider documentation from CloudFormation schemas
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+DOCS_DIR="$PROJECT_ROOT/generated-docs/awscc"
+SCHEMA_DIR="$PROJECT_ROOT/cfn-schema-cache"
+rm -rf "$DOCS_DIR"
+mkdir -p "$DOCS_DIR"
+
+cd "$PROJECT_ROOT"
+
+# Generate docs for each schema file
+for SCHEMA_FILE in "$SCHEMA_DIR"/*.json; do
+    [ -f "$SCHEMA_FILE" ] || continue
+    FILENAME=$(basename "$SCHEMA_FILE" .json)
+
+    # Convert filename to CloudFormation type name
+    # AWS__EC2__VPC.json → AWS::EC2::VPC
+    TYPE_NAME=$(echo "$FILENAME" | sed 's/__/::/g')
+
+    # Derive output path using codegen's print-dsl-resource-name
+    # AWS::EC2::VPC → ec2.vpc → ec2/vpc
+    DSL_NAME=$(cargo run --bin codegen -- --type-name "$TYPE_NAME" --print-dsl-resource-name 2>/dev/null)
+    SERVICE=$(echo "$DSL_NAME" | cut -d'.' -f1)
+    RESOURCE=$(echo "$DSL_NAME" | cut -d'.' -f2-)
+    mkdir -p "$DOCS_DIR/$SERVICE"
+    OUTPUT_FILE="$DOCS_DIR/$SERVICE/$RESOURCE.md"
+
+    echo "Generating: $TYPE_NAME → $OUTPUT_FILE"
+    cargo run --bin codegen -- \
+        --file "$SCHEMA_FILE" \
+        --type-name "$TYPE_NAME" \
+        --format markdown \
+        --output "$OUTPUT_FILE" 2>/dev/null || {
+        echo "  Warning: failed to generate docs for $TYPE_NAME, skipping"
+        continue
+    }
+
+    # Add Starlight frontmatter
+    if [ -f "$OUTPUT_FILE" ]; then
+        DSL_NAME_FULL="awscc.$DSL_NAME"
+        SERVICE_DISPLAY=$(echo "$SERVICE" | tr '[:lower:]' '[:upper:]')
+        FRONTMATTER_TMPFILE=$(mktemp)
+        {
+            echo "---"
+            echo "title: \"$DSL_NAME_FULL\""
+            echo "description: \"AWSCC $SERVICE_DISPLAY $RESOURCE resource reference\""
+            echo "---"
+            echo ""
+            sed '1{/^# /d;}' "$OUTPUT_FILE"
+        } > "$FRONTMATTER_TMPFILE"
+        mv "$FRONTMATTER_TMPFILE" "$OUTPUT_FILE"
+    fi
+done
+
+echo ""
+echo "Done! Generated documentation in $DOCS_DIR"


### PR DESCRIPTION
## Summary

- Add `scripts/generate-docs.sh` that generates markdown docs from CloudFormation schemas using existing codegen binary
- Add `.github/workflows/docs.yml` that auto-generates provider reference docs and creates a PR to `carina-rs/carina`
- Generated docs include Starlight frontmatter for the documentation site

## Dependencies

- Requires `DOCS_PR_TOKEN` secret to be configured (fine-grained PAT with `contents:write` + `pull_requests:write` on `carina-rs/carina`)

## Test plan

- [x] `./scripts/generate-docs.sh` generates 24 resource docs across ec2/, iam/, logs/, s3/
- [x] Generated docs have correct Starlight frontmatter
- [ ] Workflow creates PR in main repo after merge (requires `DOCS_PR_TOKEN`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)