### PR TITLE
revert: cargo update (needs wasmtime upgrade first)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,7 +508,7 @@ dependencies = [
 [[package]]
 name = "carina-aws-types"
 version = "0.2.0"
-source = "git+https://github.com/carina-rs/carina#e5b556f99454207b64f42b7e1d6433b0636ffd6d"
+source = "git+https://github.com/carina-rs/carina#32967a460aa59d7b2ad6d5325543304925cadf5a"
 dependencies = [
  "carina-core",
 ]
@@ -516,7 +516,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.2.0"
-source = "git+https://github.com/carina-rs/carina#e5b556f99454207b64f42b7e1d6433b0636ffd6d"
+source = "git+https://github.com/carina-rs/carina#32967a460aa59d7b2ad6d5325543304925cadf5a"
 dependencies = [
  "argon2",
  "futures",
@@ -532,7 +532,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.2.0"
-source = "git+https://github.com/carina-rs/carina#e5b556f99454207b64f42b7e1d6433b0636ffd6d"
+source = "git+https://github.com/carina-rs/carina#32967a460aa59d7b2ad6d5325543304925cadf5a"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -575,7 +575,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.2.0"
-source = "git+https://github.com/carina-rs/carina#e5b556f99454207b64f42b7e1d6433b0636ffd6d"
+source = "git+https://github.com/carina-rs/carina#32967a460aa59d7b2ad6d5325543304925cadf5a"
 dependencies = [
  "serde",
  "serde_json",
@@ -743,9 +743,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fnv"
@@ -1458,9 +1458,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.28"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -1818,11 +1818,11 @@ dependencies = [
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen 0.46.0",
 ]
 
 [[package]]
@@ -1964,11 +1964,19 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
- "bitflags",
  "wit-bindgen-rust-macro 0.51.0",
 ]
 


### PR DESCRIPTION
Reverts #59.

The `cargo update` bumped `wasip2` to `wasi-0.2.9`, which requires `wasi:http/types@0.2.9` — not supported by wasmtime 43 in carina core.

Need to upgrade wasmtime in carina-rs/carina first (carina-rs/carina#1564), then re-apply `cargo update`.

Reopens #57