### PR TITLE
fix: kill child processes on exit and detect stale locks

### DIFF
--- a/acceptance-tests/run-tests.sh
+++ b/acceptance-tests/run-tests.sh
@@ -188,7 +188,7 @@ if [ "$COMMAND" != "validate" ]; then
     if ! acquire_all_account_locks; then
         exit 1
     fi
-    trap release_account_locks EXIT
+    trap 'kill 0 2>/dev/null; release_account_locks' EXIT
 fi
 
 # Validate command
@@ -324,7 +324,7 @@ if [ "$COMMAND" = "cleanup" ]; then
     echo ""
 
     WORK_DIR=$(mktemp -d)
-    trap "rm -rf $WORK_DIR; release_account_locks" EXIT
+    trap 'kill 0 2>/dev/null; rm -rf '"$WORK_DIR"'; release_account_locks' EXIT
 
     # Pre-authenticate accounts
     echo "Pre-authenticating AWS accounts..."
@@ -446,7 +446,7 @@ if [ "$COMMAND" = "full" ]; then
     trap cleanup_main INT TERM
 
     # Clean up temp dir and release locks on normal exit
-    trap "rm -rf $WORK_DIR; release_account_locks" EXIT
+    trap 'kill 0 2>/dev/null; rm -rf '"$WORK_DIR"'; release_account_locks' EXIT
 
     # Pre-authenticate accounts sequentially to avoid opening
     # multiple SSO browser tabs simultaneously
@@ -639,7 +639,7 @@ echo ""
 # (plan/apply/destroy) to prevent cross-contamination between tests (issue #839)
 if [ "$COMMAND" != "validate" ]; then
     WORK_DIR=$(mktemp -d)
-    trap "rm -rf $WORK_DIR; release_account_locks" EXIT
+    trap 'kill 0 2>/dev/null; rm -rf '"$WORK_DIR"'; release_account_locks' EXIT
 fi
 
 PASSED=0


### PR DESCRIPTION
## Summary

- Add `kill 0 2>/dev/null` to all EXIT trap handlers so background worker processes (spawned with `&`) are killed when the parent script exits, preventing zombie child processes
- Stale lock detection was already implemented in `acquire_account_lock()`; this PR completes the fix by ensuring locks are always cleaned up even on abnormal exit

Closes #13
Closes #14