### PR TITLE
Add AWS::IAM::OIDCProvider resource

### DIFF
--- a/carina-provider-awscc/scripts/generate-schemas.sh
+++ b/carina-provider-awscc/scripts/generate-schemas.sh
@@ -52,6 +52,7 @@ RESOURCE_TYPES=(
     "AWS::EC2::TransitGatewayAttachment"
     "AWS::S3::Bucket"
     "AWS::IAM::Role"
+    "AWS::IAM::OIDCProvider"
     "AWS::Logs::LogGroup"
     "AWS::Organizations::Organization"
     "AWS::Organizations::Account"

--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -1322,22 +1322,35 @@ fn generate_schema_code(schema: &CfnSchema, type_name: &str) -> Result<String> {
         if attr_type.contains("validate_") && attr_type.contains("_pattern") {
             // Pattern can come from the property directly, from a $ref definition,
             // or from array items (e.g., type: array, items: { pattern: ... })
-            let pattern = prop
+            // Track which source provided the pattern so we use the correct length constraints.
+            let pattern_source: Option<(String, Option<u64>, Option<u64>)> = prop
                 .pattern
-                .clone()
+                .as_ref()
+                .map(|p| (p.clone(), prop.min_length, prop.max_length))
                 .or_else(|| {
                     prop.ref_path
                         .as_ref()
                         .and_then(|ref_path| resolve_ref(schema, ref_path))
-                        .and_then(|def| def.pattern.clone())
+                        .and_then(|def| {
+                            def.pattern
+                                .as_ref()
+                                .map(|p| (p.clone(), def.min_length, def.max_length))
+                        })
                 })
-                .or_else(|| prop.items.as_ref().and_then(|items| items.pattern.clone()));
-            if let Some(pattern) = pattern {
+                .or_else(|| {
+                    prop.items.as_ref().and_then(|items| {
+                        items
+                            .pattern
+                            .as_ref()
+                            .map(|p| (p.clone(), items.min_length, items.max_length))
+                    })
+                });
+            if let Some((pattern, min_length, max_length)) = pattern_source {
                 // Check if this pattern also has length constraints
-                let effective_min = prop.min_length.filter(|&m| m > 0);
-                let has_length = effective_min.is_some() || prop.max_length.is_some();
+                let effective_min = min_length.filter(|&m| m > 0);
+                let has_length = effective_min.is_some() || max_length.is_some();
                 if has_length {
-                    pattern_with_lengths.insert((pattern.clone(), effective_min, prop.max_length));
+                    pattern_with_lengths.insert((pattern.clone(), effective_min, max_length));
                 } else {
                     patterns_used_standalone.insert(pattern.clone());
                 }
@@ -9059,6 +9072,61 @@ mod tests {
         assert!(
             type_str.contains("len:"),
             "Should have length constraint: {type_str}"
+        );
+    }
+
+    #[test]
+    fn test_array_items_pattern_with_length_generates_combined_validator() {
+        // When an array property has items with both pattern and length constraints,
+        // the generated code must emit a combined pattern+length validator function.
+        // Regression test: previously the codegen used the array container's (empty)
+        // length constraints instead of the items' constraints.
+        let schema = CfnSchema {
+            type_name: "AWS::Test::ArrayPattern".to_string(),
+            description: None,
+            properties: {
+                let mut props = BTreeMap::new();
+                props.insert(
+                    "ThumbprintList".to_string(),
+                    CfnProperty {
+                        prop_type: Some(TypeValue::Single("array".to_string())),
+                        items: Some(Box::new(CfnProperty {
+                            prop_type: Some(TypeValue::Single("string".to_string())),
+                            pattern: Some("[0-9A-Fa-f]{40}".to_string()),
+                            min_length: Some(40),
+                            max_length: Some(40),
+                            ..CfnProperty::default()
+                        })),
+                        max_items: Some(5),
+                        ..CfnProperty::default()
+                    },
+                );
+                props
+            },
+            required: vec![],
+            read_only_properties: vec![],
+            create_only_properties: vec![],
+            write_only_properties: vec![],
+            primary_identifier: None,
+            definitions: None,
+            tagging: None,
+            one_of: vec![],
+            any_of: vec![],
+        };
+
+        let code = generate_schema_code(&schema, "AWS::Test::ArrayPattern")
+            .expect("codegen should succeed");
+
+        // The combined validator function must be defined
+        assert!(
+            code.contains("fn validate_string_pattern_") && code.contains("_len_40_40"),
+            "Should generate combined pattern+length validator function, got:\n{code}"
+        );
+
+        // The validator should check both pattern and length
+        assert!(
+            code.contains("[0-9A-Fa-f]{40}") && code.contains("40..=40"),
+            "Validator should check both pattern and length range"
         );
     }
 

--- a/carina-provider-awscc/src/resources.rs
+++ b/carina-provider-awscc/src/resources.rs
@@ -122,6 +122,14 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_iam_oidc_provider_config() {
+        let config =
+            get_config("iam.oidc_provider").expect("iam.oidc_provider config should exist");
+        assert_eq!(config.aws_type_name, "AWS::IAM::OIDCProvider");
+        assert!(config.has_tags, "OIDCProvider should support tags");
+    }
+
     /// VPCGatewayAttachment requires exactly one of internet_gateway_id or vpn_gateway_id.
     /// Specifying both should be rejected by the schema validator.
     /// See: https://github.com/carina-rs/carina/issues/925

--- a/carina-provider-awscc/src/schemas/generated/iam/mod.rs
+++ b/carina-provider-awscc/src/schemas/generated/iam/mod.rs
@@ -6,4 +6,5 @@
 // Re-export parent types so resource modules can use `super::` to access them.
 pub use super::*;
 
+pub mod oidc_provider;
 pub mod role;

--- a/carina-provider-awscc/src/schemas/generated/iam/oidc_provider.rs
+++ b/carina-provider-awscc/src/schemas/generated/iam/oidc_provider.rs
@@ -1,0 +1,156 @@
+//! oidc_provider schema definition for AWS Cloud Control
+//!
+//! Auto-generated from CloudFormation schema: AWS::IAM::OIDCProvider
+//!
+//! DO NOT EDIT MANUALLY - regenerate with carina-codegen
+
+use super::AwsccSchemaConfig;
+use super::tags_type;
+use super::validate_tags_map;
+use carina_core::resource::Value;
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+use regex::Regex;
+
+#[allow(dead_code)]
+fn validate_list_items_max_5(value: &Value) -> Result<(), String> {
+    if let Value::List(items) = value {
+        let len = items.len();
+        if len > 5 {
+            Err(format!("List has {} items, expected ..=5", len))
+        } else {
+            Ok(())
+        }
+    } else {
+        Err("Expected list".to_string())
+    }
+}
+
+fn validate_string_length_1_255(value: &Value) -> Result<(), String> {
+    if let Value::String(s) = value {
+        let len = s.chars().count();
+        if !(1..=255).contains(&len) {
+            Err(format!("String length {} is out of range 1..=255", len))
+        } else {
+            Ok(())
+        }
+    } else {
+        Ok(())
+    }
+}
+
+#[allow(dead_code)]
+fn validate_string_pattern_57ee0c44b504b839_len_40_40(value: &Value) -> Result<(), String> {
+    if let Value::String(s) = value {
+        static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+            Regex::new("[0-9A-Fa-f]{40}").expect("invalid pattern regex")
+        });
+        if !RE.is_match(s) {
+            return Err(format!(
+                "Value '{}' does not match pattern [0-9A-Fa-f]{{40}}",
+                s
+            ));
+        }
+        let len = s.chars().count();
+        if !(40..=40).contains(&len) {
+            return Err(format!("String length {} is out of range 40..=40", len));
+        }
+        Ok(())
+    } else {
+        Err("Expected string".to_string())
+    }
+}
+
+/// Returns the schema config for iam_oidc_provider (AWS::IAM::OIDCProvider)
+pub fn iam_oidc_provider_config() -> AwsccSchemaConfig {
+    AwsccSchemaConfig {
+        aws_type_name: "AWS::IAM::OIDCProvider",
+        resource_type_name: "iam.oidc_provider",
+        has_tags: true,
+        schema: ResourceSchema::new("awscc.iam.oidc_provider")
+            .with_description("Resource Type definition for AWS::IAM::OIDCProvider")
+            .attribute(
+                AttributeSchema::new("arn", super::arn())
+                    .read_only()
+                    .with_description("Amazon Resource Name (ARN) of the OIDC provider (read-only)")
+                    .with_provider_name("Arn"),
+            )
+            .attribute(
+                AttributeSchema::new(
+                    "client_id_list",
+                    AttributeType::unordered_list(AttributeType::Custom {
+                        name: "String(len: 1..=255)".to_string(),
+                        base: Box::new(AttributeType::String),
+                        validate: validate_string_length_1_255,
+                        namespace: None,
+                        to_dsl: None,
+                    }),
+                )
+                .with_provider_name("ClientIdList"),
+            )
+            .attribute(AttributeSchema::new("tags", tags_type()).with_provider_name("Tags"))
+            .attribute(
+                AttributeSchema::new(
+                    "thumbprint_list",
+                    AttributeType::Custom {
+                        name: "List(..=5)".to_string(),
+                        base: Box::new(AttributeType::unordered_list(AttributeType::Custom {
+                            name: "String(pattern, len: 40..=40)".to_string(),
+                            base: Box::new(AttributeType::String),
+                            validate: validate_string_pattern_57ee0c44b504b839_len_40_40,
+                            namespace: None,
+                            to_dsl: None,
+                        })),
+                        validate: validate_list_items_max_5,
+                        namespace: None,
+                        to_dsl: None,
+                    },
+                )
+                .with_provider_name("ThumbprintList"),
+            )
+            .attribute(
+                AttributeSchema::new(
+                    "url",
+                    AttributeType::Custom {
+                        name: "String(len: 1..=255)".to_string(),
+                        base: Box::new(AttributeType::String),
+                        validate: validate_string_length_1_255,
+                        namespace: None,
+                        to_dsl: None,
+                    },
+                )
+                .create_only()
+                .with_provider_name("Url"),
+            )
+            .with_validator(|attrs| {
+                let mut errors = Vec::new();
+                if let Err(mut e) = validate_tags_map(attrs) {
+                    errors.append(&mut e);
+                }
+                if errors.is_empty() {
+                    Ok(())
+                } else {
+                    Err(errors)
+                }
+            }),
+    }
+}
+
+/// Returns the resource type name and all enum valid values for this module
+pub fn enum_valid_values() -> (
+    &'static str,
+    &'static [(&'static str, &'static [&'static str])],
+) {
+    ("iam.oidc_provider", &[])
+}
+
+/// Maps DSL alias values back to canonical AWS values for this module.
+/// e.g., ("ip_protocol", "all") -> Some("-1")
+pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
+    let _ = (attr_name, value);
+    None
+}
+
+/// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
+pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
+    &[]
+}

--- a/carina-provider-awscc/src/schemas/generated/mod.rs
+++ b/carina-provider-awscc/src/schemas/generated/mod.rs
@@ -59,6 +59,7 @@ static ENUM_VALID_VALUES: LazyLock<
         ec2::transit_gateway_attachment::enum_valid_values(),
         s3::bucket::enum_valid_values(),
         iam::role::enum_valid_values(),
+        iam::oidc_provider::enum_valid_values(),
         logs::log_group::enum_valid_values(),
         organizations::organization::enum_valid_values(),
         organizations::account::enum_valid_values(),
@@ -138,6 +139,7 @@ static ENUM_ALIAS_DISPATCH: LazyLock<HashMap<&'static str, EnumAliasReverseFn>> 
             ),
             ("s3.bucket", s3::bucket::enum_alias_reverse),
             ("iam.role", iam::role::enum_alias_reverse),
+            ("iam.oidc_provider", iam::oidc_provider::enum_alias_reverse),
             ("logs.log_group", logs::log_group::enum_alias_reverse),
             (
                 "organizations.organization",
@@ -191,6 +193,7 @@ fn build_configs() -> Vec<AwsccSchemaConfig> {
         ec2::transit_gateway_attachment::ec2_transit_gateway_attachment_config(),
         s3::bucket::s3_bucket_config(),
         iam::role::iam_role_config(),
+        iam::oidc_provider::iam_oidc_provider_config(),
         logs::log_group::logs_log_group_config(),
         organizations::organization::organizations_organization_config(),
         organizations::account::organizations_account_config(),
@@ -401,6 +404,13 @@ pub fn build_enum_aliases_map() -> HashMap<String, HashMap<String, HashMap<Strin
     }
     for (attr, alias, canonical) in iam::role::enum_alias_entries() {
         map.entry("iam.role".to_string())
+            .or_default()
+            .entry(attr.to_string())
+            .or_default()
+            .insert(alias.to_string(), canonical.to_string());
+    }
+    for (attr, alias, canonical) in iam::oidc_provider::enum_alias_entries() {
+        map.entry("iam.oidc_provider".to_string())
             .or_default()
             .entry(attr.to_string())
             .or_default()


### PR DESCRIPTION
Closes #97

## Summary

- Add `awscc.iam.oidc_provider` resource to enable managing IAM OIDC Providers for GitHub Actions (and other OIDC-based) authentication
- Fix a codegen bug where array items with both `pattern` and `minLength`/`maxLength` constraints would generate a reference to a combined validator function that was never emitted
- Add regression test for the codegen bug

## Changes

- `scripts/generate-schemas.sh`: Add `AWS::IAM::OIDCProvider` to `RESOURCE_TYPES`
- `src/bin/codegen.rs`: Fix pattern+length constraint collection to use the correct source's length constraints (items, not the parent array property)
- `src/bin/codegen.rs`: Add `test_array_items_pattern_with_length_generates_combined_validator` regression test
- `src/resources.rs`: Add `test_iam_oidc_provider_config` unit test
- Generated files: `iam/oidc_provider.rs`, `iam/mod.rs`, `generated/mod.rs`

## Test plan

- [x] `cargo test` — 293 tests pass (161 codegen + 132 lib)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)