### PR TITLE
fix: retry TGW deletion when VPC attachments are still detaching

### DIFF
--- a/carina-provider-awscc/src/provider/cloudcontrol.rs
+++ b/carina-provider-awscc/src/provider/cloudcontrol.rs
@@ -362,18 +362,17 @@ impl AwsccProvider {
         /// Error message patterns that indicate retryable conditions regardless of error code.
         /// These are checked against the error message when the error code alone is not
         /// sufficient to determine retryability.
-        const RETRYABLE_MESSAGE_PATTERNS: &[&str] = &[
-            "non-deleted VPC Attachments",
-        ];
+        const RETRYABLE_MESSAGE_PATTERNS: &[&str] = &["non-deleted VPC Attachments"];
 
         match error {
             SdkError::TimeoutError(_) | SdkError::DispatchFailure(_) => true,
             SdkError::ServiceError(service_error) => {
                 let err = service_error.err();
-                if let Some(code) = err.code() {
-                    if RETRYABLE_ERROR_CODES.contains(&code) {
-                        return true;
-                    }
+                if err
+                    .code()
+                    .is_some_and(|code| RETRYABLE_ERROR_CODES.contains(&code))
+                {
+                    return true;
                 }
                 if let Some(message) = err.message() {
                     RETRYABLE_MESSAGE_PATTERNS
@@ -755,7 +754,9 @@ mod tests {
             .build();
         let err = DeleteResourceError::GeneralServiceException(
             GeneralServiceException::builder()
-                .message("tgw-0abc123def456 has non-deleted VPC Attachments: tgw-attach-0abc123def456")
+                .message(
+                    "tgw-0abc123def456 has non-deleted VPC Attachments: tgw-attach-0abc123def456",
+                )
                 .meta(meta)
                 .build(),
         );


### PR DESCRIPTION
## Summary

- Add `"non-deleted VPC Attachments"` as a retryable pattern in `is_retryable_status_message()` for async operation failures
- Add message-based retryable matching in `is_retryable_sdk_error()` for cases where the error comes as an SDK error with the TGW message
- Add tests for both code paths

During `create_before_destroy` replacement of a Transit Gateway, the old TGW deletion fails because VPC attachment detachment is asynchronous — CloudControl returns success for the attachment update but the underlying detachment takes time. The existing retry logic now recognizes this as a transient condition and retries.

refs carina-rs/carina#1523

## Test plan

- [x] `cargo test -p carina-provider-awscc -- is_retryable` — all 17 tests pass
- [x] `cargo test -p carina-provider-awscc -- is_not_retryable` — all 4 non-retryable tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)