### PR TITLE
feat: add ToDsl codegen override, strip trailing dot from hosted_zone name

### DIFF
--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -39,6 +39,8 @@ enum TypeOverride {
     IntRange(i64, i64),
     /// Override to an integer enum with specific allowed values
     IntEnum(Vec<i64>),
+    /// Override to_dsl on a Custom type (Rust code for the closure)
+    ToDsl(&'static str),
 }
 
 /// Information about a detected enum type
@@ -3117,9 +3119,30 @@ fn resource_type_overrides() -> &'static HashMap<(&'static str, &'static str), T
                 ]),
             );
 
+            // === ToDsl overrides ===
+
+            // Route 53 HostedZone Name: AWS returns FQDN with trailing dot
+            m.insert(
+                ("AWS::Route53::HostedZone", "Name"),
+                TypeOverride::ToDsl(
+                    r#"Some(|s: &str| s.strip_suffix('.').unwrap_or(s).to_string())"#,
+                ),
+            );
+
             m
         });
     &OVERRIDES
+}
+
+/// Return the `to_dsl` code for a Custom type, checking for ToDsl overrides.
+fn to_dsl_code_for(resource_type: &str, prop_name: &str) -> &'static str {
+    if let Some(TypeOverride::ToDsl(code)) =
+        resource_type_overrides().get(&(resource_type, prop_name))
+    {
+        code
+    } else {
+        "None"
+    }
 }
 
 /// Properties that should be marked as `identity` in the schema.
@@ -3765,6 +3788,7 @@ fn cfn_type_to_carina_type_with_enum(
             if has_length {
                 let validate_fn = string_length_fn_name(effective_min, prop.max_length);
                 let display = string_length_display(effective_min, prop.max_length);
+                let to_dsl = to_dsl_code_for(&schema.type_name, prop_name);
                 return (
                     format!(
                         r#"AttributeType::Custom {{
@@ -3772,9 +3796,9 @@ fn cfn_type_to_carina_type_with_enum(
                 base: Box::new(AttributeType::String),
                 validate: {},
                 namespace: None,
-                to_dsl: None,
+                to_dsl: {},
             }}"#,
-                        display, validate_fn
+                        display, validate_fn, to_dsl
                     ),
                     None,
                 );

--- a/carina-provider-awscc/src/schemas/generated/route53/hosted_zone.rs
+++ b/carina-provider-awscc/src/schemas/generated/route53/hosted_zone.rs
@@ -118,7 +118,7 @@ pub fn route53_hosted_zone_config() -> AwsccSchemaConfig {
                 base: Box::new(AttributeType::String),
                 validate: validate_string_length_max_1024,
                 namespace: None,
-                to_dsl: None,
+                to_dsl: Some(|s: &str| s.strip_suffix('.').unwrap_or(s).to_string()),
             })
                 .create_only()
                 .with_description("The name of the domain. Specify a fully qualified domain name, for example, *www.example.com*. The trailing dot is optional; Amazon Route 53 assumes that the domain name is fully qualified. This means that Route 53 treats *www.example.com* (without a trailing dot) and *www.example.com.* (with a trailing dot) as identical. If you're creating a public hosted zone, this is the name you have registered with your DNS registrar. If your domain name is registered with a registrar other than Route 53, change the name servers for your domain to the set of ``NameServers`` that are returned by the ``Fn::GetAtt`` intrinsic function.")


### PR DESCRIPTION
Closes #125
Refs #122

## Summary

- Add `TypeOverride::ToDsl` variant to the codegen for declaring `to_dsl` transformations on Custom types
- Add `to_dsl_code_for()` helper that checks the override table
- Register `(AWS::Route53::HostedZone, Name)` → strip trailing dot
- Regenerate `hosted_zone.rs` with `to_dsl: Some(|s: &str| s.strip_suffix('.').unwrap_or(s).to_string())`

Combined with #124 (which applies Custom `to_dsl` in `aws_value_to_dsl`), this fixes the spurious replacement diff from #122.

## Test plan

- [x] `cargo test -p carina-provider-awscc --lib` — all 134 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] Regenerated `hosted_zone.rs` shows `to_dsl: Some(...)` on `name` attribute

🤖 Generated with [Claude Code](https://claude.com/claude-code)