### PR TITLE
fix: restore examples in generated docs

### DIFF
--- a/examples/ec2_egress_only_internet_gateway/main.crn
+++ b/examples/ec2_egress_only_internet_gateway/main.crn
@@ -1,0 +1,19 @@
+# EC2 Egress Only Internet Gateway Example
+#
+# Creates a VPC and an egress-only internet gateway for IPv6 traffic.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let vpc = awscc.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+}
+
+awscc.ec2.egress_only_internet_gateway {
+  vpc_id = vpc.vpc_id
+
+  tags = {
+    Environment = "example"
+  }
+}

--- a/examples/ec2_eip/main.crn
+++ b/examples/ec2_eip/main.crn
@@ -1,0 +1,15 @@
+# EC2 Elastic IP Example
+#
+# Creates a standalone Elastic IP address for use in a VPC.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+awscc.ec2.eip {
+  domain = "vpc"
+
+  tags = {
+    Environment = "example"
+  }
+}

--- a/examples/ec2_flow_log/main.crn
+++ b/examples/ec2_flow_log/main.crn
@@ -1,0 +1,24 @@
+# EC2 Flow Log Example
+#
+# Creates a VPC and a flow log that sends traffic logs to S3.
+# Note: The S3 bucket must exist before applying this configuration.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let vpc = awscc.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+}
+
+awscc.ec2.flow_log {
+  resource_id          = vpc.vpc_id
+  resource_type        = VPC
+  traffic_type         = ALL
+  log_destination_type = s3
+  log_destination      = "arn:aws:s3:::example-flow-logs-bucket"
+
+  tags = {
+    Environment = "example"
+  }
+}

--- a/examples/ec2_internet_gateway/main.crn
+++ b/examples/ec2_internet_gateway/main.crn
@@ -1,0 +1,13 @@
+# EC2 Internet Gateway Example
+#
+# Creates a standalone Internet Gateway.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+awscc.ec2.internet_gateway {
+  tags = {
+    Environment = "example"
+  }
+}

--- a/examples/ec2_ipam/main.crn
+++ b/examples/ec2_ipam/main.crn
@@ -1,0 +1,20 @@
+# EC2 IPAM Example
+#
+# Creates an IP Address Manager (IPAM) instance.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+awscc.ec2.ipam {
+  description = "Example IPAM"
+  tier        = free
+
+  operating_region {
+    region_name = "ap-northeast-1"
+  }
+
+  tags = {
+    Environment = "example"
+  }
+}

--- a/examples/ec2_ipam_pool/main.crn
+++ b/examples/ec2_ipam_pool/main.crn
@@ -1,0 +1,31 @@
+# EC2 IPAM Pool Example
+#
+# Creates an IPAM and an IPv4 IPAM Pool within it.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let ipam = awscc.ec2.ipam {
+  description = "Example IPAM"
+  tier        = free
+
+  operating_region {
+    region_name = "ap-northeast-1"
+  }
+}
+
+awscc.ec2.ipam_pool {
+  ipam_scope_id  = ipam.private_default_scope_id
+  address_family = "IPv4"
+  locale         = "ap-northeast-1"
+  description    = "Example IPv4 IPAM Pool"
+
+  provisioned_cidr {
+    cidr = "10.0.0.0/8"
+  }
+
+  tags = {
+    Environment = "example"
+  }
+}

--- a/examples/ec2_nat_gateway/main.crn
+++ b/examples/ec2_nat_gateway/main.crn
@@ -1,0 +1,33 @@
+# EC2 NAT Gateway Example
+#
+# Creates a VPC, a public subnet, an Elastic IP, and a public NAT Gateway.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let vpc = awscc.ec2.vpc {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+}
+
+let public_subnet = awscc.ec2.subnet {
+  vpc_id                  = vpc.vpc_id
+  cidr_block              = "10.0.1.0/24"
+  availability_zone       = "ap-northeast-1a"
+  map_public_ip_on_launch = true
+}
+
+let eip = awscc.ec2.eip {
+  domain = "vpc"
+}
+
+awscc.ec2.nat_gateway {
+  allocation_id = eip.allocation_id
+  subnet_id     = public_subnet.subnet_id
+
+  tags = {
+    Environment = "example"
+  }
+}

--- a/examples/ec2_route/main.crn
+++ b/examples/ec2_route/main.crn
@@ -1,0 +1,31 @@
+# EC2 Route Example
+#
+# Creates a VPC with an Internet Gateway, a route table,
+# and a default route to the Internet Gateway.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let vpc = awscc.ec2.vpc {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+}
+
+let igw = awscc.ec2.internet_gateway {}
+
+let igw_attachment = awscc.ec2.vpc_gateway_attachment {
+  vpc_id              = vpc.vpc_id
+  internet_gateway_id = igw.internet_gateway_id
+}
+
+let rt = awscc.ec2.route_table {
+  vpc_id = vpc.vpc_id
+}
+
+awscc.ec2.route {
+  route_table_id         = rt.route_table_id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = igw_attachment.internet_gateway_id
+}

--- a/examples/ec2_route_table/main.crn
+++ b/examples/ec2_route_table/main.crn
@@ -1,0 +1,21 @@
+# EC2 Route Table Example
+#
+# Creates a VPC and a route table within it.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let vpc = awscc.ec2.vpc {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+}
+
+awscc.ec2.route_table {
+  vpc_id = vpc.vpc_id
+
+  tags = {
+    Environment = "example"
+  }
+}

--- a/examples/ec2_security_group/main.crn
+++ b/examples/ec2_security_group/main.crn
@@ -1,0 +1,34 @@
+# EC2 Security Group Example
+#
+# Creates a VPC and a security group within it.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let vpc = awscc.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+}
+
+awscc.ec2.security_group {
+  vpc_id            = vpc.vpc_id
+  group_description = "Example security group"
+
+  security_group_ingress {
+    ip_protocol = "tcp"
+    from_port   = 80
+    to_port     = 80
+    cidr_ip     = "0.0.0.0/0"
+  }
+
+  security_group_ingress {
+    ip_protocol = "tcp"
+    from_port   = 443
+    to_port     = 443
+    cidr_ip     = "0.0.0.0/0"
+  }
+
+  tags = {
+    Environment = "example"
+  }
+}

--- a/examples/ec2_security_group_egress/main.crn
+++ b/examples/ec2_security_group_egress/main.crn
@@ -1,0 +1,24 @@
+# EC2 Security Group Egress Rule Example
+#
+# Creates a VPC, a security group, and an outbound rule
+# allowing all traffic.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let vpc = awscc.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+}
+
+let sg = awscc.ec2.security_group {
+  vpc_id            = vpc.vpc_id
+  group_description = "Example security group"
+}
+
+awscc.ec2.security_group_egress {
+  group_id    = sg.group_id
+  description = "Allow all outbound traffic"
+  ip_protocol = all
+  cidr_ip     = "0.0.0.0/0"
+}

--- a/examples/ec2_security_group_ingress/main.crn
+++ b/examples/ec2_security_group_ingress/main.crn
@@ -1,0 +1,26 @@
+# EC2 Security Group Ingress Rule Example
+#
+# Creates a VPC, a security group, and an inbound rule
+# allowing HTTPS traffic from the VPC CIDR.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let vpc = awscc.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+}
+
+let sg = awscc.ec2.security_group {
+  vpc_id            = vpc.vpc_id
+  group_description = "Example security group"
+}
+
+awscc.ec2.security_group_ingress {
+  group_id    = sg.group_id
+  description = "Allow HTTPS from VPC"
+  ip_protocol = "tcp"
+  from_port   = 443
+  to_port     = 443
+  cidr_ip     = "10.0.0.0/16"
+}

--- a/examples/ec2_subnet/main.crn
+++ b/examples/ec2_subnet/main.crn
@@ -1,0 +1,24 @@
+# EC2 Subnet Example
+#
+# Creates a VPC and a public subnet within it.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let vpc = awscc.ec2.vpc {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+}
+
+awscc.ec2.subnet {
+  vpc_id                  = vpc.vpc_id
+  cidr_block              = "10.0.1.0/24"
+  availability_zone       = "ap-northeast-1a"
+  map_public_ip_on_launch = true
+
+  tags = {
+    Environment = "example"
+  }
+}

--- a/examples/ec2_subnet_route_table_association/main.crn
+++ b/examples/ec2_subnet_route_table_association/main.crn
@@ -1,0 +1,29 @@
+# EC2 Subnet Route Table Association Example
+#
+# Creates a VPC, a subnet, a route table, and associates the subnet
+# with the route table.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let vpc = awscc.ec2.vpc {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+}
+
+let subnet = awscc.ec2.subnet {
+  vpc_id            = vpc.vpc_id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "ap-northeast-1a"
+}
+
+let rt = awscc.ec2.route_table {
+  vpc_id = vpc.vpc_id
+}
+
+awscc.ec2.subnet_route_table_association {
+  subnet_id      = subnet.subnet_id
+  route_table_id = rt.route_table_id
+}

--- a/examples/ec2_transit_gateway/main.crn
+++ b/examples/ec2_transit_gateway/main.crn
@@ -1,0 +1,15 @@
+# EC2 Transit Gateway Example
+#
+# Creates a transit gateway.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+awscc.ec2.transit_gateway {
+  description = "Example Transit Gateway"
+
+  tags = {
+    Environment = "example"
+  }
+}

--- a/examples/ec2_transit_gateway_attachment/main.crn
+++ b/examples/ec2_transit_gateway_attachment/main.crn
@@ -1,0 +1,31 @@
+# EC2 Transit Gateway Attachment Example
+#
+# Creates a VPC, subnet, transit gateway, and attaches the VPC to the transit gateway.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let vpc = awscc.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+}
+
+let subnet = awscc.ec2.subnet {
+  vpc_id            = vpc.vpc_id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "ap-northeast-1a"
+}
+
+let tgw = awscc.ec2.transit_gateway {
+  description = "Example Transit Gateway"
+}
+
+awscc.ec2.transit_gateway_attachment {
+  transit_gateway_id = tgw.id
+  vpc_id             = vpc.vpc_id
+  subnet_ids         = [subnet.subnet_id]
+
+  tags = {
+    Environment = "example"
+  }
+}

--- a/examples/ec2_vpc/main.crn
+++ b/examples/ec2_vpc/main.crn
@@ -1,0 +1,18 @@
+# EC2 VPC Example
+#
+# Creates a VPC with DNS support enabled.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+awscc.ec2.vpc {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+  instance_tenancy     = default
+
+  tags = {
+    Environment = "example"
+  }
+}

--- a/examples/ec2_vpc_endpoint/main.crn
+++ b/examples/ec2_vpc_endpoint/main.crn
@@ -1,0 +1,43 @@
+# EC2 VPC Endpoint Example
+#
+# Creates a VPC, a subnet, a security group, and an Interface-type
+# VPC Endpoint for the ECR Docker Registry service.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let vpc = awscc.ec2.vpc {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+}
+
+let subnet = awscc.ec2.subnet {
+  vpc_id            = vpc.vpc_id
+  cidr_block        = "10.0.100.0/24"
+  availability_zone = "ap-northeast-1a"
+}
+
+let sg = awscc.ec2.security_group {
+  vpc_id            = vpc.vpc_id
+  group_description = "SG for VPC Endpoint"
+}
+
+awscc.ec2.security_group_ingress {
+  group_id    = sg.group_id
+  description = "Allow HTTPS from VPC"
+  ip_protocol = "tcp"
+  from_port   = 443
+  to_port     = 443
+  cidr_ip     = "10.0.0.0/16"
+}
+
+awscc.ec2.vpc_endpoint {
+  vpc_id              = vpc.vpc_id
+  service_name        = "com.amazonaws.ap-northeast-1.ecr.dkr"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = [subnet.subnet_id]
+  security_group_ids  = [sg.group_id]
+  private_dns_enabled = true
+}

--- a/examples/ec2_vpc_gateway_attachment/main.crn
+++ b/examples/ec2_vpc_gateway_attachment/main.crn
@@ -1,0 +1,20 @@
+# EC2 VPC Gateway Attachment Example
+#
+# Creates a VPC, an Internet Gateway, and attaches the gateway to the VPC.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let vpc = awscc.ec2.vpc {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+}
+
+let igw = awscc.ec2.internet_gateway {}
+
+awscc.ec2.vpc_gateway_attachment {
+  vpc_id              = vpc.vpc_id
+  internet_gateway_id = igw.internet_gateway_id
+}

--- a/examples/ec2_vpc_peering_connection/main.crn
+++ b/examples/ec2_vpc_peering_connection/main.crn
@@ -1,0 +1,24 @@
+# EC2 VPC Peering Connection Example
+#
+# Creates two VPCs and a peering connection between them.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+let vpc1 = awscc.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+}
+
+let vpc2 = awscc.ec2.vpc {
+  cidr_block = "10.1.0.0/16"
+}
+
+awscc.ec2.vpc_peering_connection {
+  vpc_id      = vpc1.vpc_id
+  peer_vpc_id = vpc2.vpc_id
+
+  tags = {
+    Environment = "example"
+  }
+}

--- a/examples/ec2_vpn_gateway/main.crn
+++ b/examples/ec2_vpn_gateway/main.crn
@@ -1,0 +1,15 @@
+# EC2 VPN Gateway Example
+#
+# Creates a virtual private gateway.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+awscc.ec2.vpn_gateway {
+  type = awscc.ec2.vpn_gateway.Type.ipsec.1
+
+  tags = {
+    Environment = "example"
+  }
+}

--- a/examples/iam_role/main.crn
+++ b/examples/iam_role/main.crn
@@ -1,0 +1,28 @@
+# IAM Role Example
+#
+# Creates an IAM role that can be assumed by the Lambda service.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+awscc.iam.role {
+  role_name = "my-example-role"
+
+  assume_role_policy_document = {
+    version = "2012-10-17"
+    statement {
+      effect = "Allow"
+
+      principal = {
+        service = "lambda.amazonaws.com"
+      }
+
+      action = "sts:AssumeRole"
+    }
+  }
+
+  tags = {
+    Environment = "example"
+  }
+}

--- a/examples/logs_log_group/main.crn
+++ b/examples/logs_log_group/main.crn
@@ -1,0 +1,16 @@
+# CloudWatch Logs Log Group Example
+#
+# Creates a log group with a 30-day retention period.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+awscc.logs.log_group {
+  log_group_name    = "/example/my-app"
+  retention_in_days = 30
+
+  tags = {
+    Environment = "example"
+  }
+}

--- a/examples/s3_bucket/main.crn
+++ b/examples/s3_bucket/main.crn
@@ -1,0 +1,19 @@
+# S3 Bucket Example
+#
+# Creates an S3 bucket with versioning enabled.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+awscc.s3.bucket {
+  bucket_name = "my-example-bucket"
+
+  versioning_configuration = {
+    status = Enabled
+  }
+
+  tags = {
+    Environment = "example"
+  }
+}

--- a/examples/vpc_full/main.crn
+++ b/examples/vpc_full/main.crn
@@ -1,0 +1,384 @@
+# Full VPC Example
+#
+# Creates a complete VPC setup with public, private, and database subnets
+# across three availability zones (ap-northeast-1a, 1c, 1d).
+#
+# Includes:
+# - VPC with DNS support
+# - Internet Gateway
+# - NAT Gateways (one per AZ) with Elastic IPs
+# - Public subnets (10.0.0.0/24, 10.0.1.0/24, 10.0.2.0/24)
+# - Private subnets (10.0.100.0/24, 10.0.101.0/24, 10.0.102.0/24)
+# - Database subnets (10.0.200.0/24, 10.0.201.0/24, 10.0.202.0/24)
+# - Route tables and associations for each subnet tier
+# - VPC Endpoints (ecr.dkr, ecr.api, s3, logs, ssm, ssmmessages)
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+# --- VPC and Internet Gateway ---
+
+let vpc = awscc.ec2.vpc {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = "main"
+  }
+}
+
+let igw = awscc.ec2.internet_gateway {
+  tags = {
+    Name = "main"
+  }
+}
+
+let igw_attachment = awscc.ec2.vpc_gateway_attachment {
+  vpc_id              = vpc.vpc_id
+  internet_gateway_id = igw.internet_gateway_id
+}
+
+# --- Public Subnets ---
+
+let public_subnet_1a = awscc.ec2.subnet {
+  vpc_id                  = vpc.vpc_id
+  cidr_block              = "10.0.0.0/24"
+  availability_zone       = "ap-northeast-1a"
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "public-ap-northeast-1a"
+  }
+}
+
+let public_subnet_1c = awscc.ec2.subnet {
+  vpc_id                  = vpc.vpc_id
+  cidr_block              = "10.0.1.0/24"
+  availability_zone       = "ap-northeast-1c"
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "public-ap-northeast-1c"
+  }
+}
+
+let public_subnet_1d = awscc.ec2.subnet {
+  vpc_id                  = vpc.vpc_id
+  cidr_block              = "10.0.2.0/24"
+  availability_zone       = "ap-northeast-1d"
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "public-ap-northeast-1d"
+  }
+}
+
+# --- Public Route Table ---
+
+let public_rt = awscc.ec2.route_table {
+  vpc_id = vpc.vpc_id
+
+  tags = {
+    Name = "public"
+  }
+}
+
+awscc.ec2.route {
+  route_table_id         = public_rt.route_table_id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = igw_attachment.internet_gateway_id
+}
+
+awscc.ec2.subnet_route_table_association {
+  subnet_id      = public_subnet_1a.subnet_id
+  route_table_id = public_rt.route_table_id
+}
+
+awscc.ec2.subnet_route_table_association {
+  subnet_id      = public_subnet_1c.subnet_id
+  route_table_id = public_rt.route_table_id
+}
+
+awscc.ec2.subnet_route_table_association {
+  subnet_id      = public_subnet_1d.subnet_id
+  route_table_id = public_rt.route_table_id
+}
+
+# --- Elastic IPs and NAT Gateways ---
+
+let eip_1a = awscc.ec2.eip {
+  domain = "vpc"
+
+  tags = {
+    Name = "nat-gw-ap-northeast-1a"
+  }
+}
+
+let eip_1c = awscc.ec2.eip {
+  domain = "vpc"
+
+  tags = {
+    Name = "nat-gw-ap-northeast-1c"
+  }
+}
+
+let eip_1d = awscc.ec2.eip {
+  domain = "vpc"
+
+  tags = {
+    Name = "nat-gw-ap-northeast-1d"
+  }
+}
+
+let nat_gw_1a = awscc.ec2.nat_gateway {
+  allocation_id = eip_1a.allocation_id
+  subnet_id     = public_subnet_1a.subnet_id
+
+  tags = {
+    Name = "nat-gw-ap-northeast-1a"
+  }
+}
+
+let nat_gw_1c = awscc.ec2.nat_gateway {
+  allocation_id = eip_1c.allocation_id
+  subnet_id     = public_subnet_1c.subnet_id
+
+  tags = {
+    Name = "nat-gw-ap-northeast-1c"
+  }
+}
+
+let nat_gw_1d = awscc.ec2.nat_gateway {
+  allocation_id = eip_1d.allocation_id
+  subnet_id     = public_subnet_1d.subnet_id
+
+  tags = {
+    Name = "nat-gw-ap-northeast-1d"
+  }
+}
+
+# --- Private Subnets ---
+
+let private_subnet_1a = awscc.ec2.subnet {
+  vpc_id            = vpc.vpc_id
+  cidr_block        = "10.0.100.0/24"
+  availability_zone = "ap-northeast-1a"
+
+  tags = {
+    Name = "private-ap-northeast-1a"
+  }
+}
+
+let private_subnet_1c = awscc.ec2.subnet {
+  vpc_id            = vpc.vpc_id
+  cidr_block        = "10.0.101.0/24"
+  availability_zone = "ap-northeast-1c"
+
+  tags = {
+    Name = "private-ap-northeast-1c"
+  }
+}
+
+let private_subnet_1d = awscc.ec2.subnet {
+  vpc_id            = vpc.vpc_id
+  cidr_block        = "10.0.102.0/24"
+  availability_zone = "ap-northeast-1d"
+
+  tags = {
+    Name = "private-ap-northeast-1d"
+  }
+}
+
+# --- Private Route Tables ---
+
+let private_rt_1a = awscc.ec2.route_table {
+  vpc_id = vpc.vpc_id
+
+  tags = {
+    Name = "private-ap-northeast-1a"
+  }
+}
+
+let private_rt_1c = awscc.ec2.route_table {
+  vpc_id = vpc.vpc_id
+
+  tags = {
+    Name = "private-ap-northeast-1c"
+  }
+}
+
+let private_rt_1d = awscc.ec2.route_table {
+  vpc_id = vpc.vpc_id
+
+  tags = {
+    Name = "private-ap-northeast-1d"
+  }
+}
+
+awscc.ec2.route {
+  route_table_id         = private_rt_1a.route_table_id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = nat_gw_1a.nat_gateway_id
+}
+
+awscc.ec2.route {
+  route_table_id         = private_rt_1c.route_table_id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = nat_gw_1c.nat_gateway_id
+}
+
+awscc.ec2.route {
+  route_table_id         = private_rt_1d.route_table_id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = nat_gw_1d.nat_gateway_id
+}
+
+awscc.ec2.subnet_route_table_association {
+  subnet_id      = private_subnet_1a.subnet_id
+  route_table_id = private_rt_1a.route_table_id
+}
+
+awscc.ec2.subnet_route_table_association {
+  subnet_id      = private_subnet_1c.subnet_id
+  route_table_id = private_rt_1c.route_table_id
+}
+
+awscc.ec2.subnet_route_table_association {
+  subnet_id      = private_subnet_1d.subnet_id
+  route_table_id = private_rt_1d.route_table_id
+}
+
+# --- Database Subnets ---
+
+let database_subnet_1a = awscc.ec2.subnet {
+  vpc_id            = vpc.vpc_id
+  cidr_block        = "10.0.200.0/24"
+  availability_zone = "ap-northeast-1a"
+
+  tags = {
+    Name = "database-ap-northeast-1a"
+  }
+}
+
+let database_subnet_1c = awscc.ec2.subnet {
+  vpc_id            = vpc.vpc_id
+  cidr_block        = "10.0.201.0/24"
+  availability_zone = "ap-northeast-1c"
+
+  tags = {
+    Name = "database-ap-northeast-1c"
+  }
+}
+
+let database_subnet_1d = awscc.ec2.subnet {
+  vpc_id            = vpc.vpc_id
+  cidr_block        = "10.0.202.0/24"
+  availability_zone = "ap-northeast-1d"
+
+  tags = {
+    Name = "database-ap-northeast-1d"
+  }
+}
+
+# --- Database Route Table ---
+
+let database_rt = awscc.ec2.route_table {
+  vpc_id = vpc.vpc_id
+
+  tags = {
+    Name = "database"
+  }
+}
+
+awscc.ec2.subnet_route_table_association {
+  subnet_id      = database_subnet_1a.subnet_id
+  route_table_id = database_rt.route_table_id
+}
+
+awscc.ec2.subnet_route_table_association {
+  subnet_id      = database_subnet_1c.subnet_id
+  route_table_id = database_rt.route_table_id
+}
+
+awscc.ec2.subnet_route_table_association {
+  subnet_id      = database_subnet_1d.subnet_id
+  route_table_id = database_rt.route_table_id
+}
+
+# --- Security Group for VPC Endpoints ---
+
+let endpoint_sg = awscc.ec2.security_group {
+  vpc_id            = vpc.vpc_id
+  group_description = "SG for VPC Endpoint"
+
+  tags = {
+    Name = "vpc-endpoint"
+  }
+}
+
+awscc.ec2.security_group_ingress {
+  group_id    = endpoint_sg.group_id
+  description = "Allow HTTPS from VPC"
+  ip_protocol = "tcp"
+  from_port   = 443
+  to_port     = 443
+  cidr_ip     = "10.0.0.0/16"
+}
+
+# --- VPC Endpoints (Interface type) ---
+
+awscc.ec2.vpc_endpoint {
+  vpc_id              = vpc.vpc_id
+  service_name        = "com.amazonaws.ap-northeast-1.ecr.dkr"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = [private_subnet_1a.subnet_id, private_subnet_1c.subnet_id, private_subnet_1d.subnet_id]
+  security_group_ids  = [endpoint_sg.group_id]
+  private_dns_enabled = true
+}
+
+awscc.ec2.vpc_endpoint {
+  vpc_id              = vpc.vpc_id
+  service_name        = "com.amazonaws.ap-northeast-1.ecr.api"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = [private_subnet_1a.subnet_id, private_subnet_1c.subnet_id, private_subnet_1d.subnet_id]
+  security_group_ids  = [endpoint_sg.group_id]
+  private_dns_enabled = true
+}
+
+awscc.ec2.vpc_endpoint {
+  vpc_id              = vpc.vpc_id
+  service_name        = "com.amazonaws.ap-northeast-1.logs"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = [private_subnet_1a.subnet_id, private_subnet_1c.subnet_id, private_subnet_1d.subnet_id]
+  security_group_ids  = [endpoint_sg.group_id]
+  private_dns_enabled = true
+}
+
+awscc.ec2.vpc_endpoint {
+  vpc_id              = vpc.vpc_id
+  service_name        = "com.amazonaws.ap-northeast-1.ssm"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = [private_subnet_1a.subnet_id, private_subnet_1c.subnet_id, private_subnet_1d.subnet_id]
+  security_group_ids  = [endpoint_sg.group_id]
+  private_dns_enabled = true
+}
+
+awscc.ec2.vpc_endpoint {
+  vpc_id              = vpc.vpc_id
+  service_name        = "com.amazonaws.ap-northeast-1.ssmmessages"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = [private_subnet_1a.subnet_id, private_subnet_1c.subnet_id, private_subnet_1d.subnet_id]
+  security_group_ids  = [endpoint_sg.group_id]
+  private_dns_enabled = true
+}
+
+# --- VPC Endpoint (Gateway type) ---
+
+awscc.ec2.vpc_endpoint {
+  vpc_id            = vpc.vpc_id
+  service_name      = "com.amazonaws.ap-northeast-1.s3"
+  vpc_endpoint_type = "Gateway"
+  route_table_ids   = [private_rt_1a.route_table_id, private_rt_1c.route_table_id, private_rt_1d.route_table_id]
+}

--- a/generated-docs/awscc/ec2/egress_only_internet_gateway.md
+++ b/generated-docs/awscc/ec2/egress_only_internet_gateway.md
@@ -8,6 +8,22 @@ CloudFormation Type: `AWS::EC2::EgressOnlyInternetGateway`
 
 Resource Type definition for AWS::EC2::EgressOnlyInternetGateway
 
+## Example
+
+```crn
+let vpc = awscc.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+}
+
+awscc.ec2.egress_only_internet_gateway {
+  vpc_id = vpc.vpc_id
+
+  tags = {
+    Environment = "example"
+  }
+}
+```
+
 ## Argument Reference
 
 ### `tags`

--- a/generated-docs/awscc/ec2/eip.md
+++ b/generated-docs/awscc/ec2/eip.md
@@ -10,6 +10,18 @@ Specifies an Elastic IP (EIP) address and can, optionally, associate it with an 
  You can allocate an Elastic IP address from an address pool owned by AWS or from an address pool created from a public IPv4 address range that you have brought to AWS for use with your AWS resources using bring your own IP addresses (BYOIP). For more information, see [Bring Your Own IP Addresses (BYOIP)](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-byoip.html) in the *Amazon EC2 User Guide*.
  For more information, see [Elastic IP Addresses](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-ip-addresses-eip.html) in the *Amazon EC2 User Guide*.
 
+## Example
+
+```crn
+awscc.ec2.eip {
+  domain = "vpc"
+
+  tags = {
+    Environment = "example"
+  }
+}
+```
+
 ## Argument Reference
 
 ### `address`

--- a/generated-docs/awscc/ec2/flow_log.md
+++ b/generated-docs/awscc/ec2/flow_log.md
@@ -8,6 +8,26 @@ CloudFormation Type: `AWS::EC2::FlowLog`
 
 Specifies a VPC flow log, which enables you to capture IP traffic for a specific network interface, subnet, or VPC.
 
+## Example
+
+```crn
+let vpc = awscc.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+}
+
+awscc.ec2.flow_log {
+  resource_id          = vpc.vpc_id
+  resource_type        = VPC
+  traffic_type         = ALL
+  log_destination_type = s3
+  log_destination      = "arn:aws:s3:::example-flow-logs-bucket"
+
+  tags = {
+    Environment = "example"
+  }
+}
+```
+
 ## Argument Reference
 
 ### `deliver_cross_account_role`

--- a/generated-docs/awscc/ec2/internet_gateway.md
+++ b/generated-docs/awscc/ec2/internet_gateway.md
@@ -8,6 +8,16 @@ CloudFormation Type: `AWS::EC2::InternetGateway`
 
 Allocates an internet gateway for use with a VPC. After creating the Internet gateway, you then attach it to a VPC.
 
+## Example
+
+```crn
+awscc.ec2.internet_gateway {
+  tags = {
+    Environment = "example"
+  }
+}
+```
+
 ## Argument Reference
 
 ### `tags`

--- a/generated-docs/awscc/ec2/ipam.md
+++ b/generated-docs/awscc/ec2/ipam.md
@@ -8,6 +8,23 @@ CloudFormation Type: `AWS::EC2::IPAM`
 
 Resource Schema of AWS::EC2::IPAM Type
 
+## Example
+
+```crn
+awscc.ec2.ipam {
+  description = "Example IPAM"
+  tier        = free
+
+  operating_region {
+    region_name = "ap-northeast-1"
+  }
+
+  tags = {
+    Environment = "example"
+  }
+}
+```
+
 ## Argument Reference
 
 ### `default_resource_discovery_organizational_unit_exclusions`

--- a/generated-docs/awscc/ec2/ipam_pool.md
+++ b/generated-docs/awscc/ec2/ipam_pool.md
@@ -8,6 +8,34 @@ CloudFormation Type: `AWS::EC2::IPAMPool`
 
 Resource Schema of AWS::EC2::IPAMPool Type
 
+## Example
+
+```crn
+let ipam = awscc.ec2.ipam {
+  description = "Example IPAM"
+  tier        = free
+
+  operating_region {
+    region_name = "ap-northeast-1"
+  }
+}
+
+awscc.ec2.ipam_pool {
+  ipam_scope_id  = ipam.private_default_scope_id
+  address_family = "IPv4"
+  locale         = "ap-northeast-1"
+  description    = "Example IPv4 IPAM Pool"
+
+  provisioned_cidr {
+    cidr = "10.0.0.0/8"
+  }
+
+  tags = {
+    Environment = "example"
+  }
+}
+```
+
 ## Argument Reference
 
 ### `address_family`

--- a/generated-docs/awscc/ec2/nat_gateway.md
+++ b/generated-docs/awscc/ec2/nat_gateway.md
@@ -11,6 +11,36 @@ Specifies a network address translation (NAT) gateway in the specified subnet. Y
  If you add a default route (``AWS::EC2::Route`` resource) that points to a NAT gateway, specify the NAT gateway ID for the route's ``NatGatewayId`` property.
   When you associate an Elastic IP address or secondary Elastic IP address with a public NAT gateway, the network border group of the Elastic IP address must match the network border group of the Availability Zone (AZ) that the public NAT gateway is in. Otherwise, the NAT gateway fails to launch. You can see the network border group for the AZ by viewing the details of the subnet. Similarly, you can view the network border group for the Elastic IP address by viewing its details. For more information, see [Allocate an Elastic IP address](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-eips.html#allocate-eip) in the *Amazon VPC User Guide*.
 
+## Example
+
+```crn
+let vpc = awscc.ec2.vpc {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+}
+
+let public_subnet = awscc.ec2.subnet {
+  vpc_id                  = vpc.vpc_id
+  cidr_block              = "10.0.1.0/24"
+  availability_zone       = "ap-northeast-1a"
+  map_public_ip_on_launch = true
+}
+
+let eip = awscc.ec2.eip {
+  domain = "vpc"
+}
+
+awscc.ec2.nat_gateway {
+  allocation_id = eip.allocation_id
+  subnet_id     = public_subnet.subnet_id
+
+  tags = {
+    Environment = "example"
+  }
+}
+```
+
 ## Argument Reference
 
 ### `allocation_id`

--- a/generated-docs/awscc/ec2/route.md
+++ b/generated-docs/awscc/ec2/route.md
@@ -10,6 +10,33 @@ Specifies a route in a route table. For more information, see [Routes](https://d
  You must specify either a destination CIDR block or prefix list ID. You must also specify exactly one of the resources as the target.
  If you create a route that references a transit gateway in the same template where you create the transit gateway, you must declare a dependency on the transit gateway attachment. The route table cannot use the transit gateway until it has successfully attached to the VPC. Add a [DependsOn Attribute](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html) in the ``AWS::EC2::Route`` resource to explicitly declare a dependency on the ``AWS::EC2::TransitGatewayAttachment`` resource.
 
+## Example
+
+```crn
+let vpc = awscc.ec2.vpc {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+}
+
+let igw = awscc.ec2.internet_gateway {}
+
+let igw_attachment = awscc.ec2.vpc_gateway_attachment {
+  vpc_id              = vpc.vpc_id
+  internet_gateway_id = igw.internet_gateway_id
+}
+
+let rt = awscc.ec2.route_table {
+  vpc_id = vpc.vpc_id
+}
+
+awscc.ec2.route {
+  route_table_id         = rt.route_table_id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = igw_attachment.internet_gateway_id
+}
+```
+
 ## Argument Reference
 
 ### `carrier_gateway_id`

--- a/generated-docs/awscc/ec2/route_table.md
+++ b/generated-docs/awscc/ec2/route_table.md
@@ -9,6 +9,24 @@ CloudFormation Type: `AWS::EC2::RouteTable`
 Specifies a route table for the specified VPC. After you create a route table, you can add routes and associate the table with a subnet.
  For more information, see [Route tables](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Route_Tables.html) in the *Amazon VPC User Guide*.
 
+## Example
+
+```crn
+let vpc = awscc.ec2.vpc {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+}
+
+awscc.ec2.route_table {
+  vpc_id = vpc.vpc_id
+
+  tags = {
+    Environment = "example"
+  }
+}
+```
+
 ## Argument Reference
 
 ### `tags`

--- a/generated-docs/awscc/ec2/security_group.md
+++ b/generated-docs/awscc/ec2/security_group.md
@@ -8,6 +8,37 @@ CloudFormation Type: `AWS::EC2::SecurityGroup`
 
 Resource Type definition for AWS::EC2::SecurityGroup
 
+## Example
+
+```crn
+let vpc = awscc.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+}
+
+awscc.ec2.security_group {
+  vpc_id            = vpc.vpc_id
+  group_description = "Example security group"
+
+  security_group_ingress {
+    ip_protocol = "tcp"
+    from_port   = 80
+    to_port     = 80
+    cidr_ip     = "0.0.0.0/0"
+  }
+
+  security_group_ingress {
+    ip_protocol = "tcp"
+    from_port   = 443
+    to_port     = 443
+    cidr_ip     = "0.0.0.0/0"
+  }
+
+  tags = {
+    Environment = "example"
+  }
+}
+```
+
 ## Argument Reference
 
 ### `group_description`

--- a/generated-docs/awscc/ec2/security_group_egress.md
+++ b/generated-docs/awscc/ec2/security_group_egress.md
@@ -12,6 +12,26 @@ Adds the specified outbound (egress) rule to a security group.
  You must specify a protocol for each rule (for example, TCP). If the protocol is TCP or UDP, you must also specify a port or port range. If the protocol is ICMP or ICMPv6, you must also specify the ICMP/ICMPv6 type and code. To specify all types or all codes, use -1.
  Rule changes are propagated to instances associated with the security group as quickly as possible. However, a small delay might occur.
 
+## Example
+
+```crn
+let vpc = awscc.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+}
+
+let sg = awscc.ec2.security_group {
+  vpc_id            = vpc.vpc_id
+  group_description = "Example security group"
+}
+
+awscc.ec2.security_group_egress {
+  group_id    = sg.group_id
+  description = "Allow all outbound traffic"
+  ip_protocol = all
+  cidr_ip     = "0.0.0.0/0"
+}
+```
+
 ## Argument Reference
 
 ### `cidr_ip`

--- a/generated-docs/awscc/ec2/security_group_ingress.md
+++ b/generated-docs/awscc/ec2/security_group_ingress.md
@@ -8,6 +8,28 @@ CloudFormation Type: `AWS::EC2::SecurityGroupIngress`
 
 Resource Type definition for AWS::EC2::SecurityGroupIngress
 
+## Example
+
+```crn
+let vpc = awscc.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+}
+
+let sg = awscc.ec2.security_group {
+  vpc_id            = vpc.vpc_id
+  group_description = "Example security group"
+}
+
+awscc.ec2.security_group_ingress {
+  group_id    = sg.group_id
+  description = "Allow HTTPS from VPC"
+  ip_protocol = "tcp"
+  from_port   = 443
+  to_port     = 443
+  cidr_ip     = "10.0.0.0/16"
+}
+```
+
 ## Argument Reference
 
 ### `cidr_ip`

--- a/generated-docs/awscc/ec2/subnet.md
+++ b/generated-docs/awscc/ec2/subnet.md
@@ -10,6 +10,27 @@ Specifies a subnet for the specified VPC.
  For an IPv4 only subnet, specify an IPv4 CIDR block. If the VPC has an IPv6 CIDR block, you can create an IPv6 only subnet or a dual stack subnet instead. For an IPv6 only subnet, specify an IPv6 CIDR block. For a dual stack subnet, specify both an IPv4 CIDR block and an IPv6 CIDR block.
  For more information, see [Subnets for your VPC](https://docs.aws.amazon.com/vpc/latest/userguide/configure-subnets.html) in the *Amazon VPC User Guide*.
 
+## Example
+
+```crn
+let vpc = awscc.ec2.vpc {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+}
+
+awscc.ec2.subnet {
+  vpc_id                  = vpc.vpc_id
+  cidr_block              = "10.0.1.0/24"
+  availability_zone       = "ap-northeast-1a"
+  map_public_ip_on_launch = true
+
+  tags = {
+    Environment = "example"
+  }
+}
+```
+
 ## Argument Reference
 
 ### `assign_ipv6_address_on_creation`

--- a/generated-docs/awscc/ec2/subnet_route_table_association.md
+++ b/generated-docs/awscc/ec2/subnet_route_table_association.md
@@ -8,6 +8,31 @@ CloudFormation Type: `AWS::EC2::SubnetRouteTableAssociation`
 
 Associates a subnet with a route table. The subnet and route table must be in the same VPC. This association causes traffic originating from the subnet to be routed according to the routes in the route table. A route table can be associated with multiple subnets. To create a route table, see [AWS::EC2::RouteTable](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-routetable.html).
 
+## Example
+
+```crn
+let vpc = awscc.ec2.vpc {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+}
+
+let subnet = awscc.ec2.subnet {
+  vpc_id            = vpc.vpc_id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "ap-northeast-1a"
+}
+
+let rt = awscc.ec2.route_table {
+  vpc_id = vpc.vpc_id
+}
+
+awscc.ec2.subnet_route_table_association {
+  subnet_id      = subnet.subnet_id
+  route_table_id = rt.route_table_id
+}
+```
+
 ## Argument Reference
 
 ### `route_table_id`

--- a/generated-docs/awscc/ec2/transit_gateway.md
+++ b/generated-docs/awscc/ec2/transit_gateway.md
@@ -8,6 +8,18 @@ CloudFormation Type: `AWS::EC2::TransitGateway`
 
 Resource Type definition for AWS::EC2::TransitGateway
 
+## Example
+
+```crn
+awscc.ec2.transit_gateway {
+  description = "Example Transit Gateway"
+
+  tags = {
+    Environment = "example"
+  }
+}
+```
+
 ## Argument Reference
 
 ### `amazon_side_asn`

--- a/generated-docs/awscc/ec2/transit_gateway_attachment.md
+++ b/generated-docs/awscc/ec2/transit_gateway_attachment.md
@@ -8,6 +8,34 @@ CloudFormation Type: `AWS::EC2::TransitGatewayAttachment`
 
 Resource Type definition for AWS::EC2::TransitGatewayAttachment
 
+## Example
+
+```crn
+let vpc = awscc.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+}
+
+let subnet = awscc.ec2.subnet {
+  vpc_id            = vpc.vpc_id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "ap-northeast-1a"
+}
+
+let tgw = awscc.ec2.transit_gateway {
+  description = "Example Transit Gateway"
+}
+
+awscc.ec2.transit_gateway_attachment {
+  transit_gateway_id = tgw.id
+  vpc_id             = vpc.vpc_id
+  subnet_ids         = [subnet.subnet_id]
+
+  tags = {
+    Environment = "example"
+  }
+}
+```
+
 ## Argument Reference
 
 ### `options`

--- a/generated-docs/awscc/ec2/vpc.md
+++ b/generated-docs/awscc/ec2/vpc.md
@@ -10,6 +10,21 @@ Specifies a virtual private cloud (VPC).
  To add an IPv6 CIDR block to the VPC, see [AWS::EC2::VPCCidrBlock](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpccidrblock.html).
  For more information, see [Virtual private clouds (VPC)](https://docs.aws.amazon.com/vpc/latest/userguide/configure-your-vpc.html) in the *Amazon VPC User Guide*.
 
+## Example
+
+```crn
+awscc.ec2.vpc {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+  instance_tenancy     = default
+
+  tags = {
+    Environment = "example"
+  }
+}
+```
+
 ## Argument Reference
 
 ### `cidr_block`

--- a/generated-docs/awscc/ec2/vpc_endpoint.md
+++ b/generated-docs/awscc/ec2/vpc_endpoint.md
@@ -11,6 +11,45 @@ Specifies a VPC endpoint. A VPC endpoint provides a private connection between y
  An endpoint of type ``gateway`` serves as a target for a route in your route table for traffic destined for S3 or DDB. You can specify an endpoint policy for the endpoint, which controls access to the service from your VPC. You can also specify the VPC route tables that use the endpoint. For more information about connectivity to S3, see [Why can't I connect to an S3 bucket using a gateway VPC endpoint?](https://docs.aws.amazon.com/premiumsupport/knowledge-center/connect-s3-vpc-endpoint)
  An endpoint of type ``GatewayLoadBalancer`` provides private connectivity between your VPC and virtual appliances from a service provider.
 
+## Example
+
+```crn
+let vpc = awscc.ec2.vpc {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+}
+
+let subnet = awscc.ec2.subnet {
+  vpc_id            = vpc.vpc_id
+  cidr_block        = "10.0.100.0/24"
+  availability_zone = "ap-northeast-1a"
+}
+
+let sg = awscc.ec2.security_group {
+  vpc_id            = vpc.vpc_id
+  group_description = "SG for VPC Endpoint"
+}
+
+awscc.ec2.security_group_ingress {
+  group_id    = sg.group_id
+  description = "Allow HTTPS from VPC"
+  ip_protocol = "tcp"
+  from_port   = 443
+  to_port     = 443
+  cidr_ip     = "10.0.0.0/16"
+}
+
+awscc.ec2.vpc_endpoint {
+  vpc_id              = vpc.vpc_id
+  service_name        = "com.amazonaws.ap-northeast-1.ecr.dkr"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = [subnet.subnet_id]
+  security_group_ids  = [sg.group_id]
+  private_dns_enabled = true
+}
+```
+
 ## Argument Reference
 
 ### `dns_options`

--- a/generated-docs/awscc/ec2/vpc_gateway_attachment.md
+++ b/generated-docs/awscc/ec2/vpc_gateway_attachment.md
@@ -8,6 +8,23 @@ CloudFormation Type: `AWS::EC2::VPCGatewayAttachment`
 
 Resource Type definition for AWS::EC2::VPCGatewayAttachment
 
+## Example
+
+```crn
+let vpc = awscc.ec2.vpc {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+}
+
+let igw = awscc.ec2.internet_gateway {}
+
+awscc.ec2.vpc_gateway_attachment {
+  vpc_id              = vpc.vpc_id
+  internet_gateway_id = igw.internet_gateway_id
+}
+```
+
 ## Argument Reference
 
 ### `internet_gateway_id`

--- a/generated-docs/awscc/ec2/vpc_peering_connection.md
+++ b/generated-docs/awscc/ec2/vpc_peering_connection.md
@@ -8,6 +8,27 @@ CloudFormation Type: `AWS::EC2::VPCPeeringConnection`
 
 Resource Type definition for AWS::EC2::VPCPeeringConnection
 
+## Example
+
+```crn
+let vpc1 = awscc.ec2.vpc {
+  cidr_block = "10.0.0.0/16"
+}
+
+let vpc2 = awscc.ec2.vpc {
+  cidr_block = "10.1.0.0/16"
+}
+
+awscc.ec2.vpc_peering_connection {
+  vpc_id      = vpc1.vpc_id
+  peer_vpc_id = vpc2.vpc_id
+
+  tags = {
+    Environment = "example"
+  }
+}
+```
+
 ## Argument Reference
 
 ### `assume_role_region`

--- a/generated-docs/awscc/ec2/vpn_gateway.md
+++ b/generated-docs/awscc/ec2/vpn_gateway.md
@@ -9,6 +9,18 @@ CloudFormation Type: `AWS::EC2::VPNGateway`
 Specifies a virtual private gateway. A virtual private gateway is the endpoint on the VPC side of your VPN connection. You can create a virtual private gateway before creating the VPC itself.
  For more information, see [](https://docs.aws.amazon.com/vpn/latest/s2svpn/VPC_VPN.html) in the *User Guide*.
 
+## Example
+
+```crn
+awscc.ec2.vpn_gateway {
+  type = awscc.ec2.vpn_gateway.Type.ipsec.1
+
+  tags = {
+    Environment = "example"
+  }
+}
+```
+
 ## Argument Reference
 
 ### `amazon_side_asn`

--- a/generated-docs/awscc/iam/role.md
+++ b/generated-docs/awscc/iam/role.md
@@ -9,6 +9,31 @@ CloudFormation Type: `AWS::IAM::Role`
 Creates a new role for your AWS-account.
   For more information about roles, see [IAM roles](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html) in the *IAM User Guide*. For information about quotas for role names and the number of roles you can create, see [IAM and quotas](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html) in the *IAM User Guide*.
 
+## Example
+
+```crn
+awscc.iam.role {
+  role_name = "my-example-role"
+
+  assume_role_policy_document = {
+    version = "2012-10-17"
+    statement {
+      effect = "Allow"
+
+      principal = {
+        service = "lambda.amazonaws.com"
+      }
+
+      action = "sts:AssumeRole"
+    }
+  }
+
+  tags = {
+    Environment = "example"
+  }
+}
+```
+
 ## Argument Reference
 
 ### `assume_role_policy_document`

--- a/generated-docs/awscc/logs/log_group.md
+++ b/generated-docs/awscc/logs/log_group.md
@@ -12,6 +12,19 @@ The ``AWS::Logs::LogGroup`` resource specifies a log group. A log group defines 
   +  Log group names can be between 1 and 512 characters long.
   +  Log group names consist of the following characters: a-z, A-Z, 0-9, '_' (underscore), '-' (hyphen), '/' (forward slash), and '.' (period).
 
+## Example
+
+```crn
+awscc.logs.log_group {
+  log_group_name    = "/example/my-app"
+  retention_in_days = 30
+
+  tags = {
+    Environment = "example"
+  }
+}
+```
+
 ## Argument Reference
 
 ### `data_protection_policy`

--- a/generated-docs/awscc/s3/bucket.md
+++ b/generated-docs/awscc/s3/bucket.md
@@ -10,6 +10,22 @@ The ``AWS::S3::Bucket`` resource creates an Amazon S3 bucket in the same AWS Reg
  To control how AWS CloudFormation handles the bucket when the stack is deleted, you can set a deletion policy for your bucket. You can choose to *retain* the bucket or to *delete* the bucket. For more information, see [DeletionPolicy Attribute](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html).
   You can only delete empty buckets. Deletion fails for buckets that have contents.
 
+## Example
+
+```crn
+awscc.s3.bucket {
+  bucket_name = "my-example-bucket"
+
+  versioning_configuration = {
+    status = Enabled
+  }
+
+  tags = {
+    Environment = "example"
+  }
+}
+```
+
 ## Argument Reference
 
 ### `abac_status`

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -25,6 +25,7 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 CACHE_DIR="$PROJECT_ROOT/cfn-schema-cache"
 DOCS_DIR="$PROJECT_ROOT/generated-docs/awscc"
+EXAMPLES_DIR="$PROJECT_ROOT/examples"
 mkdir -p "$CACHE_DIR"
 rm -rf "$DOCS_DIR"
 mkdir -p "$DOCS_DIR"
@@ -80,6 +81,7 @@ for TYPE_NAME in "${RESOURCE_TYPES[@]}"; do
     DSL_NAME=$("$CODEGEN_BIN" --type-name "$TYPE_NAME" --print-dsl-resource-name)
     SERVICE=$(echo "$DSL_NAME" | cut -d'.' -f1)
     RESOURCE=$(echo "$DSL_NAME" | cut -d'.' -f2-)
+    FULL_RESOURCE=$("$CODEGEN_BIN" --type-name "$TYPE_NAME" --print-full-resource-name)
     mkdir -p "$DOCS_DIR/$SERVICE"
     OUTPUT_FILE="$DOCS_DIR/$SERVICE/$RESOURCE.md"
 
@@ -121,6 +123,33 @@ for TYPE_NAME in "${RESOURCE_TYPES[@]}"; do
             sed '1{/^# /d;}' "$OUTPUT_FILE"
         } > "$FRONTMATTER_TMPFILE"
         mv "$FRONTMATTER_TMPFILE" "$OUTPUT_FILE"
+    fi
+
+    # Insert example from hand-written example file (after description, before Argument Reference)
+    EXAMPLE_FILE="$EXAMPLES_DIR/${FULL_RESOURCE}/main.crn"
+    if [ -f "$EXAMPLE_FILE" ]; then
+        EXAMPLE_TMPFILE=$(mktemp)
+        {
+            echo "## Example"
+            echo ""
+            echo '```crn'
+            # Strip provider block, leading comments, and leading blank lines
+            sed -n '/^provider /,/^}/!p' "$EXAMPLE_FILE" | \
+                sed '/^#/d' | \
+                sed '/./,$!d'
+            echo '```'
+            echo ""
+        } > "$EXAMPLE_TMPFILE"
+        # Insert the example block before "## Argument Reference"
+        MERGED_TMPFILE=$(mktemp)
+        while IFS= read -r line || [ -n "$line" ]; do
+            if [ "$line" = "## Argument Reference" ]; then
+                cat "$EXAMPLE_TMPFILE"
+            fi
+            printf '%s\n' "$line"
+        done < "$OUTPUT_FILE" > "$MERGED_TMPFILE"
+        mv "$MERGED_TMPFILE" "$OUTPUT_FILE"
+        rm -f "$EXAMPLE_TMPFILE"
     fi
 done
 


### PR DESCRIPTION
## Summary
- Add `examples/` directory that was missing from repo separation
- Restore example insertion logic in `generate-docs.sh` (from original monorepo script)
- Regenerate docs with examples included

Fixes the example sections being stripped in carina-rs/carina#1475.

## Test plan
- [ ] Verify all 24 generated docs contain `## Example` sections
- [ ] Verify docs workflow creates correct PR in carina repo after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)