### PR TITLE
fix: add union-type to WIT attribute-type variant

### DIFF
--- a/carina-plugin-wit/wit/types.wit
+++ b/carina-plugin-wit/wit/types.wit
@@ -70,6 +70,7 @@ interface types {
         list-type(string),
         /// JSON-encoded attribute-type for the value type
         map-type(string),
+        union-type(string),
         struct-type(struct-def),
     }
 


### PR DESCRIPTION
## Summary
- Add `union-type(string)` to the `attribute-type` variant in `carina-plugin-wit/wit/types.wit`
- Matches carina-rs/carina#1491
- Required for IAM policy document principal field which uses `Union(Struct, String)`

## Test plan
- [ ] Verify WIT compiles correctly with `cargo build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)