### PR TITLE
feat: update Map type to use struct variant with key field

### DIFF
--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -129,7 +129,7 @@ pub fn region_completions(prefix: &str) -> Vec<CompletionValue> {
 
 /// Tags type for AWS resources (map of string values)
 pub fn tags_type() -> AttributeType {
-    AttributeType::Map(Box::new(AttributeType::String))
+    AttributeType::map(AttributeType::String)
 }
 
 /// Validate that a tags map does not use Key/Value pair list structure.
@@ -1254,9 +1254,7 @@ fn iam_policy_statement() -> AttributeType {
                 .with_provider_name("NotPrincipal"),
             StructField::new(
                 "condition",
-                AttributeType::Map(Box::new(AttributeType::Map(Box::new(
-                    string_or_list_of_strings(),
-                )))),
+                AttributeType::map(AttributeType::map(string_or_list_of_strings())),
             )
             .with_provider_name("Condition"),
         ],

--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -3991,7 +3991,7 @@ fn cfn_type_to_carina_type_with_enum(
                 );
             }
             (
-                "AttributeType::Map(Box::new(AttributeType::String))".to_string(),
+                "AttributeType::map(AttributeType::String)".to_string(),
                 None,
             )
         }
@@ -4081,7 +4081,7 @@ fn tags_type_helper() -> &'static str {
     r#"
 /// Tags type for AWS resources
 pub fn tags_type() -> AttributeType {
-    AttributeType::Map(Box::new(AttributeType::String))
+    AttributeType::map(AttributeType::String)
 }
 "#
 }

--- a/carina-provider-awscc/src/convert.rs
+++ b/carina-provider-awscc/src/convert.rs
@@ -166,9 +166,10 @@ fn proto_to_core_attribute_type(t: &ProtoAttributeType) -> CoreAttributeType {
             inner: Box::new(proto_to_core_attribute_type(inner)),
             ordered: *ordered,
         },
-        ProtoAttributeType::Map { inner } => {
-            CoreAttributeType::Map(Box::new(proto_to_core_attribute_type(inner)))
-        }
+        ProtoAttributeType::Map { inner, key } => CoreAttributeType::Map {
+            key: Box::new(proto_to_core_attribute_type(key)),
+            value: Box::new(proto_to_core_attribute_type(inner)),
+        },
         ProtoAttributeType::Struct { name, fields } => CoreAttributeType::Struct {
             name: name.clone(),
             fields: fields.iter().map(proto_to_core_struct_field).collect(),
@@ -262,8 +263,9 @@ fn core_to_proto_attribute_type(t: &CoreAttributeType) -> ProtoAttributeType {
             inner: Box::new(core_to_proto_attribute_type(inner)),
             ordered: *ordered,
         },
-        CoreAttributeType::Map(inner) => ProtoAttributeType::Map {
+        CoreAttributeType::Map { key, value: inner } => ProtoAttributeType::Map {
             inner: Box::new(core_to_proto_attribute_type(inner)),
+            key: Box::new(core_to_proto_attribute_type(key)),
         },
         CoreAttributeType::Struct { name, fields } => ProtoAttributeType::Struct {
             name: name.clone(),

--- a/carina-provider-awscc/src/provider/conversion.rs
+++ b/carina-provider-awscc/src/provider/conversion.rs
@@ -94,7 +94,7 @@ pub(crate) fn aws_value_to_dsl(
 
     // For Map types, recurse into values.
     // For IAM condition maps, convert PascalCase operator keys back to snake_case.
-    if let AttributeType::Map(inner) = attr_type
+    if let AttributeType::Map { value: inner, .. } = attr_type
         && let Some(obj) = value.as_object()
     {
         let is_condition = dsl_name == "condition";
@@ -277,7 +277,7 @@ pub(crate) fn dsl_value_to_aws(
             })
             .collect();
         Some(serde_json::Value::Object(obj))
-    } else if let AttributeType::Map(inner) = attr_type
+    } else if let AttributeType::Map { value: inner, .. } = attr_type
         && let Value::Map(map) = value
     {
         // Map type: recurse into values with inner type.
@@ -655,7 +655,7 @@ mod tests {
 
     #[test]
     fn test_dsl_value_to_aws_map_preserves_user_keys() {
-        let attr_type = AttributeType::Map(Box::new(AttributeType::String));
+        let attr_type = AttributeType::map(AttributeType::String);
 
         let mut map = HashMap::new();
         map.insert(
@@ -689,7 +689,7 @@ mod tests {
             namespace: Some("awscc.test.resource".to_string()),
             to_dsl: None,
         };
-        let attr_type = AttributeType::Map(Box::new(inner_type));
+        let attr_type = AttributeType::map(inner_type);
 
         let mut map = HashMap::new();
         map.insert(
@@ -710,7 +710,7 @@ mod tests {
 
     #[test]
     fn test_aws_value_to_dsl_map_preserves_user_keys() {
-        let attr_type = AttributeType::Map(Box::new(AttributeType::String));
+        let attr_type = AttributeType::map(AttributeType::String);
 
         let aws_json = json!({
             "MyCustomKey": "value1",

--- a/carina-provider-awscc/src/resources.rs
+++ b/carina-provider-awscc/src/resources.rs
@@ -69,7 +69,7 @@ mod tests {
                 AttributeType::List { inner, .. } => {
                     check_type(inner, path, missing);
                 }
-                AttributeType::Map(inner) => {
+                AttributeType::Map { value: inner, .. } => {
                     check_type(inner, path, missing);
                 }
                 _ => {}

--- a/carina-provider-awscc/src/schemas/generated/logs/log_group.rs
+++ b/carina-provider-awscc/src/schemas/generated/logs/log_group.rs
@@ -73,7 +73,7 @@ pub fn logs_log_group_config() -> AwsccSchemaConfig {
                 .with_default(Value::Bool(false)),
         )
         .attribute(
-            AttributeSchema::new("data_protection_policy", AttributeType::Map(Box::new(AttributeType::String)))
+            AttributeSchema::new("data_protection_policy", AttributeType::map(AttributeType::String))
                 .with_description("Creates a data protection policy and assigns it to the log group. A data protection policy can help safeguard sensitive data that's ingested by the log group by auditing and masking the sensitive log data. When a user who does not have permission to view masked data views a log event that includes masked data, the sensitive data is replaced by asterisks.")
                 .with_provider_name("DataProtectionPolicy"),
         )
@@ -84,7 +84,7 @@ pub fn logs_log_group_config() -> AwsccSchemaConfig {
                 .with_default(Value::Bool(false)),
         )
         .attribute(
-            AttributeSchema::new("field_index_policies", AttributeType::unordered_list(AttributeType::Map(Box::new(AttributeType::String))))
+            AttributeSchema::new("field_index_policies", AttributeType::unordered_list(AttributeType::map(AttributeType::String)))
                 .with_description("Creates or updates a *field index policy* for the specified log group. Only log groups in the Standard log class support field index policies. For more information about log classes, see [Log classes](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CloudWatch_Logs_Log_Classes.html). You can use field index policies to create *field indexes* on fields found in log events in the log group. Creating field indexes lowers the costs for CWL Insights queries that reference those field indexes, because these queries attempt to skip the processing of log events that are known to not match the indexed field. Good fields to index are fields that you often need to query for and fields that have high cardinality of values Common examples of indexes include request ID, session ID, userID, and instance IDs. For more information, see [Create field indexes to improve query performance and reduce costs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CloudWatchLogs-Field-Indexing.html). Currently, this array supports only one field index policy object.")
                 .with_provider_name("FieldIndexPolicies"),
         )

--- a/carina-provider-awscc/src/schemas/generated/sso/permission_set.rs
+++ b/carina-provider-awscc/src/schemas/generated/sso/permission_set.rs
@@ -228,7 +228,7 @@ pub fn sso_permission_set_config() -> AwsccSchemaConfig {
                 .with_provider_name("Description"),
         )
         .attribute(
-            AttributeSchema::new("inline_policy", AttributeType::Map(Box::new(AttributeType::String)))
+            AttributeSchema::new("inline_policy", AttributeType::map(AttributeType::String))
                 .with_description("The inline policy to put in permission set.")
                 .with_provider_name("InlinePolicy"),
         )


### PR DESCRIPTION
## Summary
- Update `AttributeType::Map` from tuple variant `Map(Box<AttributeType>)` to struct variant `Map { key: Box<AttributeType>, value: Box<AttributeType> }` to match carina-core change
- Replace all `AttributeType::Map(Box::new(...))` with `AttributeType::map(...)` constructor
- Replace all `AttributeType::Map(inner)` pattern matches with `AttributeType::Map { value: inner, .. }`
- Update `convert.rs` to pass `key` field when constructing/deconstructing protocol Map type

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` passes (378 tests)
- [x] `cargo clippy -- -D warnings` passes
- [x] Pre-commit hooks pass (formatting + clippy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)