### PR TITLE
fix: scope SecurityGroupId inference to EC2 security groups only

### DIFF
--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -3261,7 +3261,7 @@ fn is_aws_resource_id_property(prop_name: &str) -> bool {
     let resource_id_suffixes = [
         "vpcid",
         "subnetid",
-        "groupid",
+        "securitygroupid",
         "gatewayid",
         "routetableid",
         "allocationid",
@@ -3328,7 +3328,9 @@ fn classify_resource_id(prop_name: &str) -> ResourceIdKind {
         return ResourceIdKind::SubnetId;
     }
     // Security Group IDs (including DestinationSecurityGroupId, SourceSecurityGroupId, etc.)
-    if (lower.contains("securitygroup") || lower.contains("groupid")) && lower.ends_with("id") {
+    // Only match when "securitygroup" is explicitly in the name — bare "GroupId" is too
+    // broad and catches non-EC2 identifiers (e.g., identitystore GroupId).
+    if lower.contains("securitygroup") && lower.ends_with("id") {
         return ResourceIdKind::SecurityGroupId;
     }
     // Egress Only Internet Gateway IDs (must be checked before Internet Gateway IDs)

--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -4731,7 +4731,7 @@ mod tests {
         // Known resource ID properties
         assert!(is_aws_resource_id_property("VpcId"));
         assert!(is_aws_resource_id_property("SubnetId"));
-        assert!(is_aws_resource_id_property("GroupId"));
+        assert!(is_aws_resource_id_property("SecurityGroupId"));
         assert!(is_aws_resource_id_property("RouteTableId"));
         assert!(is_aws_resource_id_property("InternetGatewayId"));
         assert!(is_aws_resource_id_property("AllocationId"));
@@ -6098,10 +6098,8 @@ mod tests {
             get_resource_id_type("SourceSecurityGroupId"),
             "super::security_group_id()"
         );
-        assert_eq!(
-            get_resource_id_type("GroupId"),
-            "super::security_group_id()"
-        );
+        // Bare "GroupId" should NOT match SecurityGroupId — it's too broad
+        assert_eq!(get_resource_id_type("GroupId"), "super::aws_resource_id()");
     }
 
     #[test]
@@ -6206,7 +6204,8 @@ mod tests {
             get_resource_id_display_name("DestinationSecurityGroupId"),
             "SecurityGroupId"
         );
-        assert_eq!(get_resource_id_display_name("GroupId"), "SecurityGroupId");
+        // Bare "GroupId" should NOT map to SecurityGroupId
+        assert_eq!(get_resource_id_display_name("GroupId"), "AwsResourceId");
     }
 
     #[test]
@@ -6289,10 +6288,8 @@ mod tests {
             classify_resource_id("SecurityGroupId"),
             ResourceIdKind::SecurityGroupId
         );
-        assert_eq!(
-            classify_resource_id("GroupId"),
-            ResourceIdKind::SecurityGroupId
-        );
+        // Bare "GroupId" should be Generic, not SecurityGroupId
+        assert_eq!(classify_resource_id("GroupId"), ResourceIdKind::Generic);
         assert_eq!(
             classify_resource_id("EgressOnlyInternetGatewayId"),
             ResourceIdKind::EgressOnlyInternetGatewayId

--- a/carina-provider-awscc/src/schemas/generated/identitystore/group.rs
+++ b/carina-provider-awscc/src/schemas/generated/identitystore/group.rs
@@ -10,6 +10,28 @@ use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 use regex::Regex;
 
 #[allow(dead_code)]
+fn validate_string_pattern_2a77a2e32f71b5f3_len_1_47(value: &Value) -> Result<(), String> {
+    if let Value::String(s) = value {
+        static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+            Regex::new("^([0-9a-f]{10}-|)[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$").expect("invalid pattern regex")
+        });
+        if !RE.is_match(s) {
+            return Err(format!(
+                "Value '{}' does not match pattern ^([0-9a-f]{{10}}-|)[A-Fa-f0-9]{{8}}-[A-Fa-f0-9]{{4}}-[A-Fa-f0-9]{{4}}-[A-Fa-f0-9]{{4}}-[A-Fa-f0-9]{{12}}$",
+                s
+            ));
+        }
+        let len = s.chars().count();
+        if !(1..=47).contains(&len) {
+            return Err(format!("String length {} is out of range 1..=47", len));
+        }
+        Ok(())
+    } else {
+        Err("Expected string".to_string())
+    }
+}
+
+#[allow(dead_code)]
 fn validate_string_pattern_a301e45ae2f7df12_len_1_1024(value: &Value) -> Result<(), String> {
     if let Value::String(s) = value {
         static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
@@ -112,7 +134,13 @@ pub fn identitystore_group_config() -> AwsccSchemaConfig {
                 .with_provider_name("DisplayName"),
         )
         .attribute(
-            AttributeSchema::new("group_id", super::security_group_id())
+            AttributeSchema::new("group_id", AttributeType::Custom {
+                name: "String(pattern, len: 1..=47)".to_string(),
+                base: Box::new(AttributeType::String),
+                validate: validate_string_pattern_2a77a2e32f71b5f3_len_1_47,
+                namespace: None,
+                to_dsl: None,
+            })
                 .read_only()
                 .with_description("The unique identifier for a group in the identity store. (read-only)")
                 .with_provider_name("GroupId"),

--- a/carina-provider-awscc/src/schemas/generated/identitystore/group_membership.rs
+++ b/carina-provider-awscc/src/schemas/generated/identitystore/group_membership.rs
@@ -65,11 +65,20 @@ pub fn identitystore_group_membership_config() -> AwsccSchemaConfig {
         schema: ResourceSchema::new("awscc.identitystore.group_membership")
             .with_description("Resource Type Definition for AWS:IdentityStore::GroupMembership")
             .attribute(
-                AttributeSchema::new("group_id", super::security_group_id())
-                    .required()
-                    .create_only()
-                    .with_description("The unique identifier for a group in the identity store.")
-                    .with_provider_name("GroupId"),
+                AttributeSchema::new(
+                    "group_id",
+                    AttributeType::Custom {
+                        name: "String(pattern, len: 1..=47)".to_string(),
+                        base: Box::new(AttributeType::String),
+                        validate: validate_string_pattern_2a77a2e32f71b5f3_len_1_47,
+                        namespace: None,
+                        to_dsl: None,
+                    },
+                )
+                .required()
+                .create_only()
+                .with_description("The unique identifier for a group in the identity store.")
+                .with_provider_name("GroupId"),
             )
             .attribute(
                 AttributeSchema::new(


### PR DESCRIPTION
Refs #128 (fixes problem 3 of 3)

## Summary

The suffix-based type inference in `classify_resource_id()` matched bare `GroupId` as `SecurityGroupId`, incorrectly typing `identitystore.group.group_id` as an EC2 security group ID.

Fix: only match `SecurityGroupId` when `securitygroup` is explicitly in the property name. Also fix `is_aws_resource_id_property()` suffix list (`"groupid"` → `"securitygroupid"`).

Regenerated identitystore group and group_membership schemas.

Problems (1) and (2) from #128 are type compatibility issues in carina-core, not codegen bugs — tracked separately.

## Test plan

- [x] `cargo test -p carina-provider-awscc --lib` — 134 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] Regenerated `identitystore/group.rs` shows `group_id` as `Custom` type, not `security_group_id()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)