### PR TITLE
fix: update for carina SDK breaking changes (WIT transport layer + prevent_destroy)

### DIFF
--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -23,10 +23,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina" }
-carina-aws-types = { git = "https://github.com/carina-rs/carina" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina" }
+carina-core = { git = "https://github.com/carina-rs/carina", branch = "fix/sdk-macro-wit-structured-types" }
+carina-aws-types = { git = "https://github.com/carina-rs/carina", branch = "fix/sdk-macro-wit-structured-types" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", branch = "fix/sdk-macro-wit-structured-types" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", branch = "fix/sdk-macro-wit-structured-types" }
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-smithy-async = { version = "1", features = ["rt-tokio"] }
 aws-sdk-cloudcontrol = { version = "1", default-features = false, features = ["behavior-version-latest"] }

--- a/carina-provider-awscc/src/convert.rs
+++ b/carina-provider-awscc/src/convert.rs
@@ -122,6 +122,7 @@ pub fn core_to_proto_lifecycle(l: &CoreLifecycle) -> ProtoLifecycle {
     ProtoLifecycle {
         force_delete: l.force_delete,
         create_before_destroy: l.create_before_destroy,
+        prevent_destroy: l.prevent_destroy,
     }
 }
 
@@ -138,6 +139,7 @@ pub fn proto_to_core_resource(r: &ProtoResource) -> CoreResource {
     resource.lifecycle = CoreLifecycle {
         force_delete: r.lifecycle.force_delete,
         create_before_destroy: r.lifecycle.create_before_destroy,
+        prevent_destroy: r.lifecycle.prevent_destroy,
     };
     resource
 }

--- a/carina-provider-awscc/src/main.rs
+++ b/carina-provider-awscc/src/main.rs
@@ -154,6 +154,7 @@ impl CarinaProvider for AwsccProcessProvider {
         let core_lifecycle = carina_core::resource::LifecycleConfig {
             force_delete: lifecycle.force_delete,
             create_before_destroy: lifecycle.create_before_destroy,
+            prevent_destroy: lifecycle.prevent_destroy,
         };
         let result = self.runtime.block_on(self.provider().delete(
             &core_id,


### PR DESCRIPTION
## Summary
- Add `prevent_destroy` field to all `LifecycleConfig` initializers (3 locations: `convert.rs` x2, `main.rs` x1)
- Point carina dependencies to `fix/sdk-macro-wit-structured-types` branch which updates the SDK macro to use structured WIT types instead of JSON passthrough

## Context
The carina monorepo made breaking changes in PRs #1503 (WIT transport layer) and #1504 (prevent_destroy):
- WIT interface now uses structured types (`provider-info`, `provider-error`, `lifecycle-config`, `resource-schema`) instead of JSON strings
- `LifecycleConfig` gained a `prevent_destroy: bool` field

The SDK macro update is in carina-rs/carina#1512. Once that PR is merged, this PR's dependency should be switched back to `main`.

## Test plan
- [x] `cargo build -p carina-provider-awscc --target wasm32-wasip2 --release` succeeds
- [x] `cargo test -p carina-provider-awscc` passes all 160 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)