### PR TITLE
Add Route 53 reference documentation

### DIFF
--- a/generated-docs/awscc/identitystore/group.md
+++ b/generated-docs/awscc/identitystore/group.md
@@ -1,0 +1,42 @@
+---
+title: "awscc.identitystore.group"
+description: "AWSCC IDENTITYSTORE group resource reference"
+---
+
+
+CloudFormation Type: `AWS::IdentityStore::Group`
+
+Resource Type definition for AWS::IdentityStore::Group
+
+## Argument Reference
+
+### `description`
+
+- **Type:** String(pattern, len: 1..=1024)
+- **Required:** No
+
+A string containing the description of the group.
+
+### `display_name`
+
+- **Type:** String(pattern, len: 1..=1024)
+- **Required:** Yes
+
+A string containing the name of the group. This value is commonly displayed when the group is referenced.
+
+### `identity_store_id`
+
+- **Type:** String(pattern, len: 1..=36)
+- **Required:** Yes
+- **Create-only:** Yes
+
+The globally unique identifier for the identity store.
+
+## Attribute Reference
+
+### `group_id`
+
+- **Type:** SecurityGroupId
+
+The unique identifier for a group in the identity store.
+

--- a/generated-docs/awscc/identitystore/group_membership.md
+++ b/generated-docs/awscc/identitystore/group_membership.md
@@ -1,0 +1,52 @@
+---
+title: "awscc.identitystore.group_membership"
+description: "AWSCC IDENTITYSTORE group_membership resource reference"
+---
+
+
+CloudFormation Type: `AWS::IdentityStore::GroupMembership`
+
+Resource Type Definition for AWS:IdentityStore::GroupMembership
+
+## Argument Reference
+
+### `group_id`
+
+- **Type:** SecurityGroupId
+- **Required:** Yes
+- **Create-only:** Yes
+
+The unique identifier for a group in the identity store.
+
+### `identity_store_id`
+
+- **Type:** String(pattern, len: 1..=36)
+- **Required:** Yes
+- **Create-only:** Yes
+
+The globally unique identifier for the identity store.
+
+### `member_id`
+
+- **Type:** [Struct(MemberId)](#memberid)
+- **Required:** Yes
+- **Create-only:** Yes
+
+An object containing the identifier of a group member.
+
+## Struct Definitions
+
+### MemberId
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `user_id` | String(pattern, len: 1..=47) | Yes | The identifier for a user in the identity store. |
+
+## Attribute Reference
+
+### `membership_id`
+
+- **Type:** String(pattern, len: 1..=47)
+
+The identifier for a GroupMembership in the identity store.
+

--- a/generated-docs/awscc/logs/log_group.md
+++ b/generated-docs/awscc/logs/log_group.md
@@ -27,6 +27,14 @@ awscc.logs.log_group {
 
 ## Argument Reference
 
+### `bearer_token_authentication_enabled`
+
+- **Type:** Bool
+- **Required:** No
+- **Default:** `false`
+
+
+
 ### `data_protection_policy`
 
 - **Type:** Map(String)

--- a/generated-docs/awscc/route53/hosted_zone.md
+++ b/generated-docs/awscc/route53/hosted_zone.md
@@ -1,0 +1,118 @@
+---
+title: "awscc.route53.hosted_zone"
+description: "AWSCC ROUTE53 hosted_zone resource reference"
+---
+
+
+CloudFormation Type: `AWS::Route53::HostedZone`
+
+Creates a new public or private hosted zone. You create records in a public hosted zone to define how you want to route traffic on the internet for a domain, such as example.com, and its subdomains (apex.example.com, acme.example.com). You create records in a private hosted zone to define how you want to route traffic for a domain and its subdomains within one or more Amazon Virtual Private Clouds (Amazon VPCs). 
+  You can't convert a public hosted zone to a private hosted zone or vice versa. Instead, you must create a new hosted zone with the same name and create new resource record sets.
+  For more information about charges for hosted zones, see [Amazon Route 53 Pricing](https://docs.aws.amazon.com/route53/pricing/).
+ Note the following:
+  +  You can't create a hosted zone for a top-level domain (TLD) such as .com.
+  +  If your domain is registered with a registrar other than Route 53, you must update the name servers with your registrar to make Route 53 the DNS service for the domain. For more information, see [Migrating DNS Service for an Existing Domain to Amazon Route 53](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/MigratingDNS.html) in the *Amazon Route 53 Developer Guide*. 
+  
+ When you submit a ``CreateHostedZone`` request, the initial status of the hosted zone is ``PENDING``. For public hosted zones, this means that the NS and SOA records are not yet available on all Route 53 DNS servers. When the NS and SOA records are available, the status of the zone changes to ``INSYNC``.
+ The ``CreateHostedZone`` request requires the caller to have an ``ec2:DescribeVpcs`` permission.
+  When creating private hosted zones, the Amazon VPC must belong to the same partition where the hosted zone is created. A partition is a group of AWS-Regions. Each AWS-account is scoped to one partition.
+ The following are the supported partitions:
+  +  ``aws`` - AWS-Regions
+  +  ``aws-cn`` - China Regions
+  +  ``aws-us-gov`` - govcloud-us-region
+  
+ For more information, see [Access Management](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) in the *General Reference*.
+
+## Argument Reference
+
+### `hosted_zone_config`
+
+- **Type:** [Struct(HostedZoneConfig)](#hostedzoneconfig)
+- **Required:** No
+
+A complex type that contains an optional comment. If you don't want to specify a comment, omit the ``HostedZoneConfig`` and ``Comment`` elements.
+
+### `hosted_zone_features`
+
+- **Type:** [Struct(HostedZoneFeatures)](#hostedzonefeatures)
+- **Required:** No
+
+The features configuration for the hosted zone, including accelerated recovery settings and status information.
+
+### `hosted_zone_tags`
+
+- **Type:** [List\<HostedZoneTag\>](#hostedzonetag)
+- **Required:** No
+
+Adds, edits, or deletes tags for a health check or a hosted zone. For information about using tags for cost allocation, see [Using Cost Allocation Tags](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/cost-alloc-tags.html) in the *User Guide*.
+
+### `name`
+
+- **Type:** String(len: ..=1024)
+- **Required:** No
+- **Create-only:** Yes
+
+The name of the domain. Specify a fully qualified domain name, for example, *www.example.com*. The trailing dot is optional; Amazon Route 53 assumes that the domain name is fully qualified. This means that Route 53 treats *www.example.com* (without a trailing dot) and *www.example.com.* (with a trailing dot) as identical. If you're creating a public hosted zone, this is the name you have registered with your DNS registrar. If your domain name is registered with a registrar other than Route 53, change the name servers for your domain to the set of ``NameServers`` that are returned by the ``Fn::GetAtt`` intrinsic function.
+
+### `query_logging_config`
+
+- **Type:** [Struct(QueryLoggingConfig)](#queryloggingconfig)
+- **Required:** No
+
+Creates a configuration for DNS query logging. After you create a query logging configuration, Amazon Route 53 begins to publish log data to an Amazon CloudWatch Logs log group. DNS query logs contain information about the queries that Route 53 receives for a specified public hosted zone, such as the following: + Route 53 edge location that responded to the DNS query + Domain or subdomain that was requested + DNS record type, such as A or AAAA + DNS response code, such as ``NoError`` or ``ServFail`` + Log Group and Resource Policy Before you create a query logging configuration, perform the following operations. If you create a query logging configuration using the Route 53 console, Route 53 performs these operations automatically. Create a CloudWatch Logs log group, and make note of the ARN, which you specify when you create a query logging configuration. Note the following: You must create the log group in the us-east-1 region. You must use the same to create the log group and the hosted zone that you want to configure query logging for. When you create log groups for query logging, we recommend that you use a consistent prefix, for example: /aws/route53/hosted zone name In the next step, you'll create a resource policy, which controls access to one or more log groups and the associated resources, such as Route 53 hosted zones. There's a limit on the number of resource policies that you can create, so we recommend that you use a consistent prefix so you can use the same resource policy for all the log groups that you create for query logging. Create a CloudWatch Logs resource policy, and give it the permissions that Route 53 needs to create log streams and to send query logs to log streams. You must create the CloudWatch Logs resource policy in the us-east-1 region. For the value of Resource, specify the ARN for the log group that you created in the previous step. To use the same resource policy for all the CloudWatch Logs log groups that you created for query logging configurations, replace the hosted zone name with *, for example: arn:aws:logs:us-east-1:123412341234:log-group:/aws/route53/* To avoid the confused deputy problem, a security issue where an entity without a permission for an action can coerce a more-privileged entity to perform it, you can optionally limit the permissions that a service has to a resource in a resource-based policy by supplying the following values: For aws:SourceArn, supply the hosted zone ARN used in creating the query logging configuration. For example, aws:SourceArn: arn:aws:route53:::hostedzone/hosted zone ID. For aws:SourceAccount, supply the account ID for the account that creates the query logging configuration. For example, aws:SourceAccount:111111111111. For more information, see The confused deputy problem in the IAM User Guide. You can't use the CloudWatch console to create or edit a resource policy. You must use the CloudWatch API, one of the SDKs, or the . + Log Streams and Edge Locations When Route 53 finishes creating the configuration for DNS query logging, it does the following: Creates a log stream for an edge location the first time that the edge location responds to DNS queries for the specified hosted zone. That log stream is used to log all queries that Route 53 responds to for that edge location. Begins to send query logs to the applicable log stream. The name of each log stream is in the following format: hosted zone ID/edge location code The edge location code is a three-letter code and an arbitrarily assigned number, for example, DFW3. The three-letter code typically corresponds with the International Air Transport Association airport code for an airport near the edge location. (These abbreviations might change in the future.) For a list of edge locations, see "The Route 53 Global Network" on the Route 53 Product Details page. + Queries That Are Logged Query logs contain only the queries that DNS resolvers forward to Route 53. If a DNS resolver has already cached the response to a query (such as the IP address for a load balancer for example.com), the resolver will continue to return the cached response. It doesn't forward another query to Route 53 until the TTL for the corresponding resource record set expires. Depending on how many DNS queries are submitted for a resource record set, and depending on the TTL for that resource record set, query logs might contain information about only one query out of every several thousand queries that are submitted to DNS. For more information about how DNS works, see Routing Internet Traffic to Your Website or Web Application in the Amazon Route 53 Developer Guide. + Log File Format For a list of the values in each query log and the format of each value, see Logging DNS Queries in the Amazon Route 53 Developer Guide. + Pricing For information about charges for query logs, see Amazon CloudWatch Pricing. + How to Stop Logging If you want Route 53 to stop sending query logs to CloudWatch Logs, delete the query logging configuration. For more information, see DeleteQueryLoggingConfig.
+
+### `vp_cs`
+
+- **Type:** [List\<VPC\>](#vpc)
+- **Required:** No
+
+*Private hosted zones:* A complex type that contains information about the VPCs that are associated with the specified hosted zone. For public hosted zones, omit ``VPCs``, ``VPCId``, and ``VPCRegion``.
+
+## Struct Definitions
+
+### HostedZoneConfig
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `comment` | String(len: ..=256) | No | Any comments that you want to include about the hosted zone. |
+
+### HostedZoneFeatures
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `enable_accelerated_recovery` | Bool | No |  |
+
+### HostedZoneTag
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `key` | String(len: ..=128) | Yes | The value of ``Key`` depends on the operation that you want to perform: + *Add a tag to a health check or hosted zone*: ``Key`` is the name that you want to give the new tag. + *Edit a tag*: ``Key`` is the name of the tag that you want to change the ``Value`` for. + *Delete a key*: ``Key`` is the name of the tag you want to remove. + *Give a name to a health check*: Edit the default ``Name`` tag. In the Amazon Route 53 console, the list of your health checks includes a *Name* column that lets you see the name that you've given to each health check. |
+| `value` | String(len: ..=256) | Yes | The value of ``Value`` depends on the operation that you want to perform: + *Add a tag to a health check or hosted zone*: ``Value`` is the value that you want to give the new tag. + *Edit a tag*: ``Value`` is the new value that you want to assign the tag. |
+
+### QueryLoggingConfig
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `cloud_watch_logs_log_group_arn` | Arn | Yes | The Amazon Resource Name (ARN) of the CloudWatch Logs log group that Amazon Route 53 is publishing logs to. |
+
+### VPC
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `vpc_id` | VpcId | Yes | *Private hosted zones only:* The ID of an Amazon VPC. For public hosted zones, omit ``VPCs``, ``VPCId``, and ``VPCRegion``. |
+| `vpc_region` | Region | Yes | *Private hosted zones only:* The region that an Amazon VPC was created in. For public hosted zones, omit ``VPCs``, ``VPCId``, and ``VPCRegion``. |
+
+## Attribute Reference
+
+### `id`
+
+- **Type:** String
+
+
+
+### `name_servers`
+
+- **Type:** `List<String>`
+
+
+

--- a/generated-docs/awscc/route53/record_set.md
+++ b/generated-docs/awscc/route53/record_set.md
@@ -1,0 +1,147 @@
+---
+title: "awscc.route53.record_set"
+description: "AWSCC ROUTE53 record_set resource reference"
+---
+
+
+CloudFormation Type: `AWS::Route53::RecordSet`
+
+Resource Type definition for AWS::Route53::RecordSet
+
+## Argument Reference
+
+### `alias_target`
+
+- **Type:** [Struct(AliasTarget)](#aliastarget)
+- **Required:** No
+
+### `cidr_routing_config`
+
+- **Type:** [Struct(CidrRoutingConfig)](#cidrroutingconfig)
+- **Required:** No
+
+### `comment`
+
+- **Type:** String
+- **Required:** No
+
+### `failover`
+
+- **Type:** String
+- **Required:** No
+
+### `geo_location`
+
+- **Type:** [Struct(GeoLocation)](#geolocation)
+- **Required:** No
+
+### `geo_proximity_location`
+
+- **Type:** [Struct(GeoProximityLocation)](#geoproximitylocation)
+- **Required:** No
+
+### `health_check_id`
+
+- **Type:** String
+- **Required:** No
+
+### `hosted_zone_id`
+
+- **Type:** String
+- **Required:** No
+- **Create-only:** Yes
+
+### `hosted_zone_name`
+
+- **Type:** String
+- **Required:** No
+- **Create-only:** Yes
+
+### `multi_value_answer`
+
+- **Type:** Bool
+- **Required:** No
+
+### `name`
+
+- **Type:** String
+- **Required:** Yes
+- **Create-only:** Yes
+
+### `region`
+
+- **Type:** Region
+- **Required:** No
+
+### `resource_records`
+
+- **Type:** `List<String>`
+- **Required:** No
+
+### `set_identifier`
+
+- **Type:** String
+- **Required:** No
+
+### `ttl`
+
+- **Type:** String
+- **Required:** No
+
+### `type`
+
+- **Type:** String
+- **Required:** Yes
+
+### `weight`
+
+- **Type:** Int
+- **Required:** No
+
+## Struct Definitions
+
+### AliasTarget
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `dns_name` | String | Yes |  |
+| `evaluate_target_health` | Bool | No |  |
+| `hosted_zone_id` | String | Yes |  |
+
+### CidrRoutingConfig
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `collection_id` | String | Yes |  |
+| `location_name` | String | Yes |  |
+
+### Coordinates
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `latitude` | String | Yes |  |
+| `longitude` | String | Yes |  |
+
+### GeoLocation
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `continent_code` | String | No |  |
+| `country_code` | String | No |  |
+| `subdivision_code` | String | No |  |
+
+### GeoProximityLocation
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `aws_region` | Region | No |  |
+| `bias` | Int | No |  |
+| `coordinates` | [Struct(Coordinates)](#coordinates) | No |  |
+| `local_zone_group` | String | No |  |
+
+## Attribute Reference
+
+### `id`
+
+- **Type:** String
+

--- a/generated-docs/awscc/s3/bucket.md
+++ b/generated-docs/awscc/s3/bucket.md
@@ -72,6 +72,24 @@ Specifies default encryption for a bucket using server-side encryption with Amaz
 
 A name for the bucket. If you don't specify a name, AWS CloudFormation generates a unique ID and uses that ID for the bucket name. The bucket name must contain only lowercase letters, numbers, periods (.), and dashes (-) and must follow [Amazon S3 bucket restrictions and limitations](https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html). For more information, see [Rules for naming Amazon S3 buckets](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html) in the *Amazon S3 User Guide*. If you specify a name, you can't perform updates that require replacement of this resource. You can perform updates that require no or some interruption. If you need to replace the resource, specify a new name.
 
+### `bucket_name_prefix`
+
+- **Type:** String
+- **Required:** No
+- **Create-only:** Yes
+- **Write-only:** Yes
+
+
+
+### `bucket_namespace`
+
+- **Type:** [Enum (BucketNamespace)](#bucket_namespace-bucketnamespace)
+- **Required:** No
+- **Create-only:** Yes
+- **Write-only:** Yes
+
+
+
 ### `cors_configuration`
 
 - **Type:** [Struct(CorsConfiguration)](#corsconfiguration)
@@ -242,6 +260,15 @@ Shorthand formats: `Destination` or `Owner.Destination`
 | `SSE-C` | `awscc.s3.bucket.EncryptionType.SSE_C` |
 
 Shorthand formats: `NONE` or `EncryptionType.NONE`
+
+### bucket_namespace (BucketNamespace)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `global` | `awscc.s3.bucket.BucketNamespace.global` |
+| `account-regional` | `awscc.s3.bucket.BucketNamespace.account_regional` |
+
+Shorthand formats: `global` or `BucketNamespace.global`
 
 ### allowed_methods (AllowedMethods)
 

--- a/generated-docs/awscc/sso/assignment.md
+++ b/generated-docs/awscc/sso/assignment.md
@@ -1,0 +1,79 @@
+---
+title: "awscc.sso.assignment"
+description: "AWSCC SSO assignment resource reference"
+---
+
+
+CloudFormation Type: `AWS::SSO::Assignment`
+
+Resource Type definition for SSO assignmet
+
+## Argument Reference
+
+### `instance_arn`
+
+- **Type:** Arn
+- **Required:** Yes
+- **Create-only:** Yes
+
+The sso instance that the permission set is owned.
+
+### `permission_set_arn`
+
+- **Type:** Arn
+- **Required:** Yes
+- **Create-only:** Yes
+
+The permission set that the assignment will be assigned
+
+### `principal_id`
+
+- **Type:** String(pattern, len: 1..=47)
+- **Required:** Yes
+- **Create-only:** Yes
+
+The assignee's identifier, user id/group id
+
+### `principal_type`
+
+- **Type:** [Enum (PrincipalType)](#principal_type-principaltype)
+- **Required:** Yes
+- **Create-only:** Yes
+
+The assignee's type, user/group
+
+### `target_id`
+
+- **Type:** String
+- **Required:** Yes
+- **Create-only:** Yes
+
+The account id to be provisioned.
+
+### `target_type`
+
+- **Type:** [Enum (TargetType)](#target_type-targettype)
+- **Required:** Yes
+- **Create-only:** Yes
+
+The type of resource to be provisioned to, only aws account now
+
+## Enum Values
+
+### principal_type (PrincipalType)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `USER` | `awscc.sso.assignment.PrincipalType.USER` |
+| `GROUP` | `awscc.sso.assignment.PrincipalType.GROUP` |
+
+Shorthand formats: `USER` or `PrincipalType.USER`
+
+### target_type (TargetType)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `AWS_ACCOUNT` | `awscc.sso.assignment.TargetType.AWS_ACCOUNT` |
+
+Shorthand formats: `AWS_ACCOUNT` or `TargetType.AWS_ACCOUNT`
+

--- a/generated-docs/awscc/sso/instance.md
+++ b/generated-docs/awscc/sso/instance.md
@@ -1,0 +1,62 @@
+---
+title: "awscc.sso.instance"
+description: "AWSCC SSO instance resource reference"
+---
+
+
+CloudFormation Type: `AWS::SSO::Instance`
+
+Resource Type definition for Identity Center (SSO) Instance
+
+## Argument Reference
+
+### `name`
+
+- **Type:** String(pattern, len: 1..=32)
+- **Required:** No
+
+The name you want to assign to this Identity Center (SSO) Instance
+
+### `tags`
+
+- **Type:** Map(String)
+- **Required:** No
+
+## Enum Values
+
+### status (Status)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `CREATE_IN_PROGRESS` | `awscc.sso.instance.Status.CREATE_IN_PROGRESS` |
+| `DELETE_IN_PROGRESS` | `awscc.sso.instance.Status.DELETE_IN_PROGRESS` |
+| `ACTIVE` | `awscc.sso.instance.Status.ACTIVE` |
+
+Shorthand formats: `CREATE_IN_PROGRESS` or `Status.CREATE_IN_PROGRESS`
+
+## Attribute Reference
+
+### `identity_store_id`
+
+- **Type:** String(pattern, len: 1..=64)
+
+The ID of the identity store associated with the created Identity Center (SSO) Instance
+
+### `instance_arn`
+
+- **Type:** Arn
+
+The SSO Instance ARN that is returned upon creation of the Identity Center (SSO) Instance
+
+### `owner_account_id`
+
+- **Type:** AwsAccountId
+
+The AWS accountId of the owner of the Identity Center (SSO) Instance
+
+### `status`
+
+- **Type:** [Enum (Status)](#status-status)
+
+The status of the Identity Center (SSO) Instance, create_in_progress/delete_in_progress/active
+

--- a/generated-docs/awscc/sso/permission_set.md
+++ b/generated-docs/awscc/sso/permission_set.md
@@ -1,0 +1,100 @@
+---
+title: "awscc.sso.permission_set"
+description: "AWSCC SSO permission_set resource reference"
+---
+
+
+CloudFormation Type: `AWS::SSO::PermissionSet`
+
+Resource Type definition for SSO PermissionSet
+
+## Argument Reference
+
+### `customer_managed_policy_references`
+
+- **Type:** [List\<CustomerManagedPolicyReference\>](#customermanagedpolicyreference) (items: ..=20)
+- **Required:** No
+
+### `description`
+
+- **Type:** String(pattern, len: 1..=700)
+- **Required:** No
+
+The permission set description.
+
+### `inline_policy`
+
+- **Type:** Map(String)
+- **Required:** No
+
+The inline policy to put in permission set.
+
+### `instance_arn`
+
+- **Type:** Arn
+- **Required:** Yes
+- **Create-only:** Yes
+
+The sso instance arn that the permission set is owned.
+
+### `managed_policies`
+
+- **Type:** `List<String>` (items: ..=20)
+- **Required:** No
+
+### `name`
+
+- **Type:** String(pattern, len: 1..=32)
+- **Required:** Yes
+- **Create-only:** Yes
+
+The name you want to assign to this permission set.
+
+### `permissions_boundary`
+
+- **Type:** [Struct(PermissionsBoundary)](#permissionsboundary)
+- **Required:** No
+
+### `relay_state_type`
+
+- **Type:** String(pattern, len: 1..=240)
+- **Required:** No
+
+The relay state URL that redirect links to any service in the AWS Management Console.
+
+### `session_duration`
+
+- **Type:** String(pattern, len: 1..=100)
+- **Required:** No
+
+The length of time that a user can be signed in to an AWS account.
+
+### `tags`
+
+- **Type:** Map(String)
+- **Required:** No
+
+## Struct Definitions
+
+### CustomerManagedPolicyReference
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | String(pattern, len: 1..=128) | Yes |  |
+| `path` | String(pattern, len: 1..=512) | No |  |
+
+### PermissionsBoundary
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `customer_managed_policy_reference` | [Struct(CustomerManagedPolicyReference)](#customermanagedpolicyreference) | No |  |
+| `managed_policy_arn` | Arn | No |  |
+
+## Attribute Reference
+
+### `permission_set_arn`
+
+- **Type:** Arn
+
+The permission set that the policy will be attached to
+


### PR DESCRIPTION
Refs #115

## Summary

- Generate reference docs for `route53.hosted_zone` and `route53.record_set`
- Add previously missing docs for `identitystore` and `sso` resources
- Refresh S3/CloudWatch Logs docs with latest CloudFormation schema attributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)