### PR TITLE
fix: improve S3 empty_s3_bucket error reporting and handle NoSuchBucket

### DIFF
--- a/carina-provider-awscc/src/provider/s3.rs
+++ b/carina-provider-awscc/src/provider/s3.rs
@@ -137,9 +137,7 @@ where
 /// In that case, there's nothing to empty and we can proceed.
 fn is_no_such_bucket<E: ProvideErrorMetadata>(error: &SdkError<E>) -> bool {
     match error {
-        SdkError::ServiceError(service_error) => {
-            service_error.err().code() == Some("NoSuchBucket")
-        }
+        SdkError::ServiceError(service_error) => service_error.err().code() == Some("NoSuchBucket"),
         _ => false,
     }
 }


### PR DESCRIPTION
## Summary

- Extract actual error code and message from S3 SDK errors in `empty_s3_bucket` instead of displaying the generic "service error" text. Uses `format_s3_error()` which mirrors the existing `format_sdk_error()` pattern in `cloudcontrol.rs`.
- Handle `NoSuchBucket` gracefully during force_delete -- if the bucket was already deleted, there is nothing to empty, so we return Ok instead of failing.

## Context

Refs carina-rs/carina#1515

The acceptance test `s3_bucket/logging.crn` fails on destroy with:
```
Failed to empty S3 bucket before deletion: Failed to list object versions: service error
```

The "service error" text comes from `SdkError::Display` which doesn't include the actual error code/message. This change ensures the real error details are surfaced (e.g., `AccessDenied: ...` or `NoSuchBucket: ...`), making it possible to diagnose the root cause.

The `NoSuchBucket` handling is a robustness improvement -- if the bucket is gone by the time `force_delete` runs, the empty operation should succeed silently.

## Test plan

- [x] `cargo check -p carina-provider-awscc` passes
- [x] `cargo test -p carina-provider-awscc` passes (160 tests)
- [ ] Re-run `s3_bucket/logging` acceptance test to see the actual error code (this will reveal whether the underlying issue is permissions, bucket-not-found, or something else)

🤖 Generated with [Claude Code](https://claude.com/claude-code)