### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -514,7 +514,8 @@ dependencies = [
 
 [[package]]
 name = "carina-core"
-version = "0.3.0"
+version = "0.4.0"
+source = "git+https://github.com/carina-rs/carina#eb36b84146173ccad987a18472a8667aa771cf54"
 dependencies = [
  "argon2",
  "futures",
@@ -529,7 +530,8 @@ dependencies = [
 
 [[package]]
 name = "carina-plugin-sdk"
-version = "0.3.0"
+version = "0.4.0"
+source = "git+https://github.com/carina-rs/carina#eb36b84146173ccad987a18472a8667aa771cf54"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -543,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "carina-provider-awscc"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -572,6 +574,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
+source = "git+https://github.com/carina-rs/carina#eb36b84146173ccad987a18472a8667aa771cf54"
 dependencies = [
  "serde",
  "serde_json",
@@ -1134,9 +1137,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "litemap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,4 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"


### PR DESCRIPTION
## Summary
- Bump all crate versions from 0.3.0 to 0.4.0
- Update carina core dependencies to v0.4.0 (eb36b841)

🤖 Generated with [Claude Code](https://claude.com/claude-code)