### PR TITLE
feat: emit exclusive_required as data so oneOf constraints cross WASM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina#64d239647c45c6daa057a6a101495e4a6381f126"
+source = "git+https://github.com/carina-rs/carina#795af1917fdd1fa2a73b2901db6b1fc13450eb89"
 dependencies = [
  "argon2",
  "futures",
@@ -531,7 +531,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina#64d239647c45c6daa057a6a101495e4a6381f126"
+source = "git+https://github.com/carina-rs/carina#795af1917fdd1fa2a73b2901db6b1fc13450eb89"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#64d239647c45c6daa057a6a101495e4a6381f126"
+source = "git+https://github.com/carina-rs/carina#795af1917fdd1fa2a73b2901db6b1fc13450eb89"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -1318,10 +1318,8 @@ fn generate_schema_code(schema: &CfnSchema, type_name: &str) -> Result<String> {
                     ranged_floats.insert(prop_name.clone(), (Some(min), Some(max)));
                 }
             }
-            Some("array") => {
-                if prop.min_items.is_some() || prop.max_items.is_some() {
-                    ranged_lists.insert(prop_name.clone(), (prop.min_items, prop.max_items));
-                }
+            Some("array") if prop.min_items.is_some() || prop.max_items.is_some() => {
+                ranged_lists.insert(prop_name.clone(), (prop.min_items, prop.max_items));
             }
             Some("string") => {
                 // Collect string length constraints (only for plain strings without
@@ -1605,7 +1603,6 @@ fn generate_schema_code(schema: &CfnSchema, type_name: &str) -> Result<String> {
 
     // Detect mutually exclusive field groups from schema structure and descriptions
     let exclusive_groups = detect_exclusive_fields(schema, type_name);
-    let has_exclusive_fields = !exclusive_groups.is_empty();
 
     // Generate header with conditional imports
     let mut schema_imports = vec!["AttributeSchema", "ResourceSchema"];
@@ -1617,9 +1614,6 @@ fn generate_schema_code(schema: &CfnSchema, type_name: &str) -> Result<String> {
     }
     if needs_types {
         schema_imports.push("types");
-    }
-    if has_exclusive_fields {
-        schema_imports.push("validators");
     }
     // Resources with custom operation config need the OperationConfig import
     const OPERATION_CONFIG_TYPES: &[&str] = &[
@@ -2151,25 +2145,25 @@ pub fn {}() -> AwsccSchemaConfig {{
         code.push_str("        })\n");
     }
 
-    // Generate validator for mutually exclusive field groups and/or tags validation.
-    let needs_validator = !exclusive_groups.is_empty() || has_tags;
-    if needs_validator {
+    // Mutually exclusive required groups are emitted as declarative data so
+    // the constraint survives the WASM plugin boundary (function-pointer
+    // validators are lost when schemas cross into the host).
+    for group in &exclusive_groups {
+        let fields_str = group
+            .iter()
+            .map(|f| format!("\"{}\"", f.to_snake_case()))
+            .collect::<Vec<_>>()
+            .join(", ");
+        code.push_str(&format!("        .exclusive_required(&[{}])\n", fields_str));
+    }
+
+    // Tags map-shape check is still emitted as a closure. It's a local
+    // safety net; the host side re-attaches the equivalent check via
+    // `ValidatorType::TagsKeyValueCheck` (see `main.rs::schemas`).
+    if has_tags {
         code.push_str("        .with_validator(|attrs| {\n");
         code.push_str("            let mut errors = Vec::new();\n");
-        for group in &exclusive_groups {
-            let fields_str = group
-                .iter()
-                .map(|f| format!("\"{}\"", f.to_snake_case()))
-                .collect::<Vec<_>>()
-                .join(", ");
-            code.push_str(&format!(
-                "            if let Err(mut e) = validators::validate_exclusive_required(attrs, &[{}]) {{\n                errors.append(&mut e);\n            }}\n",
-                fields_str
-            ));
-        }
-        if has_tags {
-            code.push_str("            if let Err(mut e) = validate_tags_map(attrs) {\n                errors.append(&mut e);\n            }\n");
-        }
+        code.push_str("            if let Err(mut e) = validate_tags_map(attrs) {\n                errors.append(&mut e);\n            }\n");
         code.push_str(
             "            if errors.is_empty() { Ok(()) } else { Err(errors) }\n        })\n",
         );
@@ -9753,8 +9747,9 @@ mod tests {
 
     #[test]
     fn test_generated_code_contains_validator_for_detected_exclusives() {
-        // Full integration: generate_schema_code should produce with_validator for
-        // description-detected exclusive fields
+        // Full integration: generate_schema_code should produce a declarative
+        // .exclusive_required(&[...]) for description-detected exclusive
+        // fields — not a closure. Closures don't cross the WASM boundary.
         let mut props = BTreeMap::new();
         props.insert(
             "InternetGatewayId".to_string(),
@@ -9801,12 +9796,16 @@ mod tests {
         };
         let code = generate_schema_code(&schema, "AWS::EC2::VPCGatewayAttachment").unwrap();
         assert!(
-            code.contains("validators::validate_exclusive_required"),
-            "Generated code should contain exclusive validator: {code}"
+            code.contains(".exclusive_required(&["),
+            "Generated code should emit declarative .exclusive_required: {code}"
         );
         assert!(
             code.contains("\"internet_gateway_id\"") && code.contains("\"vpn_gateway_id\""),
             "Generated code should reference snake_case field names: {code}"
+        );
+        assert!(
+            !code.contains("validators::validate_exclusive_required"),
+            "Generated code should not emit the old closure form: {code}"
         );
     }
 

--- a/carina-provider-awscc/src/convert.rs
+++ b/carina-provider-awscc/src/convert.rs
@@ -241,6 +241,7 @@ pub fn proto_to_core_schema(s: &ProtoResourceSchema) -> CoreResourceSchema {
                 create_max_retries: c.create_max_retries,
             }
         }),
+        exclusive_required: s.exclusive_required.clone(),
     }
 }
 
@@ -337,6 +338,7 @@ pub fn core_to_proto_schema(s: &CoreResourceSchema) -> ProtoResourceSchema {
             }
         }),
         validators: vec![],
+        exclusive_required: s.exclusive_required.clone(),
     }
 }
 

--- a/carina-provider-awscc/src/main.rs
+++ b/carina-provider-awscc/src/main.rs
@@ -366,4 +366,27 @@ mod tests {
             );
         }
     }
+
+    /// Regression for carina-rs/carina#2025: the VPC schema must carry the
+    /// `cidr_block` / `ipv4_ipam_pool_id` oneOf constraint as serializable
+    /// data, so it survives the WASM plugin boundary and validate/plan can
+    /// reject `awscc.ec2.vpc {}` before any provider call.
+    #[test]
+    fn vpc_schema_carries_cidr_block_exclusive_group_across_proto() {
+        let provider = AwsccProcessProvider::new();
+        let schemas = provider.schemas();
+        let vpc = schemas
+            .iter()
+            .find(|s| s.resource_type == "awscc.ec2.vpc")
+            .expect("ec2.vpc schema should exist");
+        assert!(
+            vpc.exclusive_required
+                .iter()
+                .any(|g| g.contains(&"cidr_block".to_string())
+                    && g.contains(&"ipv4_ipam_pool_id".to_string())),
+            "vpc schema should expose cidr_block/ipv4_ipam_pool_id as a declarative \
+             exclusive_required group, got: {:?}",
+            vpc.exclusive_required
+        );
+    }
 }

--- a/carina-provider-awscc/src/schemas/generated/ec2/vpc.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/vpc.rs
@@ -8,7 +8,7 @@ use super::AwsccSchemaConfig;
 use super::tags_type;
 use super::validate_tags_map;
 use carina_core::resource::Value;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types, validators};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
 
 const VALID_INSTANCE_TENANCY: &[&str] = &["default", "dedicated", "host"];
 
@@ -113,11 +113,9 @@ pub fn ec2_vpc_config() -> AwsccSchemaConfig {
                 .with_description(" (read-only)")
                 .with_provider_name("VpcId"),
         )
+        .exclusive_required(&["cidr_block", "ipv4_ipam_pool_id"])
         .with_validator(|attrs| {
             let mut errors = Vec::new();
-            if let Err(mut e) = validators::validate_exclusive_required(attrs, &["cidr_block", "ipv4_ipam_pool_id"]) {
-                errors.append(&mut e);
-            }
             if let Err(mut e) = validate_tags_map(attrs) {
                 errors.append(&mut e);
             }

--- a/carina-provider-awscc/src/schemas/generated/ec2/vpc_gateway_attachment.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/vpc_gateway_attachment.rs
@@ -5,9 +5,7 @@
 //! DO NOT EDIT MANUALLY - regenerate with carina-codegen
 
 use super::AwsccSchemaConfig;
-use carina_core::schema::{
-    AttributeSchema, AttributeType, OperationConfig, ResourceSchema, validators,
-};
+use carina_core::schema::{AttributeSchema, AttributeType, OperationConfig, ResourceSchema};
 
 /// Returns the schema config for ec2_vpc_gateway_attachment (AWS::EC2::VPCGatewayAttachment)
 pub fn ec2_vpc_gateway_attachment_config() -> AwsccSchemaConfig {
@@ -46,13 +44,7 @@ pub fn ec2_vpc_gateway_attachment_config() -> AwsccSchemaConfig {
             create_timeout_secs: None,
             create_max_retries: None,
         })
-        .with_validator(|attrs| {
-            let mut errors = Vec::new();
-            if let Err(mut e) = validators::validate_exclusive_required(attrs, &["internet_gateway_id", "vpn_gateway_id"]) {
-                errors.append(&mut e);
-            }
-            if errors.is_empty() { Ok(()) } else { Err(errors) }
-        })
+        .exclusive_required(&["internet_gateway_id", "vpn_gateway_id"])
     }
 }
 


### PR DESCRIPTION
Closes carina-rs/carina#2025.

Depends on (and ships alongside) carina-rs/carina#2027, which added the core-side `ResourceSchema::exclusive_required` field.

## Summary

Before this change, CloudFormation \`oneOf\` constraints on awscc schemas (e.g. VPC: exactly one of \`cidr_block\` / \`ipv4_ipam_pool_id\`) were emitted as a closure passed to \`ResourceSchema::with_validator\`. Function-pointer validators are dropped when schemas cross the WASM plugin boundary, so the constraint was silently lost on the host side and \`carina validate\` / \`plan\` happily accepted \`awscc.ec2.vpc {}\` — the failure only surfaced at apply time as a provider error.

This PR switches the codegen emit to the new \`.exclusive_required(&[...])\` builder, which stores the constraint as plain data that survives the proto round-trip.

## Changes

- **\`convert.rs\`**: copy \`exclusive_required\` in both directions of the core ↔ proto conversion (two 1-line additions — without these, the whole crate won't compile against the updated protocol).
- **\`codegen.rs\`**:
  - Emit \`.exclusive_required(&[...])\` for detected oneOf groups.
  - Drop the now-unused \`validators\` import emission for affected schemas.
  - The existing \`with_validator\` emit path is kept solely for the \`has_tags\` map-shape check.
- **Regenerated schemas**: \`ec2::vpc\` and \`ec2::vpc_gateway_attachment\` — the two resources whose detected oneOf groups previously only existed as closures. All other generated files are unchanged.
- **Regression test**: \`vpc_schema_carries_cidr_block_exclusive_group_across_proto\` — asserts the VPC schema's \`exclusive_required\` survives the full \`core_to_proto_schema\` round-trip.
- **Tangential clippy fix**: \`Some(\"array\")\` → \`Some(\"array\") if ...\` for \`clippy::collapsible_match\` (new lint on Rust 1.95). Included here because the pre-commit hook runs this lint and would otherwise block the commit on the feature work itself.

## Verification

- All 385 tests pass (\`cargo test\`).
- \`cargo clippy --all-targets --all-features -- -D warnings\` is clean.
- Manual end-to-end: installed the locally-built WASM at \`~/.carina/providers/.../carina-provider-awscc.wasm\`, ran \`carina validate\` against \`awscc.ec2.vpc {}\` — now fails with \`Exactly one of [cidr_block, ipv4_ipam_pool_id] must be specified\` and exits non-zero, instead of silently succeeding.

## Test plan

- [x] Regenerated with \`./scripts/generate-schemas.sh\` — only \`vpc.rs\` and \`vpc_gateway_attachment.rs\` changed
- [x] WASM release build succeeds
- [x] End-to-end reproduction of Issue #2025 now fails at \`validate\` (not at \`apply\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)