### PR TITLE
feat: add IAM Identity Center (SSO) resources

### DIFF
--- a/carina-provider-awscc/scripts/generate-schemas.sh
+++ b/carina-provider-awscc/scripts/generate-schemas.sh
@@ -55,6 +55,11 @@ RESOURCE_TYPES=(
     "AWS::Logs::LogGroup"
     "AWS::Organizations::Organization"
     "AWS::Organizations::Account"
+    "AWS::SSO::Instance"
+    "AWS::SSO::PermissionSet"
+    "AWS::SSO::Assignment"
+    "AWS::IdentityStore::Group"
+    "AWS::IdentityStore::GroupMembership"
 )
 
 echo "Generating awscc provider schemas..."

--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -1739,7 +1739,8 @@ fn {}(value: &Value) -> Result<(), String> {{
             generated_patterns.insert(pattern.clone());
             let fn_name = pattern_fn_name(pattern);
             // Convert PCRE-specific constructs to Rust regex equivalents
-            let rust_pattern = pattern.replace("\\Z", "\\z");
+            // (falling back to `.*` if the pattern uses unsupported features).
+            let rust_pattern = rust_compatible_pattern(pattern);
             // Escape for Rust string literal (double the backslashes, escape quotes)
             let escaped_for_rust = rust_pattern.replace('\\', "\\\\").replace('"', "\\\"");
             // For the error message, also escape { and } for the inner format!() macro
@@ -1785,7 +1786,8 @@ fn {}(value: &Value) -> Result<(), String> {{
             let fn_name = list_items_fn_name(*min, *max);
             let (condition, range_display) = list_items_condition_and_display(*min, *max);
             code.push_str(&format!(
-                r#"fn {}(value: &Value) -> Result<(), String> {{
+                r#"#[allow(dead_code)]
+fn {}(value: &Value) -> Result<(), String> {{
     if let Value::List(items) = value {{
         let len = items.len();
         if {} {{
@@ -1845,7 +1847,7 @@ fn {}(value: &Value) -> Result<(), String> {{
                 continue;
             }
             generated_combined.insert(fn_name.clone());
-            let rust_pattern = pattern.replace("\\Z", "\\z");
+            let rust_pattern = rust_compatible_pattern(pattern);
             let escaped_for_rust = rust_pattern.replace('\\', "\\\\").replace('"', "\\\"");
             let escaped_for_msg = escaped_for_rust.replace('{', "{{").replace('}', "}}");
             let (len_condition, range_display) = string_length_condition_and_display(*min, *max);
@@ -2764,6 +2766,22 @@ fn pattern_fn_name(pattern: &str) -> String {
     pattern.hash(&mut hasher);
     let hash = hasher.finish();
     format!("validate_string_pattern_{:016x}", hash)
+}
+
+/// Convert a CloudFormation regex pattern into one that Rust's `regex` crate can
+/// compile. Rust's regex does not support PCRE lookaround (`(?=`, `(?!`, `(?<=`,
+/// `(?<!`) or the `\Z` end-of-string anchor. Patterns that cannot be converted
+/// fall back to the permissive `.*` so the generated validator still compiles
+/// and the length constraint (if any) still runs.
+fn rust_compatible_pattern(pattern: &str) -> String {
+    // Cheap fixups first: convert PCRE-only anchors that have Rust equivalents.
+    let candidate = pattern.replace("\\Z", "\\z");
+    if regex::Regex::new(&candidate).is_ok() {
+        return candidate;
+    }
+    // Pattern uses a feature Rust's regex crate doesn't support (typically
+    // lookaround). Fall back to match-anything so the generated code compiles.
+    ".*".to_string()
 }
 
 /// Generate a constraint-based function name for combined pattern + length validation.

--- a/carina-provider-awscc/src/schemas/generated/ec2/vpc_endpoint.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/vpc_endpoint.rs
@@ -38,6 +38,7 @@ const VALID_VPC_ENDPOINT_TYPE: &[&str] = &[
     "Resource",
 ];
 
+#[allow(dead_code)]
 fn validate_list_items_1_10(value: &Value) -> Result<(), String> {
     if let Value::List(items) = value {
         let len = items.len();

--- a/carina-provider-awscc/src/schemas/generated/identitystore/group.rs
+++ b/carina-provider-awscc/src/schemas/generated/identitystore/group.rs
@@ -1,0 +1,149 @@
+//! group schema definition for AWS Cloud Control
+//!
+//! Auto-generated from CloudFormation schema: AWS::IdentityStore::Group
+//!
+//! DO NOT EDIT MANUALLY - regenerate with carina-codegen
+
+use super::AwsccSchemaConfig;
+use carina_core::resource::Value;
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+use regex::Regex;
+
+#[allow(dead_code)]
+fn validate_string_pattern_a301e45ae2f7df12_len_1_1024(value: &Value) -> Result<(), String> {
+    if let Value::String(s) = value {
+        static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+            Regex::new("^[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}\\t\\n\\r  ]+$")
+                .expect("invalid pattern regex")
+        });
+        if !RE.is_match(s) {
+            return Err(format!(
+                "Value '{}' does not match pattern ^[\\p{{L}}\\p{{M}}\\p{{S}}\\p{{N}}\\p{{P}}\\t\\n\\r  ]+$",
+                s
+            ));
+        }
+        let len = s.chars().count();
+        if !(1..=1024).contains(&len) {
+            return Err(format!("String length {} is out of range 1..=1024", len));
+        }
+        Ok(())
+    } else {
+        Err("Expected string".to_string())
+    }
+}
+
+#[allow(dead_code)]
+fn validate_string_pattern_3e29f1c0497511f3_len_1_1024(value: &Value) -> Result<(), String> {
+    if let Value::String(s) = value {
+        static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+            Regex::new("^[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}\\t\\n\\r  　]+$")
+                .expect("invalid pattern regex")
+        });
+        if !RE.is_match(s) {
+            return Err(format!(
+                "Value '{}' does not match pattern ^[\\p{{L}}\\p{{M}}\\p{{S}}\\p{{N}}\\p{{P}}\\t\\n\\r  　]+$",
+                s
+            ));
+        }
+        let len = s.chars().count();
+        if !(1..=1024).contains(&len) {
+            return Err(format!("String length {} is out of range 1..=1024", len));
+        }
+        Ok(())
+    } else {
+        Err("Expected string".to_string())
+    }
+}
+
+#[allow(dead_code)]
+fn validate_string_pattern_135f0b126ef95449_len_1_36(value: &Value) -> Result<(), String> {
+    if let Value::String(s) = value {
+        static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+            Regex::new(
+                "^d-[0-9a-f]{10}$|^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+            )
+            .expect("invalid pattern regex")
+        });
+        if !RE.is_match(s) {
+            return Err(format!(
+                "Value '{}' does not match pattern ^d-[0-9a-f]{{10}}$|^[0-9a-f]{{8}}-[0-9a-f]{{4}}-[0-9a-f]{{4}}-[0-9a-f]{{4}}-[0-9a-f]{{12}}$",
+                s
+            ));
+        }
+        let len = s.chars().count();
+        if !(1..=36).contains(&len) {
+            return Err(format!("String length {} is out of range 1..=36", len));
+        }
+        Ok(())
+    } else {
+        Err("Expected string".to_string())
+    }
+}
+
+/// Returns the schema config for identitystore_group (AWS::IdentityStore::Group)
+pub fn identitystore_group_config() -> AwsccSchemaConfig {
+    AwsccSchemaConfig {
+        aws_type_name: "AWS::IdentityStore::Group",
+        resource_type_name: "identitystore.group",
+        has_tags: false,
+        schema: ResourceSchema::new("awscc.identitystore.group")
+        .with_description("Resource Type definition for AWS::IdentityStore::Group")
+        .attribute(
+            AttributeSchema::new("description", AttributeType::Custom {
+                name: "String(pattern, len: 1..=1024)".to_string(),
+                base: Box::new(AttributeType::String),
+                validate: validate_string_pattern_3e29f1c0497511f3_len_1_1024,
+                namespace: None,
+                to_dsl: None,
+            })
+                .with_description("A string containing the description of the group.")
+                .with_provider_name("Description"),
+        )
+        .attribute(
+            AttributeSchema::new("display_name", AttributeType::Custom {
+                name: "String(pattern, len: 1..=1024)".to_string(),
+                base: Box::new(AttributeType::String),
+                validate: validate_string_pattern_a301e45ae2f7df12_len_1_1024,
+                namespace: None,
+                to_dsl: None,
+            })
+                .required()
+                .with_description("A string containing the name of the group. This value is commonly displayed when the group is referenced.")
+                .with_provider_name("DisplayName"),
+        )
+        .attribute(
+            AttributeSchema::new("group_id", super::security_group_id())
+                .read_only()
+                .with_description("The unique identifier for a group in the identity store. (read-only)")
+                .with_provider_name("GroupId"),
+        )
+        .attribute(
+            AttributeSchema::new("identity_store_id", AttributeType::Custom {
+                name: "String(pattern, len: 1..=36)".to_string(),
+                base: Box::new(AttributeType::String),
+                validate: validate_string_pattern_135f0b126ef95449_len_1_36,
+                namespace: None,
+                to_dsl: None,
+            })
+                .required()
+                .create_only()
+                .with_description("The globally unique identifier for the identity store.")
+                .with_provider_name("IdentityStoreId"),
+        )
+    }
+}
+
+/// Returns the resource type name and all enum valid values for this module
+pub fn enum_valid_values() -> (
+    &'static str,
+    &'static [(&'static str, &'static [&'static str])],
+) {
+    ("identitystore.group", &[])
+}
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+/// e.g., ("ip_protocol", "all") -> Some("-1")
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    let _ = (attr_name, value);
+    None
+}

--- a/carina-provider-awscc/src/schemas/generated/identitystore/group_membership.rs
+++ b/carina-provider-awscc/src/schemas/generated/identitystore/group_membership.rs
@@ -1,0 +1,150 @@
+//! group_membership schema definition for AWS Cloud Control
+//!
+//! Auto-generated from CloudFormation schema: AWS::IdentityStore::GroupMembership
+//!
+//! DO NOT EDIT MANUALLY - regenerate with carina-codegen
+
+use super::AwsccSchemaConfig;
+use carina_core::resource::Value;
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
+use regex::Regex;
+
+#[allow(dead_code)]
+fn validate_string_pattern_2a77a2e32f71b5f3_len_1_47(value: &Value) -> Result<(), String> {
+    if let Value::String(s) = value {
+        static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+            Regex::new("^([0-9a-f]{10}-|)[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$").expect("invalid pattern regex")
+        });
+        if !RE.is_match(s) {
+            return Err(format!(
+                "Value '{}' does not match pattern ^([0-9a-f]{{10}}-|)[A-Fa-f0-9]{{8}}-[A-Fa-f0-9]{{4}}-[A-Fa-f0-9]{{4}}-[A-Fa-f0-9]{{4}}-[A-Fa-f0-9]{{12}}$",
+                s
+            ));
+        }
+        let len = s.chars().count();
+        if !(1..=47).contains(&len) {
+            return Err(format!("String length {} is out of range 1..=47", len));
+        }
+        Ok(())
+    } else {
+        Err("Expected string".to_string())
+    }
+}
+
+#[allow(dead_code)]
+fn validate_string_pattern_135f0b126ef95449_len_1_36(value: &Value) -> Result<(), String> {
+    if let Value::String(s) = value {
+        static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+            Regex::new(
+                "^d-[0-9a-f]{10}$|^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+            )
+            .expect("invalid pattern regex")
+        });
+        if !RE.is_match(s) {
+            return Err(format!(
+                "Value '{}' does not match pattern ^d-[0-9a-f]{{10}}$|^[0-9a-f]{{8}}-[0-9a-f]{{4}}-[0-9a-f]{{4}}-[0-9a-f]{{4}}-[0-9a-f]{{12}}$",
+                s
+            ));
+        }
+        let len = s.chars().count();
+        if !(1..=36).contains(&len) {
+            return Err(format!("String length {} is out of range 1..=36", len));
+        }
+        Ok(())
+    } else {
+        Err("Expected string".to_string())
+    }
+}
+
+/// Returns the schema config for identitystore_group_membership (AWS::IdentityStore::GroupMembership)
+pub fn identitystore_group_membership_config() -> AwsccSchemaConfig {
+    AwsccSchemaConfig {
+        aws_type_name: "AWS::IdentityStore::GroupMembership",
+        resource_type_name: "identitystore.group_membership",
+        has_tags: false,
+        schema: ResourceSchema::new("awscc.identitystore.group_membership")
+            .with_description("Resource Type Definition for AWS:IdentityStore::GroupMembership")
+            .attribute(
+                AttributeSchema::new("group_id", super::security_group_id())
+                    .required()
+                    .create_only()
+                    .with_description("The unique identifier for a group in the identity store.")
+                    .with_provider_name("GroupId"),
+            )
+            .attribute(
+                AttributeSchema::new(
+                    "identity_store_id",
+                    AttributeType::Custom {
+                        name: "String(pattern, len: 1..=36)".to_string(),
+                        base: Box::new(AttributeType::String),
+                        validate: validate_string_pattern_135f0b126ef95449_len_1_36,
+                        namespace: None,
+                        to_dsl: None,
+                    },
+                )
+                .required()
+                .create_only()
+                .with_description("The globally unique identifier for the identity store.")
+                .with_provider_name("IdentityStoreId"),
+            )
+            .attribute(
+                AttributeSchema::new(
+                    "member_id",
+                    AttributeType::Struct {
+                        name: "MemberId".to_string(),
+                        fields: vec![
+                            StructField::new(
+                                "user_id",
+                                AttributeType::Custom {
+                                    name: "String(pattern, len: 1..=47)".to_string(),
+                                    base: Box::new(AttributeType::String),
+                                    validate: validate_string_pattern_2a77a2e32f71b5f3_len_1_47,
+                                    namespace: None,
+                                    to_dsl: None,
+                                },
+                            )
+                            .required()
+                            .with_description("The identifier for a user in the identity store.")
+                            .with_provider_name("UserId"),
+                        ],
+                    },
+                )
+                .required()
+                .create_only()
+                .with_description("An object containing the identifier of a group member.")
+                .with_provider_name("MemberId"),
+            )
+            .attribute(
+                AttributeSchema::new(
+                    "membership_id",
+                    AttributeType::Custom {
+                        name: "String(pattern, len: 1..=47)".to_string(),
+                        base: Box::new(AttributeType::String),
+                        validate: validate_string_pattern_2a77a2e32f71b5f3_len_1_47,
+                        namespace: None,
+                        to_dsl: None,
+                    },
+                )
+                .read_only()
+                .with_description(
+                    "The identifier for a GroupMembership in the identity store. (read-only)",
+                )
+                .with_provider_name("MembershipId"),
+            ),
+    }
+}
+
+/// Returns the resource type name and all enum valid values for this module
+pub fn enum_valid_values() -> (
+    &'static str,
+    &'static [(&'static str, &'static [&'static str])],
+) {
+    ("identitystore.group_membership", &[])
+}
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+/// e.g., ("ip_protocol", "all") -> Some("-1")
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    let _ = (attr_name, value);
+    None
+}

--- a/carina-provider-awscc/src/schemas/generated/identitystore/mod.rs
+++ b/carina-provider-awscc/src/schemas/generated/identitystore/mod.rs
@@ -1,0 +1,10 @@
+//! Auto-generated — DO NOT EDIT MANUALLY
+//!
+//! Regenerate with:
+//!   aws-vault exec <profile> -- ./carina-provider-awscc/scripts/generate-schemas.sh
+
+// Re-export parent types so resource modules can use `super::` to access them.
+pub use super::*;
+
+pub mod group;
+pub mod group_membership;

--- a/carina-provider-awscc/src/schemas/generated/logs/log_group.rs
+++ b/carina-provider-awscc/src/schemas/generated/logs/log_group.rs
@@ -67,6 +67,12 @@ pub fn logs_log_group_config() -> AwsccSchemaConfig {
                 .with_provider_name("Arn"),
         )
         .attribute(
+            AttributeSchema::new("bearer_token_authentication_enabled", AttributeType::Bool)
+                .with_description("")
+                .with_provider_name("BearerTokenAuthenticationEnabled")
+                .with_default(Value::Bool(false)),
+        )
+        .attribute(
             AttributeSchema::new("data_protection_policy", AttributeType::Map(Box::new(AttributeType::String)))
                 .with_description("Creates a data protection policy and assigns it to the log group. A data protection policy can help safeguard sensitive data that's ingested by the log group by auditing and masking the sensitive log data. When a user who does not have permission to view masked data views a log event that includes masked data, the sensitive data is replaced by asterisks.")
                 .with_provider_name("DataProtectionPolicy"),

--- a/carina-provider-awscc/src/schemas/generated/mod.rs
+++ b/carina-provider-awscc/src/schemas/generated/mod.rs
@@ -12,9 +12,11 @@ pub use super::awscc_types::*;
 
 pub mod ec2;
 pub mod iam;
+pub mod identitystore;
 pub mod logs;
 pub mod organizations;
 pub mod s3;
+pub mod sso;
 
 /// Cached schema configs, initialized once on first access.
 static SCHEMA_CONFIGS: LazyLock<Vec<AwsccSchemaConfig>> = LazyLock::new(build_configs);
@@ -60,6 +62,11 @@ static ENUM_VALID_VALUES: LazyLock<
         logs::log_group::enum_valid_values(),
         organizations::organization::enum_valid_values(),
         organizations::account::enum_valid_values(),
+        sso::instance::enum_valid_values(),
+        sso::permission_set::enum_valid_values(),
+        sso::assignment::enum_valid_values(),
+        identitystore::group::enum_valid_values(),
+        identitystore::group_membership::enum_valid_values(),
     ];
     let mut map: HashMap<&str, HashMap<&str, &[&str]>> = HashMap::new();
     for (rt, attrs) in modules {
@@ -140,6 +147,20 @@ static ENUM_ALIAS_DISPATCH: LazyLock<HashMap<&'static str, EnumAliasReverseFn>> 
                 "organizations.account",
                 organizations::account::enum_alias_reverse,
             ),
+            ("sso.instance", sso::instance::enum_alias_reverse),
+            (
+                "sso.permission_set",
+                sso::permission_set::enum_alias_reverse,
+            ),
+            ("sso.assignment", sso::assignment::enum_alias_reverse),
+            (
+                "identitystore.group",
+                identitystore::group::enum_alias_reverse,
+            ),
+            (
+                "identitystore.group_membership",
+                identitystore::group_membership::enum_alias_reverse,
+            ),
         ];
         entries.into_iter().collect()
     });
@@ -173,6 +194,11 @@ fn build_configs() -> Vec<AwsccSchemaConfig> {
         logs::log_group::logs_log_group_config(),
         organizations::organization::organizations_organization_config(),
         organizations::account::organizations_account_config(),
+        sso::instance::sso_instance_config(),
+        sso::permission_set::sso_permission_set_config(),
+        sso::assignment::sso_assignment_config(),
+        identitystore::group::identitystore_group_config(),
+        identitystore::group_membership::identitystore_group_membership_config(),
     ]
 }
 

--- a/carina-provider-awscc/src/schemas/generated/s3/bucket.rs
+++ b/carina-provider-awscc/src/schemas/generated/s3/bucket.rs
@@ -30,6 +30,8 @@ const VALID_ACCESS_CONTROL_TRANSLATION_OWNER: &[&str] = &["Destination"];
 
 const VALID_BLOCKED_ENCRYPTION_TYPES_ENCRYPTION_TYPE: &[&str] = &["NONE", "SSE-C"];
 
+const VALID_BUCKET_NAMESPACE: &[&str] = &["global", "account-regional"];
+
 const VALID_CORS_RULE_ALLOWED_METHODS: &[&str] = &["GET", "PUT", "HEAD", "POST", "DELETE"];
 
 const VALID_DATA_EXPORT_OUTPUT_SCHEMA_VERSION: &[&str] = &["V_1"];
@@ -362,6 +364,25 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 .create_only()
                 .with_description("A name for the bucket. If you don't specify a name, AWS CloudFormation generates a unique ID and uses that ID for the bucket name. The bucket name must contain only lowercase letters, numbers, periods (.), and dashes (-) and must follow [Amazon S3 bucket restrictions and limitations](https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html). For more information, see [Rules for naming Amazon S3 buckets](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html) in the *Amazon S3 User Guide*. If you specify a name, you can't perform updates that require replacement of this resource. You can perform updates that require no or some interruption. If you need to replace the resource, specify a new name.")
                 .with_provider_name("BucketName"),
+        )
+        .attribute(
+            AttributeSchema::new("bucket_name_prefix", AttributeType::String)
+                .create_only()
+                .write_only()
+                .with_description("")
+                .with_provider_name("BucketNamePrefix"),
+        )
+        .attribute(
+            AttributeSchema::new("bucket_namespace", AttributeType::StringEnum {
+                name: "BucketNamespace".to_string(),
+                values: vec!["global".to_string(), "account-regional".to_string()],
+                namespace: Some("awscc.s3.bucket".to_string()),
+                to_dsl: Some(|s: &str| s.replace('-', "_")),
+            })
+                .create_only()
+                .write_only()
+                .with_description("")
+                .with_provider_name("BucketNamespace"),
         )
         .attribute(
             AttributeSchema::new("cors_configuration", AttributeType::Struct {
@@ -1223,6 +1244,7 @@ pub fn enum_valid_values() -> (
                 "encryption_type",
                 VALID_BLOCKED_ENCRYPTION_TYPES_ENCRYPTION_TYPE,
             ),
+            ("bucket_namespace", VALID_BUCKET_NAMESPACE),
             ("allowed_methods", VALID_CORS_RULE_ALLOWED_METHODS),
             (
                 "output_schema_version",

--- a/carina-provider-awscc/src/schemas/generated/sso/assignment.rs
+++ b/carina-provider-awscc/src/schemas/generated/sso/assignment.rs
@@ -1,0 +1,159 @@
+//! assignment schema definition for AWS Cloud Control
+//!
+//! Auto-generated from CloudFormation schema: AWS::SSO::Assignment
+//!
+//! DO NOT EDIT MANUALLY - regenerate with carina-codegen
+
+use super::AwsccSchemaConfig;
+use carina_core::resource::Value;
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+use regex::Regex;
+
+const VALID_PRINCIPAL_TYPE: &[&str] = &["USER", "GROUP"];
+
+const VALID_TARGET_TYPE: &[&str] = &["AWS_ACCOUNT"];
+
+#[allow(dead_code)]
+fn validate_string_pattern_fd8ddd3f8bec29c4(value: &Value) -> Result<(), String> {
+    if let Value::String(s) = value {
+        static RE: std::sync::LazyLock<Regex> =
+            std::sync::LazyLock::new(|| Regex::new("\\d{12}").expect("invalid pattern regex"));
+        if RE.is_match(s) {
+            Ok(())
+        } else {
+            Err(format!("Value '{}' does not match pattern \\d{{12}}", s))
+        }
+    } else {
+        Err("Expected string".to_string())
+    }
+}
+
+#[allow(dead_code)]
+fn validate_string_pattern_2a77a2e32f71b5f3_len_1_47(value: &Value) -> Result<(), String> {
+    if let Value::String(s) = value {
+        static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+            Regex::new("^([0-9a-f]{10}-|)[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$").expect("invalid pattern regex")
+        });
+        if !RE.is_match(s) {
+            return Err(format!(
+                "Value '{}' does not match pattern ^([0-9a-f]{{10}}-|)[A-Fa-f0-9]{{8}}-[A-Fa-f0-9]{{4}}-[A-Fa-f0-9]{{4}}-[A-Fa-f0-9]{{4}}-[A-Fa-f0-9]{{12}}$",
+                s
+            ));
+        }
+        let len = s.chars().count();
+        if !(1..=47).contains(&len) {
+            return Err(format!("String length {} is out of range 1..=47", len));
+        }
+        Ok(())
+    } else {
+        Err("Expected string".to_string())
+    }
+}
+
+/// Returns the schema config for sso_assignment (AWS::SSO::Assignment)
+pub fn sso_assignment_config() -> AwsccSchemaConfig {
+    AwsccSchemaConfig {
+        aws_type_name: "AWS::SSO::Assignment",
+        resource_type_name: "sso.assignment",
+        has_tags: false,
+        schema: ResourceSchema::new("awscc.sso.assignment")
+            .with_description("Resource Type definition for SSO assignmet")
+            .attribute(
+                AttributeSchema::new("instance_arn", super::arn())
+                    .required()
+                    .create_only()
+                    .with_description("The sso instance that the permission set is owned.")
+                    .with_provider_name("InstanceArn"),
+            )
+            .attribute(
+                AttributeSchema::new("permission_set_arn", super::arn())
+                    .required()
+                    .create_only()
+                    .with_description("The permission set that the assignment will be assigned")
+                    .with_provider_name("PermissionSetArn"),
+            )
+            .attribute(
+                AttributeSchema::new(
+                    "principal_id",
+                    AttributeType::Custom {
+                        name: "String(pattern, len: 1..=47)".to_string(),
+                        base: Box::new(AttributeType::String),
+                        validate: validate_string_pattern_2a77a2e32f71b5f3_len_1_47,
+                        namespace: None,
+                        to_dsl: None,
+                    },
+                )
+                .required()
+                .create_only()
+                .with_description("The assignee's identifier, user id/group id")
+                .with_provider_name("PrincipalId"),
+            )
+            .attribute(
+                AttributeSchema::new(
+                    "principal_type",
+                    AttributeType::StringEnum {
+                        name: "PrincipalType".to_string(),
+                        values: vec!["USER".to_string(), "GROUP".to_string()],
+                        namespace: Some("awscc.sso.assignment".to_string()),
+                        to_dsl: None,
+                    },
+                )
+                .required()
+                .create_only()
+                .with_description("The assignee's type, user/group")
+                .with_provider_name("PrincipalType"),
+            )
+            .attribute(
+                AttributeSchema::new(
+                    "target_id",
+                    AttributeType::Custom {
+                        name: "String(pattern)".to_string(),
+                        base: Box::new(AttributeType::String),
+                        validate: validate_string_pattern_fd8ddd3f8bec29c4,
+                        namespace: None,
+                        to_dsl: None,
+                    },
+                )
+                .required()
+                .create_only()
+                .with_description("The account id to be provisioned.")
+                .with_provider_name("TargetId"),
+            )
+            .attribute(
+                AttributeSchema::new(
+                    "target_type",
+                    AttributeType::StringEnum {
+                        name: "TargetType".to_string(),
+                        values: vec!["AWS_ACCOUNT".to_string()],
+                        namespace: Some("awscc.sso.assignment".to_string()),
+                        to_dsl: None,
+                    },
+                )
+                .required()
+                .create_only()
+                .with_description("The type of resource to be provisioned to, only aws account now")
+                .with_provider_name("TargetType"),
+            ),
+    }
+}
+
+/// Returns the resource type name and all enum valid values for this module
+pub fn enum_valid_values() -> (
+    &'static str,
+    &'static [(&'static str, &'static [&'static str])],
+) {
+    (
+        "sso.assignment",
+        &[
+            ("principal_type", VALID_PRINCIPAL_TYPE),
+            ("target_type", VALID_TARGET_TYPE),
+        ],
+    )
+}
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+/// e.g., ("ip_protocol", "all") -> Some("-1")
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    let _ = (attr_name, value);
+    None
+}

--- a/carina-provider-awscc/src/schemas/generated/sso/instance.rs
+++ b/carina-provider-awscc/src/schemas/generated/sso/instance.rs
@@ -1,0 +1,191 @@
+//! instance schema definition for AWS Cloud Control
+//!
+//! Auto-generated from CloudFormation schema: AWS::SSO::Instance
+//!
+//! DO NOT EDIT MANUALLY - regenerate with carina-codegen
+
+use super::AwsccSchemaConfig;
+use super::tags_type;
+use super::validate_tags_map;
+use carina_core::resource::Value;
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+use regex::Regex;
+
+const VALID_STATUS: &[&str] = &["CREATE_IN_PROGRESS", "DELETE_IN_PROGRESS", "ACTIVE"];
+
+#[allow(dead_code)]
+fn validate_list_items_max_75(value: &Value) -> Result<(), String> {
+    if let Value::List(items) = value {
+        let len = items.len();
+        if len > 75 {
+            Err(format!("List has {} items, expected ..=75", len))
+        } else {
+            Ok(())
+        }
+    } else {
+        Err("Expected list".to_string())
+    }
+}
+
+#[allow(dead_code)]
+fn validate_string_pattern_9b83f4f8f3673df5_len_max_256(value: &Value) -> Result<(), String> {
+    if let Value::String(s) = value {
+        static RE: std::sync::LazyLock<Regex> =
+            std::sync::LazyLock::new(|| Regex::new("[\\w+=,.@-]+").expect("invalid pattern regex"));
+        if !RE.is_match(s) {
+            return Err(format!("Value '{}' does not match pattern [\\w+=,.@-]+", s));
+        }
+        let len = s.chars().count();
+        if len > 256 {
+            return Err(format!("String length {} is out of range ..=256", len));
+        }
+        Ok(())
+    } else {
+        Err("Expected string".to_string())
+    }
+}
+
+#[allow(dead_code)]
+fn validate_string_pattern_9b83f4f8f3673df5_len_1_128(value: &Value) -> Result<(), String> {
+    if let Value::String(s) = value {
+        static RE: std::sync::LazyLock<Regex> =
+            std::sync::LazyLock::new(|| Regex::new("[\\w+=,.@-]+").expect("invalid pattern regex"));
+        if !RE.is_match(s) {
+            return Err(format!("Value '{}' does not match pattern [\\w+=,.@-]+", s));
+        }
+        let len = s.chars().count();
+        if !(1..=128).contains(&len) {
+            return Err(format!("String length {} is out of range 1..=128", len));
+        }
+        Ok(())
+    } else {
+        Err("Expected string".to_string())
+    }
+}
+
+#[allow(dead_code)]
+fn validate_string_pattern_5a2bd7daee6344f1_len_1_32(value: &Value) -> Result<(), String> {
+    if let Value::String(s) = value {
+        static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+            Regex::new("^[\\w+=,.@-]+$").expect("invalid pattern regex")
+        });
+        if !RE.is_match(s) {
+            return Err(format!(
+                "Value '{}' does not match pattern ^[\\w+=,.@-]+$",
+                s
+            ));
+        }
+        let len = s.chars().count();
+        if !(1..=32).contains(&len) {
+            return Err(format!("String length {} is out of range 1..=32", len));
+        }
+        Ok(())
+    } else {
+        Err("Expected string".to_string())
+    }
+}
+
+#[allow(dead_code)]
+fn validate_string_pattern_52730ac83148124e_len_1_64(value: &Value) -> Result<(), String> {
+    if let Value::String(s) = value {
+        static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+            Regex::new("^[a-zA-Z0-9-]*$").expect("invalid pattern regex")
+        });
+        if !RE.is_match(s) {
+            return Err(format!(
+                "Value '{}' does not match pattern ^[a-zA-Z0-9-]*$",
+                s
+            ));
+        }
+        let len = s.chars().count();
+        if !(1..=64).contains(&len) {
+            return Err(format!("String length {} is out of range 1..=64", len));
+        }
+        Ok(())
+    } else {
+        Err("Expected string".to_string())
+    }
+}
+
+/// Returns the schema config for sso_instance (AWS::SSO::Instance)
+pub fn sso_instance_config() -> AwsccSchemaConfig {
+    AwsccSchemaConfig {
+        aws_type_name: "AWS::SSO::Instance",
+        resource_type_name: "sso.instance",
+        has_tags: true,
+        schema: ResourceSchema::new("awscc.sso.instance")
+        .with_description("Resource Type definition for Identity Center (SSO) Instance")
+        .attribute(
+            AttributeSchema::new("identity_store_id", AttributeType::Custom {
+                name: "String(pattern, len: 1..=64)".to_string(),
+                base: Box::new(AttributeType::String),
+                validate: validate_string_pattern_52730ac83148124e_len_1_64,
+                namespace: None,
+                to_dsl: None,
+            })
+                .read_only()
+                .with_description("The ID of the identity store associated with the created Identity Center (SSO) Instance (read-only)")
+                .with_provider_name("IdentityStoreId"),
+        )
+        .attribute(
+            AttributeSchema::new("instance_arn", super::arn())
+                .read_only()
+                .with_description("The SSO Instance ARN that is returned upon creation of the Identity Center (SSO) Instance (read-only)")
+                .with_provider_name("InstanceArn"),
+        )
+        .attribute(
+            AttributeSchema::new("name", AttributeType::Custom {
+                name: "String(pattern, len: 1..=32)".to_string(),
+                base: Box::new(AttributeType::String),
+                validate: validate_string_pattern_5a2bd7daee6344f1_len_1_32,
+                namespace: None,
+                to_dsl: None,
+            })
+                .with_description("The name you want to assign to this Identity Center (SSO) Instance")
+                .with_provider_name("Name"),
+        )
+        .attribute(
+            AttributeSchema::new("owner_account_id", super::aws_account_id())
+                .read_only()
+                .with_description("The AWS accountId of the owner of the Identity Center (SSO) Instance (read-only)")
+                .with_provider_name("OwnerAccountId"),
+        )
+        .attribute(
+            AttributeSchema::new("status", AttributeType::StringEnum {
+                name: "Status".to_string(),
+                values: vec!["CREATE_IN_PROGRESS".to_string(), "DELETE_IN_PROGRESS".to_string(), "ACTIVE".to_string()],
+                namespace: Some("awscc.sso.instance".to_string()),
+                to_dsl: None,
+            })
+                .read_only()
+                .with_description("The status of the Identity Center (SSO) Instance, create_in_progress/delete_in_progress/active (read-only)")
+                .with_provider_name("Status"),
+        )
+        .attribute(
+            AttributeSchema::new("tags", tags_type())
+                .with_provider_name("Tags"),
+        )
+        .with_validator(|attrs| {
+            let mut errors = Vec::new();
+            if let Err(mut e) = validate_tags_map(attrs) {
+                errors.append(&mut e);
+            }
+            if errors.is_empty() { Ok(()) } else { Err(errors) }
+        })
+    }
+}
+
+/// Returns the resource type name and all enum valid values for this module
+pub fn enum_valid_values() -> (
+    &'static str,
+    &'static [(&'static str, &'static [&'static str])],
+) {
+    ("sso.instance", &[("status", VALID_STATUS)])
+}
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+/// e.g., ("ip_protocol", "all") -> Some("-1")
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    let _ = (attr_name, value);
+    None
+}

--- a/carina-provider-awscc/src/schemas/generated/sso/mod.rs
+++ b/carina-provider-awscc/src/schemas/generated/sso/mod.rs
@@ -1,0 +1,11 @@
+//! Auto-generated — DO NOT EDIT MANUALLY
+//!
+//! Regenerate with:
+//!   aws-vault exec <profile> -- ./carina-provider-awscc/scripts/generate-schemas.sh
+
+// Re-export parent types so resource modules can use `super::` to access them.
+pub use super::*;
+
+pub mod assignment;
+pub mod instance;
+pub mod permission_set;

--- a/carina-provider-awscc/src/schemas/generated/sso/permission_set.rs
+++ b/carina-provider-awscc/src/schemas/generated/sso/permission_set.rs
@@ -1,0 +1,348 @@
+//! permission_set schema definition for AWS Cloud Control
+//!
+//! Auto-generated from CloudFormation schema: AWS::SSO::PermissionSet
+//!
+//! DO NOT EDIT MANUALLY - regenerate with carina-codegen
+
+use super::AwsccSchemaConfig;
+use super::tags_type;
+use super::validate_tags_map;
+use carina_core::resource::Value;
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
+use regex::Regex;
+
+#[allow(dead_code)]
+fn validate_list_items_max_20(value: &Value) -> Result<(), String> {
+    if let Value::List(items) = value {
+        let len = items.len();
+        if len > 20 {
+            Err(format!("List has {} items, expected ..=20", len))
+        } else {
+            Ok(())
+        }
+    } else {
+        Err("Expected list".to_string())
+    }
+}
+
+#[allow(dead_code)]
+fn validate_list_items_max_50(value: &Value) -> Result<(), String> {
+    if let Value::List(items) = value {
+        let len = items.len();
+        if len > 50 {
+            Err(format!("List has {} items, expected ..=50", len))
+        } else {
+            Ok(())
+        }
+    } else {
+        Err("Expected list".to_string())
+    }
+}
+
+#[allow(dead_code)]
+fn validate_string_pattern_b84fa12576539ca9_len_1_512(value: &Value) -> Result<(), String> {
+    if let Value::String(s) = value {
+        static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+            Regex::new("((/[A-Za-z0-9\\.,\\+@=_-]+)*)/").expect("invalid pattern regex")
+        });
+        if !RE.is_match(s) {
+            return Err(format!(
+                "Value '{}' does not match pattern ((/[A-Za-z0-9\\.,\\+@=_-]+)*)/",
+                s
+            ));
+        }
+        let len = s.chars().count();
+        if !(1..=512).contains(&len) {
+            return Err(format!("String length {} is out of range 1..=512", len));
+        }
+        Ok(())
+    } else {
+        Err("Expected string".to_string())
+    }
+}
+
+#[allow(dead_code)]
+fn validate_string_pattern_9863be410e005e12_len_1_700(value: &Value) -> Result<(), String> {
+    if let Value::String(s) = value {
+        static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+            Regex::new("[\\u0009\\u000A\\u000D\\u0020-\\u007E\\u00A1-\\u00FF]*")
+                .expect("invalid pattern regex")
+        });
+        if !RE.is_match(s) {
+            return Err(format!(
+                "Value '{}' does not match pattern [\\u0009\\u000A\\u000D\\u0020-\\u007E\\u00A1-\\u00FF]*",
+                s
+            ));
+        }
+        let len = s.chars().count();
+        if !(1..=700).contains(&len) {
+            return Err(format!("String length {} is out of range 1..=700", len));
+        }
+        Ok(())
+    } else {
+        Err("Expected string".to_string())
+    }
+}
+
+#[allow(dead_code)]
+fn validate_string_pattern_9b83f4f8f3673df5_len_max_256(value: &Value) -> Result<(), String> {
+    if let Value::String(s) = value {
+        static RE: std::sync::LazyLock<Regex> =
+            std::sync::LazyLock::new(|| Regex::new("[\\w+=,.@-]+").expect("invalid pattern regex"));
+        if !RE.is_match(s) {
+            return Err(format!("Value '{}' does not match pattern [\\w+=,.@-]+", s));
+        }
+        let len = s.chars().count();
+        if len > 256 {
+            return Err(format!("String length {} is out of range ..=256", len));
+        }
+        Ok(())
+    } else {
+        Err("Expected string".to_string())
+    }
+}
+
+#[allow(dead_code)]
+fn validate_string_pattern_9b83f4f8f3673df5_len_1_32(value: &Value) -> Result<(), String> {
+    if let Value::String(s) = value {
+        static RE: std::sync::LazyLock<Regex> =
+            std::sync::LazyLock::new(|| Regex::new("[\\w+=,.@-]+").expect("invalid pattern regex"));
+        if !RE.is_match(s) {
+            return Err(format!("Value '{}' does not match pattern [\\w+=,.@-]+", s));
+        }
+        let len = s.chars().count();
+        if !(1..=32).contains(&len) {
+            return Err(format!("String length {} is out of range 1..=32", len));
+        }
+        Ok(())
+    } else {
+        Err("Expected string".to_string())
+    }
+}
+
+#[allow(dead_code)]
+fn validate_string_pattern_9b83f4f8f3673df5_len_1_128(value: &Value) -> Result<(), String> {
+    if let Value::String(s) = value {
+        static RE: std::sync::LazyLock<Regex> =
+            std::sync::LazyLock::new(|| Regex::new("[\\w+=,.@-]+").expect("invalid pattern regex"));
+        if !RE.is_match(s) {
+            return Err(format!("Value '{}' does not match pattern [\\w+=,.@-]+", s));
+        }
+        let len = s.chars().count();
+        if !(1..=128).contains(&len) {
+            return Err(format!("String length {} is out of range 1..=128", len));
+        }
+        Ok(())
+    } else {
+        Err("Expected string".to_string())
+    }
+}
+
+#[allow(dead_code)]
+fn validate_string_pattern_4d6d630589930649_len_1_240(value: &Value) -> Result<(), String> {
+    if let Value::String(s) = value {
+        static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+            Regex::new("[a-zA-Z0-9&amp;$@#\\/%?=~\\-_'&quot;|!:,.;*+\\[\\]\\ \\(\\)\\{\\}]+")
+                .expect("invalid pattern regex")
+        });
+        if !RE.is_match(s) {
+            return Err(format!(
+                "Value '{}' does not match pattern [a-zA-Z0-9&amp;$@#\\/%?=~\\-_'&quot;|!:,.;*+\\[\\]\\ \\(\\)\\{{\\}}]+",
+                s
+            ));
+        }
+        let len = s.chars().count();
+        if !(1..=240).contains(&len) {
+            return Err(format!("String length {} is out of range 1..=240", len));
+        }
+        Ok(())
+    } else {
+        Err("Expected string".to_string())
+    }
+}
+
+#[allow(dead_code)]
+fn validate_string_pattern_1e58d8243b46a2f1_len_1_100(value: &Value) -> Result<(), String> {
+    if let Value::String(s) = value {
+        static RE: std::sync::LazyLock<Regex> =
+            std::sync::LazyLock::new(|| Regex::new(".*").expect("invalid pattern regex"));
+        if !RE.is_match(s) {
+            return Err(format!("Value '{}' does not match pattern .*", s));
+        }
+        let len = s.chars().count();
+        if !(1..=100).contains(&len) {
+            return Err(format!("String length {} is out of range 1..=100", len));
+        }
+        Ok(())
+    } else {
+        Err("Expected string".to_string())
+    }
+}
+
+/// Returns the schema config for sso_permission_set (AWS::SSO::PermissionSet)
+pub fn sso_permission_set_config() -> AwsccSchemaConfig {
+    AwsccSchemaConfig {
+        aws_type_name: "AWS::SSO::PermissionSet",
+        resource_type_name: "sso.permission_set",
+        has_tags: true,
+        schema: ResourceSchema::new("awscc.sso.permission_set")
+        .with_description("Resource Type definition for SSO PermissionSet")
+        .attribute(
+            AttributeSchema::new("customer_managed_policy_references", AttributeType::Custom {
+                name: "List(..=20)".to_string(),
+                base: Box::new(AttributeType::unordered_list(AttributeType::Struct {
+                    name: "CustomerManagedPolicyReference".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::Custom {
+                name: "String(pattern, len: 1..=128)".to_string(),
+                base: Box::new(AttributeType::String),
+                validate: validate_string_pattern_9b83f4f8f3673df5_len_1_128,
+                namespace: None,
+                to_dsl: None,
+            }).required().with_provider_name("Name"),
+                    StructField::new("path", AttributeType::Custom {
+                name: "String(pattern, len: 1..=512)".to_string(),
+                base: Box::new(AttributeType::String),
+                validate: validate_string_pattern_b84fa12576539ca9_len_1_512,
+                namespace: None,
+                to_dsl: None,
+            }).with_provider_name("Path")
+                    ],
+                })),
+                validate: validate_list_items_max_20,
+                namespace: None,
+                to_dsl: None,
+            })
+                .with_provider_name("CustomerManagedPolicyReferences")
+                .with_block_name("customer_managed_policy_reference"),
+        )
+        .attribute(
+            AttributeSchema::new("description", AttributeType::Custom {
+                name: "String(pattern, len: 1..=700)".to_string(),
+                base: Box::new(AttributeType::String),
+                validate: validate_string_pattern_9863be410e005e12_len_1_700,
+                namespace: None,
+                to_dsl: None,
+            })
+                .with_description("The permission set description.")
+                .with_provider_name("Description"),
+        )
+        .attribute(
+            AttributeSchema::new("inline_policy", AttributeType::Map(Box::new(AttributeType::String)))
+                .with_description("The inline policy to put in permission set.")
+                .with_provider_name("InlinePolicy"),
+        )
+        .attribute(
+            AttributeSchema::new("instance_arn", super::arn())
+                .required()
+                .create_only()
+                .with_description("The sso instance arn that the permission set is owned.")
+                .with_provider_name("InstanceArn"),
+        )
+        .attribute(
+            AttributeSchema::new("managed_policies", AttributeType::Custom {
+                name: "List(..=20)".to_string(),
+                base: Box::new(AttributeType::unordered_list(AttributeType::String)),
+                validate: validate_list_items_max_20,
+                namespace: None,
+                to_dsl: None,
+            })
+                .with_provider_name("ManagedPolicies"),
+        )
+        .attribute(
+            AttributeSchema::new("name", AttributeType::Custom {
+                name: "String(pattern, len: 1..=32)".to_string(),
+                base: Box::new(AttributeType::String),
+                validate: validate_string_pattern_9b83f4f8f3673df5_len_1_32,
+                namespace: None,
+                to_dsl: None,
+            })
+                .required()
+                .create_only()
+                .with_description("The name you want to assign to this permission set.")
+                .with_provider_name("Name"),
+        )
+        .attribute(
+            AttributeSchema::new("permission_set_arn", super::arn())
+                .read_only()
+                .with_description("The permission set that the policy will be attached to (read-only)")
+                .with_provider_name("PermissionSetArn"),
+        )
+        .attribute(
+            AttributeSchema::new("permissions_boundary", AttributeType::Struct {
+                    name: "PermissionsBoundary".to_string(),
+                    fields: vec![
+                    StructField::new("customer_managed_policy_reference", AttributeType::Struct {
+                    name: "CustomerManagedPolicyReference".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::Custom {
+                name: "String(pattern, len: 1..=128)".to_string(),
+                base: Box::new(AttributeType::String),
+                validate: validate_string_pattern_9b83f4f8f3673df5_len_1_128,
+                namespace: None,
+                to_dsl: None,
+            }).required().with_provider_name("Name"),
+                    StructField::new("path", AttributeType::Custom {
+                name: "String(pattern, len: 1..=512)".to_string(),
+                base: Box::new(AttributeType::String),
+                validate: validate_string_pattern_b84fa12576539ca9_len_1_512,
+                namespace: None,
+                to_dsl: None,
+            }).with_provider_name("Path")
+                    ],
+                }).with_provider_name("CustomerManagedPolicyReference"),
+                    StructField::new("managed_policy_arn", super::arn()).with_provider_name("ManagedPolicyArn")
+                    ],
+                })
+                .with_provider_name("PermissionsBoundary"),
+        )
+        .attribute(
+            AttributeSchema::new("relay_state_type", AttributeType::Custom {
+                name: "String(pattern, len: 1..=240)".to_string(),
+                base: Box::new(AttributeType::String),
+                validate: validate_string_pattern_4d6d630589930649_len_1_240,
+                namespace: None,
+                to_dsl: None,
+            })
+                .with_description("The relay state URL that redirect links to any service in the AWS Management Console.")
+                .with_provider_name("RelayStateType"),
+        )
+        .attribute(
+            AttributeSchema::new("session_duration", AttributeType::Custom {
+                name: "String(pattern, len: 1..=100)".to_string(),
+                base: Box::new(AttributeType::String),
+                validate: validate_string_pattern_1e58d8243b46a2f1_len_1_100,
+                namespace: None,
+                to_dsl: None,
+            })
+                .with_description("The length of time that a user can be signed in to an AWS account.")
+                .with_provider_name("SessionDuration"),
+        )
+        .attribute(
+            AttributeSchema::new("tags", tags_type())
+                .with_provider_name("Tags"),
+        )
+        .with_validator(|attrs| {
+            let mut errors = Vec::new();
+            if let Err(mut e) = validate_tags_map(attrs) {
+                errors.append(&mut e);
+            }
+            if errors.is_empty() { Ok(()) } else { Err(errors) }
+        })
+    }
+}
+
+/// Returns the resource type name and all enum valid values for this module
+pub fn enum_valid_values() -> (
+    &'static str,
+    &'static [(&'static str, &'static [&'static str])],
+) {
+    ("sso.permission_set", &[])
+}
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+/// e.g., ("ip_protocol", "all") -> Some("-1")
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    let _ = (attr_name, value);
+    None
+}

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -58,6 +58,11 @@ RESOURCE_TYPES=(
     "AWS::S3::Bucket"
     "AWS::IAM::Role"
     "AWS::Logs::LogGroup"
+    "AWS::SSO::Instance"
+    "AWS::SSO::PermissionSet"
+    "AWS::SSO::Assignment"
+    "AWS::IdentityStore::Group"
+    "AWS::IdentityStore::GroupMembership"
 )
 
 echo "Generating awscc provider documentation..."


### PR DESCRIPTION
Closes #88

## Summary

Adds 5 new CloudFormation resource types for IAM Identity Center / Identity Store:

| Resource | Purpose |
|---|---|
| `AWS::SSO::Instance` | Identity Center instance |
| `AWS::SSO::PermissionSet` | Permission set (e.g., AdministratorAccess) |
| `AWS::SSO::Assignment` | Assign a permission set to a principal for a target account |
| `AWS::IdentityStore::Group` | Identity Store group |
| `AWS::IdentityStore::GroupMembership` | Group membership |

`AWS::IdentityStore::User` was requested in the issue but CloudFormation does not support it (returns `TypeNotFoundException`), so it is omitted.

## Codegen fixes (also included)

The SSO schemas exposed two pre-existing codegen bugs that had to be fixed:

### 1. `rust_compatible_pattern()` — PCRE lookaround fallback
`AWS::SSO::PermissionSet.SessionDuration` uses an ISO 8601 duration pattern with lookahead: `^(-?)P(?=\d|T\d)...`. Rust's `regex` crate does not support lookaround, so the generated code failed with a clippy `invalid_regex` error. The codegen now detects patterns that fail to compile via the `regex` crate and falls back to `.*`. Length constraints continue to apply.

### 2. `#[allow(dead_code)]` on generated list-items validators
`AWS::SSO::Instance` and `AWS::SSO::PermissionSet` have list constraints on tag-typed fields. When `has_tags` special handling kicks in, those validators are generated but not referenced — triggering clippy `dead_code` errors. The codegen now emits `#[allow(dead_code)]` alongside the existing annotation on string-pattern validators.

## Incidental schema updates

Regenerating all schemas also picked up upstream CloudFormation updates for:
- `logs.log_group` — new `bearer_token_authentication_enabled` field
- `s3.bucket` — new `bucket_name_prefix` and `bucket_namespace` fields
- `ec2.vpc_endpoint` — `#[allow(dead_code)]` on an unused list validator

## Test plan

- [x] `cargo test -p carina-provider-awscc` — 160 tests pass
- [x] `cargo clippy -p carina-provider-awscc -- -D warnings` — no warnings
- [x] Full workspace `cargo test` — 355 tests pass
- [ ] Acceptance tests — skipped per the issue; Identity Center affects the entire AWS account and cannot be safely tested in acceptance

🤖 Generated with [Claude Code](https://claude.com/claude-code)