### PR TITLE
fix: retry on ClientTokenConflictException during CloudControl operations

### DIFF
--- a/carina-provider-awscc/src/provider/cloudcontrol.rs
+++ b/carina-provider-awscc/src/provider/cloudcontrol.rs
@@ -356,6 +356,7 @@ impl AwsccProvider {
             "NetworkFailureException",
             "ConcurrentOperationException",
             "NotStabilizedException",
+            "ClientTokenConflictException",
         ];
 
         match error {
@@ -699,6 +700,22 @@ mod tests {
         );
         let sdk_err = SdkError::service_error(err, http::Response::new(""));
         assert!(!AwsccProvider::is_retryable_sdk_error(&sdk_err));
+    }
+
+    #[test]
+    fn test_is_retryable_sdk_error_client_token_conflict() {
+        use aws_sdk_cloudcontrol::operation::delete_resource::DeleteResourceError;
+        use aws_sdk_cloudcontrol::types::error::ClientTokenConflictException;
+        use aws_smithy_runtime_api::client::result::SdkError;
+
+        let err = DeleteResourceError::ClientTokenConflictException(
+            ClientTokenConflictException::builder()
+                .message("ClientToken is already associated with an existing operation")
+                .meta(error_meta("ClientTokenConflictException"))
+                .build(),
+        );
+        let sdk_err = SdkError::service_error(err, http::Response::new(""));
+        assert!(AwsccProvider::is_retryable_sdk_error(&sdk_err));
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary

Add `ClientTokenConflictException` to the list of retryable CloudControl API error codes. This error occurs when a previous operation with the same client token is still in progress.

Refs carina-rs/carina#1516

## Change

1 line added to `RETRYABLE_ERROR_CODES` + 1 test.

## Test plan

- [x] `test_is_retryable_sdk_error_client_token_conflict` passes
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)