### PR TITLE
fix: populate StringEnum name field in protocol conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#bd7da981b38e8c9ca48613f6b0eefd394f00e926"
+source = "git+https://github.com/carina-rs/carina#9b2687e686cad3ed15898ee41c74853af70088b7"
 dependencies = [
  "argon2",
  "futures",
@@ -531,7 +531,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#bd7da981b38e8c9ca48613f6b0eefd394f00e926"
+source = "git+https://github.com/carina-rs/carina#9b2687e686cad3ed15898ee41c74853af70088b7"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#bd7da981b38e8c9ca48613f6b0eefd394f00e926"
+source = "git+https://github.com/carina-rs/carina#9b2687e686cad3ed15898ee41c74853af70088b7"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-provider-awscc/src/convert.rs
+++ b/carina-provider-awscc/src/convert.rs
@@ -152,8 +152,8 @@ fn proto_to_core_attribute_type(t: &ProtoAttributeType) -> CoreAttributeType {
         ProtoAttributeType::Int => CoreAttributeType::Int,
         ProtoAttributeType::Float => CoreAttributeType::Float,
         ProtoAttributeType::Bool => CoreAttributeType::Bool,
-        ProtoAttributeType::StringEnum { values } => CoreAttributeType::StringEnum {
-            name: String::new(),
+        ProtoAttributeType::StringEnum { name, values } => CoreAttributeType::StringEnum {
+            name: name.clone(),
             values: values.clone(),
             namespace: None,
             to_dsl: None,
@@ -233,7 +233,8 @@ fn core_to_proto_attribute_type(t: &CoreAttributeType) -> ProtoAttributeType {
         CoreAttributeType::Int => ProtoAttributeType::Int,
         CoreAttributeType::Float => ProtoAttributeType::Float,
         CoreAttributeType::Bool => ProtoAttributeType::Bool,
-        CoreAttributeType::StringEnum { values, .. } => ProtoAttributeType::StringEnum {
+        CoreAttributeType::StringEnum { name, values, .. } => ProtoAttributeType::StringEnum {
+            name: name.clone(),
             values: values.clone(),
         },
         CoreAttributeType::List { inner, ordered } => ProtoAttributeType::List {
@@ -302,5 +303,41 @@ pub fn core_to_proto_schema(s: &CoreResourceSchema) -> ProtoResourceSchema {
                 create_max_retries: c.create_max_retries,
             }
         }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn string_enum_name_preserved_through_core_to_proto_roundtrip() {
+        let core_type = CoreAttributeType::StringEnum {
+            name: "VersioningStatus".to_string(),
+            values: vec!["Enabled".to_string(), "Suspended".to_string()],
+            namespace: Some("awscc.s3.bucket".to_string()),
+            to_dsl: None,
+        };
+
+        let proto_type = core_to_proto_attribute_type(&core_type);
+
+        // Proto should preserve the name
+        match &proto_type {
+            ProtoAttributeType::StringEnum { name, values } => {
+                assert_eq!(name, "VersioningStatus");
+                assert_eq!(values.len(), 2);
+            }
+            _ => panic!("Expected StringEnum"),
+        }
+
+        // Round-trip back to core should preserve the name
+        let roundtripped = proto_to_core_attribute_type(&proto_type);
+        match &roundtripped {
+            CoreAttributeType::StringEnum { name, values, .. } => {
+                assert_eq!(name, "VersioningStatus");
+                assert_eq!(values.len(), 2);
+            }
+            _ => panic!("Expected StringEnum"),
+        }
     }
 }


### PR DESCRIPTION
## Summary

- `convert.rs` was not passing the `name` field when converting between core and protocol `StringEnum` types
- This caused WASM providers to lose enum type names (e.g., `"VersioningStatus"`), so LSP completions fell back to quoted strings instead of DSL-format (e.g., `awscc.s3.bucket.VersioningStatus.Enabled`)
- Also updates carina dependencies to latest main to pick up the protocol `name` field added in carina-rs/carina#1635

Closes #79

## Test plan

- [x] Added `string_enum_name_preserved_through_core_to_proto_roundtrip` test
- [x] All 291 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)