### PR TITLE
style: use single quotes for literal strings in .crn files

### DIFF
--- a/acceptance-tests/attribute_removal/ec2_vpc_endpoint_step1.crn
+++ b/acceptance-tests/attribute_removal/ec2_vpc_endpoint_step1.crn
@@ -7,7 +7,7 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.108.0.0/16"
+  cidr_block = '10.108.0.0/16'
 }
 
 let rt = awscc.ec2.route_table {
@@ -16,17 +16,17 @@ let rt = awscc.ec2.route_table {
 
 awscc.ec2.vpc_endpoint {
   vpc_id            = vpc.vpc_id
-  service_name      = "com.amazonaws.ap-northeast-1.s3"
+  service_name      = 'com.amazonaws.ap-northeast-1.s3'
   vpc_endpoint_type = Gateway
   route_table_ids   = [rt.route_table_id]
 
   policy_document = {
-    version = "2012-10-17"
+    version = '2012-10-17'
     statement {
-      effect    = "Allow"
-      principal = "*"
-      action    = "s3:GetObject"
-      resource  = "arn:aws:s3:::*"
+      effect    = 'Allow'
+      principal = '*'
+      action    = 's3:GetObject'
+      resource  = 'arn:aws:s3:::*'
     }
   }
 }

--- a/acceptance-tests/attribute_removal/ec2_vpc_endpoint_step2.crn
+++ b/acceptance-tests/attribute_removal/ec2_vpc_endpoint_step2.crn
@@ -7,7 +7,7 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.108.0.0/16"
+  cidr_block = '10.108.0.0/16'
 }
 
 let rt = awscc.ec2.route_table {
@@ -16,7 +16,7 @@ let rt = awscc.ec2.route_table {
 
 awscc.ec2.vpc_endpoint {
   vpc_id            = vpc.vpc_id
-  service_name      = "com.amazonaws.ap-northeast-1.s3"
+  service_name      = 'com.amazonaws.ap-northeast-1.s3'
   vpc_endpoint_type = Gateway
   route_table_ids   = [rt.route_table_id]
 }

--- a/acceptance-tests/attribute_removal/logs_log_group_step1.crn
+++ b/acceptance-tests/attribute_removal/logs_log_group_step1.crn
@@ -7,6 +7,6 @@ provider awscc {
 }
 
 awscc.logs.log_group {
-  log_group_name    = "/carina/acc-test-attr-removal"
+  log_group_name    = '/carina/acc-test-attr-removal'
   retention_in_days = 7
 }

--- a/acceptance-tests/attribute_removal/logs_log_group_step2.crn
+++ b/acceptance-tests/attribute_removal/logs_log_group_step2.crn
@@ -7,5 +7,5 @@ provider awscc {
 }
 
 awscc.logs.log_group {
-  log_group_name = "/carina/acc-test-attr-removal"
+  log_group_name = '/carina/acc-test-attr-removal'
 }

--- a/acceptance-tests/builtin_functions/cidr_subnet.crn
+++ b/acceptance-tests/builtin_functions/cidr_subnet.crn
@@ -2,22 +2,22 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let base_cidr = "10.0.0.0/16"
+let base_cidr = '10.0.0.0/16'
 
 let vpc = awscc.ec2.vpc {
   cidr_block = base_cidr
 
   tags = {
-    Name = "cidr-subnet-test"
+    Name = 'cidr-subnet-test'
   }
 }
 
 awscc.ec2.subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = cidr_subnet(base_cidr, 8, 1)
-  availability_zone = "ap-northeast-1a"
+  availability_zone = 'ap-northeast-1a'
 
   tags = {
-    Name = "cidr-subnet-test"
+    Name = 'cidr-subnet-test'
   }
 }

--- a/acceptance-tests/builtin_functions/concat.crn
+++ b/acceptance-tests/builtin_functions/concat.crn
@@ -2,14 +2,14 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let parts1 = ["web", "test"]
+let parts1 = ['web', 'test']
 
-let parts2 = ["vpc"]
+let parts2 = ['vpc']
 
 awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Name = join("-", concat(parts2, parts1))
+    Name = join('-', concat(parts2, parts1))
   }
 }

--- a/acceptance-tests/builtin_functions/flatten.crn
+++ b/acceptance-tests/builtin_functions/flatten.crn
@@ -2,12 +2,12 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let parts = [["flat", "test"], ["vpc"]]
+let parts = [['flat', 'test'], ['vpc']]
 
 awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Name = join("-", flatten(parts))
+    Name = join('-', flatten(parts))
   }
 }

--- a/acceptance-tests/builtin_functions/join.crn
+++ b/acceptance-tests/builtin_functions/join.crn
@@ -2,14 +2,14 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let env = "test"
+let env = 'test'
 
-let app = "web"
+let app = 'web'
 
 awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Name = join("-", [app, env, "vpc"])
+    Name = join('-', [app, env, 'vpc'])
   }
 }

--- a/acceptance-tests/builtin_functions/keys_values.crn
+++ b/acceptance-tests/builtin_functions/keys_values.crn
@@ -3,16 +3,16 @@ provider awscc {
 }
 
 let config = {
-  app  = "web"
-  env  = "test"
-  team = "infra"
+  app  = 'web'
+  env  = 'test'
+  team = 'infra'
 }
 
 awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Name   = join("-", keys(config))
-    Values = join("-", values(config))
+    Name   = join('-', keys(config))
+    Values = join('-', values(config))
   }
 }

--- a/acceptance-tests/builtin_functions/length.crn
+++ b/acceptance-tests/builtin_functions/length.crn
@@ -2,13 +2,13 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let items = ["a", "b", "c"]
+let items = ['a', 'b', 'c']
 
 awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Name      = "length-test-vpc"
+    Name      = 'length-test-vpc'
     ItemCount = "count-${length(items)}"
   }
 }

--- a/acceptance-tests/builtin_functions/local_let.crn
+++ b/acceptance-tests/builtin_functions/local_let.crn
@@ -3,9 +3,9 @@ provider awscc {
 }
 
 awscc.ec2.vpc {
-  let env = "production"
+  let env = 'production'
   let name = "local-let-${env}"
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
     Name = name

--- a/acceptance-tests/builtin_functions/lookup.crn
+++ b/acceptance-tests/builtin_functions/lookup.crn
@@ -3,15 +3,15 @@ provider awscc {
 }
 
 let env_names = {
-  prod = "production"
-  stg  = "staging"
-  dev  = "development"
+  prod = 'production'
+  stg  = 'staging'
+  dev  = 'development'
 }
 
 awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Name = lookup(env_names, "prod", "unknown")
+    Name = lookup(env_names, 'prod', 'unknown')
   }
 }

--- a/acceptance-tests/builtin_functions/min_max.crn
+++ b/acceptance-tests/builtin_functions/min_max.crn
@@ -3,10 +3,10 @@ provider awscc {
 }
 
 awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Name    = "min-max-test-vpc"
+    Name    = 'min-max-test-vpc'
     MinPort = "port-${min(8080,9090)}"
     MaxPort = "port-${max(8080,9090)}"
   }

--- a/acceptance-tests/builtin_functions/replace.crn
+++ b/acceptance-tests/builtin_functions/replace.crn
@@ -2,10 +2,10 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let name = replace("-", "_", "web-test-vpc")
+let name = replace('-', '_', 'web-test-vpc')
 
 awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
     Name = name

--- a/acceptance-tests/builtin_functions/split.crn
+++ b/acceptance-tests/builtin_functions/split.crn
@@ -2,12 +2,12 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let parts = split("-", "web-test-vpc")
+let parts = split('-', 'web-test-vpc')
 
 awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Name = join("-", parts)
+    Name = join('-', parts)
   }
 }

--- a/acceptance-tests/builtin_functions/trim.crn
+++ b/acceptance-tests/builtin_functions/trim.crn
@@ -3,9 +3,9 @@ provider awscc {
 }
 
 awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Name = trim("  trim-test-vpc  ")
+    Name = trim('  trim-test-vpc  ')
   }
 }

--- a/acceptance-tests/builtin_functions/upper_lower.crn
+++ b/acceptance-tests/builtin_functions/upper_lower.crn
@@ -2,12 +2,12 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let env = "Production"
+let env = 'Production'
 
-let app = "WebApp"
+let app = 'WebApp'
 
 awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
     Name = upper(env)

--- a/acceptance-tests/cascade_without_cbd/step1.crn
+++ b/acceptance-tests/cascade_without_cbd/step1.crn
@@ -9,21 +9,21 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.220.0.0/16"
+  cidr_block = '10.220.0.0/16'
 
   tags = {
-    Name        = "carina-acc-test-cascade-vpc"
-    Environment = "acceptance-test"
+    Name        = 'carina-acc-test-cascade-vpc'
+    Environment = 'acceptance-test'
   }
 }
 
 awscc.ec2.subnet {
   vpc_id            = vpc.vpc_id
-  cidr_block        = "10.220.1.0/24"
-  availability_zone = "ap-northeast-1a"
+  cidr_block        = '10.220.1.0/24'
+  availability_zone = 'ap-northeast-1a'
 
   tags = {
-    Name        = "carina-acc-test-cascade-subnet"
-    Environment = "acceptance-test"
+    Name        = 'carina-acc-test-cascade-subnet'
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/cascade_without_cbd/step2.crn
+++ b/acceptance-tests/cascade_without_cbd/step2.crn
@@ -9,21 +9,21 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.221.0.0/16"
+  cidr_block = '10.221.0.0/16'
 
   tags = {
-    Name        = "carina-acc-test-cascade-vpc"
-    Environment = "acceptance-test"
+    Name        = 'carina-acc-test-cascade-vpc'
+    Environment = 'acceptance-test'
   }
 }
 
 awscc.ec2.subnet {
   vpc_id            = vpc.vpc_id
-  cidr_block        = "10.221.1.0/24"
-  availability_zone = "ap-northeast-1c"
+  cidr_block        = '10.221.1.0/24'
+  availability_zone = 'ap-northeast-1c'
 
   tags = {
-    Name        = "carina-acc-test-cascade-subnet"
-    Environment = "acceptance-test"
+    Name        = 'carina-acc-test-cascade-subnet'
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/create_before_destroy/ec2_transit_gateway_attachment_step1.crn
+++ b/acceptance-tests/create_before_destroy/ec2_transit_gateway_attachment_step1.crn
@@ -9,40 +9,40 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.210.0.0/16"
+  cidr_block = '10.210.0.0/16'
 
   tags = {
-    Name        = "carina-acc-test-cbd-tgw-attach"
-    Environment = "acceptance-test"
+    Name        = 'carina-acc-test-cbd-tgw-attach'
+    Environment = 'acceptance-test'
   }
 }
 
 let subnet = awscc.ec2.subnet {
   vpc_id            = vpc.vpc_id
-  cidr_block        = "10.210.1.0/24"
-  availability_zone = "ap-northeast-1a"
+  cidr_block        = '10.210.1.0/24'
+  availability_zone = 'ap-northeast-1a'
 
   tags = {
-    Name        = "carina-acc-test-cbd-tgw-attach"
-    Environment = "acceptance-test"
+    Name        = 'carina-acc-test-cbd-tgw-attach'
+    Environment = 'acceptance-test'
   }
 }
 
 let tgw_a = awscc.ec2.transit_gateway {
-  description = "carina-acc-test-cbd-tgw-attach-a"
+  description = 'carina-acc-test-cbd-tgw-attach-a'
 
   tags = {
-    Name        = "carina-acc-test-cbd-tgw-attach-a"
-    Environment = "acceptance-test"
+    Name        = 'carina-acc-test-cbd-tgw-attach-a'
+    Environment = 'acceptance-test'
   }
 }
 
 awscc.ec2.transit_gateway {
-  description = "carina-acc-test-cbd-tgw-attach-b"
+  description = 'carina-acc-test-cbd-tgw-attach-b'
 
   tags = {
-    Name        = "carina-acc-test-cbd-tgw-attach-b"
-    Environment = "acceptance-test"
+    Name        = 'carina-acc-test-cbd-tgw-attach-b'
+    Environment = 'acceptance-test'
   }
 }
 
@@ -52,7 +52,7 @@ awscc.ec2.transit_gateway_attachment {
   vpc_id             = vpc.vpc_id
 
   tags = {
-    Name        = "carina-acc-test-cbd-tgw-attach"
-    Environment = "acceptance-test"
+    Name        = 'carina-acc-test-cbd-tgw-attach'
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/create_before_destroy/ec2_transit_gateway_attachment_step2.crn
+++ b/acceptance-tests/create_before_destroy/ec2_transit_gateway_attachment_step2.crn
@@ -10,40 +10,40 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.210.0.0/16"
+  cidr_block = '10.210.0.0/16'
 
   tags = {
-    Name        = "carina-acc-test-cbd-tgw-attach"
-    Environment = "acceptance-test"
+    Name        = 'carina-acc-test-cbd-tgw-attach'
+    Environment = 'acceptance-test'
   }
 }
 
 let subnet = awscc.ec2.subnet {
   vpc_id            = vpc.vpc_id
-  cidr_block        = "10.210.1.0/24"
-  availability_zone = "ap-northeast-1a"
+  cidr_block        = '10.210.1.0/24'
+  availability_zone = 'ap-northeast-1a'
 
   tags = {
-    Name        = "carina-acc-test-cbd-tgw-attach"
-    Environment = "acceptance-test"
+    Name        = 'carina-acc-test-cbd-tgw-attach'
+    Environment = 'acceptance-test'
   }
 }
 
 awscc.ec2.transit_gateway {
-  description = "carina-acc-test-cbd-tgw-attach-a"
+  description = 'carina-acc-test-cbd-tgw-attach-a'
 
   tags = {
-    Name        = "carina-acc-test-cbd-tgw-attach-a"
-    Environment = "acceptance-test"
+    Name        = 'carina-acc-test-cbd-tgw-attach-a'
+    Environment = 'acceptance-test'
   }
 }
 
 let tgw_b = awscc.ec2.transit_gateway {
-  description = "carina-acc-test-cbd-tgw-attach-b"
+  description = 'carina-acc-test-cbd-tgw-attach-b'
 
   tags = {
-    Name        = "carina-acc-test-cbd-tgw-attach-b"
-    Environment = "acceptance-test"
+    Name        = 'carina-acc-test-cbd-tgw-attach-b'
+    Environment = 'acceptance-test'
   }
 }
 
@@ -57,7 +57,7 @@ awscc.ec2.transit_gateway_attachment {
   }
 
   tags = {
-    Name        = "carina-acc-test-cbd-tgw-attach"
-    Environment = "acceptance-test"
+    Name        = 'carina-acc-test-cbd-tgw-attach'
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/create_before_destroy/ec2_vpc_step1.crn
+++ b/acceptance-tests/create_before_destroy/ec2_vpc_step1.crn
@@ -8,12 +8,12 @@ provider awscc {
 }
 
 awscc.ec2.vpc {
-  cidr_block           = "10.200.0.0/16"
+  cidr_block           = '10.200.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 
   tags = {
-    Name        = "carina-acc-test-cbd-vpc"
-    Environment = "acceptance-test"
+    Name        = 'carina-acc-test-cbd-vpc'
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/create_before_destroy/ec2_vpc_step2.crn
+++ b/acceptance-tests/create_before_destroy/ec2_vpc_step2.crn
@@ -9,7 +9,7 @@ provider awscc {
 }
 
 awscc.ec2.vpc {
-  cidr_block           = "10.201.0.0/16"
+  cidr_block           = '10.201.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 
@@ -18,7 +18,7 @@ awscc.ec2.vpc {
   }
 
   tags = {
-    Name        = "carina-acc-test-cbd-vpc"
-    Environment = "acceptance-test"
+    Name        = 'carina-acc-test-cbd-vpc'
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/create_before_destroy/iam_role_step1.crn
+++ b/acceptance-tests/create_before_destroy/iam_role_step1.crn
@@ -9,19 +9,19 @@ provider awscc {
 }
 
 awscc.iam.role {
-  role_name = "carina-acc-test-cbd-role"
-  path      = "/"
+  role_name = 'carina-acc-test-cbd-role'
+  path      = '/'
 
   assume_role_policy_document = {
-    version = "2012-10-17"
+    version = '2012-10-17'
     statement {
-      effect = "Allow"
+      effect = 'Allow'
 
       principal = {
-        service = "lambda.amazonaws.com"
+        service = 'lambda.amazonaws.com'
       }
 
-      action = "sts:AssumeRole"
+      action = 'sts:AssumeRole'
     }
   }
 }

--- a/acceptance-tests/create_before_destroy/iam_role_step2.crn
+++ b/acceptance-tests/create_before_destroy/iam_role_step2.crn
@@ -12,23 +12,23 @@ provider awscc {
 }
 
 awscc.iam.role {
-  role_name = "carina-acc-test-cbd-role"
-  path      = "/carina/"
+  role_name = 'carina-acc-test-cbd-role'
+  path      = '/carina/'
 
   lifecycle {
     create_before_destroy = true
   }
 
   assume_role_policy_document = {
-    version = "2012-10-17"
+    version = '2012-10-17'
     statement {
-      effect = "Allow"
+      effect = 'Allow'
 
       principal = {
-        service = "lambda.amazonaws.com"
+        service = 'lambda.amazonaws.com'
       }
 
-      action = "sts:AssumeRole"
+      action = 'sts:AssumeRole'
     }
   }
 }

--- a/acceptance-tests/ec2_egress_only_internet_gateway/basic.crn
+++ b/acceptance-tests/ec2_egress_only_internet_gateway/basic.crn
@@ -7,13 +7,13 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 awscc.ec2.egress_only_internet_gateway {
   vpc_id = vpc.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/ec2_eip/basic.crn
+++ b/acceptance-tests/ec2_eip/basic.crn
@@ -7,9 +7,9 @@ provider awscc {
 }
 
 awscc.ec2.eip {
-  domain = "vpc"
+  domain = 'vpc'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/ec2_flow_log/cloudwatch.crn
+++ b/acceptance-tests/ec2_flow_log/cloudwatch.crn
@@ -8,27 +8,27 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 let log_group = awscc.logs.log_group {
-  log_group_name    = "/acceptance-test/vpc-flow-logs"
+  log_group_name    = '/acceptance-test/vpc-flow-logs'
   retention_in_days = 1
 }
 
 let flow_log_role = awscc.iam.role {
-  role_name = "acceptance-test-flow-log-role"
+  role_name = 'acceptance-test-flow-log-role'
 
   assume_role_policy_document = {
-    version = "2012-10-17"
+    version = '2012-10-17'
     statement {
-      effect = "Allow"
+      effect = 'Allow'
 
       principal = {
-        service = "vpc-flow-logs.amazonaws.com"
+        service = 'vpc-flow-logs.amazonaws.com'
       }
 
-      action = "sts:AssumeRole"
+      action = 'sts:AssumeRole'
     }
   }
 }
@@ -42,6 +42,6 @@ awscc.ec2.flow_log {
   deliver_logs_permission_arn = flow_log_role.arn
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/ec2_flow_log/s3.crn
+++ b/acceptance-tests/ec2_flow_log/s3.crn
@@ -8,7 +8,7 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 let bucket = awscc.s3.bucket {
@@ -25,12 +25,12 @@ awscc.ec2.flow_log {
   log_destination      = bucket.arn
 
   destination_options = {
-    file_format                = "plain-text"
+    file_format                = 'plain-text'
     hive_compatible_partitions = false
     per_hour_partition         = false
   }
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/ec2_internet_gateway/basic.crn
+++ b/acceptance-tests/ec2_internet_gateway/basic.crn
@@ -8,6 +8,6 @@ provider awscc {
 
 awscc.ec2.internet_gateway {
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/ec2_ipam/basic.crn
+++ b/acceptance-tests/ec2_ipam/basic.crn
@@ -8,13 +8,13 @@ provider awscc {
 
 awscc.ec2.ipam {
   tier        = advanced
-  description = "Acceptance test IPAM"
+  description = 'Acceptance test IPAM'
 
   operating_region {
-    region_name = "ap-northeast-1"
+    region_name = 'ap-northeast-1'
   }
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/ec2_ipam_pool/basic.crn
+++ b/acceptance-tests/ec2_ipam_pool/basic.crn
@@ -11,21 +11,21 @@ let ipam = awscc.ec2.ipam {
   tier = advanced
 
   operating_region {
-    region_name = "ap-northeast-1"
+    region_name = 'ap-northeast-1'
   }
 }
 
 awscc.ec2.ipam_pool {
   ipam_scope_id  = ipam.private_default_scope_id
-  address_family = "IPv4"
-  locale         = "ap-northeast-1"
-  description    = "Acceptance test IPv4 IPAM Pool"
+  address_family = 'IPv4'
+  locale         = 'ap-northeast-1'
+  description    = 'Acceptance test IPv4 IPAM Pool'
 
   provisioned_cidr {
-    cidr = "10.0.0.0/8"
+    cidr = '10.0.0.0/8'
   }
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/ec2_nat_gateway/private.crn
+++ b/acceptance-tests/ec2_nat_gateway/private.crn
@@ -7,21 +7,21 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 let private_subnet = awscc.ec2.subnet {
   vpc_id            = vpc.vpc_id
-  cidr_block        = "10.0.1.0/24"
-  availability_zone = "ap-northeast-1a"
+  cidr_block        = '10.0.1.0/24'
+  availability_zone = 'ap-northeast-1a'
 }
 
 awscc.ec2.nat_gateway {
   subnet_id          = private_subnet.subnet_id
   connectivity_type  = private
-  private_ip_address = "10.0.1.100"
+  private_ip_address = '10.0.1.100'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/ec2_nat_gateway/public.crn
+++ b/acceptance-tests/ec2_nat_gateway/public.crn
@@ -7,7 +7,7 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block           = "10.0.0.0/16"
+  cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
@@ -21,13 +21,13 @@ awscc.ec2.vpc_gateway_attachment {
 
 let public_subnet = awscc.ec2.subnet {
   vpc_id                  = vpc.vpc_id
-  cidr_block              = "10.0.1.0/24"
-  availability_zone       = "ap-northeast-1a"
+  cidr_block              = '10.0.1.0/24'
+  availability_zone       = 'ap-northeast-1a'
   map_public_ip_on_launch = true
 }
 
 let eip = awscc.ec2.eip {
-  domain = "vpc"
+  domain = 'vpc'
 }
 
 awscc.ec2.nat_gateway {
@@ -35,6 +35,6 @@ awscc.ec2.nat_gateway {
   subnet_id     = public_subnet.subnet_id
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/ec2_route/igw.crn
+++ b/acceptance-tests/ec2_route/igw.crn
@@ -7,7 +7,7 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 let igw = awscc.ec2.internet_gateway {}
@@ -23,6 +23,6 @@ let rt = awscc.ec2.route_table {
 
 awscc.ec2.route {
   route_table_id         = rt.route_table_id
-  destination_cidr_block = "0.0.0.0/0"
+  destination_cidr_block = '0.0.0.0/0'
   gateway_id             = igw_attachment.internet_gateway_id
 }

--- a/acceptance-tests/ec2_route/ipv6.crn
+++ b/acceptance-tests/ec2_route/ipv6.crn
@@ -8,7 +8,7 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 let eoigw = awscc.ec2.egress_only_internet_gateway {
@@ -21,6 +21,6 @@ let rt = awscc.ec2.route_table {
 
 awscc.ec2.route {
   route_table_id                  = rt.route_table_id
-  destination_ipv6_cidr_block     = "::/0"
+  destination_ipv6_cidr_block     = '::/0'
   egress_only_internet_gateway_id = eoigw.id
 }

--- a/acceptance-tests/ec2_route/nat_gateway.crn
+++ b/acceptance-tests/ec2_route/nat_gateway.crn
@@ -7,7 +7,7 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block           = "10.0.0.0/16"
+  cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
@@ -21,13 +21,13 @@ awscc.ec2.vpc_gateway_attachment {
 
 let public_subnet = awscc.ec2.subnet {
   vpc_id                  = vpc.vpc_id
-  cidr_block              = "10.0.1.0/24"
-  availability_zone       = "ap-northeast-1a"
+  cidr_block              = '10.0.1.0/24'
+  availability_zone       = 'ap-northeast-1a'
   map_public_ip_on_launch = true
 }
 
 let eip = awscc.ec2.eip {
-  domain = "vpc"
+  domain = 'vpc'
 }
 
 let nat_gw = awscc.ec2.nat_gateway {
@@ -41,6 +41,6 @@ let rt = awscc.ec2.route_table {
 
 awscc.ec2.route {
   route_table_id         = rt.route_table_id
-  destination_cidr_block = "0.0.0.0/0"
+  destination_cidr_block = '0.0.0.0/0'
   nat_gateway_id         = nat_gw.nat_gateway_id
 }

--- a/acceptance-tests/ec2_route/transit_gateway.crn
+++ b/acceptance-tests/ec2_route/transit_gateway.crn
@@ -8,17 +8,17 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 let subnet = awscc.ec2.subnet {
   vpc_id            = vpc.vpc_id
-  cidr_block        = "10.0.1.0/24"
-  availability_zone = "ap-northeast-1a"
+  cidr_block        = '10.0.1.0/24'
+  availability_zone = 'ap-northeast-1a'
 }
 
 let tgw = awscc.ec2.transit_gateway {
-  description = "Transit Gateway for route test"
+  description = 'Transit Gateway for route test'
 }
 
 let tgw_attach = awscc.ec2.transit_gateway_attachment {
@@ -33,6 +33,6 @@ let rt = awscc.ec2.route_table {
 
 awscc.ec2.route {
   route_table_id         = rt.route_table_id
-  destination_cidr_block = "10.1.0.0/16"
+  destination_cidr_block = '10.1.0.0/16'
   transit_gateway_id     = tgw_attach.transit_gateway_id
 }

--- a/acceptance-tests/ec2_route/vpc_peering.crn
+++ b/acceptance-tests/ec2_route/vpc_peering.crn
@@ -8,11 +8,11 @@ provider awscc {
 }
 
 let vpc1 = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 let vpc2 = awscc.ec2.vpc {
-  cidr_block = "10.1.0.0/16"
+  cidr_block = '10.1.0.0/16'
 }
 
 let peering = awscc.ec2.vpc_peering_connection {
@@ -26,6 +26,6 @@ let rt = awscc.ec2.route_table {
 
 awscc.ec2.route {
   route_table_id            = rt.route_table_id
-  destination_cidr_block    = "10.1.0.0/16"
+  destination_cidr_block    = '10.1.0.0/16'
   vpc_peering_connection_id = peering.id
 }

--- a/acceptance-tests/ec2_route_table/basic.crn
+++ b/acceptance-tests/ec2_route_table/basic.crn
@@ -7,13 +7,13 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 awscc.ec2.route_table {
   vpc_id = vpc.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/ec2_security_group/ipv6_rules.crn
+++ b/acceptance-tests/ec2_security_group/ipv6_rules.crn
@@ -7,28 +7,28 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 awscc.ec2.security_group {
   vpc_id            = vpc.vpc_id
-  group_description = "Acceptance test - IPv6 rules"
+  group_description = 'Acceptance test - IPv6 rules'
 
   security_group_ingress {
-    ip_protocol = "tcp"
+    ip_protocol = 'tcp'
     from_port   = 443
     to_port     = 443
-    cidr_ipv6   = "::/0"
-    description = "Allow HTTPS from IPv6"
+    cidr_ipv6   = '::/0'
+    description = 'Allow HTTPS from IPv6'
   }
 
   security_group_egress {
-    ip_protocol = "-1"
-    cidr_ipv6   = "::/0"
-    description = "Allow all IPv6 outbound"
+    ip_protocol = '-1'
+    cidr_ipv6   = '::/0'
+    description = 'Allow all IPv6 outbound'
   }
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/ec2_security_group/prefix.crn
+++ b/acceptance-tests/ec2_security_group/prefix.crn
@@ -9,11 +9,11 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 awscc.ec2.security_group {
   vpc_id            = vpc.vpc_id
-  group_description = "Acceptance test - group_name_prefix"
-  group_name_prefix = "carina-acc-test-"
+  group_description = 'Acceptance test - group_name_prefix'
+  group_name_prefix = 'carina-acc-test-'
 }

--- a/acceptance-tests/ec2_security_group/with_egress.crn
+++ b/acceptance-tests/ec2_security_group/with_egress.crn
@@ -7,28 +7,28 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 awscc.ec2.security_group {
   vpc_id            = vpc.vpc_id
-  group_description = "Acceptance test - egress rules"
+  group_description = 'Acceptance test - egress rules'
 
   security_group_egress {
     ip_protocol = tcp
     from_port   = 443
     to_port     = 443
-    cidr_ip     = "0.0.0.0/0"
-    description = "Allow HTTPS outbound"
+    cidr_ip     = '0.0.0.0/0'
+    description = 'Allow HTTPS outbound'
   }
 
   security_group_egress {
     ip_protocol = all
-    cidr_ip     = "10.0.0.0/8"
-    description = "Allow all to private ranges"
+    cidr_ip     = '10.0.0.0/8'
+    description = 'Allow all to private ranges'
   }
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/ec2_security_group/with_ingress.crn
+++ b/acceptance-tests/ec2_security_group/with_ingress.crn
@@ -7,30 +7,30 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 awscc.ec2.security_group {
   vpc_id            = vpc.vpc_id
-  group_description = "Acceptance test - ingress rules"
+  group_description = 'Acceptance test - ingress rules'
 
   security_group_ingress {
-    ip_protocol = "tcp"
+    ip_protocol = 'tcp'
     from_port   = 80
     to_port     = 80
-    cidr_ip     = "0.0.0.0/0"
-    description = "Allow HTTP"
+    cidr_ip     = '0.0.0.0/0'
+    description = 'Allow HTTP'
   }
 
   security_group_ingress {
-    ip_protocol = "tcp"
+    ip_protocol = 'tcp'
     from_port   = 443
     to_port     = 443
-    cidr_ip     = "0.0.0.0/0"
-    description = "Allow HTTPS"
+    cidr_ip     = '0.0.0.0/0'
+    description = 'Allow HTTPS'
   }
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/ec2_security_group_egress/basic.crn
+++ b/acceptance-tests/ec2_security_group_egress/basic.crn
@@ -7,17 +7,17 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 let sg = awscc.ec2.security_group {
   vpc_id            = vpc.vpc_id
-  group_description = "SG for egress rule test"
+  group_description = 'SG for egress rule test'
 }
 
 awscc.ec2.security_group_egress {
   group_id    = sg.group_id
-  description = "Allow all outbound"
+  description = 'Allow all outbound'
   ip_protocol = all
-  cidr_ip     = "0.0.0.0/0"
+  cidr_ip     = '0.0.0.0/0'
 }

--- a/acceptance-tests/ec2_security_group_egress/dest_sg.crn
+++ b/acceptance-tests/ec2_security_group_egress/dest_sg.crn
@@ -7,23 +7,23 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 let source_sg = awscc.ec2.security_group {
   vpc_id            = vpc.vpc_id
-  group_description = "Source security group"
+  group_description = 'Source security group'
 }
 
 let dest_sg = awscc.ec2.security_group {
   vpc_id            = vpc.vpc_id
-  group_description = "Destination security group"
+  group_description = 'Destination security group'
 }
 
 awscc.ec2.security_group_egress {
   group_id                      = source_sg.group_id
-  description                   = "Allow HTTPS to destination SG"
-  ip_protocol                   = "tcp"
+  description                   = 'Allow HTTPS to destination SG'
+  ip_protocol                   = 'tcp'
   from_port                     = 443
   to_port                       = 443
   destination_security_group_id = dest_sg.group_id

--- a/acceptance-tests/ec2_security_group_egress/ipv6.crn
+++ b/acceptance-tests/ec2_security_group_egress/ipv6.crn
@@ -7,17 +7,17 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 let sg = awscc.ec2.security_group {
   vpc_id            = vpc.vpc_id
-  group_description = "SG for IPv6 egress rule test"
+  group_description = 'SG for IPv6 egress rule test'
 }
 
 awscc.ec2.security_group_egress {
   group_id    = sg.group_id
-  description = "Allow all IPv6 outbound"
+  description = 'Allow all IPv6 outbound'
   ip_protocol = all
-  cidr_ipv6   = "::/0"
+  cidr_ipv6   = '::/0'
 }

--- a/acceptance-tests/ec2_security_group_ingress/basic.crn
+++ b/acceptance-tests/ec2_security_group_ingress/basic.crn
@@ -7,19 +7,19 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 let sg = awscc.ec2.security_group {
   vpc_id            = vpc.vpc_id
-  group_description = "SG for ingress rule test"
+  group_description = 'SG for ingress rule test'
 }
 
 awscc.ec2.security_group_ingress {
   group_id    = sg.group_id
-  description = "Allow HTTPS from VPC"
-  ip_protocol = "tcp"
+  description = 'Allow HTTPS from VPC'
+  ip_protocol = 'tcp'
   from_port   = 443
   to_port     = 443
-  cidr_ip     = "10.0.0.0/16"
+  cidr_ip     = '10.0.0.0/16'
 }

--- a/acceptance-tests/ec2_security_group_ingress/ipv6.crn
+++ b/acceptance-tests/ec2_security_group_ingress/ipv6.crn
@@ -7,19 +7,19 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 let sg = awscc.ec2.security_group {
   vpc_id            = vpc.vpc_id
-  group_description = "SG for IPv6 ingress rule test"
+  group_description = 'SG for IPv6 ingress rule test'
 }
 
 awscc.ec2.security_group_ingress {
   group_id    = sg.group_id
-  description = "Allow HTTPS from IPv6"
-  ip_protocol = "tcp"
+  description = 'Allow HTTPS from IPv6'
+  ip_protocol = 'tcp'
   from_port   = 443
   to_port     = 443
-  cidr_ipv6   = "::/0"
+  cidr_ipv6   = '::/0'
 }

--- a/acceptance-tests/ec2_security_group_ingress/source_sg.crn
+++ b/acceptance-tests/ec2_security_group_ingress/source_sg.crn
@@ -7,23 +7,23 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 let source_sg = awscc.ec2.security_group {
   vpc_id            = vpc.vpc_id
-  group_description = "Source security group"
+  group_description = 'Source security group'
 }
 
 let dest_sg = awscc.ec2.security_group {
   vpc_id            = vpc.vpc_id
-  group_description = "Destination security group"
+  group_description = 'Destination security group'
 }
 
 awscc.ec2.security_group_ingress {
   group_id                 = dest_sg.group_id
-  description              = "Allow HTTPS from source SG"
-  ip_protocol              = "tcp"
+  description              = 'Allow HTTPS from source SG'
+  ip_protocol              = 'tcp'
   from_port                = 443
   to_port                  = 443
   source_security_group_id = source_sg.group_id

--- a/acceptance-tests/ec2_subnet/basic.crn
+++ b/acceptance-tests/ec2_subnet/basic.crn
@@ -7,16 +7,16 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 awscc.ec2.subnet {
   vpc_id                  = vpc.vpc_id
-  cidr_block              = "10.0.1.0/24"
-  availability_zone       = "ap-northeast-1a"
+  cidr_block              = '10.0.1.0/24'
+  availability_zone       = 'ap-northeast-1a'
   map_public_ip_on_launch = true
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/ec2_subnet/ipv6.crn
+++ b/acceptance-tests/ec2_subnet/ipv6.crn
@@ -7,16 +7,16 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 awscc.ec2.subnet {
   vpc_id                          = vpc.vpc_id
-  cidr_block                      = "10.0.1.0/24"
-  availability_zone               = "ap-northeast-1a"
+  cidr_block                      = '10.0.1.0/24'
+  availability_zone               = 'ap-northeast-1a'
   assign_ipv6_address_on_creation = false
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/ec2_subnet/with_dns_options.crn
+++ b/acceptance-tests/ec2_subnet/with_dns_options.crn
@@ -7,22 +7,22 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block           = "10.0.0.0/16"
+  cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
 awscc.ec2.subnet {
   vpc_id            = vpc.vpc_id
-  cidr_block        = "10.0.1.0/24"
-  availability_zone = "ap-northeast-1a"
+  cidr_block        = '10.0.1.0/24'
+  availability_zone = 'ap-northeast-1a'
 
   private_dns_name_options_on_launch = {
     enable_resource_name_dns_a_record = true
-    hostname_type                     = "ip-name"
+    hostname_type                     = 'ip-name'
   }
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/ec2_subnet/with_ipam.crn
+++ b/acceptance-tests/ec2_subnet/with_ipam.crn
@@ -28,17 +28,17 @@ let ipam = awscc.ec2.ipam {
   tier = advanced
 
   operating_region {
-    region_name = "ap-northeast-1"
+    region_name = 'ap-northeast-1'
   }
 }
 
 let top_pool = awscc.ec2.ipam_pool {
   ipam_scope_id  = ipam.private_default_scope_id
-  address_family = "IPv4"
-  locale         = "ap-northeast-1"
+  address_family = 'IPv4'
+  locale         = 'ap-northeast-1'
 
   provisioned_cidr {
-    cidr = "10.0.0.0/8"
+    cidr = '10.0.0.0/8'
   }
 }
 
@@ -49,15 +49,15 @@ let vpc = awscc.ec2.vpc {
 
 let vpc_pool = awscc.ec2.ipam_pool {
   ipam_scope_id       = ipam.private_default_scope_id
-  address_family      = "IPv4"
-  locale              = "ap-northeast-1"
+  address_family      = 'IPv4'
+  locale              = 'ap-northeast-1'
   source_ipam_pool_id = top_pool.ipam_pool_id
 
   source_resource = {
     resource_id     = vpc.vpc_id
     resource_owner  = identity.account_id
-    resource_region = "ap-northeast-1"
-    resource_type   = "vpc"
+    resource_region = 'ap-northeast-1'
+    resource_type   = 'vpc'
   }
 
   provisioned_cidr {
@@ -69,9 +69,9 @@ awscc.ec2.subnet {
   vpc_id              = vpc.vpc_id
   ipv4_ipam_pool_id   = vpc_pool.ipam_pool_id
   ipv4_netmask_length = 24
-  availability_zone   = "ap-northeast-1a"
+  availability_zone   = 'ap-northeast-1a'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/ec2_subnet_route_table_association/basic.crn
+++ b/acceptance-tests/ec2_subnet_route_table_association/basic.crn
@@ -7,13 +7,13 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 let subnet = awscc.ec2.subnet {
   vpc_id            = vpc.vpc_id
-  cidr_block        = "10.0.1.0/24"
-  availability_zone = "ap-northeast-1a"
+  cidr_block        = '10.0.1.0/24'
+  availability_zone = 'ap-northeast-1a'
 }
 
 let rt = awscc.ec2.route_table {

--- a/acceptance-tests/ec2_transit_gateway/basic.crn
+++ b/acceptance-tests/ec2_transit_gateway/basic.crn
@@ -7,9 +7,9 @@ provider awscc {
 }
 
 awscc.ec2.transit_gateway {
-  description = "Acceptance test Transit Gateway"
+  description = 'Acceptance test Transit Gateway'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/ec2_transit_gateway_attachment/basic.crn
+++ b/acceptance-tests/ec2_transit_gateway_attachment/basic.crn
@@ -7,17 +7,17 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 let subnet = awscc.ec2.subnet {
   vpc_id            = vpc.vpc_id
-  cidr_block        = "10.0.1.0/24"
-  availability_zone = "ap-northeast-1a"
+  cidr_block        = '10.0.1.0/24'
+  availability_zone = 'ap-northeast-1a'
 }
 
 let tgw = awscc.ec2.transit_gateway {
-  description = "Acceptance test Transit Gateway"
+  description = 'Acceptance test Transit Gateway'
 }
 
 awscc.ec2.transit_gateway_attachment {
@@ -26,6 +26,6 @@ awscc.ec2.transit_gateway_attachment {
   vpc_id             = vpc.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/ec2_vpc/basic.crn
+++ b/acceptance-tests/ec2_vpc/basic.crn
@@ -7,12 +7,12 @@ provider awscc {
 }
 
 awscc.ec2.vpc {
-  cidr_block           = "10.0.0.0/16"
+  cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
   instance_tenancy     = default
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/ec2_vpc_endpoint/gateway.crn
+++ b/acceptance-tests/ec2_vpc_endpoint/gateway.crn
@@ -7,7 +7,7 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 let rt = awscc.ec2.route_table {
@@ -16,17 +16,17 @@ let rt = awscc.ec2.route_table {
 
 awscc.ec2.vpc_endpoint {
   vpc_id            = vpc.vpc_id
-  service_name      = "com.amazonaws.ap-northeast-1.s3"
+  service_name      = 'com.amazonaws.ap-northeast-1.s3'
   vpc_endpoint_type = Gateway
   route_table_ids   = [rt.route_table_id]
 
   policy_document = {
-    version = "2012-10-17"
+    version = '2012-10-17'
     statement {
-      effect    = "Allow"
-      principal = "*"
-      action    = "s3:GetObject"
-      resource  = "arn:aws:s3:::*"
+      effect    = 'Allow'
+      principal = '*'
+      action    = 's3:GetObject'
+      resource  = 'arn:aws:s3:::*'
     }
   }
 }

--- a/acceptance-tests/ec2_vpc_endpoint/interface.crn
+++ b/acceptance-tests/ec2_vpc_endpoint/interface.crn
@@ -8,34 +8,34 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block           = "10.0.0.0/16"
+  cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
 let subnet = awscc.ec2.subnet {
   vpc_id            = vpc.vpc_id
-  cidr_block        = "10.0.100.0/24"
-  availability_zone = "ap-northeast-1a"
+  cidr_block        = '10.0.100.0/24'
+  availability_zone = 'ap-northeast-1a'
 }
 
 let sg = awscc.ec2.security_group {
   vpc_id            = vpc.vpc_id
-  group_description = "SG for VPC Endpoint"
+  group_description = 'SG for VPC Endpoint'
 }
 
 awscc.ec2.security_group_ingress {
   group_id    = sg.group_id
-  description = "Allow HTTPS from VPC"
-  ip_protocol = "tcp"
+  description = 'Allow HTTPS from VPC'
+  ip_protocol = 'tcp'
   from_port   = 443
   to_port     = 443
-  cidr_ip     = "10.0.0.0/16"
+  cidr_ip     = '10.0.0.0/16'
 }
 
 awscc.ec2.vpc_endpoint {
   vpc_id              = vpc.vpc_id
-  service_name        = "com.amazonaws.ap-northeast-1.ecr.dkr"
+  service_name        = 'com.amazonaws.ap-northeast-1.ecr.dkr'
   vpc_endpoint_type   = Interface
   subnet_ids          = [subnet.subnet_id]
   security_group_ids  = [sg.group_id]

--- a/acceptance-tests/ec2_vpc_gateway_attachment/igw.crn
+++ b/acceptance-tests/ec2_vpc_gateway_attachment/igw.crn
@@ -7,7 +7,7 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 let igw = awscc.ec2.internet_gateway {}

--- a/acceptance-tests/ec2_vpc_gateway_attachment/vpn.crn
+++ b/acceptance-tests/ec2_vpc_gateway_attachment/vpn.crn
@@ -8,7 +8,7 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 let vpn_gw = awscc.ec2.vpn_gateway {

--- a/acceptance-tests/ec2_vpc_peering_connection/basic.crn
+++ b/acceptance-tests/ec2_vpc_peering_connection/basic.crn
@@ -7,11 +7,11 @@ provider awscc {
 }
 
 let vpc1 = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 let vpc2 = awscc.ec2.vpc {
-  cidr_block = "10.1.0.0/16"
+  cidr_block = '10.1.0.0/16'
 }
 
 awscc.ec2.vpc_peering_connection {
@@ -19,6 +19,6 @@ awscc.ec2.vpc_peering_connection {
   peer_vpc_id = vpc2.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/ec2_vpn_gateway/basic.crn
+++ b/acceptance-tests/ec2_vpn_gateway/basic.crn
@@ -10,6 +10,6 @@ awscc.ec2.vpn_gateway {
   type = awscc.ec2.vpn_gateway.Type.ipsec.1
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/for_expression/for_list.crn
+++ b/acceptance-tests/for_expression/for_list.crn
@@ -2,9 +2,9 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpcs = for (i, env) in ["dev", "stg"] {
+let vpcs = for (i, env) in ['dev', 'stg'] {
   awscc.ec2.vpc {
-    cidr_block = cidr_subnet("10.0.0.0/8", 8, i)
+    cidr_block = cidr_subnet('10.0.0.0/8', 8, i)
 
     tags = {
       Name        = "for-list-test-${env}"

--- a/acceptance-tests/for_expression/for_map.crn
+++ b/acceptance-tests/for_expression/for_map.crn
@@ -3,8 +3,8 @@ provider awscc {
 }
 
 let cidrs = {
-  dev = "10.0.0.0/16"
-  stg = "10.1.0.0/16"
+  dev = '10.0.0.0/16'
+  stg = '10.1.0.0/16'
 }
 
 let vpcs = for name, cidr in cidrs {

--- a/acceptance-tests/for_expression/for_module.crn
+++ b/acceptance-tests/for_expression/for_module.crn
@@ -2,11 +2,11 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc_mod = import "./modules/vpc_only"
+let vpc_mod = import './modules/vpc_only'
 
 let cidrs = {
-  dev = "10.0.0.0/16"
-  stg = "10.1.0.0/16"
+  dev = '10.0.0.0/16'
+  stg = '10.1.0.0/16'
 }
 
 let networks = for name, cidr in cidrs {

--- a/acceptance-tests/for_expression/for_module_complex.crn
+++ b/acceptance-tests/for_expression/for_module_complex.crn
@@ -2,17 +2,17 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let network = import "./modules/network"
+let network = import './modules/network'
 
 let cidrs = {
-  dev = "10.0.0.0/16"
-  stg = "10.1.0.0/16"
+  dev = '10.0.0.0/16'
+  stg = '10.1.0.0/16'
 }
 
 let networks = for name, cidr in cidrs {
   network {
     cidr_block  = cidr
     subnet_cidr = cidr_subnet(cidr, 8, 1)
-    az          = "ap-northeast-1a"
+    az          = 'ap-northeast-1a'
   }
 }

--- a/acceptance-tests/for_expression/index_access.crn
+++ b/acceptance-tests/for_expression/index_access.crn
@@ -2,9 +2,9 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpcs = for env in ["dev", "stg"] {
+let vpcs = for env in ['dev', 'stg'] {
   awscc.ec2.vpc {
-    cidr_block = "10.0.0.0/16"
+    cidr_block = '10.0.0.0/16'
 
     tags = {
       Name        = "index-access-test-${env}"
@@ -16,10 +16,10 @@ let vpcs = for env in ["dev", "stg"] {
 # Use index access to reference for expression result
 awscc.ec2.subnet {
   vpc_id            = vpcs[0].vpc_id
-  cidr_block        = "10.0.1.0/24"
-  availability_zone = "ap-northeast-1a"
+  cidr_block        = '10.0.1.0/24'
+  availability_zone = 'ap-northeast-1a'
 
   tags = {
-    Name = "index-access-test-subnet"
+    Name = 'index-access-test-subnet'
   }
 }

--- a/acceptance-tests/for_expression/modules/network/main.crn
+++ b/acceptance-tests/for_expression/modules/network/main.crn
@@ -12,7 +12,7 @@ let vpc = awscc.ec2.vpc {
   cidr_block = cidr_block
 
   tags = {
-    Name = "module-test"
+    Name = 'module-test'
   }
 }
 
@@ -22,7 +22,7 @@ let subnet = awscc.ec2.subnet {
   availability_zone = az
 
   tags = {
-    Name = "module-test-subnet"
+    Name = 'module-test-subnet'
   }
 }
 

--- a/acceptance-tests/iam_role/managed_policy.crn
+++ b/acceptance-tests/iam_role/managed_policy.crn
@@ -7,25 +7,25 @@ provider awscc {
 }
 
 awscc.iam.role {
-  role_name_prefix = "carina-acc-test-"
+  role_name_prefix = 'carina-acc-test-'
 
   assume_role_policy_document = {
-    version = "2012-10-17"
+    version = '2012-10-17'
     statement {
-      effect = "Allow"
+      effect = 'Allow'
 
       principal = {
-        service = "lambda.amazonaws.com"
+        service = 'lambda.amazonaws.com'
       }
 
-      action = "sts:AssumeRole"
+      action = 'sts:AssumeRole'
     }
   }
 
-  managed_policy_arns = ["arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"]
+  managed_policy_arns = ['arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess']
 
   tags = {
-    Environment = "acceptance-test"
-    ManagedBy   = "carina"
+    Environment = 'acceptance-test'
+    ManagedBy   = 'carina'
   }
 }

--- a/acceptance-tests/iam_role/prefix.crn
+++ b/acceptance-tests/iam_role/prefix.crn
@@ -9,18 +9,18 @@ provider awscc {
 }
 
 awscc.iam.role {
-  role_name_prefix = "carina-acc-test-"
+  role_name_prefix = 'carina-acc-test-'
 
   assume_role_policy_document = {
-    version = "2012-10-17"
+    version = '2012-10-17'
     statement {
-      effect = "Allow"
+      effect = 'Allow'
 
       principal = {
-        service = "lambda.amazonaws.com"
+        service = 'lambda.amazonaws.com'
       }
 
-      action = "sts:AssumeRole"
+      action = 'sts:AssumeRole'
     }
   }
 }

--- a/acceptance-tests/iam_role/with_path.crn
+++ b/acceptance-tests/iam_role/with_path.crn
@@ -7,24 +7,24 @@ provider awscc {
 }
 
 awscc.iam.role {
-  role_name_prefix = "carina-acc-test-"
-  path             = "/carina/acceptance-test/"
+  role_name_prefix = 'carina-acc-test-'
+  path             = '/carina/acceptance-test/'
 
   assume_role_policy_document = {
-    version = "2012-10-17"
+    version = '2012-10-17'
     statement {
-      effect = "Allow"
+      effect = 'Allow'
 
       principal = {
-        service = "lambda.amazonaws.com"
+        service = 'lambda.amazonaws.com'
       }
 
-      action = "sts:AssumeRole"
+      action = 'sts:AssumeRole'
     }
   }
 
   tags = {
-    Environment = "acceptance-test"
-    ManagedBy   = "carina"
+    Environment = 'acceptance-test'
+    ManagedBy   = 'carina'
   }
 }

--- a/acceptance-tests/iam_role/with_policy.crn
+++ b/acceptance-tests/iam_role/with_policy.crn
@@ -8,32 +8,32 @@ provider awscc {
 }
 
 awscc.iam.role {
-  role_name_prefix     = "carina-acc-test-"
-  description          = "Carina acceptance test role with inline policy"
+  role_name_prefix     = 'carina-acc-test-'
+  description          = 'Carina acceptance test role with inline policy'
   max_session_duration = 7200
 
   assume_role_policy_document = {
-    version = "2012-10-17"
+    version = '2012-10-17'
     statement {
-      effect = "Allow"
+      effect = 'Allow'
 
       principal = {
-        service = "lambda.amazonaws.com"
+        service = 'lambda.amazonaws.com'
       }
 
-      action = "sts:AssumeRole"
+      action = 'sts:AssumeRole'
     }
   }
 
   policy {
-    policy_name = "test-policy"
+    policy_name = 'test-policy'
 
     policy_document = {
-      version = "2012-10-17"
+      version = '2012-10-17'
       statement {
-        effect   = "Allow"
-        action   = "logs:CreateLogGroup"
-        resource = "*"
+        effect   = 'Allow'
+        action   = 'logs:CreateLogGroup'
+        resource = '*'
       }
     }
   }

--- a/acceptance-tests/if_expression/if_else_value.crn
+++ b/acceptance-tests/if_expression/if_else_value.crn
@@ -5,9 +5,9 @@ provider awscc {
 let is_production = true
 
 awscc.ec2.vpc {
-  cidr_block = if is_production { "10.0.0.0/16" } else { "172.16.0.0/16" }
+  cidr_block = if is_production { '10.0.0.0/16' } else { '172.16.0.0/16' }
 
   tags = {
-    Name = if is_production { "prod-vpc" } else { "dev-vpc" }
+    Name = if is_production { 'prod-vpc' } else { 'dev-vpc' }
   }
 }

--- a/acceptance-tests/if_expression/if_false.crn
+++ b/acceptance-tests/if_expression/if_false.crn
@@ -6,10 +6,10 @@ let enabled = false
 
 let vpc = if enabled {
   awscc.ec2.vpc {
-    cidr_block = "10.0.0.0/16"
+    cidr_block = '10.0.0.0/16'
 
     tags = {
-      Name = "if-false-test"
+      Name = 'if-false-test'
     }
   }
 }

--- a/acceptance-tests/if_expression/if_true.crn
+++ b/acceptance-tests/if_expression/if_true.crn
@@ -6,10 +6,10 @@ let enabled = true
 
 let vpc = if enabled {
   awscc.ec2.vpc {
-    cidr_block = "10.0.0.0/16"
+    cidr_block = '10.0.0.0/16'
 
     tags = {
-      Name = "if-true-test"
+      Name = 'if-true-test'
     }
   }
 }

--- a/acceptance-tests/in_place_update/ec2_egress_only_internet_gateway_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_egress_only_internet_gateway_step1.crn
@@ -7,13 +7,13 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.106.0.0/16"
+  cidr_block = '10.106.0.0/16'
 }
 
 awscc.ec2.egress_only_internet_gateway {
   vpc_id = vpc.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/in_place_update/ec2_egress_only_internet_gateway_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_egress_only_internet_gateway_step2.crn
@@ -7,14 +7,14 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.106.0.0/16"
+  cidr_block = '10.106.0.0/16'
 }
 
 awscc.ec2.egress_only_internet_gateway {
   vpc_id = vpc.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
-    UpdatedBy   = "carina"
+    Environment = 'acceptance-test'
+    UpdatedBy   = 'carina'
   }
 }

--- a/acceptance-tests/in_place_update/ec2_eip_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_eip_step1.crn
@@ -7,9 +7,9 @@ provider awscc {
 }
 
 awscc.ec2.eip {
-  domain = "vpc"
+  domain = 'vpc'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/in_place_update/ec2_eip_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_eip_step2.crn
@@ -7,10 +7,10 @@ provider awscc {
 }
 
 awscc.ec2.eip {
-  domain = "vpc"
+  domain = 'vpc'
 
   tags = {
-    Environment = "acceptance-test"
-    UpdatedBy   = "carina"
+    Environment = 'acceptance-test'
+    UpdatedBy   = 'carina'
   }
 }

--- a/acceptance-tests/in_place_update/ec2_flow_log_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_flow_log_step1.crn
@@ -7,27 +7,27 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.104.0.0/16"
+  cidr_block = '10.104.0.0/16'
 }
 
 let log_group = awscc.logs.log_group {
-  log_group_name    = "/carina/acc-test-update-flow-log"
+  log_group_name    = '/carina/acc-test-update-flow-log'
   retention_in_days = 1
 }
 
 let flow_log_role = awscc.iam.role {
-  role_name = "carina-acc-test-update-flow-log-role"
+  role_name = 'carina-acc-test-update-flow-log-role'
 
   assume_role_policy_document = {
-    version = "2012-10-17"
+    version = '2012-10-17'
     statement {
-      effect = "Allow"
+      effect = 'Allow'
 
       principal = {
-        service = "vpc-flow-logs.amazonaws.com"
+        service = 'vpc-flow-logs.amazonaws.com'
       }
 
-      action = "sts:AssumeRole"
+      action = 'sts:AssumeRole'
     }
   }
 }
@@ -41,6 +41,6 @@ awscc.ec2.flow_log {
   deliver_logs_permission_arn = flow_log_role.arn
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/in_place_update/ec2_flow_log_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_flow_log_step2.crn
@@ -7,27 +7,27 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.104.0.0/16"
+  cidr_block = '10.104.0.0/16'
 }
 
 let log_group = awscc.logs.log_group {
-  log_group_name    = "/carina/acc-test-update-flow-log"
+  log_group_name    = '/carina/acc-test-update-flow-log'
   retention_in_days = 1
 }
 
 let flow_log_role = awscc.iam.role {
-  role_name = "carina-acc-test-update-flow-log-role"
+  role_name = 'carina-acc-test-update-flow-log-role'
 
   assume_role_policy_document = {
-    version = "2012-10-17"
+    version = '2012-10-17'
     statement {
-      effect = "Allow"
+      effect = 'Allow'
 
       principal = {
-        service = "vpc-flow-logs.amazonaws.com"
+        service = 'vpc-flow-logs.amazonaws.com'
       }
 
-      action = "sts:AssumeRole"
+      action = 'sts:AssumeRole'
     }
   }
 }
@@ -41,7 +41,7 @@ awscc.ec2.flow_log {
   deliver_logs_permission_arn = flow_log_role.arn
 
   tags = {
-    Environment = "acceptance-test"
-    UpdatedBy   = "carina"
+    Environment = 'acceptance-test'
+    UpdatedBy   = 'carina'
   }
 }

--- a/acceptance-tests/in_place_update/ec2_ipam_pool_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_ipam_pool_step1.crn
@@ -10,17 +10,17 @@ let ipam = awscc.ec2.ipam {
   tier = advanced
 
   operating_region {
-    region_name = "ap-northeast-1"
+    region_name = 'ap-northeast-1'
   }
 }
 
 awscc.ec2.ipam_pool {
   ipam_scope_id  = ipam.private_default_scope_id
-  address_family = "IPv4"
-  locale         = "ap-northeast-1"
-  description    = "in-place update test"
+  address_family = 'IPv4'
+  locale         = 'ap-northeast-1'
+  description    = 'in-place update test'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/in_place_update/ec2_ipam_pool_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_ipam_pool_step2.crn
@@ -10,17 +10,17 @@ let ipam = awscc.ec2.ipam {
   tier = advanced
 
   operating_region {
-    region_name = "ap-northeast-1"
+    region_name = 'ap-northeast-1'
   }
 }
 
 awscc.ec2.ipam_pool {
   ipam_scope_id  = ipam.private_default_scope_id
-  address_family = "IPv4"
-  locale         = "ap-northeast-1"
-  description    = "in-place update test (updated)"
+  address_family = 'IPv4'
+  locale         = 'ap-northeast-1'
+  description    = 'in-place update test (updated)'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/in_place_update/ec2_nat_gateway_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_nat_gateway_step1.crn
@@ -7,7 +7,7 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block           = "10.105.0.0/16"
+  cidr_block           = '10.105.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
@@ -21,13 +21,13 @@ awscc.ec2.vpc_gateway_attachment {
 
 let public_subnet = awscc.ec2.subnet {
   vpc_id                  = vpc.vpc_id
-  cidr_block              = "10.105.1.0/24"
-  availability_zone       = "ap-northeast-1a"
+  cidr_block              = '10.105.1.0/24'
+  availability_zone       = 'ap-northeast-1a'
   map_public_ip_on_launch = true
 }
 
 let eip = awscc.ec2.eip {
-  domain = "vpc"
+  domain = 'vpc'
 }
 
 awscc.ec2.nat_gateway {
@@ -35,6 +35,6 @@ awscc.ec2.nat_gateway {
   subnet_id     = public_subnet.subnet_id
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/in_place_update/ec2_nat_gateway_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_nat_gateway_step2.crn
@@ -7,7 +7,7 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block           = "10.105.0.0/16"
+  cidr_block           = '10.105.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
@@ -21,13 +21,13 @@ awscc.ec2.vpc_gateway_attachment {
 
 let public_subnet = awscc.ec2.subnet {
   vpc_id                  = vpc.vpc_id
-  cidr_block              = "10.105.1.0/24"
-  availability_zone       = "ap-northeast-1a"
+  cidr_block              = '10.105.1.0/24'
+  availability_zone       = 'ap-northeast-1a'
   map_public_ip_on_launch = true
 }
 
 let eip = awscc.ec2.eip {
-  domain = "vpc"
+  domain = 'vpc'
 }
 
 awscc.ec2.nat_gateway {
@@ -35,7 +35,7 @@ awscc.ec2.nat_gateway {
   subnet_id     = public_subnet.subnet_id
 
   tags = {
-    Environment = "acceptance-test"
-    UpdatedBy   = "carina"
+    Environment = 'acceptance-test'
+    UpdatedBy   = 'carina'
   }
 }

--- a/acceptance-tests/in_place_update/ec2_route_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_route_step1.crn
@@ -7,7 +7,7 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block           = "10.110.0.0/16"
+  cidr_block           = '10.110.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
@@ -21,13 +21,13 @@ let igw_attachment = awscc.ec2.vpc_gateway_attachment {
 
 let public_subnet = awscc.ec2.subnet {
   vpc_id                  = vpc.vpc_id
-  cidr_block              = "10.110.1.0/24"
-  availability_zone       = "ap-northeast-1a"
+  cidr_block              = '10.110.1.0/24'
+  availability_zone       = 'ap-northeast-1a'
   map_public_ip_on_launch = true
 }
 
 let eip = awscc.ec2.eip {
-  domain = "vpc"
+  domain = 'vpc'
 }
 
 awscc.ec2.nat_gateway {
@@ -41,6 +41,6 @@ let rt = awscc.ec2.route_table {
 
 awscc.ec2.route {
   route_table_id         = rt.route_table_id
-  destination_cidr_block = "10.1.0.0/16"
+  destination_cidr_block = '10.1.0.0/16'
   gateway_id             = igw_attachment.internet_gateway_id
 }

--- a/acceptance-tests/in_place_update/ec2_route_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_route_step2.crn
@@ -7,7 +7,7 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block           = "10.110.0.0/16"
+  cidr_block           = '10.110.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
@@ -21,13 +21,13 @@ awscc.ec2.vpc_gateway_attachment {
 
 let public_subnet = awscc.ec2.subnet {
   vpc_id                  = vpc.vpc_id
-  cidr_block              = "10.110.1.0/24"
-  availability_zone       = "ap-northeast-1a"
+  cidr_block              = '10.110.1.0/24'
+  availability_zone       = 'ap-northeast-1a'
   map_public_ip_on_launch = true
 }
 
 let eip = awscc.ec2.eip {
-  domain = "vpc"
+  domain = 'vpc'
 }
 
 let nat_gw = awscc.ec2.nat_gateway {
@@ -41,6 +41,6 @@ let rt = awscc.ec2.route_table {
 
 awscc.ec2.route {
   route_table_id         = rt.route_table_id
-  destination_cidr_block = "10.1.0.0/16"
+  destination_cidr_block = '10.1.0.0/16'
   nat_gateway_id         = nat_gw.nat_gateway_id
 }

--- a/acceptance-tests/in_place_update/ec2_route_table_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_route_table_step1.crn
@@ -7,13 +7,13 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.103.0.0/16"
+  cidr_block = '10.103.0.0/16'
 }
 
 awscc.ec2.route_table {
   vpc_id = vpc.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/in_place_update/ec2_route_table_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_route_table_step2.crn
@@ -7,14 +7,14 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.103.0.0/16"
+  cidr_block = '10.103.0.0/16'
 }
 
 awscc.ec2.route_table {
   vpc_id = vpc.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
-    UpdatedBy   = "carina"
+    Environment = 'acceptance-test'
+    UpdatedBy   = 'carina'
   }
 }

--- a/acceptance-tests/in_place_update/ec2_security_group_egress_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_security_group_egress_step1.crn
@@ -7,17 +7,17 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 let sg = awscc.ec2.security_group {
   vpc_id            = vpc.vpc_id
-  group_description = "carina acceptance test - egress in-place update"
+  group_description = 'carina acceptance test - egress in-place update'
 }
 
 awscc.ec2.security_group_egress {
   group_id    = sg.group_id
-  description = "Allow all outbound"
+  description = 'Allow all outbound'
   ip_protocol = all
-  cidr_ip     = "0.0.0.0/0"
+  cidr_ip     = '0.0.0.0/0'
 }

--- a/acceptance-tests/in_place_update/ec2_security_group_egress_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_security_group_egress_step2.crn
@@ -7,17 +7,17 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 let sg = awscc.ec2.security_group {
   vpc_id            = vpc.vpc_id
-  group_description = "carina acceptance test - egress in-place update"
+  group_description = 'carina acceptance test - egress in-place update'
 }
 
 awscc.ec2.security_group_egress {
   group_id    = sg.group_id
-  description = "Allow all outbound (updated)"
+  description = 'Allow all outbound (updated)'
   ip_protocol = all
-  cidr_ip     = "0.0.0.0/0"
+  cidr_ip     = '0.0.0.0/0'
 }

--- a/acceptance-tests/in_place_update/ec2_security_group_ingress_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_security_group_ingress_step1.crn
@@ -7,19 +7,19 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 let sg = awscc.ec2.security_group {
   vpc_id            = vpc.vpc_id
-  group_description = "carina acceptance test - ingress in-place update"
+  group_description = 'carina acceptance test - ingress in-place update'
 }
 
 awscc.ec2.security_group_ingress {
   group_id    = sg.group_id
-  description = "Allow HTTPS from VPC"
-  ip_protocol = "tcp"
+  description = 'Allow HTTPS from VPC'
+  ip_protocol = 'tcp'
   from_port   = 443
   to_port     = 443
-  cidr_ip     = "10.0.0.0/16"
+  cidr_ip     = '10.0.0.0/16'
 }

--- a/acceptance-tests/in_place_update/ec2_security_group_ingress_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_security_group_ingress_step2.crn
@@ -7,19 +7,19 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 let sg = awscc.ec2.security_group {
   vpc_id            = vpc.vpc_id
-  group_description = "carina acceptance test - ingress in-place update"
+  group_description = 'carina acceptance test - ingress in-place update'
 }
 
 awscc.ec2.security_group_ingress {
   group_id    = sg.group_id
-  description = "Allow HTTPS from VPC (updated)"
-  ip_protocol = "tcp"
+  description = 'Allow HTTPS from VPC (updated)'
+  ip_protocol = 'tcp'
   from_port   = 443
   to_port     = 443
-  cidr_ip     = "10.0.0.0/16"
+  cidr_ip     = '10.0.0.0/16'
 }

--- a/acceptance-tests/in_place_update/ec2_security_group_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_security_group_step1.crn
@@ -7,22 +7,22 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.102.0.0/16"
+  cidr_block = '10.102.0.0/16'
 }
 
 awscc.ec2.security_group {
   vpc_id            = vpc.vpc_id
-  group_description = "carina acceptance test - in-place update"
+  group_description = 'carina acceptance test - in-place update'
 
   security_group_ingress {
-    ip_protocol = "tcp"
+    ip_protocol = 'tcp'
     from_port   = 80
     to_port     = 80
-    cidr_ip     = "0.0.0.0/0"
-    description = "Allow HTTP"
+    cidr_ip     = '0.0.0.0/0'
+    description = 'Allow HTTP'
   }
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/in_place_update/ec2_security_group_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_security_group_step2.crn
@@ -7,30 +7,30 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.102.0.0/16"
+  cidr_block = '10.102.0.0/16'
 }
 
 awscc.ec2.security_group {
   vpc_id            = vpc.vpc_id
-  group_description = "carina acceptance test - in-place update"
+  group_description = 'carina acceptance test - in-place update'
 
   security_group_ingress {
-    ip_protocol = "tcp"
+    ip_protocol = 'tcp'
     from_port   = 80
     to_port     = 80
-    cidr_ip     = "0.0.0.0/0"
-    description = "Allow HTTP"
+    cidr_ip     = '0.0.0.0/0'
+    description = 'Allow HTTP'
   }
 
   security_group_ingress {
-    ip_protocol = "tcp"
+    ip_protocol = 'tcp'
     from_port   = 443
     to_port     = 443
-    cidr_ip     = "0.0.0.0/0"
-    description = "Allow HTTPS"
+    cidr_ip     = '0.0.0.0/0'
+    description = 'Allow HTTPS'
   }
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/in_place_update/ec2_subnet_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_subnet_step1.crn
@@ -7,16 +7,16 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.101.0.0/16"
+  cidr_block = '10.101.0.0/16'
 }
 
 awscc.ec2.subnet {
   vpc_id                  = vpc.vpc_id
-  cidr_block              = "10.101.1.0/24"
-  availability_zone       = "ap-northeast-1a"
+  cidr_block              = '10.101.1.0/24'
+  availability_zone       = 'ap-northeast-1a'
   map_public_ip_on_launch = false
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/in_place_update/ec2_subnet_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_subnet_step2.crn
@@ -7,16 +7,16 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.101.0.0/16"
+  cidr_block = '10.101.0.0/16'
 }
 
 awscc.ec2.subnet {
   vpc_id                  = vpc.vpc_id
-  cidr_block              = "10.101.1.0/24"
-  availability_zone       = "ap-northeast-1a"
+  cidr_block              = '10.101.1.0/24'
+  availability_zone       = 'ap-northeast-1a'
   map_public_ip_on_launch = true
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/in_place_update/ec2_transit_gateway_attachment_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_transit_gateway_attachment_step1.crn
@@ -7,17 +7,17 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 let subnet = awscc.ec2.subnet {
   vpc_id            = vpc.vpc_id
-  cidr_block        = "10.0.1.0/24"
-  availability_zone = "ap-northeast-1a"
+  cidr_block        = '10.0.1.0/24'
+  availability_zone = 'ap-northeast-1a'
 }
 
 let tgw = awscc.ec2.transit_gateway {
-  description = "carina acceptance test - tgw attachment update"
+  description = 'carina acceptance test - tgw attachment update'
 }
 
 awscc.ec2.transit_gateway_attachment {
@@ -26,6 +26,6 @@ awscc.ec2.transit_gateway_attachment {
   vpc_id             = vpc.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/in_place_update/ec2_transit_gateway_attachment_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_transit_gateway_attachment_step2.crn
@@ -7,17 +7,17 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 }
 
 let subnet = awscc.ec2.subnet {
   vpc_id            = vpc.vpc_id
-  cidr_block        = "10.0.1.0/24"
-  availability_zone = "ap-northeast-1a"
+  cidr_block        = '10.0.1.0/24'
+  availability_zone = 'ap-northeast-1a'
 }
 
 let tgw = awscc.ec2.transit_gateway {
-  description = "carina acceptance test - tgw attachment update"
+  description = 'carina acceptance test - tgw attachment update'
 }
 
 awscc.ec2.transit_gateway_attachment {
@@ -26,7 +26,7 @@ awscc.ec2.transit_gateway_attachment {
   vpc_id             = vpc.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
-    UpdatedBy   = "carina"
+    Environment = 'acceptance-test'
+    UpdatedBy   = 'carina'
   }
 }

--- a/acceptance-tests/in_place_update/ec2_transit_gateway_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_transit_gateway_step1.crn
@@ -7,9 +7,9 @@ provider awscc {
 }
 
 awscc.ec2.transit_gateway {
-  description = "carina acceptance test - step 1"
+  description = 'carina acceptance test - step 1'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/in_place_update/ec2_transit_gateway_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_transit_gateway_step2.crn
@@ -7,9 +7,9 @@ provider awscc {
 }
 
 awscc.ec2.transit_gateway {
-  description = "carina acceptance test - step 2 updated"
+  description = 'carina acceptance test - step 2 updated'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/in_place_update/ec2_vpc_endpoint_interface_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_vpc_endpoint_interface_step1.crn
@@ -7,19 +7,19 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block           = "10.108.0.0/16"
+  cidr_block           = '10.108.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
 let sg = awscc.ec2.security_group {
   vpc_id            = vpc.vpc_id
-  group_description = "SG for interface endpoint test"
+  group_description = 'SG for interface endpoint test'
 }
 
 awscc.ec2.vpc_endpoint {
   vpc_id              = vpc.vpc_id
-  service_name        = "com.amazonaws.ap-northeast-1.sts"
+  service_name        = 'com.amazonaws.ap-northeast-1.sts'
   vpc_endpoint_type   = Interface
   security_group_ids  = [sg.group_id]
   private_dns_enabled = false

--- a/acceptance-tests/in_place_update/ec2_vpc_endpoint_interface_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_vpc_endpoint_interface_step2.crn
@@ -7,19 +7,19 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block           = "10.108.0.0/16"
+  cidr_block           = '10.108.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
 let sg = awscc.ec2.security_group {
   vpc_id            = vpc.vpc_id
-  group_description = "SG for interface endpoint test"
+  group_description = 'SG for interface endpoint test'
 }
 
 awscc.ec2.vpc_endpoint {
   vpc_id              = vpc.vpc_id
-  service_name        = "com.amazonaws.ap-northeast-1.sts"
+  service_name        = 'com.amazonaws.ap-northeast-1.sts'
   vpc_endpoint_type   = Interface
   security_group_ids  = [sg.group_id]
   private_dns_enabled = true

--- a/acceptance-tests/in_place_update/ec2_vpc_endpoint_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_vpc_endpoint_step1.crn
@@ -7,7 +7,7 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.107.0.0/16"
+  cidr_block = '10.107.0.0/16'
 }
 
 let rt = awscc.ec2.route_table {
@@ -16,7 +16,7 @@ let rt = awscc.ec2.route_table {
 
 awscc.ec2.vpc_endpoint {
   vpc_id            = vpc.vpc_id
-  service_name      = "com.amazonaws.ap-northeast-1.s3"
+  service_name      = 'com.amazonaws.ap-northeast-1.s3'
   vpc_endpoint_type = Gateway
   route_table_ids   = [rt.route_table_id]
 }

--- a/acceptance-tests/in_place_update/ec2_vpc_endpoint_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_vpc_endpoint_step2.crn
@@ -7,7 +7,7 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.107.0.0/16"
+  cidr_block = '10.107.0.0/16'
 }
 
 let rt = awscc.ec2.route_table {
@@ -16,17 +16,17 @@ let rt = awscc.ec2.route_table {
 
 awscc.ec2.vpc_endpoint {
   vpc_id            = vpc.vpc_id
-  service_name      = "com.amazonaws.ap-northeast-1.s3"
+  service_name      = 'com.amazonaws.ap-northeast-1.s3'
   vpc_endpoint_type = Gateway
   route_table_ids   = [rt.route_table_id]
 
   policy_document = {
-    version = "2012-10-17"
+    version = '2012-10-17'
     statement {
-      effect    = "Allow"
-      principal = "*"
-      action    = "s3:GetObject"
-      resource  = "arn:aws:s3:::*"
+      effect    = 'Allow'
+      principal = '*'
+      action    = 's3:GetObject'
+      resource  = 'arn:aws:s3:::*'
     }
   }
 }

--- a/acceptance-tests/in_place_update/ec2_vpc_peering_connection_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_vpc_peering_connection_step1.crn
@@ -7,11 +7,11 @@ provider awscc {
 }
 
 let vpc1 = awscc.ec2.vpc {
-  cidr_block = "10.108.0.0/16"
+  cidr_block = '10.108.0.0/16'
 }
 
 let vpc2 = awscc.ec2.vpc {
-  cidr_block = "10.109.0.0/16"
+  cidr_block = '10.109.0.0/16'
 }
 
 awscc.ec2.vpc_peering_connection {
@@ -19,6 +19,6 @@ awscc.ec2.vpc_peering_connection {
   peer_vpc_id = vpc2.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/in_place_update/ec2_vpc_peering_connection_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_vpc_peering_connection_step2.crn
@@ -7,11 +7,11 @@ provider awscc {
 }
 
 let vpc1 = awscc.ec2.vpc {
-  cidr_block = "10.108.0.0/16"
+  cidr_block = '10.108.0.0/16'
 }
 
 let vpc2 = awscc.ec2.vpc {
-  cidr_block = "10.109.0.0/16"
+  cidr_block = '10.109.0.0/16'
 }
 
 awscc.ec2.vpc_peering_connection {
@@ -19,7 +19,7 @@ awscc.ec2.vpc_peering_connection {
   peer_vpc_id = vpc2.vpc_id
 
   tags = {
-    Environment = "acceptance-test"
-    UpdatedBy   = "carina"
+    Environment = 'acceptance-test'
+    UpdatedBy   = 'carina'
   }
 }

--- a/acceptance-tests/in_place_update/ec2_vpc_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_vpc_step1.crn
@@ -7,11 +7,11 @@ provider awscc {
 }
 
 awscc.ec2.vpc {
-  cidr_block           = "10.100.0.0/16"
+  cidr_block           = '10.100.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = false
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/in_place_update/ec2_vpc_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_vpc_step2.crn
@@ -7,11 +7,11 @@ provider awscc {
 }
 
 awscc.ec2.vpc {
-  cidr_block           = "10.100.0.0/16"
+  cidr_block           = '10.100.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/in_place_update/iam_role_step1.crn
+++ b/acceptance-tests/in_place_update/iam_role_step1.crn
@@ -7,24 +7,24 @@ provider awscc {
 }
 
 awscc.iam.role {
-  role_name_prefix = "carina-acc-test-update-"
+  role_name_prefix = 'carina-acc-test-update-'
 
   assume_role_policy_document = {
-    version = "2012-10-17"
+    version = '2012-10-17'
     statement {
-      effect = "Allow"
+      effect = 'Allow'
 
       principal = {
-        service = "lambda.amazonaws.com"
+        service = 'lambda.amazonaws.com'
       }
 
-      action = "sts:AssumeRole"
+      action = 'sts:AssumeRole'
     }
   }
 
   max_session_duration = 3600
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/in_place_update/iam_role_step2.crn
+++ b/acceptance-tests/in_place_update/iam_role_step2.crn
@@ -7,24 +7,24 @@ provider awscc {
 }
 
 awscc.iam.role {
-  role_name_prefix = "carina-acc-test-update-"
+  role_name_prefix = 'carina-acc-test-update-'
 
   assume_role_policy_document = {
-    version = "2012-10-17"
+    version = '2012-10-17'
     statement {
-      effect = "Allow"
+      effect = 'Allow'
 
       principal = {
-        service = "lambda.amazonaws.com"
+        service = 'lambda.amazonaws.com'
       }
 
-      action = "sts:AssumeRole"
+      action = 'sts:AssumeRole'
     }
   }
 
   max_session_duration = 7200
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/in_place_update/logs_log_group_step1.crn
+++ b/acceptance-tests/in_place_update/logs_log_group_step1.crn
@@ -7,10 +7,10 @@ provider awscc {
 }
 
 awscc.logs.log_group {
-  log_group_name_prefix = "/carina/acc-test-update-"
+  log_group_name_prefix = '/carina/acc-test-update-'
   retention_in_days     = 7
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/in_place_update/logs_log_group_step2.crn
+++ b/acceptance-tests/in_place_update/logs_log_group_step2.crn
@@ -7,10 +7,10 @@ provider awscc {
 }
 
 awscc.logs.log_group {
-  log_group_name_prefix = "/carina/acc-test-update-"
+  log_group_name_prefix = '/carina/acc-test-update-'
   retention_in_days     = 14
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/in_place_update/s3_bucket_step1.crn
+++ b/acceptance-tests/in_place_update/s3_bucket_step1.crn
@@ -7,7 +7,7 @@ provider awscc {
 }
 
 awscc.s3.bucket {
-  bucket_name_prefix = "carina-acc-test-update-"
+  bucket_name_prefix = 'carina-acc-test-update-'
 
   versioning_configuration = {
     status = awscc.s3.bucket.VersioningConfigurationStatus.Enabled

--- a/acceptance-tests/in_place_update/s3_bucket_step2.crn
+++ b/acceptance-tests/in_place_update/s3_bucket_step2.crn
@@ -7,7 +7,7 @@ provider awscc {
 }
 
 awscc.s3.bucket {
-  bucket_name_prefix = "carina-acc-test-update-"
+  bucket_name_prefix = 'carina-acc-test-update-'
 
   versioning_configuration = {
     status = awscc.s3.bucket.VersioningConfigurationStatus.Suspended

--- a/acceptance-tests/logs_log_group/infrequent_access.crn
+++ b/acceptance-tests/logs_log_group/infrequent_access.crn
@@ -7,7 +7,7 @@ provider awscc {
 }
 
 awscc.logs.log_group {
-  log_group_name_prefix = "/carina/acc-test-"
+  log_group_name_prefix = '/carina/acc-test-'
   log_group_class       = awscc.logs.log_group.LogGroupClass.INFREQUENT_ACCESS
   retention_in_days     = 1
 }

--- a/acceptance-tests/logs_log_group/prefix.crn
+++ b/acceptance-tests/logs_log_group/prefix.crn
@@ -9,6 +9,6 @@ provider awscc {
 }
 
 awscc.logs.log_group {
-  log_group_name_prefix = "/carina/acc-test-"
+  log_group_name_prefix = '/carina/acc-test-'
   retention_in_days     = 1
 }

--- a/acceptance-tests/logs_log_group/retention.crn
+++ b/acceptance-tests/logs_log_group/retention.crn
@@ -7,10 +7,10 @@ provider awscc {
 }
 
 awscc.logs.log_group {
-  log_group_name_prefix = "/carina/acc-test-"
+  log_group_name_prefix = '/carina/acc-test-'
   retention_in_days     = 7
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/module/attributes_access.crn
+++ b/acceptance-tests/module/attributes_access.crn
@@ -6,16 +6,16 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let network = import "./modules/network"
+let network = import './modules/network'
 
 let net = network {
-  cidr_block  = "10.0.0.0/16"
-  subnet_cidr = "10.0.1.0/24"
-  az          = "ap-northeast-1a"
+  cidr_block  = '10.0.0.0/16'
+  subnet_cidr = '10.0.1.0/24'
+  az          = 'ap-northeast-1a'
 }
 
 # Use module attributes to create a resource that depends on module output
 awscc.ec2.route_table {
   vpc_id = net.vpc_id
-  tags   = { Name = "module-attr-test" }
+  tags   = { Name = 'module-attr-test' }
 }

--- a/acceptance-tests/module/basic.crn
+++ b/acceptance-tests/module/basic.crn
@@ -6,10 +6,10 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let network = import "./modules/network"
+let network = import './modules/network'
 
 network {
-  cidr_block  = "10.0.0.0/16"
-  subnet_cidr = "10.0.1.0/24"
-  az          = "ap-northeast-1a"
+  cidr_block  = '10.0.0.0/16'
+  subnet_cidr = '10.0.1.0/24'
+  az          = 'ap-northeast-1a'
 }

--- a/acceptance-tests/module/modules/network/main.crn
+++ b/acceptance-tests/module/modules/network/main.crn
@@ -12,7 +12,7 @@ let vpc = awscc.ec2.vpc {
   cidr_block = cidr_block
 
   tags = {
-    Name = "module-test"
+    Name = 'module-test'
   }
 }
 
@@ -22,7 +22,7 @@ let subnet = awscc.ec2.subnet {
   availability_zone = az
 
   tags = {
-    Name = "module-test-subnet"
+    Name = 'module-test-subnet'
   }
 }
 

--- a/acceptance-tests/module/modules/network_with_rt/main.crn
+++ b/acceptance-tests/module/modules/network_with_rt/main.crn
@@ -3,7 +3,7 @@
 # Imports the network module (VPC + Subnet) and adds a route table.
 # Demonstrates nested module imports.
 
-let network = import "../network"
+let network = import '../network'
 
 arguments {
   cidr_block : string
@@ -21,7 +21,7 @@ let rt = awscc.ec2.route_table {
   vpc_id = net.vpc_id
 
   tags = {
-    Name = "nested-module-test-rt"
+    Name = 'nested-module-test-rt'
   }
 }
 

--- a/acceptance-tests/module/nested_module.crn
+++ b/acceptance-tests/module/nested_module.crn
@@ -6,10 +6,10 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let network_with_rt = import "./modules/network_with_rt"
+let network_with_rt = import './modules/network_with_rt'
 
 let infra = network_with_rt {
-  cidr_block  = "10.0.0.0/16"
-  subnet_cidr = "10.0.1.0/24"
-  az          = "ap-northeast-1a"
+  cidr_block  = '10.0.0.0/16'
+  subnet_cidr = '10.0.1.0/24'
+  az          = 'ap-northeast-1a'
 }

--- a/acceptance-tests/s3_bucket/encryption.crn
+++ b/acceptance-tests/s3_bucket/encryption.crn
@@ -10,12 +10,12 @@ provider awscc {
 }
 
 awscc.s3.bucket {
-  bucket_name_prefix = "carina-acc-test-"
+  bucket_name_prefix = 'carina-acc-test-'
 
   bucket_encryption = {
     server_side_encryption_configuration {
       server_side_encryption_by_default = {
-        sse_algorithm = "AES256"
+        sse_algorithm = 'AES256'
       }
     }
   }

--- a/acceptance-tests/s3_bucket/kms_encryption.crn
+++ b/acceptance-tests/s3_bucket/kms_encryption.crn
@@ -11,15 +11,15 @@ provider awscc {
 }
 
 awscc.s3.bucket {
-  bucket_name_prefix = "carina-acc-test-"
+  bucket_name_prefix = 'carina-acc-test-'
 
   bucket_encryption = {
     server_side_encryption_configuration {
       bucket_key_enabled = true
 
       server_side_encryption_by_default = {
-        sse_algorithm     = "aws:kms"
-        kms_master_key_id = "alias/aws/s3"
+        sse_algorithm     = 'aws:kms'
+        kms_master_key_id = 'alias/aws/s3'
       }
     }
   }

--- a/acceptance-tests/s3_bucket/lifecycle.crn
+++ b/acceptance-tests/s3_bucket/lifecycle.crn
@@ -11,16 +11,16 @@ provider awscc {
 }
 
 awscc.s3.bucket {
-  bucket_name_prefix = "carina-acc-test-"
+  bucket_name_prefix = 'carina-acc-test-'
 
   lifecycle_configuration = {
     rule {
-      id                 = "expire-old-objects"
+      id                 = 'expire-old-objects'
       status             = awscc.s3.bucket.RuleStatus.Enabled
       expiration_in_days = 90
     }
     rule {
-      id     = "transition-to-glacier"
+      id     = 'transition-to-glacier'
       status = awscc.s3.bucket.RuleStatus.Enabled
       transition {
         storage_class      = awscc.s3.bucket.TransitionStorageClass.GLACIER

--- a/acceptance-tests/s3_bucket/logging.crn
+++ b/acceptance-tests/s3_bucket/logging.crn
@@ -10,7 +10,7 @@ provider awscc {
 }
 
 let log_bucket = awscc.s3.bucket {
-  bucket_name_prefix = "carina-acc-test-log-"
+  bucket_name_prefix = 'carina-acc-test-log-'
 
   lifecycle {
     force_delete = true
@@ -18,11 +18,11 @@ let log_bucket = awscc.s3.bucket {
 }
 
 awscc.s3.bucket {
-  bucket_name_prefix = "carina-acc-test-src-"
+  bucket_name_prefix = 'carina-acc-test-src-'
 
   logging_configuration = {
     destination_bucket_name = log_bucket.bucket_name
-    log_file_prefix         = "access-logs/"
+    log_file_prefix         = 'access-logs/'
   }
 
   lifecycle {

--- a/acceptance-tests/s3_bucket/prefix.crn
+++ b/acceptance-tests/s3_bucket/prefix.crn
@@ -9,7 +9,7 @@ provider awscc {
 }
 
 awscc.s3.bucket {
-  bucket_name_prefix = "carina-acc-test-"
+  bucket_name_prefix = 'carina-acc-test-'
 
   lifecycle {
     force_delete = true

--- a/acceptance-tests/s3_bucket/public_access_block.crn
+++ b/acceptance-tests/s3_bucket/public_access_block.crn
@@ -9,7 +9,7 @@ provider awscc {
 }
 
 awscc.s3.bucket {
-  bucket_name_prefix = "carina-acc-test-"
+  bucket_name_prefix = 'carina-acc-test-'
 
   public_access_block_configuration = {
     block_public_acls       = true

--- a/acceptance-tests/s3_bucket/versioning.crn
+++ b/acceptance-tests/s3_bucket/versioning.crn
@@ -9,7 +9,7 @@ provider awscc {
 }
 
 awscc.s3.bucket {
-  bucket_name_prefix = "carina-acc-test-"
+  bucket_name_prefix = 'carina-acc-test-'
 
   versioning_configuration = {
     status = awscc.s3.bucket.VersioningConfigurationStatus.Enabled

--- a/acceptance-tests/s3_bucket/website.crn
+++ b/acceptance-tests/s3_bucket/website.crn
@@ -9,11 +9,11 @@ provider awscc {
 }
 
 awscc.s3.bucket {
-  bucket_name_prefix = "carina-acc-test-"
+  bucket_name_prefix = 'carina-acc-test-'
 
   website_configuration = {
-    index_document = "index.html"
-    error_document = "error.html"
+    index_document = 'index.html'
+    error_document = 'error.html'
   }
 
   lifecycle {

--- a/acceptance-tests/secret_env/decrypt_tag.crn
+++ b/acceptance-tests/secret_env/decrypt_tag.crn
@@ -4,13 +4,13 @@ provider awscc {
 
 # KMS-encrypted value (encrypted with alias/carina-test key in carina-test-000 account)
 # Plaintext: "decrypt-test-value"
-let encrypted = "AQICAHiUU4BhXxV/24kFblvFgRinfx00Rva9nBXHESKU/n2W1QHeJgFItWvJdpm6QXmCH3s7AAAAajBoBgkqhkiG9w0BBwagWzBZAgEAMFQGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMdsKc/QPUdhV6Uy4dAgEQgCeZSRW3iwDwiszbvKUyTpsZRQZdGQzY9M94i6ZO70MQdiy8wEi+DEs="
+let encrypted = 'AQICAHiUU4BhXxV/24kFblvFgRinfx00Rva9nBXHESKU/n2W1QHeJgFItWvJdpm6QXmCH3s7AAAAajBoBgkqhkiG9w0BBwagWzBZAgEAMFQGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMdsKc/QPUdhV6Uy4dAgEQgCeZSRW3iwDwiszbvKUyTpsZRQZdGQzY9M94i6ZO70MQdiy8wEi+DEs='
 
 awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Name         = "decrypt-test"
+    Name         = 'decrypt-test'
     DecryptedTag = secret(decrypt(encrypted))
   }
 }

--- a/acceptance-tests/secret_env/env_tag.crn
+++ b/acceptance-tests/secret_env/env_tag.crn
@@ -3,10 +3,10 @@ provider awscc {
 }
 
 awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Name        = "secret-env-test"
-    Environment = env("CARINA_TEST_ENV_VALUE")
+    Name        = 'secret-env-test'
+    Environment = env('CARINA_TEST_ENV_VALUE')
   }
 }

--- a/acceptance-tests/secret_env/secret_tag.crn
+++ b/acceptance-tests/secret_env/secret_tag.crn
@@ -3,10 +3,10 @@ provider awscc {
 }
 
 awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Name       = "secret-env-test"
-    SecretTag  = secret(env("CARINA_TEST_SECRET_VALUE"))
+    Name       = 'secret-env-test'
+    SecretTag  = secret(env('CARINA_TEST_SECRET_VALUE'))
   }
 }

--- a/acceptance-tests/simhash_update/ec2_eip_step1.crn
+++ b/acceptance-tests/simhash_update/ec2_eip_step1.crn
@@ -8,10 +8,10 @@ provider awscc {
 }
 
 awscc.ec2.eip {
-  domain = "vpc"
+  domain = 'vpc'
 
   tags = {
-    Environment = "acceptance-test"
-    Purpose     = "simhash-test"
+    Environment = 'acceptance-test'
+    Purpose     = 'simhash-test'
   }
 }

--- a/acceptance-tests/simhash_update/ec2_eip_step2.crn
+++ b/acceptance-tests/simhash_update/ec2_eip_step2.crn
@@ -8,10 +8,10 @@ provider awscc {
 }
 
 awscc.ec2.eip {
-  domain = "vpc"
+  domain = 'vpc'
 
   tags = {
-    Environment = "staging"
-    Purpose     = "simhash-test"
+    Environment = 'staging'
+    Purpose     = 'simhash-test'
   }
 }

--- a/acceptance-tests/simhash_update/ec2_ipam_step1.crn
+++ b/acceptance-tests/simhash_update/ec2_ipam_step1.crn
@@ -8,11 +8,11 @@ provider awscc {
 }
 
 awscc.ec2.ipam {
-  description = "simhash acceptance test"
+  description = 'simhash acceptance test'
   tier        = awscc.ec2.ipam.Tier.free
 
   tags = {
-    Environment = "acceptance-test"
-    Purpose     = "simhash-test"
+    Environment = 'acceptance-test'
+    Purpose     = 'simhash-test'
   }
 }

--- a/acceptance-tests/simhash_update/ec2_ipam_step2.crn
+++ b/acceptance-tests/simhash_update/ec2_ipam_step2.crn
@@ -8,11 +8,11 @@ provider awscc {
 }
 
 awscc.ec2.ipam {
-  description = "simhash acceptance test updated"
+  description = 'simhash acceptance test updated'
   tier        = awscc.ec2.ipam.Tier.free
 
   tags = {
-    Environment = "acceptance-test"
-    Purpose     = "simhash-test"
+    Environment = 'acceptance-test'
+    Purpose     = 'simhash-test'
   }
 }

--- a/acceptance-tests/state_blocks/step1_create.crn
+++ b/acceptance-tests/state_blocks/step1_create.crn
@@ -3,9 +3,9 @@ provider awscc {
 }
 
 awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Name = "state-blocks-test"
+    Name = 'state-blocks-test'
   }
 }

--- a/acceptance-tests/state_blocks/step2_moved.crn
+++ b/acceptance-tests/state_blocks/step2_moved.crn
@@ -3,14 +3,14 @@ provider awscc {
 }
 
 moved {
-  from = awscc.ec2.vpc "vpc"
-  to   = awscc.ec2.vpc "main_vpc"
+  from = awscc.ec2.vpc 'vpc'
+  to   = awscc.ec2.vpc 'main_vpc'
 }
 
 awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Name = "state-blocks-test"
+    Name = 'state-blocks-test'
   }
 }

--- a/acceptance-tests/state_blocks/step3_removed.crn
+++ b/acceptance-tests/state_blocks/step3_removed.crn
@@ -3,5 +3,5 @@ provider awscc {
 }
 
 removed {
-  from = awscc.ec2.vpc "main_vpc"
+  from = awscc.ec2.vpc 'main_vpc'
 }

--- a/acceptance-tests/state_blocks/step4_import.crn
+++ b/acceptance-tests/state_blocks/step4_import.crn
@@ -3,14 +3,14 @@ provider awscc {
 }
 
 import {
-  to = awscc.ec2.vpc "imported_vpc"
-  id = "PLACEHOLDER"
+  to = awscc.ec2.vpc 'imported_vpc'
+  id = 'PLACEHOLDER'
 }
 
 awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Name = "state-blocks-test"
+    Name = 'state-blocks-test'
   }
 }

--- a/acceptance-tests/string_interpolation/basic.crn
+++ b/acceptance-tests/string_interpolation/basic.crn
@@ -2,10 +2,10 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let env = "test"
+let env = 'test'
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
     Name        = "interp-${env}-vpc"
@@ -15,8 +15,8 @@ let vpc = awscc.ec2.vpc {
 
 awscc.ec2.subnet {
   vpc_id            = vpc.vpc_id
-  cidr_block        = "10.0.1.0/24"
-  availability_zone = "ap-northeast-1a"
+  cidr_block        = '10.0.1.0/24'
+  availability_zone = 'ap-northeast-1a'
 
   tags = {
     Name  = "interp-${env}-subnet"

--- a/acceptance-tests/tag_deletion/ec2_nat_gateway_step1.crn
+++ b/acceptance-tests/tag_deletion/ec2_nat_gateway_step1.crn
@@ -9,7 +9,7 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block           = "10.112.0.0/16"
+  cidr_block           = '10.112.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
@@ -23,13 +23,13 @@ awscc.ec2.vpc_gateway_attachment {
 
 let public_subnet = awscc.ec2.subnet {
   vpc_id                  = vpc.vpc_id
-  cidr_block              = "10.112.1.0/24"
-  availability_zone       = "ap-northeast-1a"
+  cidr_block              = '10.112.1.0/24'
+  availability_zone       = 'ap-northeast-1a'
   map_public_ip_on_launch = true
 }
 
 let eip = awscc.ec2.eip {
-  domain = "vpc"
+  domain = 'vpc'
 }
 
 awscc.ec2.nat_gateway {
@@ -37,7 +37,7 @@ awscc.ec2.nat_gateway {
   subnet_id     = public_subnet.subnet_id
 
   tags = {
-    Environment = "acceptance-test"
-    ToBeRemoved = "this-tag-will-be-deleted"
+    Environment = 'acceptance-test'
+    ToBeRemoved = 'this-tag-will-be-deleted'
   }
 }

--- a/acceptance-tests/tag_deletion/ec2_nat_gateway_step2.crn
+++ b/acceptance-tests/tag_deletion/ec2_nat_gateway_step2.crn
@@ -9,7 +9,7 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block           = "10.112.0.0/16"
+  cidr_block           = '10.112.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
@@ -23,13 +23,13 @@ awscc.ec2.vpc_gateway_attachment {
 
 let public_subnet = awscc.ec2.subnet {
   vpc_id                  = vpc.vpc_id
-  cidr_block              = "10.112.1.0/24"
-  availability_zone       = "ap-northeast-1a"
+  cidr_block              = '10.112.1.0/24'
+  availability_zone       = 'ap-northeast-1a'
   map_public_ip_on_launch = true
 }
 
 let eip = awscc.ec2.eip {
-  domain = "vpc"
+  domain = 'vpc'
 }
 
 awscc.ec2.nat_gateway {
@@ -37,6 +37,6 @@ awscc.ec2.nat_gateway {
   subnet_id     = public_subnet.subnet_id
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/tag_deletion/ec2_nat_gateway_step3.crn
+++ b/acceptance-tests/tag_deletion/ec2_nat_gateway_step3.crn
@@ -9,7 +9,7 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block           = "10.112.0.0/16"
+  cidr_block           = '10.112.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
@@ -23,13 +23,13 @@ awscc.ec2.vpc_gateway_attachment {
 
 let public_subnet = awscc.ec2.subnet {
   vpc_id                  = vpc.vpc_id
-  cidr_block              = "10.112.1.0/24"
-  availability_zone       = "ap-northeast-1a"
+  cidr_block              = '10.112.1.0/24'
+  availability_zone       = 'ap-northeast-1a'
   map_public_ip_on_launch = true
 }
 
 let eip = awscc.ec2.eip {
-  domain = "vpc"
+  domain = 'vpc'
 }
 
 awscc.ec2.nat_gateway {

--- a/acceptance-tests/tag_deletion/ec2_vpc_step1.crn
+++ b/acceptance-tests/tag_deletion/ec2_vpc_step1.crn
@@ -8,12 +8,12 @@ provider awscc {
 }
 
 awscc.ec2.vpc {
-  cidr_block           = "10.100.0.0/16"
+  cidr_block           = '10.100.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 
   tags = {
-    Environment = "acceptance-test"
-    ToBeRemoved = "this-tag-will-be-deleted"
+    Environment = 'acceptance-test'
+    ToBeRemoved = 'this-tag-will-be-deleted'
   }
 }

--- a/acceptance-tests/tag_deletion/ec2_vpc_step2.crn
+++ b/acceptance-tests/tag_deletion/ec2_vpc_step2.crn
@@ -9,11 +9,11 @@ provider awscc {
 }
 
 awscc.ec2.vpc {
-  cidr_block           = "10.100.0.0/16"
+  cidr_block           = '10.100.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/tag_deletion/ec2_vpc_step3.crn
+++ b/acceptance-tests/tag_deletion/ec2_vpc_step3.crn
@@ -9,7 +9,7 @@ provider awscc {
 }
 
 awscc.ec2.vpc {
-  cidr_block           = "10.100.0.0/16"
+  cidr_block           = '10.100.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }

--- a/acceptance-tests/tag_deletion/iam_role_step1.crn
+++ b/acceptance-tests/tag_deletion/iam_role_step1.crn
@@ -8,23 +8,23 @@ provider awscc {
 }
 
 awscc.iam.role {
-  role_name_prefix = "carina-acc-test-tag-del-"
+  role_name_prefix = 'carina-acc-test-tag-del-'
 
   assume_role_policy_document = {
-    version = "2012-10-17"
+    version = '2012-10-17'
     statement {
-      effect = "Allow"
+      effect = 'Allow'
 
       principal = {
-        service = "lambda.amazonaws.com"
+        service = 'lambda.amazonaws.com'
       }
 
-      action = "sts:AssumeRole"
+      action = 'sts:AssumeRole'
     }
   }
 
   tags = {
-    Environment = "acceptance-test"
-    ToBeRemoved = "this-tag-will-be-deleted"
+    Environment = 'acceptance-test'
+    ToBeRemoved = 'this-tag-will-be-deleted'
   }
 }

--- a/acceptance-tests/tag_deletion/iam_role_step2.crn
+++ b/acceptance-tests/tag_deletion/iam_role_step2.crn
@@ -9,22 +9,22 @@ provider awscc {
 }
 
 awscc.iam.role {
-  role_name_prefix = "carina-acc-test-tag-del-"
+  role_name_prefix = 'carina-acc-test-tag-del-'
 
   assume_role_policy_document = {
-    version = "2012-10-17"
+    version = '2012-10-17'
     statement {
-      effect = "Allow"
+      effect = 'Allow'
 
       principal = {
-        service = "lambda.amazonaws.com"
+        service = 'lambda.amazonaws.com'
       }
 
-      action = "sts:AssumeRole"
+      action = 'sts:AssumeRole'
     }
   }
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 }

--- a/acceptance-tests/tag_deletion/iam_role_step3.crn
+++ b/acceptance-tests/tag_deletion/iam_role_step3.crn
@@ -9,18 +9,18 @@ provider awscc {
 }
 
 awscc.iam.role {
-  role_name_prefix = "carina-acc-test-tag-del-"
+  role_name_prefix = 'carina-acc-test-tag-del-'
 
   assume_role_policy_document = {
-    version = "2012-10-17"
+    version = '2012-10-17'
     statement {
-      effect = "Allow"
+      effect = 'Allow'
 
       principal = {
-        service = "lambda.amazonaws.com"
+        service = 'lambda.amazonaws.com'
       }
 
-      action = "sts:AssumeRole"
+      action = 'sts:AssumeRole'
     }
   }
 }

--- a/acceptance-tests/tag_deletion/s3_bucket_step1.crn
+++ b/acceptance-tests/tag_deletion/s3_bucket_step1.crn
@@ -8,11 +8,11 @@ provider awscc {
 }
 
 awscc.s3.bucket {
-  bucket_name_prefix = "carina-acc-test-tag-del-"
+  bucket_name_prefix = 'carina-acc-test-tag-del-'
 
   tags = {
-    Environment = "acceptance-test"
-    ToBeRemoved = "this-tag-will-be-deleted"
+    Environment = 'acceptance-test'
+    ToBeRemoved = 'this-tag-will-be-deleted'
   }
 
   lifecycle {

--- a/acceptance-tests/tag_deletion/s3_bucket_step2.crn
+++ b/acceptance-tests/tag_deletion/s3_bucket_step2.crn
@@ -9,10 +9,10 @@ provider awscc {
 }
 
 awscc.s3.bucket {
-  bucket_name_prefix = "carina-acc-test-tag-del-"
+  bucket_name_prefix = 'carina-acc-test-tag-del-'
 
   tags = {
-    Environment = "acceptance-test"
+    Environment = 'acceptance-test'
   }
 
   lifecycle {

--- a/acceptance-tests/tag_deletion/s3_bucket_step3.crn
+++ b/acceptance-tests/tag_deletion/s3_bucket_step3.crn
@@ -9,7 +9,7 @@ provider awscc {
 }
 
 awscc.s3.bucket {
-  bucket_name_prefix = "carina-acc-test-tag-del-"
+  bucket_name_prefix = 'carina-acc-test-tag-del-'
 
   lifecycle {
     force_delete = true

--- a/acceptance-tests/user_functions/value_fn.crn
+++ b/acceptance-tests/user_functions/value_fn.crn
@@ -3,13 +3,13 @@ provider awscc {
 }
 
 fn tag_name(env: string, service: string): string {
-  join("-", [env, service, "vpc"])
+  join('-', [env, service, 'vpc'])
 }
 
 awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Name = tag_name("test", "web")
+    Name = tag_name('test', 'web')
   }
 }

--- a/acceptance-tests/vpc_full/basic.crn
+++ b/acceptance-tests/vpc_full/basic.crn
@@ -20,18 +20,18 @@ provider awscc {
 # --- VPC and Internet Gateway ---
 
 let vpc = awscc.ec2.vpc {
-  cidr_block           = "10.0.0.0/16"
+  cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 
   tags = {
-    Name = "main"
+    Name = 'main'
   }
 }
 
 let igw = awscc.ec2.internet_gateway {
   tags = {
-    Name = "main"
+    Name = 'main'
   }
 }
 
@@ -44,34 +44,34 @@ let igw_attachment = awscc.ec2.vpc_gateway_attachment {
 
 let public_subnet_1a = awscc.ec2.subnet {
   vpc_id                  = vpc.vpc_id
-  cidr_block              = "10.0.0.0/24"
-  availability_zone       = "ap-northeast-1a"
+  cidr_block              = '10.0.0.0/24'
+  availability_zone       = 'ap-northeast-1a'
   map_public_ip_on_launch = true
 
   tags = {
-    Name = "public-ap-northeast-1a"
+    Name = 'public-ap-northeast-1a'
   }
 }
 
 let public_subnet_1c = awscc.ec2.subnet {
   vpc_id                  = vpc.vpc_id
-  cidr_block              = "10.0.1.0/24"
-  availability_zone       = "ap-northeast-1c"
+  cidr_block              = '10.0.1.0/24'
+  availability_zone       = 'ap-northeast-1c'
   map_public_ip_on_launch = true
 
   tags = {
-    Name = "public-ap-northeast-1c"
+    Name = 'public-ap-northeast-1c'
   }
 }
 
 let public_subnet_1d = awscc.ec2.subnet {
   vpc_id                  = vpc.vpc_id
-  cidr_block              = "10.0.2.0/24"
-  availability_zone       = "ap-northeast-1d"
+  cidr_block              = '10.0.2.0/24'
+  availability_zone       = 'ap-northeast-1d'
   map_public_ip_on_launch = true
 
   tags = {
-    Name = "public-ap-northeast-1d"
+    Name = 'public-ap-northeast-1d'
   }
 }
 
@@ -81,13 +81,13 @@ let public_rt = awscc.ec2.route_table {
   vpc_id = vpc.vpc_id
 
   tags = {
-    Name = "public"
+    Name = 'public'
   }
 }
 
 awscc.ec2.route {
   route_table_id         = public_rt.route_table_id
-  destination_cidr_block = "0.0.0.0/0"
+  destination_cidr_block = '0.0.0.0/0'
   gateway_id             = igw_attachment.internet_gateway_id
 }
 
@@ -109,26 +109,26 @@ awscc.ec2.subnet_route_table_association {
 # --- Elastic IPs and NAT Gateways ---
 
 let eip_1a = awscc.ec2.eip {
-  domain = "vpc"
+  domain = 'vpc'
 
   tags = {
-    Name = "nat-gw-ap-northeast-1a"
+    Name = 'nat-gw-ap-northeast-1a'
   }
 }
 
 let eip_1c = awscc.ec2.eip {
-  domain = "vpc"
+  domain = 'vpc'
 
   tags = {
-    Name = "nat-gw-ap-northeast-1c"
+    Name = 'nat-gw-ap-northeast-1c'
   }
 }
 
 let eip_1d = awscc.ec2.eip {
-  domain = "vpc"
+  domain = 'vpc'
 
   tags = {
-    Name = "nat-gw-ap-northeast-1d"
+    Name = 'nat-gw-ap-northeast-1d'
   }
 }
 
@@ -137,7 +137,7 @@ let nat_gw_1a = awscc.ec2.nat_gateway {
   subnet_id     = public_subnet_1a.subnet_id
 
   tags = {
-    Name = "nat-gw-ap-northeast-1a"
+    Name = 'nat-gw-ap-northeast-1a'
   }
 }
 
@@ -146,7 +146,7 @@ let nat_gw_1c = awscc.ec2.nat_gateway {
   subnet_id     = public_subnet_1c.subnet_id
 
   tags = {
-    Name = "nat-gw-ap-northeast-1c"
+    Name = 'nat-gw-ap-northeast-1c'
   }
 }
 
@@ -155,7 +155,7 @@ let nat_gw_1d = awscc.ec2.nat_gateway {
   subnet_id     = public_subnet_1d.subnet_id
 
   tags = {
-    Name = "nat-gw-ap-northeast-1d"
+    Name = 'nat-gw-ap-northeast-1d'
   }
 }
 
@@ -163,31 +163,31 @@ let nat_gw_1d = awscc.ec2.nat_gateway {
 
 let private_subnet_1a = awscc.ec2.subnet {
   vpc_id            = vpc.vpc_id
-  cidr_block        = "10.0.100.0/24"
-  availability_zone = "ap-northeast-1a"
+  cidr_block        = '10.0.100.0/24'
+  availability_zone = 'ap-northeast-1a'
 
   tags = {
-    Name = "private-ap-northeast-1a"
+    Name = 'private-ap-northeast-1a'
   }
 }
 
 let private_subnet_1c = awscc.ec2.subnet {
   vpc_id            = vpc.vpc_id
-  cidr_block        = "10.0.101.0/24"
-  availability_zone = "ap-northeast-1c"
+  cidr_block        = '10.0.101.0/24'
+  availability_zone = 'ap-northeast-1c'
 
   tags = {
-    Name = "private-ap-northeast-1c"
+    Name = 'private-ap-northeast-1c'
   }
 }
 
 let private_subnet_1d = awscc.ec2.subnet {
   vpc_id            = vpc.vpc_id
-  cidr_block        = "10.0.102.0/24"
-  availability_zone = "ap-northeast-1d"
+  cidr_block        = '10.0.102.0/24'
+  availability_zone = 'ap-northeast-1d'
 
   tags = {
-    Name = "private-ap-northeast-1d"
+    Name = 'private-ap-northeast-1d'
   }
 }
 
@@ -197,7 +197,7 @@ let private_rt_1a = awscc.ec2.route_table {
   vpc_id = vpc.vpc_id
 
   tags = {
-    Name = "private-ap-northeast-1a"
+    Name = 'private-ap-northeast-1a'
   }
 }
 
@@ -205,7 +205,7 @@ let private_rt_1c = awscc.ec2.route_table {
   vpc_id = vpc.vpc_id
 
   tags = {
-    Name = "private-ap-northeast-1c"
+    Name = 'private-ap-northeast-1c'
   }
 }
 
@@ -213,25 +213,25 @@ let private_rt_1d = awscc.ec2.route_table {
   vpc_id = vpc.vpc_id
 
   tags = {
-    Name = "private-ap-northeast-1d"
+    Name = 'private-ap-northeast-1d'
   }
 }
 
 awscc.ec2.route {
   route_table_id         = private_rt_1a.route_table_id
-  destination_cidr_block = "0.0.0.0/0"
+  destination_cidr_block = '0.0.0.0/0'
   nat_gateway_id         = nat_gw_1a.nat_gateway_id
 }
 
 awscc.ec2.route {
   route_table_id         = private_rt_1c.route_table_id
-  destination_cidr_block = "0.0.0.0/0"
+  destination_cidr_block = '0.0.0.0/0'
   nat_gateway_id         = nat_gw_1c.nat_gateway_id
 }
 
 awscc.ec2.route {
   route_table_id         = private_rt_1d.route_table_id
-  destination_cidr_block = "0.0.0.0/0"
+  destination_cidr_block = '0.0.0.0/0'
   nat_gateway_id         = nat_gw_1d.nat_gateway_id
 }
 
@@ -254,31 +254,31 @@ awscc.ec2.subnet_route_table_association {
 
 let database_subnet_1a = awscc.ec2.subnet {
   vpc_id            = vpc.vpc_id
-  cidr_block        = "10.0.200.0/24"
-  availability_zone = "ap-northeast-1a"
+  cidr_block        = '10.0.200.0/24'
+  availability_zone = 'ap-northeast-1a'
 
   tags = {
-    Name = "database-ap-northeast-1a"
+    Name = 'database-ap-northeast-1a'
   }
 }
 
 let database_subnet_1c = awscc.ec2.subnet {
   vpc_id            = vpc.vpc_id
-  cidr_block        = "10.0.201.0/24"
-  availability_zone = "ap-northeast-1c"
+  cidr_block        = '10.0.201.0/24'
+  availability_zone = 'ap-northeast-1c'
 
   tags = {
-    Name = "database-ap-northeast-1c"
+    Name = 'database-ap-northeast-1c'
   }
 }
 
 let database_subnet_1d = awscc.ec2.subnet {
   vpc_id            = vpc.vpc_id
-  cidr_block        = "10.0.202.0/24"
-  availability_zone = "ap-northeast-1d"
+  cidr_block        = '10.0.202.0/24'
+  availability_zone = 'ap-northeast-1d'
 
   tags = {
-    Name = "database-ap-northeast-1d"
+    Name = 'database-ap-northeast-1d'
   }
 }
 
@@ -288,7 +288,7 @@ let database_rt = awscc.ec2.route_table {
   vpc_id = vpc.vpc_id
 
   tags = {
-    Name = "database"
+    Name = 'database'
   }
 }
 
@@ -311,28 +311,28 @@ awscc.ec2.subnet_route_table_association {
 
 let endpoint_sg = awscc.ec2.security_group {
   vpc_id            = vpc.vpc_id
-  group_description = "SG for VPC Endpoint"
+  group_description = 'SG for VPC Endpoint'
 
   tags = {
-    Name = "vpc-endpoint"
+    Name = 'vpc-endpoint'
   }
 }
 
 awscc.ec2.security_group_ingress {
   group_id    = endpoint_sg.group_id
-  description = "Allow HTTPS from VPC"
-  ip_protocol = "tcp"
+  description = 'Allow HTTPS from VPC'
+  ip_protocol = 'tcp'
   from_port   = 443
   to_port     = 443
-  cidr_ip     = "10.0.0.0/16"
+  cidr_ip     = '10.0.0.0/16'
 }
 
 # --- VPC Endpoints (Interface type) ---
 
 awscc.ec2.vpc_endpoint {
   vpc_id              = vpc.vpc_id
-  service_name        = "com.amazonaws.ap-northeast-1.ecr.dkr"
-  vpc_endpoint_type   = "Interface"
+  service_name        = 'com.amazonaws.ap-northeast-1.ecr.dkr'
+  vpc_endpoint_type   = 'Interface'
   subnet_ids          = [private_subnet_1a.subnet_id, private_subnet_1c.subnet_id, private_subnet_1d.subnet_id]
   security_group_ids  = [endpoint_sg.group_id]
   private_dns_enabled = true
@@ -340,8 +340,8 @@ awscc.ec2.vpc_endpoint {
 
 awscc.ec2.vpc_endpoint {
   vpc_id              = vpc.vpc_id
-  service_name        = "com.amazonaws.ap-northeast-1.ecr.api"
-  vpc_endpoint_type   = "Interface"
+  service_name        = 'com.amazonaws.ap-northeast-1.ecr.api'
+  vpc_endpoint_type   = 'Interface'
   subnet_ids          = [private_subnet_1a.subnet_id, private_subnet_1c.subnet_id, private_subnet_1d.subnet_id]
   security_group_ids  = [endpoint_sg.group_id]
   private_dns_enabled = true
@@ -349,8 +349,8 @@ awscc.ec2.vpc_endpoint {
 
 awscc.ec2.vpc_endpoint {
   vpc_id              = vpc.vpc_id
-  service_name        = "com.amazonaws.ap-northeast-1.logs"
-  vpc_endpoint_type   = "Interface"
+  service_name        = 'com.amazonaws.ap-northeast-1.logs'
+  vpc_endpoint_type   = 'Interface'
   subnet_ids          = [private_subnet_1a.subnet_id, private_subnet_1c.subnet_id, private_subnet_1d.subnet_id]
   security_group_ids  = [endpoint_sg.group_id]
   private_dns_enabled = true
@@ -358,8 +358,8 @@ awscc.ec2.vpc_endpoint {
 
 awscc.ec2.vpc_endpoint {
   vpc_id              = vpc.vpc_id
-  service_name        = "com.amazonaws.ap-northeast-1.ssm"
-  vpc_endpoint_type   = "Interface"
+  service_name        = 'com.amazonaws.ap-northeast-1.ssm'
+  vpc_endpoint_type   = 'Interface'
   subnet_ids          = [private_subnet_1a.subnet_id, private_subnet_1c.subnet_id, private_subnet_1d.subnet_id]
   security_group_ids  = [endpoint_sg.group_id]
   private_dns_enabled = true
@@ -367,8 +367,8 @@ awscc.ec2.vpc_endpoint {
 
 awscc.ec2.vpc_endpoint {
   vpc_id              = vpc.vpc_id
-  service_name        = "com.amazonaws.ap-northeast-1.ssmmessages"
-  vpc_endpoint_type   = "Interface"
+  service_name        = 'com.amazonaws.ap-northeast-1.ssmmessages'
+  vpc_endpoint_type   = 'Interface'
   subnet_ids          = [private_subnet_1a.subnet_id, private_subnet_1c.subnet_id, private_subnet_1d.subnet_id]
   security_group_ids  = [endpoint_sg.group_id]
   private_dns_enabled = true
@@ -378,7 +378,7 @@ awscc.ec2.vpc_endpoint {
 
 awscc.ec2.vpc_endpoint {
   vpc_id            = vpc.vpc_id
-  service_name      = "com.amazonaws.ap-northeast-1.s3"
-  vpc_endpoint_type = "Gateway"
+  service_name      = 'com.amazonaws.ap-northeast-1.s3'
+  vpc_endpoint_type = 'Gateway'
   route_table_ids   = [private_rt_1a.route_table_id, private_rt_1c.route_table_id, private_rt_1d.route_table_id]
 }

--- a/acceptance-tests/write_only_attrs/step1_create.crn
+++ b/acceptance-tests/write_only_attrs/step1_create.crn
@@ -3,27 +3,27 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Name = "write-only-test"
+    Name = 'write-only-test'
   }
 }
 
 let subnet = awscc.ec2.subnet {
   vpc_id                  = vpc.vpc_id
-  cidr_block              = "10.0.1.0/24"
-  availability_zone       = "ap-northeast-1a"
+  cidr_block              = '10.0.1.0/24'
+  availability_zone       = 'ap-northeast-1a'
   map_public_ip_on_launch = true
 
   tags = {
-    Name = "write-only-test-public"
+    Name = 'write-only-test-public'
   }
 }
 
 let igw = awscc.ec2.internet_gateway {
   tags = {
-    Name = "write-only-test"
+    Name = 'write-only-test'
   }
 }
 
@@ -33,10 +33,10 @@ awscc.ec2.vpc_gateway_attachment {
 }
 
 let eip = awscc.ec2.eip {
-  domain = "vpc"
+  domain = 'vpc'
 
   tags = {
-    Name = "write-only-test"
+    Name = 'write-only-test'
   }
 }
 
@@ -46,6 +46,6 @@ awscc.ec2.nat_gateway {
   max_drain_duration_seconds = 120
 
   tags = {
-    Name = "write-only-test"
+    Name = 'write-only-test'
   }
 }

--- a/acceptance-tests/write_only_attrs/step2_change.crn
+++ b/acceptance-tests/write_only_attrs/step2_change.crn
@@ -3,27 +3,27 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Name = "write-only-test"
+    Name = 'write-only-test'
   }
 }
 
 let subnet = awscc.ec2.subnet {
   vpc_id                  = vpc.vpc_id
-  cidr_block              = "10.0.1.0/24"
-  availability_zone       = "ap-northeast-1a"
+  cidr_block              = '10.0.1.0/24'
+  availability_zone       = 'ap-northeast-1a'
   map_public_ip_on_launch = true
 
   tags = {
-    Name = "write-only-test-public"
+    Name = 'write-only-test-public'
   }
 }
 
 let igw = awscc.ec2.internet_gateway {
   tags = {
-    Name = "write-only-test"
+    Name = 'write-only-test'
   }
 }
 
@@ -33,10 +33,10 @@ awscc.ec2.vpc_gateway_attachment {
 }
 
 let eip = awscc.ec2.eip {
-  domain = "vpc"
+  domain = 'vpc'
 
   tags = {
-    Name = "write-only-test"
+    Name = 'write-only-test'
   }
 }
 
@@ -46,6 +46,6 @@ awscc.ec2.nat_gateway {
   max_drain_duration_seconds = 240
 
   tags = {
-    Name = "write-only-test"
+    Name = 'write-only-test'
   }
 }

--- a/acceptance-tests/write_only_attrs/step3_remove.crn
+++ b/acceptance-tests/write_only_attrs/step3_remove.crn
@@ -3,27 +3,27 @@ provider awscc {
 }
 
 let vpc = awscc.ec2.vpc {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = '10.0.0.0/16'
 
   tags = {
-    Name = "write-only-test"
+    Name = 'write-only-test'
   }
 }
 
 let subnet = awscc.ec2.subnet {
   vpc_id                  = vpc.vpc_id
-  cidr_block              = "10.0.1.0/24"
-  availability_zone       = "ap-northeast-1a"
+  cidr_block              = '10.0.1.0/24'
+  availability_zone       = 'ap-northeast-1a'
   map_public_ip_on_launch = true
 
   tags = {
-    Name = "write-only-test-public"
+    Name = 'write-only-test-public'
   }
 }
 
 let igw = awscc.ec2.internet_gateway {
   tags = {
-    Name = "write-only-test"
+    Name = 'write-only-test'
   }
 }
 
@@ -33,10 +33,10 @@ awscc.ec2.vpc_gateway_attachment {
 }
 
 let eip = awscc.ec2.eip {
-  domain = "vpc"
+  domain = 'vpc'
 
   tags = {
-    Name = "write-only-test"
+    Name = 'write-only-test'
   }
 }
 
@@ -46,6 +46,6 @@ awscc.ec2.nat_gateway {
   subnet_id     = subnet.subnet_id
 
   tags = {
-    Name = "write-only-test"
+    Name = 'write-only-test'
   }
 }


### PR DESCRIPTION
## Summary

- Replace double quotes with single quotes in all 162 acceptance test `.crn` files where no string interpolation (`${...}`) is needed
- Double quotes are preserved only in strings containing variable expansion (8 files with interpolation patterns)

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)