### PR TITLE
ci: cache cargo target and vela-cli to speed up WASM build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
       - run: cargo check
 
   test:
@@ -27,6 +28,7 @@ jobs:
         with:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
       - run: cargo test
 
   clippy:
@@ -39,6 +41,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+      - uses: Swatinem/rust-cache@v2
       - run: cargo clippy -- -D warnings
 
   fmt:
@@ -61,11 +64,21 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-wasip2
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: wasm
       - run: cargo build -p carina-provider-awscc --target wasm32-wasip2 --release
+      - name: Cache vela-cli
+        id: cache-vela
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/vela
+          key: vela-cli-${{ runner.os }}-v1
+      - name: Install vela-cli
+        if: steps.cache-vela.outputs.cache-hit != 'true'
+        run: cargo install --git https://github.com/mizzy/vela vela-cli --quiet
       - name: Optimize WASM with vela
-        run: |
-          cargo install --git https://github.com/mizzy/vela vela-cli --quiet
-          vela optimize target/wasm32-wasip2/release/carina-provider-awscc.wasm -o target/wasm32-wasip2/release/carina-provider-awscc.wasm
+        run: vela optimize target/wasm32-wasip2/release/carina-provider-awscc.wasm -o target/wasm32-wasip2/release/carina-provider-awscc.wasm
       - uses: actions/upload-artifact@v4
         with:
           name: carina-provider-awscc.wasm


### PR DESCRIPTION
## Summary

- Add `Swatinem/rust-cache@v2` to every Rust job (`check`, `test`, `clippy`, and `wasm-build`). The `wasm-build` job uses `shared-key: wasm` so the `wasm32-wasip2` target cache is kept in its own partition and does not fight the native-target caches for slots.
- Cache the installed `vela-cli` binary at `~/.cargo/bin/vela` via `actions/cache@v4`, keyed on `vela-cli-<os>-v1`. The existing `cargo install --git ...` step now runs only when the cache misses, so vela is not rebuilt from source on every CI run. To pick up a new vela revision, bump the `v1` suffix.

## Test plan

- [ ] First run after merge: confirm all jobs succeed and populate their caches (expect one full build).
- [ ] Follow-up PR / re-run without dep changes: confirm `wasm-build` and other jobs show a cache hit and complete noticeably faster.
- [ ] Confirm the vela cache step shows `cache-hit: true` on the second run and the Install step is skipped.

Refs #111