### PR TITLE
fix: unify schema and docs resource lists, add drift CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,13 @@ jobs:
           components: rustfmt
       - run: cargo fmt --check
 
+  docs-drift:
+    name: Check Docs Drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: ./scripts/check-docs-drift.sh
+
   wasm-build:
     name: WASM Build
     runs-on: ubuntu-latest

--- a/generated-docs/awscc/ec2/security_group.md
+++ b/generated-docs/awscc/ec2/security_group.md
@@ -135,7 +135,7 @@ Shorthand formats: `tcp` or `IpProtocol.tcp`
 
 ### `group_id`
 
-- **Type:** SecurityGroupId
+- **Type:** String
 
 The group ID of the specified security group.
 

--- a/generated-docs/awscc/ec2/security_group_egress.md
+++ b/generated-docs/awscc/ec2/security_group_egress.md
@@ -83,7 +83,7 @@ If the protocol is TCP or UDP, this is the start of the port range. If the proto
 
 ### `group_id`
 
-- **Type:** SecurityGroupId
+- **Type:** String
 - **Required:** Yes
 - **Create-only:** Yes
 

--- a/generated-docs/awscc/ec2/security_group_ingress.md
+++ b/generated-docs/awscc/ec2/security_group_ingress.md
@@ -65,7 +65,7 @@ The start of port range for the TCP and UDP protocols, or an ICMP/ICMPv6 type nu
 
 ### `group_id`
 
-- **Type:** SecurityGroupId
+- **Type:** String
 - **Required:** No
 - **Create-only:** Yes
 

--- a/generated-docs/awscc/iam/oidc_provider.md
+++ b/generated-docs/awscc/iam/oidc_provider.md
@@ -1,0 +1,41 @@
+---
+title: "awscc.iam.oidc_provider"
+description: "AWSCC IAM oidc_provider resource reference"
+---
+
+
+CloudFormation Type: `AWS::IAM::OIDCProvider`
+
+Resource Type definition for AWS::IAM::OIDCProvider
+
+## Argument Reference
+
+### `client_id_list`
+
+- **Type:** `List<String>`
+- **Required:** No
+
+### `tags`
+
+- **Type:** Map(String)
+- **Required:** No
+
+### `thumbprint_list`
+
+- **Type:** `List<String>` (items: ..=5)
+- **Required:** No
+
+### `url`
+
+- **Type:** String(len: 1..=255)
+- **Required:** No
+- **Create-only:** Yes
+
+## Attribute Reference
+
+### `arn`
+
+- **Type:** Arn
+
+Amazon Resource Name (ARN) of the OIDC provider
+

--- a/generated-docs/awscc/identitystore/group.md
+++ b/generated-docs/awscc/identitystore/group.md
@@ -36,7 +36,7 @@ The globally unique identifier for the identity store.
 
 ### `group_id`
 
-- **Type:** SecurityGroupId
+- **Type:** String(pattern, len: 1..=47)
 
 The unique identifier for a group in the identity store.
 

--- a/generated-docs/awscc/identitystore/group_membership.md
+++ b/generated-docs/awscc/identitystore/group_membership.md
@@ -12,7 +12,7 @@ Resource Type Definition for AWS:IdentityStore::GroupMembership
 
 ### `group_id`
 
-- **Type:** SecurityGroupId
+- **Type:** String(pattern, len: 1..=47)
 - **Required:** Yes
 - **Create-only:** Yes
 

--- a/generated-docs/awscc/organizations/account.md
+++ b/generated-docs/awscc/organizations/account.md
@@ -1,0 +1,120 @@
+---
+title: "awscc.organizations.account"
+description: "AWSCC ORGANIZATIONS account resource reference"
+---
+
+
+CloudFormation Type: `AWS::Organizations::Account`
+
+You can use AWS::Organizations::Account to manage accounts in organization.
+
+## Argument Reference
+
+### `account_name`
+
+- **Type:** String(pattern, len: 1..=50)
+- **Required:** Yes
+
+The friendly name of the member account.
+
+### `email`
+
+- **Type:** String(pattern, len: 6..=64)
+- **Required:** Yes
+
+The email address of the owner to assign to the new member account.
+
+### `parent_ids`
+
+- **Type:** `List<String>`
+- **Required:** No
+
+List of parent nodes for the member account. Currently only one parent at a time is supported. Default is root.
+
+### `role_name`
+
+- **Type:** String(pattern, len: 1..=64)
+- **Required:** No
+- **Write-only:** Yes
+- **Default:** `"OrganizationAccountAccessRole"`
+
+The name of an IAM role that AWS Organizations automatically preconfigures in the new member account. Default name is OrganizationAccountAccessRole if not specified.
+
+### `tags`
+
+- **Type:** Map(String)
+- **Required:** No
+
+A list of tags that you want to attach to the newly created account. For each tag in the list, you must specify both a tag key and a value.
+
+## Enum Values
+
+### joined_method (JoinedMethod)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `INVITED` | `awscc.organizations.account.JoinedMethod.INVITED` |
+| `CREATED` | `awscc.organizations.account.JoinedMethod.CREATED` |
+
+Shorthand formats: `INVITED` or `JoinedMethod.INVITED`
+
+### state (State)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `PENDING_ACTIVATION` | `awscc.organizations.account.State.PENDING_ACTIVATION` |
+| `ACTIVE` | `awscc.organizations.account.State.ACTIVE` |
+| `SUSPENDED` | `awscc.organizations.account.State.SUSPENDED` |
+| `PENDING_CLOSURE` | `awscc.organizations.account.State.PENDING_CLOSURE` |
+| `CLOSED` | `awscc.organizations.account.State.CLOSED` |
+
+Shorthand formats: `PENDING_ACTIVATION` or `State.PENDING_ACTIVATION`
+
+### status (Status)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `ACTIVE` | `awscc.organizations.account.Status.ACTIVE` |
+| `SUSPENDED` | `awscc.organizations.account.Status.SUSPENDED` |
+| `PENDING_CLOSURE` | `awscc.organizations.account.Status.PENDING_CLOSURE` |
+
+Shorthand formats: `ACTIVE` or `Status.ACTIVE`
+
+## Attribute Reference
+
+### `account_id`
+
+- **Type:** AwsAccountId
+
+If the account was created successfully, the unique identifier (ID) of the new account.
+
+### `arn`
+
+- **Type:** Arn
+
+The Amazon Resource Name (ARN) of the account.
+
+### `joined_method`
+
+- **Type:** [Enum (JoinedMethod)](#joined_method-joinedmethod)
+
+The method by which the account joined the organization.
+
+### `joined_timestamp`
+
+- **Type:** String
+
+The date the account became a part of the organization.
+
+### `state`
+
+- **Type:** [Enum (State)](#state-state)
+
+The state of the account in the organization.
+
+### `status`
+
+- **Type:** [Enum (Status)](#status-status)
+
+The status of the account in the organization.
+

--- a/generated-docs/awscc/organizations/organization.md
+++ b/generated-docs/awscc/organizations/organization.md
@@ -1,0 +1,69 @@
+---
+title: "awscc.organizations.organization"
+description: "AWSCC ORGANIZATIONS organization resource reference"
+---
+
+
+CloudFormation Type: `AWS::Organizations::Organization`
+
+Resource schema for AWS::Organizations::Organization
+
+## Argument Reference
+
+### `feature_set`
+
+- **Type:** [Enum (FeatureSet)](#feature_set-featureset)
+- **Required:** No
+- **Default:** `"ALL"`
+
+Specifies the feature set supported by the new organization. Each feature set supports different levels of functionality.
+
+## Enum Values
+
+### feature_set (FeatureSet)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `ALL` | `awscc.organizations.organization.FeatureSet.ALL` |
+| `CONSOLIDATED_BILLING` | `awscc.organizations.organization.FeatureSet.CONSOLIDATED_BILLING` |
+
+Shorthand formats: `ALL` or `FeatureSet.ALL`
+
+## Attribute Reference
+
+### `arn`
+
+- **Type:** Arn
+
+The Amazon Resource Name (ARN) of an organization.
+
+### `id`
+
+- **Type:** String
+
+The unique identifier (ID) of an organization.
+
+### `management_account_arn`
+
+- **Type:** Arn
+
+The Amazon Resource Name (ARN) of the account that is designated as the management account for the organization.
+
+### `management_account_email`
+
+- **Type:** String(pattern, len: 6..=64)
+
+The email address that is associated with the AWS account that is designated as the management account for the organization.
+
+### `management_account_id`
+
+- **Type:** AwsAccountId
+
+The unique identifier (ID) of the management account of an organization.
+
+### `root_id`
+
+- **Type:** String(pattern, len: ..=64)
+
+The unique identifier (ID) for the root.
+

--- a/scripts/check-docs-drift.sh
+++ b/scripts/check-docs-drift.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Check that generated docs cover every generated schema.
+#
+# Fails if any schema resource is missing a corresponding docs file,
+# or if docs exist for a resource that has no schema.
+set -e
+
+SCHEMAS_DIR="carina-provider-awscc/src/schemas/generated"
+DOCS_DIR="generated-docs/awscc"
+
+EXIT_CODE=0
+
+# Collect schema resources: service/resource from .rs files (excluding mod.rs)
+schema_resources=()
+for rs_file in "$SCHEMAS_DIR"/*/*.rs; do
+    [ "$(basename "$rs_file")" = "mod.rs" ] && continue
+    svc=$(basename "$(dirname "$rs_file")")
+    resource=$(basename "$rs_file" .rs)
+    schema_resources+=("$svc/$resource")
+done
+
+# Collect doc resources: service/resource from .md files
+doc_resources=()
+for md_file in "$DOCS_DIR"/*/*.md; do
+    [ -f "$md_file" ] || continue
+    svc=$(basename "$(dirname "$md_file")")
+    resource=$(basename "$md_file" .md)
+    doc_resources+=("$svc/$resource")
+done
+
+# Check for schemas without docs
+for sr in "${schema_resources[@]}"; do
+    found=false
+    for dr in "${doc_resources[@]}"; do
+        if [ "$sr" = "$dr" ]; then
+            found=true
+            break
+        fi
+    done
+    if [ "$found" = false ]; then
+        echo "MISSING DOCS: $sr (schema exists but docs missing)"
+        EXIT_CODE=1
+    fi
+done
+
+# Check for docs without schemas
+for dr in "${doc_resources[@]}"; do
+    found=false
+    for sr in "${schema_resources[@]}"; do
+        if [ "$dr" = "$sr" ]; then
+            found=true
+            break
+        fi
+    done
+    if [ "$found" = false ]; then
+        echo "ORPHAN DOCS: $dr (docs exist but schema missing)"
+        EXIT_CODE=1
+    fi
+done
+
+if [ "$EXIT_CODE" = 0 ]; then
+    echo "OK: schemas and docs are in sync (${#schema_resources[@]} resources)"
+fi
+
+exit $EXIT_CODE

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -26,45 +26,24 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 CACHE_DIR="$PROJECT_ROOT/cfn-schema-cache"
 DOCS_DIR="$PROJECT_ROOT/generated-docs/awscc"
 EXAMPLES_DIR="$PROJECT_ROOT/examples"
+SCHEMAS_DIR="$PROJECT_ROOT/carina-provider-awscc/src/schemas/generated"
 mkdir -p "$CACHE_DIR"
 rm -rf "$DOCS_DIR"
 mkdir -p "$DOCS_DIR"
 
 cd "$PROJECT_ROOT"
 
-# Same resource types as generate-schemas.sh
-RESOURCE_TYPES=(
-    "AWS::EC2::VPC"
-    "AWS::EC2::Subnet"
-    "AWS::EC2::InternetGateway"
-    "AWS::EC2::RouteTable"
-    "AWS::EC2::Route"
-    "AWS::EC2::SubnetRouteTableAssociation"
-    "AWS::EC2::EIP"
-    "AWS::EC2::NatGateway"
-    "AWS::EC2::SecurityGroup"
-    "AWS::EC2::SecurityGroupIngress"
-    "AWS::EC2::SecurityGroupEgress"
-    "AWS::EC2::VPCEndpoint"
-    "AWS::EC2::VPCGatewayAttachment"
-    "AWS::EC2::FlowLog"
-    "AWS::EC2::IPAM"
-    "AWS::EC2::IPAMPool"
-    "AWS::EC2::VPNGateway"
-    "AWS::EC2::TransitGateway"
-    "AWS::EC2::VPCPeeringConnection"
-    "AWS::EC2::EgressOnlyInternetGateway"
-    "AWS::EC2::TransitGatewayAttachment"
-    "AWS::S3::Bucket"
-    "AWS::IAM::Role"
-    "AWS::Logs::LogGroup"
-    "AWS::SSO::Instance"
-    "AWS::SSO::PermissionSet"
-    "AWS::SSO::Assignment"
-    "AWS::IdentityStore::Group"
-    "AWS::IdentityStore::GroupMembership"
-    "AWS::Route53::HostedZone"
-)
+# Derive resource types from generated schema files (single source of truth).
+# Each .rs file (excluding mod.rs) has a header comment:
+#   Auto-generated from CloudFormation schema: AWS::EC2::VPC
+RESOURCE_TYPES=()
+for rs_file in "$SCHEMAS_DIR"/*/*.rs; do
+    [ "$(basename "$rs_file")" = "mod.rs" ] && continue
+    cfn_type=$(grep -m1 'Auto-generated from CloudFormation schema:' "$rs_file" | sed 's/.*schema: //')
+    if [ -n "$cfn_type" ]; then
+        RESOURCE_TYPES+=("$cfn_type")
+    fi
+done
 
 echo "Generating awscc provider documentation..."
 echo "Output directory: $DOCS_DIR"


### PR DESCRIPTION
Closes #130

## Summary

- **`generate-docs.sh`**: Replaced hardcoded `RESOURCE_TYPES` array with introspection of `src/schemas/generated/` — extracts CFN type names from the `Auto-generated from CloudFormation schema:` header in each `.rs` file. Schemas are now the single source of truth; docs can never fall behind.
- **`scripts/check-docs-drift.sh`**: New CI guard that compares schema dirs against docs dirs. Fails if any schema resource is missing docs or vice versa.
- **CI**: Added "Check Docs Drift" job to `ci.yml`.
- **Regenerated docs**: Added missing `organizations/account.md`, `organizations/organization.md`, and `iam/oidc_provider.md`.

### Before
```
$ ./scripts/check-docs-drift.sh
MISSING DOCS: iam/oidc_provider (schema exists but docs missing)
MISSING DOCS: organizations/account (schema exists but docs missing)
MISSING DOCS: organizations/organization (schema exists but docs missing)
```

### After
```
$ ./scripts/check-docs-drift.sh
OK: schemas and docs are in sync (33 resources)
```

## Test plan
- [x] check-docs-drift.sh correctly detects missing docs (verified before fix)
- [x] check-docs-drift.sh passes after regeneration (33 resources in sync)
- [x] CI job added

🤖 Generated with [Claude Code](https://claude.com/claude-code)