### PR TITLE
refactor: expose provider config attribute types as data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#0c5247b5adb207b86485327abe974c7df84397fa"
+source = "git+https://github.com/carina-rs/carina#e70e36f4b1e9bc4052179d92ca287ee6da0bf91f"
 dependencies = [
  "argon2",
  "futures",
@@ -531,7 +531,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#0c5247b5adb207b86485327abe974c7df84397fa"
+source = "git+https://github.com/carina-rs/carina#e70e36f4b1e9bc4052179d92ca287ee6da0bf91f"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#0c5247b5adb207b86485327abe974c7df84397fa"
+source = "git+https://github.com/carina-rs/carina#e70e36f4b1e9bc4052179d92ca287ee6da0bf91f"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-plugin-wit/wit/provider.wit
+++ b/carina-plugin-wit/wit/provider.wit
@@ -7,6 +7,13 @@ interface provider {
     /// Returns JSON-serialized Vec<ResourceSchema>
     schemas: func() -> string;
 
+    /// Returns JSON-serialized HashMap<String, AttributeType> describing
+    /// the provider block's configuration attributes (e.g., `region`).
+    /// The host validates provider config against this schema before
+    /// calling `validate-config`, so DSL format bugs in carina-core are
+    /// fixed on the host without rebuilding providers.
+    provider-config-attribute-types: func() -> string;
+
     validate-config: func(attrs: list<tuple<string, value>>) -> result<_, string>;
     initialize: func(attrs: list<tuple<string, value>>) -> result<_, string>;
 

--- a/carina-provider-awscc/src/convert.rs
+++ b/carina-provider-awscc/src/convert.rs
@@ -152,10 +152,14 @@ fn proto_to_core_attribute_type(t: &ProtoAttributeType) -> CoreAttributeType {
         ProtoAttributeType::Int => CoreAttributeType::Int,
         ProtoAttributeType::Float => CoreAttributeType::Float,
         ProtoAttributeType::Bool => CoreAttributeType::Bool,
-        ProtoAttributeType::StringEnum { name, values } => CoreAttributeType::StringEnum {
+        ProtoAttributeType::StringEnum {
+            name,
+            values,
+            namespace,
+        } => CoreAttributeType::StringEnum {
             name: name.clone(),
             values: values.clone(),
-            namespace: None,
+            namespace: namespace.clone(),
             to_dsl: None,
         },
         ProtoAttributeType::List { inner, ordered } => CoreAttributeType::List {
@@ -233,9 +237,15 @@ fn core_to_proto_attribute_type(t: &CoreAttributeType) -> ProtoAttributeType {
         CoreAttributeType::Int => ProtoAttributeType::Int,
         CoreAttributeType::Float => ProtoAttributeType::Float,
         CoreAttributeType::Bool => ProtoAttributeType::Bool,
-        CoreAttributeType::StringEnum { name, values, .. } => ProtoAttributeType::StringEnum {
+        CoreAttributeType::StringEnum {
+            name,
+            values,
+            namespace,
+            ..
+        } => ProtoAttributeType::StringEnum {
             name: name.clone(),
             values: values.clone(),
+            namespace: namespace.clone(),
         },
         CoreAttributeType::List { inner, ordered } => ProtoAttributeType::List {
             inner: Box::new(core_to_proto_attribute_type(inner)),
@@ -324,9 +334,14 @@ mod tests {
 
         // Proto should preserve the name
         match &proto_type {
-            ProtoAttributeType::StringEnum { name, values } => {
+            ProtoAttributeType::StringEnum {
+                name,
+                values,
+                namespace,
+            } => {
                 assert_eq!(name, "VersioningStatus");
                 assert_eq!(values.len(), 2);
+                assert_eq!(namespace.as_deref(), Some("awscc.s3.bucket"));
             }
             _ => panic!("Expected StringEnum"),
         }

--- a/carina-provider-awscc/src/lib.rs
+++ b/carina-provider-awscc/src/lib.rs
@@ -69,13 +69,29 @@ impl ProviderFactory for AwsccProviderFactory {
         "AWS Cloud Control provider"
     }
 
-    fn validate_config(&self, attributes: &HashMap<String, Value>) -> Result<(), String> {
-        let region_type = schemas::awscc_types::awscc_region();
-        if let Some(region_value) = attributes.get("region") {
-            region_type
-                .validate(region_value)
-                .map_err(|e| e.to_string())?;
-        }
+    fn provider_config_attribute_types(
+        &self,
+    ) -> HashMap<String, carina_core::schema::AttributeType> {
+        let mut types = HashMap::new();
+        types.insert(
+            "region".to_string(),
+            carina_core::schema::AttributeType::StringEnum {
+                name: "Region".to_string(),
+                values: carina_aws_types::REGIONS
+                    .iter()
+                    .map(|(code, _)| code.to_string())
+                    .collect(),
+                namespace: Some("awscc".to_string()),
+                to_dsl: Some(|s| s.replace('-', "_")),
+            },
+        );
+        types
+    }
+
+    fn validate_config(&self, _attributes: &HashMap<String, Value>) -> Result<(), String> {
+        // Region format/value validation is handled by the host via
+        // `provider_config_attribute_types`. No provider-specific semantic
+        // checks are needed beyond that for now.
         Ok(())
     }
 

--- a/carina-provider-awscc/src/main.rs
+++ b/carina-provider-awscc/src/main.rs
@@ -84,14 +84,26 @@ impl CarinaProvider for AwsccProcessProvider {
             .collect()
     }
 
-    fn validate_config(&self, attrs: &HashMap<String, proto::Value>) -> Result<(), String> {
-        let core_attrs = convert::proto_to_core_value_map(attrs);
-        let region_type = schemas::awscc_types::awscc_region();
-        if let Some(region_value) = core_attrs.get("region") {
-            region_type
-                .validate(region_value)
-                .map_err(|e| e.to_string())?;
-        }
+    fn provider_config_attribute_types(&self) -> HashMap<String, proto::AttributeType> {
+        let mut types = HashMap::new();
+        types.insert(
+            "region".to_string(),
+            proto::AttributeType::StringEnum {
+                name: "Region".to_string(),
+                values: carina_aws_types::REGIONS
+                    .iter()
+                    .map(|(code, _)| code.to_string())
+                    .collect(),
+                namespace: Some("awscc".to_string()),
+            },
+        );
+        types
+    }
+
+    fn validate_config(&self, _attrs: &HashMap<String, proto::Value>) -> Result<(), String> {
+        // Region format/value validation is handled by the host via
+        // `provider_config_attribute_types`. No provider-specific semantic
+        // checks are needed beyond that for now.
         Ok(())
     }
 


### PR DESCRIPTION
Implements the new `provider_config_attribute_types` method introduced in carina-rs/carina#1653.

## Summary

The AWSCC provider now exposes `region` as a `StringEnum` attribute type (data) instead of embedding a `Custom` validator closure that required provider rebuilds for generic DSL format fixes in carina-core.

The host validates region format and membership against this schema before calling `validate_config`, so fixes like the strict namespace check in carina-core take effect immediately without rebuilding the provider.

## Changes

- `carina-plugin-wit/wit/provider.wit`: add `provider-config-attribute-types` WIT function
- `carina-provider-awscc/src/lib.rs`: implement `provider_config_attribute_types` on `AwsccProviderFactory`
- `carina-provider-awscc/src/main.rs`: implement `provider_config_attribute_types` on `AwsccProcessProvider`
- `carina-provider-awscc/src/convert.rs`: preserve `namespace` in StringEnum proto↔core conversion

## Test plan

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` clean
- [x] Manual E2E: double-namespace region rejected at validate time
- [x] Manual E2E: valid DSL format and AWS string format accepted

Refs carina-rs/carina#1650