### PR TITLE
design: trailing dot normalization for Route 53 DNS names

### DIFF
--- a/docs/specs/2026-04-14-trailing-dot-normalization-design.md
+++ b/docs/specs/2026-04-14-trailing-dot-normalization-design.md
@@ -1,0 +1,69 @@
+# Trailing Dot Normalization for Route 53 DNS Names
+
+## Goal
+
+Prevent spurious replacement diffs when Route 53 returns DNS names with a trailing dot (FQDN format) that the user omitted in their `.crn` file.
+
+## Problem
+
+Route 53 always returns fully qualified domain names with a trailing dot (`carina-rs.dev.`). When the user writes `name = 'carina-rs.dev'`, the differ sees a change on a `create_only` attribute and schedules a replacement — even though the two forms are DNS-equivalent.
+
+## Chosen Approach
+
+**Extend `aws_value_to_dsl` to apply `to_dsl` on non-namespaced `Custom` types.**
+
+The `to_dsl` field already exists on `AttributeType::Custom` but is currently only used for namespaced enums. By also checking it for plain Custom types in the `aws_value_to_dsl` conversion, any Custom attribute can declare a read-path normalization function.
+
+This is generic: future cases where AWS APIs normalize values differently from user input (e.g., trailing slashes, case normalization) can use the same mechanism.
+
+## Design
+
+### 1. `aws_value_to_dsl` change (conversion.rs)
+
+Add a check before the final `json_to_value` fallback:
+
+```rust
+// For Custom types with to_dsl, apply the transformation on read.
+if let AttributeType::Custom { to_dsl: Some(transform), .. } = attr_type
+    && let Some(s) = value.as_str()
+{
+    return Some(Value::String(transform(s)));
+}
+```
+
+This handles non-namespaced Custom types. Namespaced Custom types are already handled earlier in the function.
+
+### 2. Schema change (hosted_zone.rs)
+
+Add `to_dsl` to the `name` attribute's Custom type:
+
+```rust
+to_dsl: Some(|s: &str| s.strip_suffix('.').unwrap_or(s).to_string()),
+```
+
+### 3. Codegen override (codegen.rs)
+
+Add a new `TypeOverride` variant or a `to_dsl` override table so the codegen can emit `to_dsl` for specific attributes. This ensures re-generation preserves the fix.
+
+### 4. aws provider (record_set.rs)
+
+The `aws.route53.record_set` resource is hand-coded (not codegen). Its `name` attribute also needs trailing dot stripping, but that's handled differently since it uses `normalize_dns_name()` in the write path. The read path (`extract_attributes`) strips the trailing dot already. Verify this is consistent.
+
+## Scope
+
+| Repository | Resource | Attribute | Change |
+|-----------|----------|-----------|--------|
+| carina-provider-awscc | route53.hosted_zone | name | Add `to_dsl` to strip trailing dot |
+| carina-provider-awscc | (conversion.rs) | - | Handle Custom `to_dsl` in `aws_value_to_dsl` |
+| carina-provider-awscc | (codegen.rs) | - | Add `to_dsl` override support |
+| carina-provider-aws | route53.record_set | name | Verify read path already handles this |
+
+## Edge Cases
+
+- User writes `name = 'carina-rs.dev.'` (with dot): `to_dsl` strips it → `carina-rs.dev`. Consistent.
+- Empty string: `strip_suffix('.')` returns the original. Safe.
+- Multiple trailing dots (malformed): only one dot stripped. AWS would reject this anyway.
+
+## No inverse needed
+
+`dsl_value_to_aws` does not need a corresponding change. AWS Route 53 accepts both `carina-rs.dev` and `carina-rs.dev.` — the trailing dot is optional on input.

--- a/docs/specs/2026-04-14-trailing-dot-normalization-plan.md
+++ b/docs/specs/2026-04-14-trailing-dot-normalization-plan.md
@@ -1,0 +1,42 @@
+# Implementation Plan: Trailing Dot Normalization
+
+## Task 1/3: Apply Custom to_dsl in aws_value_to_dsl
+
+**Files:**
+- `carina-provider-awscc/src/provider/conversion.rs`
+
+**Changes:**
+- Add a Custom type check in `aws_value_to_dsl` before the `json_to_value` fallback
+- When `AttributeType::Custom { to_dsl: Some(transform), namespace: None, .. }`, apply `transform` to string values
+
+**Tests:**
+- Unit test in conversion.rs: Custom type with `to_dsl` transforms value on read
+- Unit test: Custom type without `to_dsl` passes through unchanged
+- Unit test: Custom type with namespace (existing enum behavior) is unaffected
+
+## Task 2/3: Add to_dsl override support in codegen
+
+**Files:**
+- `carina-provider-awscc/src/bin/codegen.rs`
+
+**Changes:**
+- Add a `to_dsl` override mechanism (either a new `TypeOverride` variant or a separate override table keyed by `(resource_type, property_name)`)
+- For `(AWS::Route53::HostedZone, Name)`, emit `to_dsl: Some(|s: &str| s.strip_suffix('.').unwrap_or(s).to_string())`
+- Regenerate `hosted_zone.rs`
+
+**Tests:**
+- Codegen test: verify the override produces correct `to_dsl` in generated code
+- Regenerate and verify `hosted_zone.rs` has the `to_dsl` field
+
+## Task 3/3: Verify aws provider record_set read path
+
+**Files:**
+- `carina-provider-aws/src/services/route53/record_set.rs`
+
+**Changes:**
+- Verify `extract_attributes` already strips trailing dot from `name`
+- If not, add `strip_suffix('.')` in the read path
+- This is a hand-coded file, so direct edit is fine
+
+**Tests:**
+- Unit test or manual verification that read values don't have trailing dots


### PR DESCRIPTION
Refs #122

Design document and implementation plan for normalizing Route 53 trailing dots.

## Approach

Extend `aws_value_to_dsl` to apply `to_dsl` on non-namespaced `Custom` types. This is a generic mechanism that any attribute can use for read-path normalization.

## Tasks

See implementation plan for 3 tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)