### PR TITLE
feat: generate to_dsl reverse mappings in enum alias table

### DIFF
--- a/carina-provider-awscc/scripts/generate-schemas.sh
+++ b/carina-provider-awscc/scripts/generate-schemas.sh
@@ -304,6 +304,33 @@ pub fn get_enum_alias_reverse(resource_type: &str, attr_name: &str, value: &str)
         .get(resource_type)
         .and_then(|f| f(attr_name, value))
 }
+
+/// Build a complete enum aliases map for all resource types.
+/// Returns: resource_type -> attr_name -> alias -> canonical_value.
+/// Used by CarinaProvider::enum_aliases() for the WASM host cache.
+pub fn build_enum_aliases_map() -> HashMap<String, HashMap<String, HashMap<String, String>>> {
+    let mut map: HashMap<String, HashMap<String, HashMap<String, String>>> = HashMap::new();
+EOF
+
+# Add enum_alias_entries calls dynamically
+for TYPE_NAME in "${RESOURCE_TYPES[@]}"; do
+    SVC=$(service_name "$TYPE_NAME")
+    RESOURCE=$(resource_module_name "$TYPE_NAME")
+    DSL_NAME=$("$CODEGEN_BIN" --type-name "$TYPE_NAME" --print-dsl-resource-name)
+    cat >> "$OUTPUT_DIR/mod.rs" << INNER_EOF
+    for (attr, alias, canonical) in ${SVC}::${RESOURCE}::enum_alias_entries() {
+        map.entry("${DSL_NAME}".to_string())
+            .or_default()
+            .entry(attr.to_string())
+            .or_default()
+            .insert(alias.to_string(), canonical.to_string());
+    }
+INNER_EOF
+done
+
+cat >> "$OUTPUT_DIR/mod.rs" << 'EOF'
+    map
+}
 EOF
 
 echo ""

--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -2160,42 +2160,83 @@ pub fn {}() -> AwsccSchemaConfig {{
         }
     ));
 
-    // Generate enum_alias_reverse() function that maps DSL alias -> canonical AWS value
+    // Generate enum_alias_reverse() and enum_alias_entries() functions.
+    // Both share the same alias data: (attr_name, alias, canonical).
     {
-        let mut match_arms: Vec<String> = Vec::new();
-        let mut seen_arms: HashSet<String> = HashSet::new();
-        for prop_name in enums.keys() {
-            // For composite keys "DefName.FieldName", use just "FieldName" for alias lookup
+        // Collect alias entries as (attr_name, alias, canonical) tuples.
+        let mut alias_entries: Vec<(String, String, String)> = Vec::new();
+        let mut seen: HashSet<(String, String)> = HashSet::new();
+        for (prop_name, enum_info) in &enums {
             let field_name = prop_name
                 .split('.')
                 .next_back()
                 .unwrap_or(prop_name.as_str());
+            let attr_name = field_name.to_snake_case();
+
+            // Add explicit aliases from known_enum_aliases()
             if let Some(prop_aliases) = aliases.get(field_name) {
-                let attr_name = field_name.to_snake_case();
                 for (canonical, alias) in prop_aliases {
-                    let arm = format!(
-                        "        (\"{}\", \"{}\") => Some(\"{}\")",
-                        attr_name, alias, canonical
-                    );
-                    if seen_arms.insert(arm.clone()) {
-                        match_arms.push(arm);
+                    if seen.insert((attr_name.clone(), alias.to_string())) {
+                        alias_entries.push((
+                            attr_name.clone(),
+                            alias.to_string(),
+                            canonical.to_string(),
+                        ));
+                    }
+                }
+            }
+
+            // Add to_dsl reverse mappings for values containing hyphens.
+            for value in &enum_info.values {
+                if value.contains('-') {
+                    let dsl_form = value.replace('-', "_");
+                    if dsl_form != *value && seen.insert((attr_name.clone(), dsl_form.clone())) {
+                        alias_entries.push((attr_name.clone(), dsl_form, value.clone()));
                     }
                 }
             }
         }
+
+        // enum_alias_reverse(): match-based lookup
         code.push_str(
             "\n/// Maps DSL alias values back to canonical AWS values for this module.\n\
              /// e.g., (\"ip_protocol\", \"all\") -> Some(\"-1\")\n\
              pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {\n",
         );
-        if match_arms.is_empty() {
+        if alias_entries.is_empty() {
             code.push_str("    let _ = (attr_name, value);\n    None\n");
         } else {
-            match_arms.push("        _ => None".to_string());
+            let match_arms: Vec<String> = alias_entries
+                .iter()
+                .map(|(attr, alias, canonical)| {
+                    format!(
+                        "        (\"{}\", \"{}\") => Some(\"{}\")",
+                        attr, alias, canonical
+                    )
+                })
+                .collect();
             code.push_str(&format!(
-                "    match (attr_name, value) {{\n{}\n    }}\n",
+                "    match (attr_name, value) {{\n{},\n        _ => None\n    }}\n",
                 match_arms.join(",\n")
             ));
+        }
+        code.push_str("}\n");
+
+        // enum_alias_entries(): static slice of all entries
+        code.push_str(
+            "\n/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.\n\
+             pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {\n",
+        );
+        if alias_entries.is_empty() {
+            code.push_str("    &[]\n");
+        } else {
+            let entry_strs: Vec<String> = alias_entries
+                .iter()
+                .map(|(attr, alias, canonical)| {
+                    format!("        (\"{}\", \"{}\", \"{}\")", attr, alias, canonical)
+                })
+                .collect();
+            code.push_str(&format!("    &[\n{}\n    ]\n", entry_strs.join(",\n")));
         }
         code.push_str("}\n");
     }

--- a/carina-provider-awscc/src/main.rs
+++ b/carina-provider-awscc/src/main.rs
@@ -136,6 +136,10 @@ impl CarinaProvider for AwsccProcessProvider {
         vec!["region".to_string()]
     }
 
+    fn enum_aliases(&self) -> HashMap<String, HashMap<String, HashMap<String, String>>> {
+        schemas::generated::build_enum_aliases_map()
+    }
+
     fn read(
         &self,
         id: &proto::ResourceId,

--- a/carina-provider-awscc/src/schemas/generated/ec2/egress_only_internet_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/egress_only_internet_gateway.rs
@@ -67,3 +67,8 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-awscc/src/schemas/generated/ec2/eip.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/eip.rs
@@ -107,3 +107,8 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-awscc/src/schemas/generated/ec2/flow_log.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/flow_log.rs
@@ -184,6 +184,25 @@ pub fn enum_valid_values() -> (
 /// Maps DSL alias values back to canonical AWS values for this module.
 /// e.g., ("ip_protocol", "all") -> Some("-1")
 pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
-    let _ = (attr_name, value);
-    None
+    match (attr_name, value) {
+        ("log_destination_type", "cloud_watch_logs") => Some("cloud-watch-logs"),
+        ("log_destination_type", "kinesis_data_firehose") => Some("kinesis-data-firehose"),
+        _ => None,
+    }
+}
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[
+        (
+            "log_destination_type",
+            "cloud_watch_logs",
+            "cloud-watch-logs",
+        ),
+        (
+            "log_destination_type",
+            "kinesis_data_firehose",
+            "kinesis-data-firehose",
+        ),
+    ]
 }

--- a/carina-provider-awscc/src/schemas/generated/ec2/internet_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/internet_gateway.rs
@@ -53,3 +53,8 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-awscc/src/schemas/generated/ec2/ipam.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/ipam.rs
@@ -200,6 +200,17 @@ pub fn enum_valid_values() -> (
 /// Maps DSL alias values back to canonical AWS values for this module.
 /// e.g., ("ip_protocol", "all") -> Some("-1")
 pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
-    let _ = (attr_name, value);
-    None
+    match (attr_name, value) {
+        ("metered_account", "ipam_owner") => Some("ipam-owner"),
+        ("metered_account", "resource_owner") => Some("resource-owner"),
+        _ => None,
+    }
+}
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[
+        ("metered_account", "ipam_owner", "ipam-owner"),
+        ("metered_account", "resource_owner", "resource-owner"),
+    ]
 }

--- a/carina-provider-awscc/src/schemas/generated/ec2/ipam_pool.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/ipam_pool.rs
@@ -247,6 +247,27 @@ pub fn enum_valid_values() -> (
 /// Maps DSL alias values back to canonical AWS values for this module.
 /// e.g., ("ip_protocol", "all") -> Some("-1")
 pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
-    let _ = (attr_name, value);
-    None
+    match (attr_name, value) {
+        ("aws_service", "global_services") => Some("global-services"),
+        ("state", "create_in_progress") => Some("create-in-progress"),
+        ("state", "create_complete") => Some("create-complete"),
+        ("state", "modify_in_progress") => Some("modify-in-progress"),
+        ("state", "modify_complete") => Some("modify-complete"),
+        ("state", "delete_in_progress") => Some("delete-in-progress"),
+        ("state", "delete_complete") => Some("delete-complete"),
+        _ => None,
+    }
+}
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[
+        ("aws_service", "global_services", "global-services"),
+        ("state", "create_in_progress", "create-in-progress"),
+        ("state", "create_complete", "create-complete"),
+        ("state", "modify_in_progress", "modify-in-progress"),
+        ("state", "modify_complete", "modify-complete"),
+        ("state", "delete_in_progress", "delete-in-progress"),
+        ("state", "delete_complete", "delete-complete"),
+    ]
 }

--- a/carina-provider-awscc/src/schemas/generated/ec2/nat_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/nat_gateway.rs
@@ -193,3 +193,8 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-awscc/src/schemas/generated/ec2/route.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/route.rs
@@ -118,3 +118,8 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-awscc/src/schemas/generated/ec2/route_table.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/route_table.rs
@@ -59,3 +59,8 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-awscc/src/schemas/generated/ec2/security_group.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/security_group.rs
@@ -183,6 +183,12 @@ pub fn enum_valid_values() -> (
 pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
     match (attr_name, value) {
         ("ip_protocol", "all") => Some("-1"),
+        ("ip_protocol", "_1") => Some("-1"),
         _ => None,
     }
+}
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[("ip_protocol", "all", "-1"), ("ip_protocol", "_1", "-1")]
 }

--- a/carina-provider-awscc/src/schemas/generated/ec2/security_group_egress.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/security_group_egress.rs
@@ -139,6 +139,12 @@ pub fn enum_valid_values() -> (
 pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
     match (attr_name, value) {
         ("ip_protocol", "all") => Some("-1"),
+        ("ip_protocol", "_1") => Some("-1"),
         _ => None,
     }
+}
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[("ip_protocol", "all", "-1"), ("ip_protocol", "_1", "-1")]
 }

--- a/carina-provider-awscc/src/schemas/generated/ec2/security_group_ingress.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/security_group_ingress.rs
@@ -156,6 +156,12 @@ pub fn enum_valid_values() -> (
 pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
     match (attr_name, value) {
         ("ip_protocol", "all") => Some("-1"),
+        ("ip_protocol", "_1") => Some("-1"),
         _ => None,
     }
+}
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[("ip_protocol", "all", "-1"), ("ip_protocol", "_1", "-1")]
 }

--- a/carina-provider-awscc/src/schemas/generated/ec2/subnet.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/subnet.rs
@@ -225,3 +225,8 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-awscc/src/schemas/generated/ec2/subnet_route_table_association.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/subnet_route_table_association.rs
@@ -52,3 +52,8 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-awscc/src/schemas/generated/ec2/transit_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/transit_gateway.rs
@@ -268,3 +268,8 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-awscc/src/schemas/generated/ec2/transit_gateway_attachment.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/transit_gateway_attachment.rs
@@ -108,3 +108,8 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-awscc/src/schemas/generated/ec2/vpc.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/vpc.rs
@@ -140,3 +140,8 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-awscc/src/schemas/generated/ec2/vpc_endpoint.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/vpc_endpoint.rs
@@ -259,6 +259,19 @@ pub fn enum_valid_values() -> (
 /// Maps DSL alias values back to canonical AWS values for this module.
 /// e.g., ("ip_protocol", "all") -> Some("-1")
 pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
-    let _ = (attr_name, value);
-    None
+    match (attr_name, value) {
+        ("dns_record_ip_type", "service_defined") => Some("service-defined"),
+        ("dns_record_ip_type", "not_specified") => Some("not-specified"),
+        ("ip_address_type", "not_specified") => Some("not-specified"),
+        _ => None,
+    }
+}
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[
+        ("dns_record_ip_type", "service_defined", "service-defined"),
+        ("dns_record_ip_type", "not_specified", "not-specified"),
+        ("ip_address_type", "not_specified", "not-specified"),
+    ]
 }

--- a/carina-provider-awscc/src/schemas/generated/ec2/vpc_gateway_attachment.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/vpc_gateway_attachment.rs
@@ -70,3 +70,8 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-awscc/src/schemas/generated/ec2/vpc_peering_connection.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/vpc_peering_connection.rs
@@ -90,3 +90,8 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-awscc/src/schemas/generated/ec2/vpn_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/vpn_gateway.rs
@@ -91,3 +91,8 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-awscc/src/schemas/generated/iam/role.rs
+++ b/carina-provider-awscc/src/schemas/generated/iam/role.rs
@@ -129,3 +129,8 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-awscc/src/schemas/generated/identitystore/group.rs
+++ b/carina-provider-awscc/src/schemas/generated/identitystore/group.rs
@@ -147,3 +147,8 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-awscc/src/schemas/generated/identitystore/group_membership.rs
+++ b/carina-provider-awscc/src/schemas/generated/identitystore/group_membership.rs
@@ -148,3 +148,8 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-awscc/src/schemas/generated/logs/log_group.rs
+++ b/carina-provider-awscc/src/schemas/generated/logs/log_group.rs
@@ -165,3 +165,8 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-awscc/src/schemas/generated/mod.rs
+++ b/carina-provider-awscc/src/schemas/generated/mod.rs
@@ -239,3 +239,228 @@ pub fn get_enum_alias_reverse(
         .get(resource_type)
         .and_then(|f| f(attr_name, value))
 }
+
+/// Build a complete enum aliases map for all resource types.
+/// Returns: resource_type -> attr_name -> alias -> canonical_value.
+/// Used by CarinaProvider::enum_aliases() for the WASM host cache.
+pub fn build_enum_aliases_map() -> HashMap<String, HashMap<String, HashMap<String, String>>> {
+    let mut map: HashMap<String, HashMap<String, HashMap<String, String>>> = HashMap::new();
+    for (attr, alias, canonical) in ec2::vpc::enum_alias_entries() {
+        map.entry("ec2.vpc".to_string())
+            .or_default()
+            .entry(attr.to_string())
+            .or_default()
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in ec2::subnet::enum_alias_entries() {
+        map.entry("ec2.subnet".to_string())
+            .or_default()
+            .entry(attr.to_string())
+            .or_default()
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in ec2::internet_gateway::enum_alias_entries() {
+        map.entry("ec2.internet_gateway".to_string())
+            .or_default()
+            .entry(attr.to_string())
+            .or_default()
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in ec2::route_table::enum_alias_entries() {
+        map.entry("ec2.route_table".to_string())
+            .or_default()
+            .entry(attr.to_string())
+            .or_default()
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in ec2::route::enum_alias_entries() {
+        map.entry("ec2.route".to_string())
+            .or_default()
+            .entry(attr.to_string())
+            .or_default()
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in ec2::subnet_route_table_association::enum_alias_entries() {
+        map.entry("ec2.subnet_route_table_association".to_string())
+            .or_default()
+            .entry(attr.to_string())
+            .or_default()
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in ec2::eip::enum_alias_entries() {
+        map.entry("ec2.eip".to_string())
+            .or_default()
+            .entry(attr.to_string())
+            .or_default()
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in ec2::nat_gateway::enum_alias_entries() {
+        map.entry("ec2.nat_gateway".to_string())
+            .or_default()
+            .entry(attr.to_string())
+            .or_default()
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in ec2::security_group::enum_alias_entries() {
+        map.entry("ec2.security_group".to_string())
+            .or_default()
+            .entry(attr.to_string())
+            .or_default()
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in ec2::security_group_ingress::enum_alias_entries() {
+        map.entry("ec2.security_group_ingress".to_string())
+            .or_default()
+            .entry(attr.to_string())
+            .or_default()
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in ec2::security_group_egress::enum_alias_entries() {
+        map.entry("ec2.security_group_egress".to_string())
+            .or_default()
+            .entry(attr.to_string())
+            .or_default()
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in ec2::vpc_endpoint::enum_alias_entries() {
+        map.entry("ec2.vpc_endpoint".to_string())
+            .or_default()
+            .entry(attr.to_string())
+            .or_default()
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in ec2::vpc_gateway_attachment::enum_alias_entries() {
+        map.entry("ec2.vpc_gateway_attachment".to_string())
+            .or_default()
+            .entry(attr.to_string())
+            .or_default()
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in ec2::flow_log::enum_alias_entries() {
+        map.entry("ec2.flow_log".to_string())
+            .or_default()
+            .entry(attr.to_string())
+            .or_default()
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in ec2::ipam::enum_alias_entries() {
+        map.entry("ec2.ipam".to_string())
+            .or_default()
+            .entry(attr.to_string())
+            .or_default()
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in ec2::ipam_pool::enum_alias_entries() {
+        map.entry("ec2.ipam_pool".to_string())
+            .or_default()
+            .entry(attr.to_string())
+            .or_default()
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in ec2::vpn_gateway::enum_alias_entries() {
+        map.entry("ec2.vpn_gateway".to_string())
+            .or_default()
+            .entry(attr.to_string())
+            .or_default()
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in ec2::transit_gateway::enum_alias_entries() {
+        map.entry("ec2.transit_gateway".to_string())
+            .or_default()
+            .entry(attr.to_string())
+            .or_default()
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in ec2::vpc_peering_connection::enum_alias_entries() {
+        map.entry("ec2.vpc_peering_connection".to_string())
+            .or_default()
+            .entry(attr.to_string())
+            .or_default()
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in ec2::egress_only_internet_gateway::enum_alias_entries() {
+        map.entry("ec2.egress_only_internet_gateway".to_string())
+            .or_default()
+            .entry(attr.to_string())
+            .or_default()
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in ec2::transit_gateway_attachment::enum_alias_entries() {
+        map.entry("ec2.transit_gateway_attachment".to_string())
+            .or_default()
+            .entry(attr.to_string())
+            .or_default()
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in s3::bucket::enum_alias_entries() {
+        map.entry("s3.bucket".to_string())
+            .or_default()
+            .entry(attr.to_string())
+            .or_default()
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in iam::role::enum_alias_entries() {
+        map.entry("iam.role".to_string())
+            .or_default()
+            .entry(attr.to_string())
+            .or_default()
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in logs::log_group::enum_alias_entries() {
+        map.entry("logs.log_group".to_string())
+            .or_default()
+            .entry(attr.to_string())
+            .or_default()
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in organizations::organization::enum_alias_entries() {
+        map.entry("organizations.organization".to_string())
+            .or_default()
+            .entry(attr.to_string())
+            .or_default()
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in organizations::account::enum_alias_entries() {
+        map.entry("organizations.account".to_string())
+            .or_default()
+            .entry(attr.to_string())
+            .or_default()
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in sso::instance::enum_alias_entries() {
+        map.entry("sso.instance".to_string())
+            .or_default()
+            .entry(attr.to_string())
+            .or_default()
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in sso::permission_set::enum_alias_entries() {
+        map.entry("sso.permission_set".to_string())
+            .or_default()
+            .entry(attr.to_string())
+            .or_default()
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in sso::assignment::enum_alias_entries() {
+        map.entry("sso.assignment".to_string())
+            .or_default()
+            .entry(attr.to_string())
+            .or_default()
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in identitystore::group::enum_alias_entries() {
+        map.entry("identitystore.group".to_string())
+            .or_default()
+            .entry(attr.to_string())
+            .or_default()
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in identitystore::group_membership::enum_alias_entries() {
+        map.entry("identitystore.group_membership".to_string())
+            .or_default()
+            .entry(attr.to_string())
+            .or_default()
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    map
+}

--- a/carina-provider-awscc/src/schemas/generated/organizations/account.rs
+++ b/carina-provider-awscc/src/schemas/generated/organizations/account.rs
@@ -288,3 +288,8 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-awscc/src/schemas/generated/organizations/organization.rs
+++ b/carina-provider-awscc/src/schemas/generated/organizations/organization.rs
@@ -167,3 +167,8 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-awscc/src/schemas/generated/s3/bucket.rs
+++ b/carina-provider-awscc/src/schemas/generated/s3/bucket.rs
@@ -1322,6 +1322,17 @@ pub fn enum_valid_values() -> (
 /// Maps DSL alias values back to canonical AWS values for this module.
 /// e.g., ("ip_protocol", "all") -> Some("-1")
 pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
-    let _ = (attr_name, value);
-    None
+    match (attr_name, value) {
+        ("encryption_type", "SSE_C") => Some("SSE-C"),
+        ("bucket_namespace", "account_regional") => Some("account-regional"),
+        _ => None,
+    }
+}
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[
+        ("encryption_type", "SSE_C", "SSE-C"),
+        ("bucket_namespace", "account_regional", "account-regional"),
+    ]
 }

--- a/carina-provider-awscc/src/schemas/generated/sso/assignment.rs
+++ b/carina-provider-awscc/src/schemas/generated/sso/assignment.rs
@@ -157,3 +157,8 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-awscc/src/schemas/generated/sso/instance.rs
+++ b/carina-provider-awscc/src/schemas/generated/sso/instance.rs
@@ -189,3 +189,8 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-awscc/src/schemas/generated/sso/permission_set.rs
+++ b/carina-provider-awscc/src/schemas/generated/sso/permission_set.rs
@@ -346,3 +346,8 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     let _ = (attr_name, value);
     None
 }
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}


### PR DESCRIPTION
Closes #92

## Summary

- Extend codegen to generate reverse alias entries for enum values containing hyphens (e.g., `cloud-watch-logs` → alias `cloud_watch_logs → cloud-watch-logs`)
- Add `enum_alias_entries()` function to each generated module, returning all (attr, alias, canonical) tuples
- Add `build_enum_aliases_map()` to generated `mod.rs` for building the full aliases HashMap
- Implement `CarinaProvider::enum_aliases()` to populate the WASM host's alias cache

This is Phase 2 of the carina-rs/carina#1675 fix. Phase 1 (carina-rs/carina#1691) removed the incorrect `replace('_', '-')` from `convert_enum_value`. This PR provides the schema-aware reverse mappings so that `resolve_value_alias` can canonicalize enum values (e.g., `ap_northeast_1 → ap-northeast-1`) before they reach the display layer.

## Test plan

- [x] `cargo test` — 160 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] Schema regeneration with `generate-schemas.sh --refresh-cache` succeeds
- [x] Generated `enum_alias_entries` verified for flow_log, security_group

🤖 Generated with [Claude Code](https://claude.com/claude-code)