### PR TITLE
feat: use ValidatorType for tags validation across WASM boundary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#9b2687e686cad3ed15898ee41c74853af70088b7"
+source = "git+https://github.com/carina-rs/carina#85d3a7bac3de8c65bc00a6580c941e828933c3b6"
 dependencies = [
  "argon2",
  "futures",
@@ -531,7 +531,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#9b2687e686cad3ed15898ee41c74853af70088b7"
+source = "git+https://github.com/carina-rs/carina#85d3a7bac3de8c65bc00a6580c941e828933c3b6"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#9b2687e686cad3ed15898ee41c74853af70088b7"
+source = "git+https://github.com/carina-rs/carina#85d3a7bac3de8c65bc00a6580c941e828933c3b6"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-provider-awscc/src/convert.rs
+++ b/carina-provider-awscc/src/convert.rs
@@ -303,6 +303,7 @@ pub fn core_to_proto_schema(s: &CoreResourceSchema) -> ProtoResourceSchema {
                 create_max_retries: c.create_max_retries,
             }
         }),
+        validators: vec![],
     }
 }
 
@@ -339,5 +340,12 @@ mod tests {
             }
             _ => panic!("Expected StringEnum"),
         }
+    }
+
+    #[test]
+    fn core_to_proto_schema_initializes_empty_validators() {
+        let schema = CoreResourceSchema::new("awscc.s3.bucket");
+        let proto = core_to_proto_schema(&schema);
+        assert!(proto.validators.is_empty());
     }
 }

--- a/carina-provider-awscc/src/main.rs
+++ b/carina-provider-awscc/src/main.rs
@@ -70,9 +70,17 @@ impl CarinaProvider for AwsccProcessProvider {
     }
 
     fn schemas(&self) -> Vec<proto::ResourceSchema> {
-        schemas::all_schemas()
+        schemas::generated::configs()
             .iter()
-            .map(convert::core_to_proto_schema)
+            .map(|config| {
+                let mut schema = convert::core_to_proto_schema(&config.schema);
+                if config.has_tags {
+                    schema
+                        .validators
+                        .push(proto::ValidatorType::TagsKeyValueCheck);
+                }
+                schema
+            })
             .collect()
     }
 
@@ -283,3 +291,44 @@ carina_plugin_sdk::export_provider!(AwsccProcessProvider, http);
 
 #[cfg(target_arch = "wasm32")]
 fn main() {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use carina_plugin_sdk::types::ValidatorType;
+
+    #[test]
+    fn schemas_include_tags_validator_for_tagged_resources() {
+        let provider = AwsccProcessProvider::new();
+        let schemas = provider.schemas();
+        let bucket = schemas
+            .iter()
+            .find(|s| s.resource_type == "awscc.s3.bucket")
+            .expect("s3.bucket schema should exist");
+        assert!(
+            bucket
+                .validators
+                .contains(&ValidatorType::TagsKeyValueCheck),
+            "s3.bucket should have TagsKeyValueCheck validator"
+        );
+    }
+
+    #[test]
+    fn schemas_exclude_tags_validator_for_untagged_resources() {
+        let provider = AwsccProcessProvider::new();
+        let schemas = provider.schemas();
+        let configs = schemas::generated::configs();
+        if let Some(untagged) = configs.iter().find(|c| !c.has_tags) {
+            let schema = schemas
+                .iter()
+                .find(|s| s.resource_type == format!("awscc.{}", untagged.resource_type_name))
+                .expect("untagged schema should exist");
+            assert!(
+                !schema
+                    .validators
+                    .contains(&ValidatorType::TagsKeyValueCheck),
+                "untagged resource should not have TagsKeyValueCheck"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Closes #75

## Summary

- Update `schemas()` to set `ValidatorType::TagsKeyValueCheck` on protocol schemas for resources with `has_tags=true`
- Add `validators: vec![]` initialization to `core_to_proto_schema()` for the new protocol field
- Update Cargo.lock to latest carina (which includes `ValidatorType` in `carina-provider-protocol`)

## Context

carina-rs/carina#1645 added `ValidatorType` enum and host-side validator reconstruction. This PR completes the fix by having the awscc provider declare `TagsKeyValueCheck` validators in its protocol schemas, so the host can reconstruct them after WASM deserialization.

## Test plan

- [x] `cargo test -p carina-provider-awscc` — all 294 tests pass (130 lib + 4 bin + 160 codegen)
- [x] `cargo clippy -p carina-provider-awscc -- -D warnings` — no warnings
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)