### PR TITLE
fix: update acceptance tests to use WASM provider binary

### DIFF
--- a/acceptance-tests/shared/_helpers.sh
+++ b/acceptance-tests/shared/_helpers.sh
@@ -27,8 +27,10 @@ if [ -z "$CARINA_BIN" ]; then
 fi
 
 # ── Provider source injection ────────────────────────────────────────
-AWSCC_PROVIDER_BIN="$PROJECT_ROOT/target/debug/carina-provider-awscc"
-AWS_PROVIDER_BIN="${AWS_PROVIDER_BIN:-$PROJECT_ROOT/target/debug/carina-provider-aws}"
+# Use WASM provider binaries (carina CLI only supports WASM providers)
+# Build with: cargo build -p carina-provider-awscc --target wasm32-wasip2 --release
+AWSCC_PROVIDER_BIN="${AWSCC_PROVIDER_BIN:-$PROJECT_ROOT/target/wasm32-wasip2/release/carina-provider-awscc.wasm}"
+AWS_PROVIDER_BIN="${AWS_PROVIDER_BIN:-$PROJECT_ROOT/target/wasm32-wasip2/release/carina-provider-aws.wasm}"
 
 # inject_provider_source: Create a temp copy of a .crn file with source/version
 # injected into provider blocks. Prints the temp file path.


### PR DESCRIPTION
## Summary
- Update `_helpers.sh` to use WASM binary (`target/wasm32-wasip2/release/carina-provider-awscc.wasm`)
- Both `AWSCC_PROVIDER_BIN` and `AWS_PROVIDER_BIN` are overridable via env vars

Closes #9

## Test plan
- [ ] Build WASM: `cargo build -p carina-provider-awscc --target wasm32-wasip2 --release`
- [ ] Run acceptance tests with WASM provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)