### PR TITLE
fix: skip destroy in cleanup when no state file exists

### DIFF
--- a/acceptance-tests/run-tests.sh
+++ b/acceptance-tests/run-tests.sh
@@ -615,6 +615,11 @@ if [ "$COMMAND" = "cleanup" ]; then
                 cp "$INJECTED_FILE" "$TEST_STATE_DIR/main.crn"
                 rm -f "$INJECTED_FILE"
                 TEST_INDEX=$((TEST_INDEX + 1))
+                # Skip if no state file exists — nothing to destroy
+                if [ ! -f "$TEST_STATE_DIR/carina.state.json" ]; then
+                    SKIPPED=$((SKIPPED + 1))
+                    continue
+                fi
                 echo "RUNNING destroy $REL_PATH"
                 DESTROY_OUTPUT=$(cd "$TEST_STATE_DIR" && aws-vault exec "$ACCOUNT" -- "$CARINA_BIN" destroy --auto-approve "$TEST_STATE_DIR" 2>&1)
                 DESTROY_RC=$?


### PR DESCRIPTION
## Summary

- Skip `carina destroy` in cleanup when `carina.state.json` doesn't exist
- Previously, every test was attempted for every account during cleanup, causing spurious FAIL lines for tests that were never applied
- These false FAILs mask real errors (e.g., provider WASM load failures)

## Change

4-line guard before the destroy call: check for state file, skip if absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)