### PR TITLE
Mark route53.record_set type as identity attribute

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina#eb36b84146173ccad987a18472a8667aa771cf54"
+source = "git+https://github.com/carina-rs/carina#ecaee6c7e604528dddf4da71da4429fa479da6e4"
 dependencies = [
  "argon2",
  "futures",
@@ -531,7 +531,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina#eb36b84146173ccad987a18472a8667aa771cf54"
+source = "git+https://github.com/carina-rs/carina#ecaee6c7e604528dddf4da71da4429fa479da6e4"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#eb36b84146173ccad987a18472a8667aa771cf54"
+source = "git+https://github.com/carina-rs/carina#ecaee6c7e604528dddf4da71da4429fa479da6e4"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -1936,6 +1936,7 @@ pub fn {}() -> AwsccSchemaConfig {{
         // The parent is still returned by the CloudControl API read; only the
         // specific nested sub-properties are omitted.
         let is_write_only = write_only.contains(prop_name);
+        let is_identity = identity_properties().contains(&(type_name, prop_name));
 
         let attr_type = if let Some(enum_info) = enums.get(prop_name) {
             // Use shared schema enum type for constrained strings.
@@ -2023,6 +2024,10 @@ pub fn {}() -> AwsccSchemaConfig {{
 
         if is_write_only {
             attr_code.push_str("\n                .write_only()");
+        }
+
+        if is_identity {
+            attr_code.push_str("\n                .identity()");
         }
 
         if let Some(desc) = &prop.description {
@@ -3087,6 +3092,21 @@ fn resource_type_overrides() -> &'static HashMap<(&'static str, &'static str), T
             m
         });
     &OVERRIDES
+}
+
+/// Properties that should be marked as `identity` in the schema.
+/// Identity attributes are included in the anonymous resource identifier hash
+/// alongside create-only attributes.
+fn identity_properties() -> &'static HashSet<(&'static str, &'static str)> {
+    static IDENTITY: LazyLock<HashSet<(&'static str, &'static str)>> = LazyLock::new(|| {
+        let mut s = HashSet::new();
+        // Route 53 RecordSet: (HostedZoneId, Name, Type) uniquely identifies a record,
+        // but Type is not create-only in CloudFormation. Without identity, two records
+        // with the same name/zone but different types (A vs AAAA) collide.
+        s.insert(("AWS::Route53::RecordSet", "Type"));
+        s
+    });
+    &IDENTITY
 }
 
 /// Infer the Carina type string for a property based on its name.

--- a/carina-provider-awscc/src/convert.rs
+++ b/carina-provider-awscc/src/convert.rs
@@ -216,6 +216,7 @@ fn _proto_to_core_attribute_schema(a: &ProtoAttributeSchema) -> CoreAttributeSch
         removable: a.removable,
         block_name: a.block_name.clone(),
         write_only: a.write_only,
+        identity: a.identity,
     }
 }
 
@@ -311,6 +312,7 @@ fn core_to_proto_attribute_schema(a: &CoreAttributeSchema) -> ProtoAttributeSche
         block_name: a.block_name.clone(),
         provider_name: a.provider_name.clone(),
         removable: a.removable,
+        identity: a.identity,
     }
 }
 

--- a/carina-provider-awscc/src/schemas/generated/route53/record_set.rs
+++ b/carina-provider-awscc/src/schemas/generated/route53/record_set.rs
@@ -154,6 +154,7 @@ pub fn route53_record_set_config() -> AwsccSchemaConfig {
             .attribute(
                 AttributeSchema::new("type", AttributeType::String)
                     .required()
+                    .identity()
                     .with_provider_name("Type"),
             )
             .attribute(


### PR DESCRIPTION
Closes #118

## Summary

- Add `identity_properties()` lookup in codegen for attributes that should be marked as `.identity()`
- Mark `Type` on `AWS::Route53::RecordSet` as identity so that A/AAAA/CNAME records with the same name and hosted zone get distinct anonymous identifiers
- Update `convert.rs` to pass `identity` field through protocol conversion

## Test plan

- [x] `cargo test -p carina-provider-awscc` — 162 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] Verified generated `record_set.rs` contains `.identity()` on `type` attribute
- [x] Docs regenerated (no changes — identity doesn't affect markdown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)