### PR TITLE
chore: sync vendored WIT with carina#1678 read_data_source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#e70e36f4b1e9bc4052179d92ca287ee6da0bf91f"
+source = "git+https://github.com/carina-rs/carina#a1895114ff0dc035bbe14a4b137e159e99c7613c"
 dependencies = [
  "argon2",
  "futures",
@@ -531,7 +531,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#e70e36f4b1e9bc4052179d92ca287ee6da0bf91f"
+source = "git+https://github.com/carina-rs/carina#a1895114ff0dc035bbe14a4b137e159e99c7613c"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#e70e36f4b1e9bc4052179d92ca287ee6da0bf91f"
+source = "git+https://github.com/carina-rs/carina#a1895114ff0dc035bbe14a4b137e159e99c7613c"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-plugin-wit/wit/provider.wit
+++ b/carina-plugin-wit/wit/provider.wit
@@ -18,6 +18,14 @@ interface provider {
     initialize: func(attrs: list<tuple<string, value>>) -> result<_, string>;
 
     read: func(id: resource-id, identifier: option<string>) -> result<state, string>;
+
+    /// Read a data source resource. Receives the full `resource-def` so
+    /// providers can see user-supplied input attributes (e.g. the
+    /// `user_name` for `aws.identitystore.user`). Zero-input data sources
+    /// should still route through `read` on the host side — callers
+    /// dispatch on `resource.is_data_source()` before picking this path.
+    read-data-source: func(res: resource-def) -> result<state, string>;
+
     create: func(res: resource-def) -> result<state, string>;
     update: func(id: resource-id, identifier: string, current: state, to: resource-def) -> result<state, string>;
 


### PR DESCRIPTION
## Summary

- Picks up carina-rs/carina#1678, which added `read_data_source` to the WIT plugin interface + SDK trait + plugin host.
- Bumps `carina-core` / `carina-plugin-sdk` / `carina-provider-protocol` git deps and syncs the vendored `carina-plugin-wit/wit/provider.wit` copy.
- No code changes needed in `AwsccProcessProvider`: awscc has no data sources with user-supplied input attributes, so the SDK's default `read_data_source` impl (which falls through to `read(&id, None)` for zero-input cases) is sufficient.

## Why the vendored WIT sync is necessary

`wit_bindgen::generate!` inside `carina_plugin_sdk::export_provider!` reads the WIT at compile time from the relative path `../carina-plugin-wit/wit`, which resolves into this repo's vendored copy — not the upstream carina repo. Without the sync, the WASM build fails with:

\`\`\`
error[E0407]: method `read_data_source` is not a member of trait `exports::carina::provider::provider::Guest`
\`\`\`

because the newly bumped SDK's `export_provider!` macro expands a `read_data_source` Guest impl while the vendored WIT still declares the old interface shape.

## Test plan

- [x] `cargo update -p carina-core -p carina-plugin-sdk -p carina-provider-protocol`
- [x] `cargo build -p carina-provider-awscc`
- [x] `cargo test -p carina-provider-awscc` — 131 + 4 + 160 passed
- [x] `cargo clippy -p carina-provider-awscc --all-targets -- -D warnings`
- [x] `cargo fmt -p carina-provider-awscc -- --check`
- [x] `cargo build -p carina-provider-awscc --target wasm32-wasip2 --release`

Refs carina-rs/carina#1677

🤖 Generated with [Claude Code](https://claude.com/claude-code)