### PR TITLE
chore: release v0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,4 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"


### PR DESCRIPTION
Bump version to 0.2.0 to match carina core release.