### PR TITLE
fix: add capabilities field to ProviderInfo

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,7 @@ impl CarinaProvider for AwsccProcessProvider {
         proto::ProviderInfo {
             name: "awscc".into(),
             display_name: "AWS Cloud Control provider".into(),
+            capabilities: vec![],
         }
     }
 


### PR DESCRIPTION
## Summary

- Add `capabilities: vec![]` to `ProviderInfo` initialization
- Update `carina-provider-protocol` git dependency to latest

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)