### PR TITLE
fix: run-tests.sh exits with code 144 on successful completion

### DIFF
--- a/acceptance-tests/run-tests.sh
+++ b/acceptance-tests/run-tests.sh
@@ -189,7 +189,7 @@ if [ "$COMMAND" != "validate" ]; then
     if ! acquire_all_account_locks; then
         exit 1
     fi
-    trap 'kill 0 2>/dev/null; release_account_locks' EXIT
+    trap 'trap "" TERM; kill 0 2>/dev/null; release_account_locks' EXIT
 fi
 
 # Validate command
@@ -573,7 +573,7 @@ if [ "$COMMAND" = "cleanup" ]; then
     echo ""
 
     WORK_DIR=$(mktemp -d)
-    trap 'kill 0 2>/dev/null; rm -rf '"$WORK_DIR"'; release_account_locks' EXIT
+    trap 'trap "" TERM; kill 0 2>/dev/null; rm -rf '"$WORK_DIR"'; release_account_locks' EXIT
 
     # Pre-authenticate accounts
     echo "Pre-authenticating AWS accounts..."
@@ -695,7 +695,7 @@ if [ "$COMMAND" = "full" ]; then
     trap cleanup_main INT TERM
 
     # Clean up temp dir and release locks on normal exit
-    trap 'kill 0 2>/dev/null; rm -rf '"$WORK_DIR"'; release_account_locks' EXIT
+    trap 'trap "" TERM; kill 0 2>/dev/null; rm -rf '"$WORK_DIR"'; release_account_locks' EXIT
 
     # Pre-authenticate accounts sequentially to avoid opening
     # multiple SSO browser tabs simultaneously
@@ -897,7 +897,7 @@ echo ""
 # (plan/apply/destroy) to prevent cross-contamination between tests (issue #839)
 if [ "$COMMAND" != "validate" ]; then
     WORK_DIR=$(mktemp -d)
-    trap 'kill 0 2>/dev/null; rm -rf '"$WORK_DIR"'; release_account_locks' EXIT
+    trap 'trap "" TERM; kill 0 2>/dev/null; rm -rf '"$WORK_DIR"'; release_account_locks' EXIT
 fi
 
 PASSED=0


### PR DESCRIPTION
## Summary
- Fix EXIT trap sending SIGTERM to the shell itself via `kill 0`, which triggered the `cleanup_main` TERM handler on normal exit
- Add `trap "" TERM` before `kill 0` in all EXIT traps so the shell ignores the signal while child processes are still terminated
- Affects all code paths that set EXIT traps: non-validate single commands, cleanup, full cycle, and single-command stateful modes

## Root cause
`kill 0` sends SIGTERM to the entire process group (PID 0 = current group). When both an EXIT trap and a TERM trap (`cleanup_main`) were registered, normal script exit would: EXIT fires -> `kill 0` -> SIGTERM delivered to shell -> TERM trap fires -> prints "Interrupted!" -> `exit 1`. The shell then exits with 128+16=144.

## Test plan
- [x] `./acceptance-tests/run-tests.sh validate` exits with code 0 (54 passed)
- [ ] `./acceptance-tests/run-tests.sh full` no longer prints "Interrupted!" on success
- [ ] Ctrl+C during `full` still triggers cleanup

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)