### PR TITLE
feat: add vela WASM optimization to CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,7 @@ jobs:
         with:
           targets: wasm32-wasip2
       - run: cargo build -p carina-provider-awscc --target wasm32-wasip2 --release
+      - name: Optimize WASM with vela
+        run: |
+          cargo install --git https://github.com/mizzy/vela vela-cli --quiet
+          vela optimize target/wasm32-wasip2/release/carina-provider-awscc.wasm -o target/wasm32-wasip2/release/carina-provider-awscc.wasm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,11 @@ jobs:
       - name: Build
         run: cargo build --release --target wasm32-wasip2 --bin carina-provider-awscc
 
+      - name: Optimize WASM with vela
+        run: |
+          cargo install --git https://github.com/mizzy/vela vela-cli --quiet
+          vela optimize target/wasm32-wasip2/release/carina-provider-awscc.wasm -o target/wasm32-wasip2/release/carina-provider-awscc.wasm
+
       - name: Package
         run: |
           cp target/wasm32-wasip2/release/carina-provider-awscc.wasm carina-provider-awscc-${{ github.ref_name }}.wasm


### PR DESCRIPTION
## Summary

- Add vela WASM optimization step to `wasm-build` job in CI workflow
- Add vela WASM optimization step to `build-wasm` job in release workflow
- Optimization runs after build and before packaging

## Test plan

- [ ] Verify CI wasm-build job runs vela optimization after cargo build
- [ ] Verify release build-wasm job runs vela optimization before packaging

Closes #24