### PR TITLE
fix: extend Transit Gateway delete retry/polling for CBD operations

### DIFF
--- a/carina-provider-awscc/src/provider/cloudcontrol.rs
+++ b/carina-provider-awscc/src/provider/cloudcontrol.rs
@@ -910,10 +910,7 @@ mod tests {
     #[test]
     fn test_max_polling_attempts_transit_gateway_attachment_delete() {
         assert_eq!(
-            AwsccProvider::max_polling_attempts(
-                "AWS::EC2::TransitGatewayAttachment",
-                "delete"
-            ),
+            AwsccProvider::max_polling_attempts("AWS::EC2::TransitGatewayAttachment", "delete"),
             360
         );
     }


### PR DESCRIPTION
## Summary

- Add `max_delete_retry_attempts()` method for per-resource-type delete retry limits
- Transit Gateway resources get 24 retries (~35 min) instead of default 12 (~18 min)
- Add Transit Gateway to extended polling timeout (30 min instead of 10 min default)

During `create_before_destroy`, the old Transit Gateway deletion fails with `"non-deleted VPC Attachments"` because the attachment detach is asynchronous and takes 15-30 minutes. The existing retry logic was firing but exhausting its 12-retry limit before the attachment finished detaching.

Refs #47

## Test plan

- [x] `cargo test -p carina-provider-awscc` — 160 tests pass (8 new tests)
- [x] New tests cover: `max_polling_attempts` for TGW/TGW Attachment, `max_delete_retry_attempts` for TGW/default
- [ ] Acceptance test: `create_before_destroy` Test 3 (TGW Attachment) — requires live AWS

🤖 Generated with [Claude Code](https://claude.com/claude-code)