### PR TITLE
feat: serialize Custom types through WASM protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#a1895114ff0dc035bbe14a4b137e159e99c7613c"
+source = "git+https://github.com/carina-rs/carina#ba5e2eeaaee9a6d162542476aca668fdc03ba076"
 dependencies = [
  "argon2",
  "futures",
@@ -531,7 +531,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#a1895114ff0dc035bbe14a4b137e159e99c7613c"
+source = "git+https://github.com/carina-rs/carina#ba5e2eeaaee9a6d162542476aca668fdc03ba076"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#a1895114ff0dc035bbe14a4b137e159e99c7613c"
+source = "git+https://github.com/carina-rs/carina#ba5e2eeaaee9a6d162542476aca668fdc03ba076"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-provider-awscc/src/convert.rs
+++ b/carina-provider-awscc/src/convert.rs
@@ -176,6 +176,17 @@ fn proto_to_core_attribute_type(t: &ProtoAttributeType) -> CoreAttributeType {
         ProtoAttributeType::Union { members } => {
             CoreAttributeType::Union(members.iter().map(proto_to_core_attribute_type).collect())
         }
+        ProtoAttributeType::Custom {
+            name,
+            base,
+            namespace,
+        } => CoreAttributeType::Custom {
+            name: name.clone(),
+            base: Box::new(proto_to_core_attribute_type(base)),
+            validate: |_| Ok(()),
+            namespace: namespace.clone(),
+            to_dsl: None,
+        },
     }
 }
 
@@ -258,8 +269,16 @@ fn core_to_proto_attribute_type(t: &CoreAttributeType) -> ProtoAttributeType {
             name: name.clone(),
             fields: fields.iter().map(core_to_proto_struct_field).collect(),
         },
-        // Custom -> base type: function pointers can't cross process boundary
-        CoreAttributeType::Custom { base, .. } => core_to_proto_attribute_type(base),
+        CoreAttributeType::Custom {
+            name,
+            base,
+            namespace,
+            ..
+        } => ProtoAttributeType::Custom {
+            name: name.clone(),
+            base: Box::new(core_to_proto_attribute_type(base)),
+            namespace: namespace.clone(),
+        },
         CoreAttributeType::Union(members) => ProtoAttributeType::Union {
             members: members.iter().map(core_to_proto_attribute_type).collect(),
         },

--- a/carina-provider-awscc/src/provider/conversion.rs
+++ b/carina-provider-awscc/src/provider/conversion.rs
@@ -185,7 +185,14 @@ pub(crate) fn dsl_value_to_aws(
                     let raw_extracted = extract_enum_value_with_values(s, &valid);
                     canonicalize_enum_value(raw_extracted, &valid)
                 } else {
-                    convert_enum_value(s)
+                    let extracted = convert_enum_value(s);
+                    // Custom types with namespace (e.g., Region) use underscores in DSL
+                    // but hyphens in AWS. Convert back.
+                    if attr_type.namespaced_enum_parts().is_some() {
+                        extracted.replace('_', "-")
+                    } else {
+                        extracted.to_string()
+                    }
                 };
                 // Apply alias reverse mapping (e.g., "all" -> "-1")
                 let resolved = match get_enum_alias_reverse(resource_type, attr_name, &raw) {


### PR DESCRIPTION
Closes #99

- core_to_proto_attribute_type: Custom → ProtoAttributeType::Custom (was: stripped to base)
- proto_to_core_attribute_type: handle new Custom variant
- Fix convert_enum_value &str return type
- Fix Region underscore→hyphen conversion for namespaced custom types

🤖 Generated with [Claude Code](https://claude.com/claude-code)