### PR TITLE
fix: update for carina SDK breaking changes (WIT transport layer + prevent_destroy)

### DIFF
--- a/carina-plugin-wit/wit/provider.wit
+++ b/carina-plugin-wit/wit/provider.wit
@@ -1,40 +1,26 @@
 interface provider {
-    use types.{
-        resource-id, state, resource-def, lifecycle-config,
-        provider-error, resource-schema, value, provider-info,
-    };
+    use types.{ resource-id, state, resource-def, value };
 
-    info: func() -> provider-info;
+    /// Returns JSON-serialized ProviderInfo
+    info: func() -> string;
 
-    schemas: func() -> list<resource-schema>;
+    /// Returns JSON-serialized Vec<ResourceSchema>
+    schemas: func() -> string;
 
     validate-config: func(attrs: list<tuple<string, value>>) -> result<_, string>;
-
     initialize: func(attrs: list<tuple<string, value>>) -> result<_, string>;
 
-    read: func(id: resource-id, identifier: option<string>) -> result<state, provider-error>;
+    read: func(id: resource-id, identifier: option<string>) -> result<state, string>;
+    create: func(res: resource-def) -> result<state, string>;
+    update: func(id: resource-id, identifier: string, current: state, to: resource-def) -> result<state, string>;
 
-    create: func(res: resource-def) -> result<state, provider-error>;
-
-    update: func(
-        id: resource-id,
-        identifier: string,
-        current: state,
-        to: resource-def,
-    ) -> result<state, provider-error>;
-
-    delete: func(
-        id: resource-id,
-        identifier: string,
-        lifecycle: lifecycle-config,
-    ) -> result<_, provider-error>;
+    /// options is JSON-serialized provider options map
+    delete: func(id: resource-id, identifier: string, options: string) -> result<_, string>;
 
     normalize-desired: func(resources: list<resource-def>) -> list<resource-def>;
-
     normalize-state: func(
         states: list<tuple<string, state>>,
     ) -> list<tuple<string, state>>;
-
     hydrate-read-state: func(
         states: list<tuple<string, state>>,
         saved-attrs: list<tuple<string, list<tuple<string, value>>>>,

--- a/carina-plugin-wit/wit/types.wit
+++ b/carina-plugin-wit/wit/types.wit
@@ -6,7 +6,6 @@ interface types {
     }
 
     /// Attribute values serialized as JSON strings for complex/nested types.
-    /// Simple scalar values use typed variants; list and map values are JSON-encoded strings.
     variant value {
         bool-val(bool),
         int-val(s64),
@@ -27,62 +26,5 @@ interface types {
     record resource-def {
         id: resource-id,
         attributes: list<tuple<string, value>>,
-    }
-
-    record lifecycle-config {
-        prevent-destroy: bool,
-    }
-
-    record provider-error {
-        message: string,
-        resource-id: option<resource-id>,
-        is-timeout: bool,
-    }
-
-    record resource-schema {
-        resource-type: string,
-        attributes: list<attribute-schema>,
-        description: option<string>,
-        data-source: bool,
-        name-attribute: option<string>,
-        force-replace: bool,
-    }
-
-    record attribute-schema {
-        name: string,
-        attr-type: attribute-type,
-        required: bool,
-        description: option<string>,
-        create-only: bool,
-        read-only: bool,
-        write-only: bool,
-    }
-
-    /// Attribute type descriptor. Recursive list/map/struct types are encoded
-    /// as JSON strings to avoid WIT's restriction on recursive type definitions.
-    variant attribute-type {
-        string-type,
-        int-type,
-        float-type,
-        bool-type,
-        string-enum(list<string>),
-        /// JSON-encoded attribute-type for the element type
-        list-type(string),
-        /// JSON-encoded attribute-type for the value type
-        map-type(string),
-        struct-type(struct-def),
-        /// JSON-encoded list of member attribute-types
-        union-type(string),
-    }
-
-    record struct-def {
-        name: string,
-        /// JSON-encoded list of struct-field records
-        fields: string,
-    }
-
-    record provider-info {
-        name: string,
-        display-name: string,
     }
 }

--- a/carina-provider-awscc/src/convert.rs
+++ b/carina-provider-awscc/src/convert.rs
@@ -122,6 +122,7 @@ pub fn core_to_proto_lifecycle(l: &CoreLifecycle) -> ProtoLifecycle {
     ProtoLifecycle {
         force_delete: l.force_delete,
         create_before_destroy: l.create_before_destroy,
+        prevent_destroy: l.prevent_destroy,
     }
 }
 
@@ -138,6 +139,7 @@ pub fn proto_to_core_resource(r: &ProtoResource) -> CoreResource {
     resource.lifecycle = CoreLifecycle {
         force_delete: r.lifecycle.force_delete,
         create_before_destroy: r.lifecycle.create_before_destroy,
+        prevent_destroy: r.lifecycle.prevent_destroy,
     };
     resource
 }

--- a/carina-provider-awscc/src/main.rs
+++ b/carina-provider-awscc/src/main.rs
@@ -154,6 +154,7 @@ impl CarinaProvider for AwsccProcessProvider {
         let core_lifecycle = carina_core::resource::LifecycleConfig {
             force_delete: lifecycle.force_delete,
             create_before_destroy: lifecycle.create_before_destroy,
+            prevent_destroy: lifecycle.prevent_destroy,
         };
         let result = self.runtime.block_on(self.provider().delete(
             &core_id,


### PR DESCRIPTION
## Summary

- Update local WIT files to match carina main (JSON passthrough from carina-rs/carina#1503)
- Add `prevent_destroy` field to `LifecycleConfig` initializers (carina-rs/carina#1504)

## Changes

- `carina-plugin-wit/wit/types.wit` — removed provider-specific WIT types (now JSON passthrough)
- `carina-plugin-wit/wit/provider.wit` — JSON string signatures for info/schemas/errors/delete
- `carina-plugin-wit/wit/world.wit` — added `wasi:http/types@0.2.6` import
- `carina-provider-awscc/src/convert.rs` — added `prevent_destroy` to lifecycle conversions (2 places)
- `carina-provider-awscc/src/main.rs` — added `prevent_destroy` to lifecycle initializer

## Test plan

- [x] `cargo build -p carina-provider-awscc --target wasm32-wasip2 --release` succeeds
- [x] `carina validate` with the built WASM binary loads provider successfully
- [ ] Acceptance tests (after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)