### PR TITLE
fix: read provider version from Cargo.toml instead of hardcoding

### DIFF
--- a/acceptance-tests/run-tests.sh
+++ b/acceptance-tests/run-tests.sh
@@ -429,6 +429,9 @@ fi
 AWSCC_PROVIDER_BIN="${AWSCC_PROVIDER_BIN:-$PROJECT_ROOT/target/wasm32-wasip2/release/carina-provider-awscc.wasm}"
 AWS_PROVIDER_BIN="${AWS_PROVIDER_BIN:-$PROJECT_ROOT/target/wasm32-wasip2/release/carina-provider-aws.wasm}"
 
+# Read provider version from workspace Cargo.toml to avoid hardcoding
+PROVIDER_VERSION=$(grep '^version = ' "$PROJECT_ROOT/Cargo.toml" | head -1 | sed 's/version = "\(.*\)"/\1/')
+
 # Validate that provider binaries are WASM components, not native binaries.
 # Native binaries are no longer supported and will cause cryptic linker errors.
 for bin_var in AWSCC_PROVIDER_BIN AWS_PROVIDER_BIN; do
@@ -452,10 +455,10 @@ inject_provider_source() {
     sed \
         -e '/^provider awscc {/a\
   source = "file://'"$AWSCC_PROVIDER_BIN"'"\
-  version = "0.1.0"' \
+  version = "'"$PROVIDER_VERSION"'"' \
         -e '/^provider aws {/a\
   source = "file://'"$AWS_PROVIDER_BIN"'"\
-  version = "0.1.0"' \
+  version = "'"$PROVIDER_VERSION"'"' \
         "$original" > "$tmp_file"
 
     echo "$tmp_file"

--- a/acceptance-tests/shared/_helpers.sh
+++ b/acceptance-tests/shared/_helpers.sh
@@ -31,6 +31,7 @@ fi
 # Build with: cargo build -p carina-provider-awscc --target wasm32-wasip2 --release
 AWSCC_PROVIDER_BIN="${AWSCC_PROVIDER_BIN:-$PROJECT_ROOT/target/wasm32-wasip2/release/carina-provider-awscc.wasm}"
 AWS_PROVIDER_BIN="${AWS_PROVIDER_BIN:-$PROJECT_ROOT/target/wasm32-wasip2/release/carina-provider-aws.wasm}"
+PROVIDER_VERSION=$(grep '^version = ' "$PROJECT_ROOT/Cargo.toml" | head -1 | sed 's/version = "\(.*\)"/\1/')
 
 # inject_provider_source: Create a temp directory containing a .crn file with
 # source/version injected into provider blocks. Prints the temp directory path.
@@ -44,10 +45,10 @@ inject_provider_source() {
     sed \
         -e '/^provider awscc {/a\
   source = "file://'"$AWSCC_PROVIDER_BIN"'"\
-  version = "0.1.0"' \
+  version = "'"$PROVIDER_VERSION"'"' \
         -e '/^provider aws {/a\
   source = "file://'"$AWS_PROVIDER_BIN"'"\
-  version = "0.1.0"' \
+  version = "'"$PROVIDER_VERSION"'"' \
         "$original" > "$tmp_dir/main.crn"
 
     echo "$tmp_dir"
@@ -65,10 +66,10 @@ inject_provider_source_dir() {
         sed -i '' \
             -e '/^provider awscc {/a\
   source = "file://'"$AWSCC_PROVIDER_BIN"'"\
-  version = "0.1.0"' \
+  version = "'"$PROVIDER_VERSION"'"' \
             -e '/^provider aws {/a\
   source = "file://'"$AWS_PROVIDER_BIN"'"\
-  version = "0.1.0"' \
+  version = "'"$PROVIDER_VERSION"'"' \
             "$crn_file"
     done
 }


### PR DESCRIPTION
## Summary

- Read `PROVIDER_VERSION` from workspace `Cargo.toml` instead of hardcoding `"0.1.0"`
- Updated both `run-tests.sh` and `shared/_helpers.sh`

After bumping to v0.2.0, acceptance tests failed because `inject_provider_source()` injected `version = "0.1.0"` but the provider reported `0.2.0`, triggering version constraint rejection.

Closes #45

## Test plan

- [x] Verified `PROVIDER_VERSION` extraction produces `0.2.0`
- [x] Verified `sed` injection produces `version = "0.2.0"` in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)