### PR TITLE
fix: update WIT State with exists field and downgrade wasi/wit-bindgen

### DIFF
--- a/carina-plugin-wit/wit/types.wit
+++ b/carina-plugin-wit/wit/types.wit
@@ -21,6 +21,7 @@ interface types {
     record state {
         identifier: option<string>,
         attributes: list<tuple<string, value>>,
+        exists: bool,
     }
 
     record resource-def {

--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -48,5 +48,5 @@ tokio = { version = "1", features = ["full"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tokio = { version = "1", default-features = false, features = ["rt", "macros", "time"] }
-wit-bindgen = { version = "0.51", default-features = false, features = ["macros"] }
-wasi = "0.14"
+wit-bindgen = { version = "0.39", default-features = false, features = ["macros"] }
+wasi = "0.13"


### PR DESCRIPTION
## Summary

- Add `exists: bool` to `record state` in `carina-plugin-wit/wit/types.wit` (matches carina-rs/carina#1480)
- Downgrade `wasi` 0.14→0.13 and `wit-bindgen` 0.51→0.39 for wasmtime 29 / `wasi:http@0.2.0` compatibility

## Test plan

- [x] `cargo check -p carina-provider-awscc` passes
- [x] `cargo build -p carina-provider-awscc --target wasm32-wasip2 --release` passes

refs carina-rs/carina#1480