### PR TITLE
fix: multi-step test scripts pass directory to carina CLI

### DIFF
--- a/acceptance-tests/attribute_removal/run.sh
+++ b/acceptance-tests/attribute_removal/run.sh
@@ -159,7 +159,7 @@ run_test() {
     if ! run_step "$work_dir" "step1: apply initial (with attribute)" "apply" "$step1" "--auto-approve"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -168,7 +168,7 @@ run_test() {
     if ! run_plan_verify "$work_dir" "step1: plan-verify initial" "$step1"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -177,7 +177,7 @@ run_test() {
     if ! run_step "$work_dir" "step2: apply attribute removal" "apply" "$step2" "--auto-approve"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -186,7 +186,7 @@ run_test() {
     if ! run_plan_verify "$work_dir" "step3: plan-verify after attribute removal" "$step2"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -196,14 +196,14 @@ run_test() {
         echo "  WARNING: All destroy attempts failed. Preserving work dir for debugging:"
         echo "    $work_dir"
         TOTAL_FAILED=$((TOTAL_FAILED + 1))
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         echo ""
         return 1
     fi
 
     rm -rf "$work_dir"
-    rm -f "$step1" "$step2"
+    rm -rf "$step1" "$step2"
     ACTIVE_WORK_DIR=""
     echo ""
 }

--- a/acceptance-tests/cascade_without_cbd/run.sh
+++ b/acceptance-tests/cascade_without_cbd/run.sh
@@ -21,7 +21,7 @@ source "$SCRIPT_DIR/../shared/_helpers.sh"
 
 STEP1=$(inject_provider_source "$SCRIPT_DIR/step1.crn")
 STEP2=$(inject_provider_source "$SCRIPT_DIR/step2.crn")
-trap "rm -f $STEP1 $STEP2" EXIT
+trap "rm -rf $STEP1 $STEP2" EXIT
 
 PASS=0
 FAIL=0

--- a/acceptance-tests/create_before_destroy/run.sh
+++ b/acceptance-tests/create_before_destroy/run.sh
@@ -220,7 +220,7 @@ run_test() {
     if ! run_step "$work_dir" "step1: apply initial" "apply" "$step1" "--auto-approve"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -229,7 +229,7 @@ run_test() {
     if ! run_plan_verify "$work_dir" "step1: plan-verify initial" "$step1"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -242,7 +242,7 @@ run_test() {
     if ! run_step "$work_dir" "step2: apply replace (create_before_destroy)" "apply" "$step2" "--auto-approve"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -255,7 +255,7 @@ run_test() {
     if ! assert_identifiers "assert: identifiers changed after replace" "$ids_after_step1" "$ids_after_step2" "different"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -264,7 +264,7 @@ run_test() {
     if ! run_plan_verify "$work_dir" "step3: plan-verify after replace" "$step2"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -274,14 +274,14 @@ run_test() {
         echo "  WARNING: All destroy attempts failed. Preserving work dir for debugging:"
         echo "    $work_dir"
         TOTAL_FAILED=$((TOTAL_FAILED + 1))
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         echo ""
         return 1
     fi
 
     rm -rf "$work_dir"
-    rm -f "$step1" "$step2"
+    rm -rf "$step1" "$step2"
     ACTIVE_WORK_DIR=""
     echo ""
 }

--- a/acceptance-tests/in_place_update/run.sh
+++ b/acceptance-tests/in_place_update/run.sh
@@ -229,7 +229,7 @@ run_test() {
     if ! run_step "$work_dir" "step1: apply initial" "apply" "$step1" "--auto-approve"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -238,7 +238,7 @@ run_test() {
     if ! run_plan_verify "$work_dir" "step1: plan-verify initial" "$step1"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -251,7 +251,7 @@ run_test() {
     if ! run_step "$work_dir" "step2: apply in-place update" "apply" "$step2" "--auto-approve"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -264,7 +264,7 @@ run_test() {
     if ! assert_identifiers "assert: identifiers preserved after update" "$ids_after_step1" "$ids_after_step2" "equal"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -273,7 +273,7 @@ run_test() {
     if ! run_plan_verify "$work_dir" "step3: plan-verify after update" "$step2"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -283,14 +283,14 @@ run_test() {
         echo "  WARNING: All destroy attempts failed. Preserving work dir for debugging:"
         echo "    $work_dir"
         TOTAL_FAILED=$((TOTAL_FAILED + 1))
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         echo ""
         return 1
     fi
 
     rm -rf "$work_dir"
-    rm -f "$step1" "$step2"
+    rm -rf "$step1" "$step2"
     ACTIVE_WORK_DIR=""
     echo ""
 }

--- a/acceptance-tests/shared/_helpers.sh
+++ b/acceptance-tests/shared/_helpers.sh
@@ -32,13 +32,14 @@ fi
 AWSCC_PROVIDER_BIN="${AWSCC_PROVIDER_BIN:-$PROJECT_ROOT/target/wasm32-wasip2/release/carina-provider-awscc.wasm}"
 AWS_PROVIDER_BIN="${AWS_PROVIDER_BIN:-$PROJECT_ROOT/target/wasm32-wasip2/release/carina-provider-aws.wasm}"
 
-# inject_provider_source: Create a temp copy of a .crn file with source/version
-# injected into provider blocks. Prints the temp file path.
+# inject_provider_source: Create a temp directory containing a .crn file with
+# source/version injected into provider blocks. Prints the temp directory path.
+# carina CLI expects a directory path, not a file path.
 # Args: original_crn_file
 inject_provider_source() {
     local original="$1"
-    local tmp_file
-    tmp_file=$(mktemp).crn
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
 
     sed \
         -e '/^provider awscc {/a\
@@ -47,9 +48,9 @@ inject_provider_source() {
         -e '/^provider aws {/a\
   source = "file://'"$AWS_PROVIDER_BIN"'"\
   version = "0.1.0"' \
-        "$original" > "$tmp_file"
+        "$original" > "$tmp_dir/main.crn"
 
-    echo "$tmp_file"
+    echo "$tmp_dir"
 }
 
 # inject_provider_source_dir: Inject source/version into all .crn files in a directory (in-place).

--- a/acceptance-tests/simhash_update/run.sh
+++ b/acceptance-tests/simhash_update/run.sh
@@ -215,7 +215,7 @@ run_test() {
     if ! run_step "$work_dir" "step1: apply initial" "apply" "$step1" "--auto-approve"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -224,7 +224,7 @@ run_test() {
     if ! run_plan_verify "$work_dir" "step1: plan-verify initial" "$step1"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -237,7 +237,7 @@ run_test() {
     if ! run_step "$work_dir" "step2: apply update (simhash reconcile)" "apply" "$step2" "--auto-approve"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -250,7 +250,7 @@ run_test() {
     if ! assert_identifiers "assert: identifiers preserved after update" "$ids_after_step1" "$ids_after_step2" "equal"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -259,7 +259,7 @@ run_test() {
     if ! run_plan_verify "$work_dir" "step3: plan-verify after update" "$step2"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -269,14 +269,14 @@ run_test() {
         echo "  WARNING: All destroy attempts failed. Preserving work dir for debugging:"
         echo "    $work_dir"
         TOTAL_FAILED=$((TOTAL_FAILED + 1))
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         echo ""
         return 1
     fi
 
     rm -rf "$work_dir"
-    rm -f "$step1" "$step2"
+    rm -rf "$step1" "$step2"
     ACTIVE_WORK_DIR=""
     echo ""
 }
@@ -334,7 +334,7 @@ run_test_single() {
     if ! run_step "$work_dir" "step1: apply" "apply" "$crn_file" "--auto-approve"; then
         cleanup_single "$work_dir" "$crn_file"
         rm -rf "$work_dir"
-        rm -f "$crn_file"
+        rm -rf "$crn_file"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -343,7 +343,7 @@ run_test_single() {
     if ! run_plan_verify "$work_dir" "step2: plan-verify" "$crn_file"; then
         cleanup_single "$work_dir" "$crn_file"
         rm -rf "$work_dir"
-        rm -f "$crn_file"
+        rm -rf "$crn_file"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -353,14 +353,14 @@ run_test_single() {
         echo "  WARNING: All destroy attempts failed. Preserving work dir for debugging:"
         echo "    $work_dir"
         TOTAL_FAILED=$((TOTAL_FAILED + 1))
-        rm -f "$crn_file"
+        rm -rf "$crn_file"
         ACTIVE_WORK_DIR=""
         echo ""
         return 1
     fi
 
     rm -rf "$work_dir"
-    rm -f "$crn_file"
+    rm -rf "$crn_file"
     ACTIVE_WORK_DIR=""
     echo ""
 }

--- a/acceptance-tests/tag_deletion/run.sh
+++ b/acceptance-tests/tag_deletion/run.sh
@@ -165,7 +165,7 @@ run_test() {
     if ! run_step "$work_dir" "step1: apply initial (two tags)" "apply" "$step1" "--auto-approve"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -174,7 +174,7 @@ run_test() {
     if ! run_plan_verify "$work_dir" "step1: plan-verify initial" "$step1"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -183,7 +183,7 @@ run_test() {
     if ! run_step "$work_dir" "step2: apply tag removal" "apply" "$step2" "--auto-approve"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -192,7 +192,7 @@ run_test() {
     if ! run_plan_verify "$work_dir" "step3: plan-verify after tag removal" "$step2"; then
         cleanup "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -202,14 +202,14 @@ run_test() {
         echo "  WARNING: All destroy attempts failed. Preserving work dir for debugging:"
         echo "    $work_dir"
         TOTAL_FAILED=$((TOTAL_FAILED + 1))
-        rm -f "$step1" "$step2"
+        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         echo ""
         return 1
     fi
 
     rm -rf "$work_dir"
-    rm -f "$step1" "$step2"
+    rm -rf "$step1" "$step2"
     ACTIVE_WORK_DIR=""
     echo ""
 }


### PR DESCRIPTION
## Summary
- Changed `inject_provider_source` in `_helpers.sh` to create a temp directory containing `main.crn` instead of returning a bare temp file path
- Updated all multi-step `run.sh` scripts to use `rm -rf` for cleanup since injected paths are now directories
- Fixes all multi-step tests: create_before_destroy, tag_deletion, simhash_update, attribute_removal, in_place_update, cascade_without_cbd

## Background
carina CLI expects a directory path, not a file path. The multi-step test scripts were calling `inject_provider_source` which returned a temp `.crn` file path, then passing that directly to `carina apply/plan/destroy`, causing:
```
Error: expected directory, got file: /var/folders/.../tmp.xxx.crn
```

## Test plan
- [ ] Run `aws-vault exec carina-test-000 -- ./acceptance-tests/create_before_destroy/run.sh` and verify it gets past the "expected directory" error
- [ ] Verify inject_provider_source returns a directory containing main.crn

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)