### PR TITLE
fix: improve validate_service_arn resource prefix error message

### DIFF
--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -801,8 +801,8 @@ pub fn validate_service_arn(
         && !parts[5].starts_with(prefix)
     {
         return Err(format!(
-            "ARN resource segment must begin with '{}', but got '{}' in '{}'",
-            prefix, parts[5], arn
+            "expected resource starting with '{}', got '{}'",
+            prefix, parts[5]
         ));
     }
     Ok(())
@@ -816,23 +816,36 @@ pub fn validate_service_arn(
 /// - Resource name after `resource_prefix` must be non-empty and contain only
 ///   valid IAM path/name characters
 pub fn validate_iam_arn(arn: &str, resource_prefix: &str) -> Result<(), String> {
-    validate_service_arn(arn, "iam", Some(resource_prefix))?;
+    validate_arn(arn)?;
     let parts: Vec<&str> = arn.splitn(6, ':').collect();
+    if parts[2] != "iam" {
+        return Err(format!(
+            "expected IAM ARN but service is '{}' in '{arn}'",
+            parts[2]
+        ));
+    }
     if !parts[3].is_empty() {
-        return Err(format!("IAM ARN region must be empty, got '{}'", parts[3]));
+        return Err(format!(
+            "IAM ARN region must be empty, got '{}' in '{arn}'",
+            parts[3]
+        ));
     }
     let account = parts[4];
     if account != "aws" && (account.len() != 12 || !account.chars().all(|c| c.is_ascii_digit())) {
         return Err(format!(
-            "IAM ARN account must be 'aws' or a 12-digit ID, got '{}'",
-            account
+            "IAM ARN account must be 'aws' or a 12-digit ID, got '{account}' in '{arn}'"
+        ));
+    }
+    if !parts[5].starts_with(resource_prefix) {
+        return Err(format!(
+            "IAM ARN resource must begin with '{resource_prefix}', but got '{}' in '{arn}'",
+            parts[5]
         ));
     }
     let resource_name = &parts[5][resource_prefix.len()..];
     if resource_name.is_empty() {
         return Err(format!(
-            "resource name after '{}' must not be empty",
-            resource_prefix
+            "IAM ARN resource name after '{resource_prefix}' must not be empty in '{arn}'"
         ));
     }
     // IAM names/paths allow: alphanumeric, plus +, =, ,, ., @, -, _, /
@@ -841,8 +854,7 @@ pub fn validate_iam_arn(arn: &str, resource_prefix: &str) -> Result<(), String> 
         .all(|c| c.is_ascii_alphanumeric() || "+=,.@-_/".contains(c))
     {
         return Err(format!(
-            "resource name contains invalid characters: '{}'",
-            resource_name
+            "IAM ARN resource name contains invalid characters: '{resource_name}' in '{arn}'"
         ));
     }
     Ok(())
@@ -1690,9 +1702,10 @@ mod tests {
     #[test]
     fn validate_iam_arn_error_message_is_descriptive() {
         let err = validate_iam_arn("arn:aws:iam:us-east-1:aws:policy/Foo", "policy/").unwrap_err();
+        assert!(err.contains("IAM ARN"), "Error should say 'IAM ARN': {err}");
         assert!(
-            err.contains("region must be empty"),
-            "Error should describe the problem: {err}"
+            err.contains("arn:aws:iam:us-east-1:aws:policy/Foo"),
+            "Error should include full ARN: {err}"
         );
     }
 

--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -801,8 +801,8 @@ pub fn validate_service_arn(
         && !parts[5].starts_with(prefix)
     {
         return Err(format!(
-            "expected resource starting with '{}', got '{}'",
-            prefix, parts[5]
+            "ARN resource segment must begin with '{}', but got '{}' in '{}'",
+            prefix, parts[5], arn
         ));
     }
     Ok(())

--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -816,36 +816,47 @@ pub fn validate_service_arn(
 /// - Resource name after `resource_prefix` must be non-empty and contain only
 ///   valid IAM path/name characters
 pub fn validate_iam_arn(arn: &str, resource_prefix: &str) -> Result<(), String> {
+    // Derive type label from prefix: "policy/" -> "IAM Policy ARN", "role/" -> "IAM Role ARN"
+    let resource_type = resource_prefix.trim_end_matches('/');
+    let label = format!(
+        "IAM {} ARN",
+        resource_type
+            .chars()
+            .next()
+            .map(|c| c.to_uppercase().to_string() + &resource_type[1..])
+            .unwrap_or_default()
+    );
+
     validate_arn(arn)?;
     let parts: Vec<&str> = arn.splitn(6, ':').collect();
     if parts[2] != "iam" {
         return Err(format!(
-            "expected IAM ARN but service is '{}' in '{arn}'",
+            "expected {label} but service is '{}' in '{arn}'",
             parts[2]
         ));
     }
     if !parts[3].is_empty() {
         return Err(format!(
-            "IAM ARN region must be empty, got '{}' in '{arn}'",
+            "{label} region must be empty, got '{}' in '{arn}'",
             parts[3]
         ));
     }
     let account = parts[4];
     if account != "aws" && (account.len() != 12 || !account.chars().all(|c| c.is_ascii_digit())) {
         return Err(format!(
-            "IAM ARN account must be 'aws' or a 12-digit ID, got '{account}' in '{arn}'"
+            "{label} account must be 'aws' or a 12-digit ID, got '{account}' in '{arn}'"
         ));
     }
     if !parts[5].starts_with(resource_prefix) {
         return Err(format!(
-            "IAM ARN resource must begin with '{resource_prefix}', but got '{}' in '{arn}'",
+            "{label} resource must begin with '{resource_prefix}', but got '{}' in '{arn}'",
             parts[5]
         ));
     }
     let resource_name = &parts[5][resource_prefix.len()..];
     if resource_name.is_empty() {
         return Err(format!(
-            "IAM ARN resource name after '{resource_prefix}' must not be empty in '{arn}'"
+            "{label} name after '{resource_prefix}' must not be empty in '{arn}'"
         ));
     }
     // IAM names/paths allow: alphanumeric, plus +, =, ,, ., @, -, _, /
@@ -854,7 +865,7 @@ pub fn validate_iam_arn(arn: &str, resource_prefix: &str) -> Result<(), String> 
         .all(|c| c.is_ascii_alphanumeric() || "+=,.@-_/".contains(c))
     {
         return Err(format!(
-            "IAM ARN resource name contains invalid characters: '{resource_name}' in '{arn}'"
+            "{label} name contains invalid characters: '{resource_name}' in '{arn}'"
         ));
     }
     Ok(())
@@ -1700,12 +1711,24 @@ mod tests {
     }
 
     #[test]
-    fn validate_iam_arn_error_message_is_descriptive() {
+    fn validate_iam_arn_error_says_iam_policy_arn() {
         let err = validate_iam_arn("arn:aws:iam:us-east-1:aws:policy/Foo", "policy/").unwrap_err();
-        assert!(err.contains("IAM ARN"), "Error should say 'IAM ARN': {err}");
+        assert!(
+            err.contains("IAM Policy ARN"),
+            "Error should say 'IAM Policy ARN': {err}"
+        );
         assert!(
             err.contains("arn:aws:iam:us-east-1:aws:policy/Foo"),
             "Error should include full ARN: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_iam_arn_error_says_iam_role_arn() {
+        let err = validate_iam_arn("arn:aws:iam:us-east-1:aws:role/Foo", "role/").unwrap_err();
+        assert!(
+            err.contains("IAM Role ARN"),
+            "Error should say 'IAM Role ARN': {err}"
         );
     }
 


### PR DESCRIPTION
Refs #103

The error message for resource prefix mismatch was misleading:
- Old: `expected resource starting with 'policy/', got 'olicy/...'`
- New: `ARN resource segment must begin with 'policy/', but got 'olicy/...' in 'arn:aws:iam::...'`

Includes full ARN for context and clarifies that "resource segment" is being checked.