### PR TITLE
Migrate to new Custom shape and add SSO semantic helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina#795af1917fdd1fa2a73b2901db6b1fc13450eb89"
+source = "git+https://github.com/carina-rs/carina#aaa17511613befcec5f014b7d3ccc85e8a9b8298"
 dependencies = [
  "argon2",
  "futures",
@@ -531,7 +531,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina#795af1917fdd1fa2a73b2901db6b1fc13450eb89"
+source = "git+https://github.com/carina-rs/carina#aaa17511613befcec5f014b7d3ccc85e8a9b8298"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#795af1917fdd1fa2a73b2901db6b1fc13450eb89"
+source = "git+https://github.com/carina-rs/carina#aaa17511613befcec5f014b7d3ccc85e8a9b8298"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -203,7 +203,9 @@ pub fn validate_prefixed_resource_id(id: &str, expected_prefix: &str) -> Result<
 #[allow(dead_code)]
 pub fn aws_resource_id() -> AttributeType {
     AttributeType::Custom {
-        name: "AwsResourceId".to_string(),
+        semantic_name: Some("AwsResourceId".to_string()),
+        pattern: None,
+        length: None,
         base: Box::new(AttributeType::String),
         validate: |value| {
             if let Value::String(s) = value {
@@ -221,7 +223,9 @@ pub fn aws_resource_id() -> AttributeType {
 /// VPC ID type (e.g., "vpc-1a2b3c4d")
 pub fn vpc_id() -> AttributeType {
     AttributeType::Custom {
-        name: "VpcId".to_string(),
+        semantic_name: Some("VpcId".to_string()),
+        pattern: None,
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -239,7 +243,9 @@ pub fn vpc_id() -> AttributeType {
 /// Subnet ID type (e.g., "subnet-0123456789abcdef0")
 pub fn subnet_id() -> AttributeType {
     AttributeType::Custom {
-        name: "SubnetId".to_string(),
+        semantic_name: Some("SubnetId".to_string()),
+        pattern: None,
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -257,7 +263,9 @@ pub fn subnet_id() -> AttributeType {
 /// Security Group ID type (e.g., "sg-12345678")
 pub fn security_group_id() -> AttributeType {
     AttributeType::Custom {
-        name: "SecurityGroupId".to_string(),
+        semantic_name: Some("SecurityGroupId".to_string()),
+        pattern: None,
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -275,7 +283,9 @@ pub fn security_group_id() -> AttributeType {
 /// Internet Gateway ID type (e.g., "igw-12345678")
 pub fn internet_gateway_id() -> AttributeType {
     AttributeType::Custom {
-        name: "InternetGatewayId".to_string(),
+        semantic_name: Some("InternetGatewayId".to_string()),
+        pattern: None,
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -293,7 +303,9 @@ pub fn internet_gateway_id() -> AttributeType {
 /// Route Table ID type (e.g., "rtb-abcdef12")
 pub fn route_table_id() -> AttributeType {
     AttributeType::Custom {
-        name: "RouteTableId".to_string(),
+        semantic_name: Some("RouteTableId".to_string()),
+        pattern: None,
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -311,7 +323,9 @@ pub fn route_table_id() -> AttributeType {
 /// NAT Gateway ID type (e.g., "nat-12345678")
 pub fn nat_gateway_id() -> AttributeType {
     AttributeType::Custom {
-        name: "NatGatewayId".to_string(),
+        semantic_name: Some("NatGatewayId".to_string()),
+        pattern: None,
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -329,7 +343,9 @@ pub fn nat_gateway_id() -> AttributeType {
 /// VPC Peering Connection ID type (e.g., "pcx-12345678")
 pub fn vpc_peering_connection_id() -> AttributeType {
     AttributeType::Custom {
-        name: "VpcPeeringConnectionId".to_string(),
+        semantic_name: Some("VpcPeeringConnectionId".to_string()),
+        pattern: None,
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -348,7 +364,9 @@ pub fn vpc_peering_connection_id() -> AttributeType {
 /// Transit Gateway ID type (e.g., "tgw-12345678")
 pub fn transit_gateway_id() -> AttributeType {
     AttributeType::Custom {
-        name: "TransitGatewayId".to_string(),
+        semantic_name: Some("TransitGatewayId".to_string()),
+        pattern: None,
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -366,7 +384,9 @@ pub fn transit_gateway_id() -> AttributeType {
 /// VPC CIDR Block Association ID type (e.g., "vpc-cidr-assoc-12345678")
 pub fn vpc_cidr_block_association_id() -> AttributeType {
     AttributeType::Custom {
-        name: "VpcCidrBlockAssociationId".to_string(),
+        semantic_name: Some("VpcCidrBlockAssociationId".to_string()),
+        pattern: None,
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -385,7 +405,9 @@ pub fn vpc_cidr_block_association_id() -> AttributeType {
 /// Transit Gateway Route Table ID type (e.g., "tgw-rtb-12345678")
 pub fn tgw_route_table_id() -> AttributeType {
     AttributeType::Custom {
-        name: "TgwRouteTableId".to_string(),
+        semantic_name: Some("TgwRouteTableId".to_string()),
+        pattern: None,
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -403,7 +425,9 @@ pub fn tgw_route_table_id() -> AttributeType {
 /// VPN Gateway ID type (e.g., "vgw-12345678")
 pub fn vpn_gateway_id() -> AttributeType {
     AttributeType::Custom {
-        name: "VpnGatewayId".to_string(),
+        semantic_name: Some("VpnGatewayId".to_string()),
+        pattern: None,
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -426,7 +450,9 @@ pub fn gateway_id() -> AttributeType {
 /// Egress Only Internet Gateway ID type (e.g., "eigw-12345678")
 pub fn egress_only_internet_gateway_id() -> AttributeType {
     AttributeType::Custom {
-        name: "EgressOnlyInternetGatewayId".to_string(),
+        semantic_name: Some("EgressOnlyInternetGatewayId".to_string()),
+        pattern: None,
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -448,7 +474,9 @@ pub fn egress_only_internet_gateway_id() -> AttributeType {
 /// VPC Endpoint ID type (e.g., "vpce-12345678")
 pub fn vpc_endpoint_id() -> AttributeType {
     AttributeType::Custom {
-        name: "VpcEndpointId".to_string(),
+        semantic_name: Some("VpcEndpointId".to_string()),
+        pattern: None,
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -466,7 +494,9 @@ pub fn vpc_endpoint_id() -> AttributeType {
 /// Instance ID type (e.g., "i-0123456789abcdef0")
 pub fn instance_id() -> AttributeType {
     AttributeType::Custom {
-        name: "InstanceId".to_string(),
+        semantic_name: Some("InstanceId".to_string()),
+        pattern: None,
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -484,7 +514,9 @@ pub fn instance_id() -> AttributeType {
 /// Network Interface ID type (e.g., "eni-0123456789abcdef0")
 pub fn network_interface_id() -> AttributeType {
     AttributeType::Custom {
-        name: "NetworkInterfaceId".to_string(),
+        semantic_name: Some("NetworkInterfaceId".to_string()),
+        pattern: None,
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -503,7 +535,9 @@ pub fn network_interface_id() -> AttributeType {
 #[allow(dead_code)]
 pub fn allocation_id() -> AttributeType {
     AttributeType::Custom {
-        name: "AllocationId".to_string(),
+        semantic_name: Some("AllocationId".to_string()),
+        pattern: None,
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -521,7 +555,9 @@ pub fn allocation_id() -> AttributeType {
 /// Prefix List ID type (e.g., "pl-0123456789abcdef0")
 pub fn prefix_list_id() -> AttributeType {
     AttributeType::Custom {
-        name: "PrefixListId".to_string(),
+        semantic_name: Some("PrefixListId".to_string()),
+        pattern: None,
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -539,7 +575,9 @@ pub fn prefix_list_id() -> AttributeType {
 /// Carrier Gateway ID type (e.g., "cagw-0123456789abcdef0")
 pub fn carrier_gateway_id() -> AttributeType {
     AttributeType::Custom {
-        name: "CarrierGatewayId".to_string(),
+        semantic_name: Some("CarrierGatewayId".to_string()),
+        pattern: None,
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -557,7 +595,9 @@ pub fn carrier_gateway_id() -> AttributeType {
 /// Local Gateway ID type (e.g., "lgw-0123456789abcdef0")
 pub fn local_gateway_id() -> AttributeType {
     AttributeType::Custom {
-        name: "LocalGatewayId".to_string(),
+        semantic_name: Some("LocalGatewayId".to_string()),
+        pattern: None,
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -576,7 +616,9 @@ pub fn local_gateway_id() -> AttributeType {
 #[allow(dead_code)]
 pub fn network_acl_id() -> AttributeType {
     AttributeType::Custom {
-        name: "NetworkAclId".to_string(),
+        semantic_name: Some("NetworkAclId".to_string()),
+        pattern: None,
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -594,7 +636,9 @@ pub fn network_acl_id() -> AttributeType {
 /// Transit Gateway Attachment ID type (e.g., "tgw-attach-0123456789abcdef0")
 pub fn transit_gateway_attachment_id() -> AttributeType {
     AttributeType::Custom {
-        name: "TransitGatewayAttachmentId".to_string(),
+        semantic_name: Some("TransitGatewayAttachmentId".to_string()),
+        pattern: None,
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -613,7 +657,9 @@ pub fn transit_gateway_attachment_id() -> AttributeType {
 /// Flow Log ID type (e.g., "fl-0123456789abcdef0")
 pub fn flow_log_id() -> AttributeType {
     AttributeType::Custom {
-        name: "FlowLogId".to_string(),
+        semantic_name: Some("FlowLogId".to_string()),
+        pattern: None,
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -631,7 +677,9 @@ pub fn flow_log_id() -> AttributeType {
 /// IPAM ID type (e.g., "ipam-0123456789abcdef0")
 pub fn ipam_id() -> AttributeType {
     AttributeType::Custom {
-        name: "IpamId".to_string(),
+        semantic_name: Some("IpamId".to_string()),
+        pattern: None,
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -649,7 +697,9 @@ pub fn ipam_id() -> AttributeType {
 /// Subnet Route Table Association ID type (e.g., "rtbassoc-0123456789abcdef0")
 pub fn subnet_route_table_association_id() -> AttributeType {
     AttributeType::Custom {
-        name: "SubnetRouteTableAssociationId".to_string(),
+        semantic_name: Some("SubnetRouteTableAssociationId".to_string()),
+        pattern: None,
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -671,7 +721,9 @@ pub fn subnet_route_table_association_id() -> AttributeType {
 /// Security Group Rule ID type (e.g., "sgr-0123456789abcdef0")
 pub fn security_group_rule_id() -> AttributeType {
     AttributeType::Custom {
-        name: "SecurityGroupRuleId".to_string(),
+        semantic_name: Some("SecurityGroupRuleId".to_string()),
+        pattern: None,
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -703,7 +755,9 @@ pub fn validate_iam_role_id(id: &str) -> Result<(), String> {
 /// IAM Role ID type (e.g., "AROAEXAMPLEID")
 pub fn iam_role_id() -> AttributeType {
     AttributeType::Custom {
-        name: "IamRoleId".to_string(),
+        semantic_name: Some("IamRoleId".to_string()),
+        pattern: None,
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -737,12 +791,85 @@ pub fn validate_aws_account_id(id: &str) -> Result<(), String> {
 /// AWS Account ID type (12-digit numeric string, e.g., "123456789012")
 pub fn aws_account_id() -> AttributeType {
     AttributeType::Custom {
-        name: "AwsAccountId".to_string(),
+        semantic_name: Some("AwsAccountId".to_string()),
+        pattern: None,
+        length: None,
         base: Box::new(AttributeType::String),
         validate: |value| {
             if let Value::String(s) = value {
                 validate_aws_account_id(s)
                     .map_err(|reason| format!("Invalid AWS Account ID '{}': {}", s, reason))
+            } else {
+                Err("Expected string".to_string())
+            }
+        },
+        namespace: None,
+        to_dsl: None,
+    }
+}
+
+// ========== SSO / Identity Center helpers ==========
+
+/// Validate an SSO principal ID. Accepts either an IdentityStore user id
+/// (`<region>-<uuid>`) or a group id (`<region>-<uuid>`) as defined by the
+/// AWS::SSO::Assignment CFN schema (pattern: `^([0-9a-f]{10}-|)[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$`).
+pub fn validate_sso_principal_id(id: &str) -> Result<(), String> {
+    if id.is_empty() {
+        return Err("must not be empty".to_string());
+    }
+    if id.len() > 64 {
+        return Err(format!("must be at most 64 characters, got {}", id.len()));
+    }
+    Ok(())
+}
+
+/// SSO PrincipalId type (user or group id from IdentityStore).
+pub fn sso_principal_id() -> AttributeType {
+    AttributeType::Custom {
+        semantic_name: Some("SsoPrincipalId".to_string()),
+        pattern: None,
+        length: None,
+        base: Box::new(AttributeType::String),
+        validate: |value| {
+            if let Value::String(s) = value {
+                validate_sso_principal_id(s)
+                    .map_err(|reason| format!("Invalid SSO principal ID '{}': {}", s, reason))
+            } else {
+                Err("Expected string".to_string())
+            }
+        },
+        namespace: None,
+        to_dsl: None,
+    }
+}
+
+/// Validate an SSO Instance ARN
+/// (`arn:aws:sso:::instance/ssoins-<hex>`).
+pub fn validate_sso_instance_arn(arn: &str) -> Result<(), String> {
+    validate_arn(arn)?;
+    let parts: Vec<&str> = arn.splitn(6, ':').collect();
+    if parts[2] != "sso" {
+        return Err(format!("expected service 'sso', got '{}'", parts[2]));
+    }
+    if !parts[5].starts_with("instance/") {
+        return Err(
+            "resource must start with 'instance/' (e.g. 'instance/ssoins-...')".to_string(),
+        );
+    }
+    Ok(())
+}
+
+/// SSO Instance ARN type (e.g., "arn:aws:sso:::instance/ssoins-xxxxxxxx").
+pub fn sso_instance_arn() -> AttributeType {
+    AttributeType::Custom {
+        semantic_name: Some("SsoInstanceArn".to_string()),
+        pattern: None,
+        length: None,
+        base: Box::new(arn()),
+        validate: |value| {
+            if let Value::String(s) = value {
+                validate_sso_instance_arn(s)
+                    .map_err(|reason| format!("Invalid SSO instance ARN '{}': {}", s, reason))
             } else {
                 Err("Expected string".to_string())
             }
@@ -874,7 +1001,9 @@ pub fn validate_iam_arn(arn: &str, resource_prefix: &str) -> Result<(), String> 
 /// ARN type (e.g., "arn:aws:s3:::my-bucket")
 pub fn arn() -> AttributeType {
     AttributeType::Custom {
-        name: "Arn".to_string(),
+        semantic_name: Some("Arn".to_string()),
+        pattern: None,
+        length: None,
         base: Box::new(AttributeType::String),
         validate: |value| {
             if let Value::String(s) = value {
@@ -892,7 +1021,9 @@ pub fn arn() -> AttributeType {
 #[allow(dead_code)]
 pub fn iam_role_arn() -> AttributeType {
     AttributeType::Custom {
-        name: "IamRoleArn".to_string(),
+        semantic_name: Some("IamRoleArn".to_string()),
+        pattern: None,
+        length: None,
         base: Box::new(arn()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -911,7 +1042,9 @@ pub fn iam_role_arn() -> AttributeType {
 #[allow(dead_code)]
 pub fn iam_policy_arn() -> AttributeType {
     AttributeType::Custom {
-        name: "IamPolicyArn".to_string(),
+        semantic_name: Some("IamPolicyArn".to_string()),
+        pattern: None,
+        length: None,
         base: Box::new(arn()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -930,7 +1063,9 @@ pub fn iam_policy_arn() -> AttributeType {
 #[allow(dead_code)]
 pub fn kms_key_arn() -> AttributeType {
     AttributeType::Custom {
-        name: "KmsKeyArn".to_string(),
+        semantic_name: Some("KmsKeyArn".to_string()),
+        pattern: None,
+        length: None,
         base: Box::new(arn()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -998,7 +1133,9 @@ pub fn validate_kms_key_id(value: &str) -> Result<(), String> {
 #[allow(dead_code)]
 pub fn kms_key_id() -> AttributeType {
     AttributeType::Custom {
-        name: "KmsKeyId".to_string(),
+        semantic_name: Some("KmsKeyId".to_string()),
+        pattern: None,
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -1032,7 +1169,9 @@ pub fn validate_ipam_pool_id(id: &str) -> Result<(), String> {
 /// IPAM Pool ID type (e.g., "ipam-pool-0123456789abcdef0")
 pub fn ipam_pool_id() -> AttributeType {
     AttributeType::Custom {
-        name: "IpamPoolId".to_string(),
+        semantic_name: Some("IpamPoolId".to_string()),
+        pattern: None,
+        length: None,
         base: Box::new(aws_resource_id()),
         validate: |value| {
             if let Value::String(s) = value {
@@ -1139,7 +1278,9 @@ pub fn validate_availability_zone_id(az_id: &str) -> Result<(), String> {
 /// Availability Zone ID type (e.g., "use1-az1", "usw2-az2", "apne1-az4")
 pub fn availability_zone_id() -> AttributeType {
     AttributeType::Custom {
-        name: "AvailabilityZoneId".to_string(),
+        semantic_name: Some("AvailabilityZoneId".to_string()),
+        pattern: None,
+        length: None,
         base: Box::new(AttributeType::String),
         validate: |value| {
             if let Value::String(s) = value {
@@ -1190,7 +1331,9 @@ fn string_or_principal_struct() -> AttributeType {
 /// Only allows "Allow" or "Deny"
 fn iam_policy_effect() -> AttributeType {
     AttributeType::Custom {
-        name: "IamPolicyEffect".to_string(),
+        semantic_name: Some("IamPolicyEffect".to_string()),
+        pattern: None,
+        length: None,
         base: Box::new(AttributeType::String),
         validate: |value| {
             if let Value::String(s) = value {
@@ -1214,7 +1357,9 @@ fn iam_policy_effect() -> AttributeType {
 /// Only allows "2012-10-17" or "2008-10-17"
 fn iam_policy_version() -> AttributeType {
     AttributeType::Custom {
-        name: "IamPolicyVersion".to_string(),
+        semantic_name: Some("IamPolicyVersion".to_string()),
+        pattern: None,
+        length: None,
         base: Box::new(AttributeType::String),
         validate: |value| {
             if let Value::String(s) = value {
@@ -1764,6 +1909,40 @@ mod tests {
         assert!(validate_aws_account_id("1234").is_err());
         assert!(validate_aws_account_id("12345678901a").is_err());
         assert!(validate_aws_account_id("").is_err());
+    }
+
+    // SSO principal ID / instance ARN tests
+
+    #[test]
+    fn validate_sso_principal_id_valid() {
+        assert!(validate_sso_principal_id("11111111-2222-3333-4444-555555555555").is_ok());
+        assert!(
+            validate_sso_principal_id("d-1234567890-11111111-2222-3333-4444-555555555555").is_ok()
+        );
+    }
+
+    #[test]
+    fn validate_sso_principal_id_invalid() {
+        assert!(validate_sso_principal_id("").is_err());
+        let too_long = "x".repeat(65);
+        assert!(validate_sso_principal_id(&too_long).is_err());
+    }
+
+    #[test]
+    fn validate_sso_instance_arn_valid() {
+        assert!(
+            validate_sso_instance_arn("arn:aws:sso:::instance/ssoins-1234567890abcdef").is_ok()
+        );
+    }
+
+    #[test]
+    fn validate_sso_instance_arn_invalid() {
+        // Wrong service
+        assert!(validate_sso_instance_arn("arn:aws:iam:::instance/ssoins-abc").is_err());
+        // Wrong resource type
+        assert!(validate_sso_instance_arn("arn:aws:sso:::user/abc").is_err());
+        // Not an ARN
+        assert!(validate_sso_instance_arn("ssoins-1234567890abcdef").is_err());
     }
 
     // KMS Key ID tests

--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -2853,6 +2853,37 @@ fn pattern_fn_name(pattern: &str) -> String {
     format!("validate_string_pattern_{:016x}", hash)
 }
 
+/// Emit a Rust expression for `Option<String>` pattern field. Escapes `"` and `\`
+/// so the generated source compiles; matching/validation logic itself stays in
+/// the `validate` closure.
+fn emit_pattern_option(pattern: Option<&str>) -> String {
+    match pattern {
+        Some(p) => {
+            let escaped = p.replace('\\', "\\\\").replace('"', "\\\"");
+            format!("Some(\"{}\".to_string())", escaped)
+        }
+        None => "None".to_string(),
+    }
+}
+
+/// Emit a Rust expression for the `length` field on `AttributeType::Custom`
+/// (i.e. `Option<(Option<u64>, Option<u64>)>`).
+fn emit_length_option(min: Option<u64>, max: Option<u64>) -> String {
+    let effective_min = min.filter(|&m| m > 0);
+    if effective_min.is_none() && max.is_none() {
+        return "None".to_string();
+    }
+    let min_str = match effective_min {
+        Some(m) => format!("Some({})", m),
+        None => "None".to_string(),
+    };
+    let max_str = match max {
+        Some(m) => format!("Some({})", m),
+        None => "None".to_string(),
+    };
+    format!("Some(({}, {}))", min_str, max_str)
+}
+
 /// Convert a CloudFormation regex pattern into one that Rust's `regex` crate can
 /// compile. Rust's regex does not support PCRE lookaround (`(?=`, `(?!`, `(?<=`,
 /// `(?<!`) or the `\Z` end-of-string anchor. Patterns that cannot be converted
@@ -3075,6 +3106,24 @@ fn resource_type_overrides() -> &'static HashMap<(&'static str, &'static str), T
             m.insert(
                 ("AWS::S3::Bucket", "ReplaceKeyPrefixWith"),
                 TypeOverride::StringType("AttributeType::String"),
+            );
+
+            // SSO Assignment identity semantics
+            m.insert(
+                ("AWS::SSO::Assignment", "TargetId"),
+                TypeOverride::StringType("super::aws_account_id()"),
+            );
+            m.insert(
+                ("AWS::SSO::Assignment", "PrincipalId"),
+                TypeOverride::StringType("super::sso_principal_id()"),
+            );
+            m.insert(
+                ("AWS::SSO::Assignment", "InstanceArn"),
+                TypeOverride::StringType("super::sso_instance_arn()"),
+            );
+            m.insert(
+                ("AWS::SSO::PermissionSet", "InstanceArn"),
+                TypeOverride::StringType("super::sso_instance_arn()"),
             );
 
             // === Enum overrides ===
@@ -3577,22 +3626,20 @@ fn cfn_type_to_carina_type_with_enum(
                     } else {
                         pattern_fn_name(pattern)
                     };
-                    let name = if has_length {
-                        let range = string_length_display(effective_min, def.max_length);
-                        format!("String(pattern, len: {})", range)
-                    } else {
-                        "String(pattern)".to_string()
-                    };
+                    let pattern_expr = emit_pattern_option(Some(pattern));
+                    let length_expr = emit_length_option(effective_min, def.max_length);
                     return (
                         format!(
                             r#"AttributeType::Custom {{
-                name: "{}".to_string(),
+                semantic_name: None,
+                pattern: {},
+                length: {},
                 base: Box::new(AttributeType::String),
                 validate: {},
                 namespace: None,
                 to_dsl: None,
             }}"#,
-                            name, validate_fn
+                            pattern_expr, length_expr, validate_fn
                         ),
                         None,
                     );
@@ -3618,22 +3665,20 @@ fn cfn_type_to_carina_type_with_enum(
                     _ => None,
                 })
                 .collect();
-            let values_str = values
-                .iter()
-                .map(|v| v.to_string())
-                .collect::<Vec<_>>()
-                .join(", ");
+            let _ = values;
             let validate_fn = format!("validate_{}_int_enum", prop_name.to_snake_case());
             return (
                 format!(
                     r#"AttributeType::Custom {{
-                name: "IntEnum([{}])".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: None,
                 base: Box::new(AttributeType::Int),
                 validate: {},
                 namespace: None,
                 to_dsl: None,
             }}"#,
-                    values_str, validate_fn
+                    validate_fn
                 ),
                 None,
             );
@@ -3714,22 +3759,20 @@ fn cfn_type_to_carina_type_with_enum(
                 } else {
                     pattern_fn_name(pattern)
                 };
-                let name = if has_length {
-                    let range = string_length_display(effective_min, prop.max_length);
-                    format!("NumericString(len: {})", range)
-                } else {
-                    "NumericString".to_string()
-                };
+                let pattern_expr = emit_pattern_option(Some(pattern));
+                let length_expr = emit_length_option(effective_min, prop.max_length);
                 return (
                     format!(
                         r#"AttributeType::Custom {{
-                name: "{}".to_string(),
+                semantic_name: None,
+                pattern: {},
+                length: {},
                 base: Box::new(AttributeType::String),
                 validate: {},
                 namespace: None,
                 to_dsl: None,
             }}"#,
-                        name, validate_fn
+                        pattern_expr, length_expr, validate_fn
                     ),
                     None,
                 );
@@ -3742,40 +3785,38 @@ fn cfn_type_to_carina_type_with_enum(
                 } else {
                     pattern_fn_name(pattern)
                 };
-                let name = if has_length {
-                    let range = string_length_display(effective_min, prop.max_length);
-                    format!("String(pattern, len: {})", range)
-                } else {
-                    "String(pattern)".to_string()
-                };
+                let pattern_expr = emit_pattern_option(Some(pattern));
+                let length_expr = emit_length_option(effective_min, prop.max_length);
                 return (
                     format!(
                         r#"AttributeType::Custom {{
-                name: "{}".to_string(),
+                semantic_name: None,
+                pattern: {},
+                length: {},
                 base: Box::new(AttributeType::String),
                 validate: {},
                 namespace: None,
                 to_dsl: None,
             }}"#,
-                        name, validate_fn
+                        pattern_expr, length_expr, validate_fn
                     ),
                     None,
                 );
             }
 
             // Check for string format constraint (e.g., "uri", "date-time")
-            if let Some(ref fmt) = prop.format {
+            if prop.format.is_some() {
                 return (
-                    format!(
-                        r#"AttributeType::Custom {{
-                name: "String({})".to_string(),
+                    r#"AttributeType::Custom {
+                semantic_name: None,
+                pattern: None,
+                length: None,
                 base: Box::new(AttributeType::String),
                 validate: |_| Ok(()),
                 namespace: None,
                 to_dsl: None,
-            }}"#,
-                        fmt
-                    ),
+            }"#
+                    .to_string(),
                     None,
                 );
             }
@@ -3783,18 +3824,20 @@ fn cfn_type_to_carina_type_with_enum(
             // Check for string length constraints (minLength/maxLength)
             if has_length {
                 let validate_fn = string_length_fn_name(effective_min, prop.max_length);
-                let display = string_length_display(effective_min, prop.max_length);
+                let length_expr = emit_length_option(effective_min, prop.max_length);
                 let to_dsl = to_dsl_code_for(&schema.type_name, prop_name);
                 return (
                     format!(
                         r#"AttributeType::Custom {{
-                name: "String(len: {})".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: {},
                 base: Box::new(AttributeType::String),
                 validate: {},
                 namespace: None,
                 to_dsl: {},
             }}"#,
-                        display, validate_fn, to_dsl
+                        length_expr, validate_fn, to_dsl
                     ),
                     None,
                 );
@@ -3807,40 +3850,38 @@ fn cfn_type_to_carina_type_with_enum(
             // Check resource-scoped overrides first
             let res_override =
                 resource_type_overrides().get(&(schema.type_name.as_str(), prop_name));
-            if let Some(TypeOverride::IntRange(min, max)) = res_override {
+            if let Some(TypeOverride::IntRange(_min, _max)) = res_override {
                 let validate_fn = format!("validate_{}_range", prop_name.to_snake_case());
-                let display = range_display_string(Some(*min), Some(*max));
                 return (
                     format!(
                         r#"AttributeType::Custom {{
-                name: "Int({})".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: None,
                 base: Box::new(AttributeType::Int),
                 validate: {},
                 namespace: None,
                 to_dsl: None,
             }}"#,
-                        display, validate_fn
+                        validate_fn
                     ),
                     None,
                 );
             }
-            if let Some(TypeOverride::IntEnum(values)) = res_override {
+            if let Some(TypeOverride::IntEnum(_values)) = res_override {
                 let validate_fn = format!("validate_{}_int_enum", prop_name.to_snake_case());
-                let values_str = values
-                    .iter()
-                    .map(|v| v.to_string())
-                    .collect::<Vec<_>>()
-                    .join(", ");
                 return (
                     format!(
                         r#"AttributeType::Custom {{
-                name: "IntEnum([{}])".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: None,
                 base: Box::new(AttributeType::Int),
                 validate: {},
                 namespace: None,
                 to_dsl: None,
             }}"#,
-                        values_str, validate_fn
+                        validate_fn
                     ),
                     None,
                 );
@@ -3854,41 +3895,37 @@ fn cfn_type_to_carina_type_with_enum(
                         .get(prop_name)
                         .map(|&(min, max)| (Some(min), Some(max)))
                 };
-            if let Some((min, max)) = range {
+            if range.is_some() {
                 // Generate a ranged int type with validation
                 let validate_fn = format!("validate_{}_range", prop_name.to_snake_case());
-                let range_str = range_display_string(min, max);
-                let display = if let Some(ref fmt) = prop.format {
-                    format!("{}, {}", range_str, fmt)
-                } else {
-                    range_str
-                };
                 (
                     format!(
                         r#"AttributeType::Custom {{
-                name: "Int({})".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: None,
                 base: Box::new(AttributeType::Int),
                 validate: {},
                 namespace: None,
                 to_dsl: None,
             }}"#,
-                        display, validate_fn
+                        validate_fn
                     ),
                     None,
                 )
-            } else if let Some(ref fmt) = prop.format {
+            } else if prop.format.is_some() {
                 // Format-only integer (e.g., int64) - informational, no range validation
                 (
-                    format!(
-                        r#"AttributeType::Custom {{
-                name: "Int({})".to_string(),
+                    r#"AttributeType::Custom {
+                semantic_name: None,
+                pattern: None,
+                length: None,
                 base: Box::new(AttributeType::Int),
                 validate: |_| Ok(()),
                 namespace: None,
                 to_dsl: None,
-            }}"#,
-                        fmt
-                    ),
+            }"#
+                    .to_string(),
                     None,
                 )
             } else {
@@ -3899,19 +3936,20 @@ fn cfn_type_to_carina_type_with_enum(
             // Check resource-scoped overrides first
             let res_override =
                 resource_type_overrides().get(&(schema.type_name.as_str(), prop_name));
-            if let Some(TypeOverride::IntRange(min, max)) = res_override {
+            if let Some(TypeOverride::IntRange(_min, _max)) = res_override {
                 let validate_fn = format!("validate_{}_range", prop_name.to_snake_case());
-                let display = range_display_string(Some(*min), Some(*max));
                 return (
                     format!(
                         r#"AttributeType::Custom {{
-                name: "Float({})".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: None,
                 base: Box::new(AttributeType::Float),
                 validate: {},
                 namespace: None,
                 to_dsl: None,
             }}"#,
-                        display, validate_fn
+                        validate_fn
                     ),
                     None,
                 );
@@ -3925,41 +3963,37 @@ fn cfn_type_to_carina_type_with_enum(
                         .get(prop_name)
                         .map(|&(min, max)| (Some(min), Some(max)))
                 };
-            if let Some((min, max)) = range {
+            if range.is_some() {
                 // Generate a ranged float type with validation
                 let validate_fn = format!("validate_{}_range", prop_name.to_snake_case());
-                let range_str = range_display_string(min, max);
-                let display = if let Some(ref fmt) = prop.format {
-                    format!("{}, {}", range_str, fmt)
-                } else {
-                    range_str
-                };
                 (
                     format!(
                         r#"AttributeType::Custom {{
-                name: "Float({})".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: None,
                 base: Box::new(AttributeType::Float),
                 validate: {},
                 namespace: None,
                 to_dsl: None,
             }}"#,
-                        display, validate_fn
+                        validate_fn
                     ),
                     None,
                 )
-            } else if let Some(ref fmt) = prop.format {
+            } else if prop.format.is_some() {
                 // Format-only float (e.g., double) - informational, no range validation
                 (
-                    format!(
-                        r#"AttributeType::Custom {{
-                name: "Float({})".to_string(),
+                    r#"AttributeType::Custom {
+                semantic_name: None,
+                pattern: None,
+                length: None,
                 base: Box::new(AttributeType::Float),
                 validate: |_| Ok(()),
                 namespace: None,
                 to_dsl: None,
-            }}"#,
-                        fmt
-                    ),
+            }"#
+                    .to_string(),
                     None,
                 )
             } else {
@@ -4006,17 +4040,18 @@ fn cfn_type_to_carina_type_with_enum(
             // Wrap in Custom type if minItems/maxItems constraints exist
             if prop.min_items.is_some() || prop.max_items.is_some() {
                 let validate_fn = list_items_fn_name(prop.min_items, prop.max_items);
-                let display = range_display_string(prop.min_items, prop.max_items);
                 (
                     format!(
                         r#"AttributeType::Custom {{
-                name: "List({})".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: None,
                 base: Box::new({}),
                 validate: {},
                 namespace: None,
                 to_dsl: None,
             }}"#,
-                        display, list_type, validate_fn
+                        list_type, validate_fn
                     ),
                     item_enum,
                 )
@@ -5405,8 +5440,8 @@ mod tests {
             type_str
         );
         assert!(
-            type_str.contains("Int(0..=32)"),
-            "Custom type name should include range, got: {}",
+            type_str.contains("Box::new(AttributeType::Int)"),
+            "Custom should wrap Int base, got: {}",
             type_str
         );
         assert!(
@@ -5506,8 +5541,8 @@ mod tests {
             type_str
         );
         assert!(
-            type_str.contains("Int(0..)"),
-            "Custom type name should show one-sided range, got: {}",
+            type_str.contains("Box::new(AttributeType::Int)"),
+            "Custom should wrap Int base, got: {}",
             type_str
         );
     }
@@ -5559,8 +5594,8 @@ mod tests {
             type_str
         );
         assert!(
-            type_str.contains("Int(..=100)"),
-            "Custom type name should show one-sided range, got: {}",
+            type_str.contains("Box::new(AttributeType::Int)"),
+            "Custom should wrap Int base, got: {}",
             type_str
         );
     }
@@ -5623,8 +5658,8 @@ mod tests {
             type_str
         );
         assert!(
-            type_str.contains("IntEnum([1, 3, 5, 7, 14])"),
-            "Custom type name should list enum values, got: {}",
+            type_str.contains("Box::new(AttributeType::Int)"),
+            "Custom should wrap Int base, got: {}",
             type_str
         );
         assert!(
@@ -5948,8 +5983,13 @@ mod tests {
         let (type_str, _) =
             cfn_type_to_carina_type_with_enum(&prop, "FromPort", &schema, "", &BTreeMap::new());
         assert!(
-            type_str.contains("Int(-1..=65535)"),
-            "FromPort should use override range, got: {}",
+            type_str.contains("validate_from_port_range"),
+            "FromPort should use override range validator, got: {}",
+            type_str
+        );
+        assert!(
+            type_str.contains("Box::new(AttributeType::Int)"),
+            "FromPort override should wrap Int base, got: {}",
             type_str
         );
     }
@@ -6057,8 +6097,8 @@ mod tests {
         let (type_str, _) =
             cfn_type_to_carina_type_with_enum(&prop, "FromPort", &schema, "", &BTreeMap::new());
         assert!(
-            type_str.contains("Float(0..=65535)"),
-            "Number with range should produce Float type, got: {}",
+            type_str.contains("validate_from_port_range"),
+            "Number with range should use range validator, got: {}",
             type_str
         );
         assert!(
@@ -8097,7 +8137,7 @@ mod tests {
             "array with minItems/maxItems should produce Custom type: {type_str}"
         );
         assert!(
-            type_str.contains("List"),
+            type_str.contains("AttributeType::list(") || type_str.contains("AttributeType::List"),
             "Custom type should wrap a List: {type_str}"
         );
         assert!(
@@ -8146,8 +8186,8 @@ mod tests {
             "array with only minItems should produce Custom type: {type_str}"
         );
         assert!(
-            type_str.contains("1.."),
-            "should show min bound in type name: {type_str}"
+            type_str.contains("validate_list_items_min_1"),
+            "should reference min-items validator: {type_str}"
         );
     }
 
@@ -8964,8 +9004,12 @@ mod tests {
         let (type_str, _) =
             cfn_type_to_carina_type_with_enum(&prop, "SomeValue", &schema, "", &BTreeMap::new());
         assert!(
-            type_str.contains("int64"),
-            "int64 format should appear in type: {type_str}"
+            type_str.contains("AttributeType::Custom"),
+            "int64 format should produce Custom type: {type_str}"
+        );
+        assert!(
+            type_str.contains("Box::new(AttributeType::Int)"),
+            "int64 format should wrap Int base: {type_str}"
         );
     }
 
@@ -9027,8 +9071,12 @@ mod tests {
         let (type_str, _) =
             cfn_type_to_carina_type_with_enum(&prop, "Url", &schema, "", &BTreeMap::new());
         assert!(
-            type_str.contains("uri"),
-            "uri format should appear in type: {type_str}"
+            type_str.contains("AttributeType::Custom"),
+            "uri format should produce Custom type: {type_str}"
+        );
+        assert!(
+            type_str.contains("Box::new(AttributeType::String)"),
+            "uri format should wrap String base: {type_str}"
         );
     }
 
@@ -9096,8 +9144,12 @@ mod tests {
             &BTreeMap::new(),
         );
         assert!(
-            type_str.contains("NumericString"),
-            "Numeric string pattern should produce NumericString type: {type_str}"
+            type_str.contains("pattern: Some(\"[0-9]+\".to_string())"),
+            "Numeric string pattern should be captured in Custom.pattern: {type_str}"
+        );
+        assert!(
+            type_str.contains("Some((None, Some(20)))"),
+            "maxLength=20 should be captured in Custom.length: {type_str}"
         );
     }
 
@@ -9194,14 +9246,14 @@ mod tests {
         };
         let (type_str, _) =
             cfn_type_to_carina_type_with_enum(&prop, "BoundedValue", &schema, "", &BTreeMap::new());
-        // Should have range validation (0..=100) and int64 format info
+        // Range validation is encoded in the generated validator fn name.
         assert!(
-            type_str.contains("0..=100"),
-            "Should have range constraint: {type_str}"
+            type_str.contains("validate_bounded_value_range"),
+            "Should reference range validator fn: {type_str}"
         );
         assert!(
-            type_str.contains("int64"),
-            "Should have int64 format info: {type_str}"
+            type_str.contains("Box::new(AttributeType::Int)"),
+            "Should wrap Int base: {type_str}"
         );
     }
 
@@ -9240,12 +9292,12 @@ mod tests {
         );
         // Should mention both constraints
         assert!(
-            type_str.contains("NumericString"),
-            "Should have NumericString type: {type_str}"
+            type_str.contains("pattern: Some(\"[0-9]+\".to_string())"),
+            "Should capture pattern: {type_str}"
         );
         assert!(
-            type_str.contains("20"),
-            "Should have max length constraint 20: {type_str}"
+            type_str.contains("Some((None, Some(20)))"),
+            "Should capture max length 20: {type_str}"
         );
     }
 
@@ -9280,12 +9332,12 @@ mod tests {
             cfn_type_to_carina_type_with_enum(&prop, "SomeName", &schema, "", &BTreeMap::new());
         // Should mention both constraints
         assert!(
-            type_str.contains("pattern"),
-            "Should have pattern constraint: {type_str}"
+            type_str.contains("pattern: Some(\"^[a-z]+$\".to_string())"),
+            "Should capture pattern: {type_str}"
         );
         assert!(
-            type_str.contains("len:"),
-            "Should have length constraint: {type_str}"
+            type_str.contains("Some((Some(1), Some(64)))"),
+            "Should capture length bounds 1..=64: {type_str}"
         );
     }
 

--- a/carina-provider-awscc/src/convert.rs
+++ b/carina-provider-awscc/src/convert.rs
@@ -182,7 +182,13 @@ fn proto_to_core_attribute_type(t: &ProtoAttributeType) -> CoreAttributeType {
             base,
             namespace,
         } => CoreAttributeType::Custom {
-            name: name.clone(),
+            semantic_name: if name.is_empty() {
+                None
+            } else {
+                Some(name.clone())
+            },
+            pattern: None,
+            length: None,
             base: Box::new(proto_to_core_attribute_type(base)),
             validate: |_| Ok(()),
             namespace: namespace.clone(),
@@ -274,12 +280,12 @@ fn core_to_proto_attribute_type(t: &CoreAttributeType) -> ProtoAttributeType {
             fields: fields.iter().map(core_to_proto_struct_field).collect(),
         },
         CoreAttributeType::Custom {
-            name,
+            semantic_name,
             base,
             namespace,
             ..
         } => ProtoAttributeType::Custom {
-            name: name.clone(),
+            name: semantic_name.clone().unwrap_or_default(),
             base: Box::new(core_to_proto_attribute_type(base)),
             namespace: namespace.clone(),
         },

--- a/carina-provider-awscc/src/provider/conversion.rs
+++ b/carina-provider-awscc/src/provider/conversion.rs
@@ -584,7 +584,9 @@ mod tests {
     #[test]
     fn test_dsl_value_to_aws_converts_underscores_for_region() {
         let attr_type = AttributeType::Custom {
-            name: "Region".to_string(),
+            semantic_name: Some("Region".to_string()),
+            pattern: None,
+            length: None,
             base: Box::new(AttributeType::String),
             validate: |_| Ok(()),
             namespace: Some("awscc".to_string()),
@@ -1233,7 +1235,9 @@ mod tests {
     #[test]
     fn test_aws_value_to_dsl_custom_to_dsl_strips_trailing_dot() {
         let attr_type = AttributeType::Custom {
-            name: "DnsName".to_string(),
+            semantic_name: Some("DnsName".to_string()),
+            pattern: None,
+            length: None,
             base: Box::new(AttributeType::String),
             validate: |_| Ok(()),
             namespace: None,
@@ -1247,7 +1251,9 @@ mod tests {
     #[test]
     fn test_aws_value_to_dsl_custom_without_to_dsl_passes_through() {
         let attr_type = AttributeType::Custom {
-            name: "DnsName".to_string(),
+            semantic_name: Some("DnsName".to_string()),
+            pattern: None,
+            length: None,
             base: Box::new(AttributeType::String),
             validate: |_| Ok(()),
             namespace: None,

--- a/carina-provider-awscc/src/provider/normalizer.rs
+++ b/carina-provider-awscc/src/provider/normalizer.rs
@@ -480,7 +480,9 @@ mod tests {
             StructField::new(
                 "ip_protocol",
                 AttributeType::Custom {
-                    name: "IpProtocol".to_string(),
+                    semantic_name: Some("IpProtocol".to_string()),
+                    pattern: None,
+                    length: None,
                     base: Box::new(AttributeType::String),
                     validate: |_| Ok(()),
                     namespace: Some("awscc.ec2.security_group".to_string()),

--- a/carina-provider-awscc/src/schemas/awscc_types.rs
+++ b/carina-provider-awscc/src/schemas/awscc_types.rs
@@ -130,7 +130,9 @@ pub(crate) fn validate_namespaced_enum(
 /// - Shorthand: ap_northeast_1
 pub fn awscc_region() -> AttributeType {
     AttributeType::Custom {
-        name: "Region".to_string(),
+        semantic_name: Some("Region".to_string()),
+        pattern: None,
+        length: None,
         base: Box::new(AttributeType::String),
         validate: |value| {
             if let Value::String(s) = value {
@@ -159,7 +161,9 @@ pub fn awscc_region() -> AttributeType {
 /// Validates format: region + single letter zone identifier
 pub fn availability_zone() -> AttributeType {
     AttributeType::Custom {
-        name: "AvailabilityZone".to_string(),
+        semantic_name: Some("AvailabilityZone".to_string()),
+        pattern: None,
+        length: None,
         base: Box::new(AttributeType::String),
         validate: |value| {
             if let Value::String(s) = value {

--- a/carina-provider-awscc/src/schemas/generated/ec2/flow_log.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/flow_log.rs
@@ -111,7 +111,9 @@ pub fn ec2_flow_log_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("max_aggregation_interval", AttributeType::Custom {
-                name: "IntEnum([60, 600])".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: None,
                 base: Box::new(AttributeType::Int),
                 validate: validate_max_aggregation_interval_int_enum,
                 namespace: None,

--- a/carina-provider-awscc/src/schemas/generated/ec2/ipam.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/ipam.rs
@@ -73,7 +73,9 @@ pub fn ec2_ipam_config() -> AwsccSchemaConfig {
                     name: "IpamOrganizationalUnitExclusion".to_string(),
                     fields: vec![
                     StructField::new("organizations_entity_path", AttributeType::Custom {
-                name: "String(len: 1..)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: Some((Some(1), None)),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_length_min_1,
                 namespace: None,
@@ -129,7 +131,9 @@ pub fn ec2_ipam_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("public_default_scope_id", AttributeType::Custom {
-                name: "String(len: ..=255)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: Some((None, Some(255))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_length_max_255,
                 namespace: None,

--- a/carina-provider-awscc/src/schemas/generated/ec2/nat_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/nat_gateway.rs
@@ -126,7 +126,9 @@ pub fn ec2_nat_gateway_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("secondary_private_ip_address_count", AttributeType::Custom {
-                name: "Int(1..)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: None,
                 base: Box::new(AttributeType::Int),
                 validate: validate_secondary_private_ip_address_count_range,
                 namespace: None,

--- a/carina-provider-awscc/src/schemas/generated/ec2/security_group.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/security_group.rs
@@ -54,7 +54,7 @@ pub fn ec2_security_group_config() -> AwsccSchemaConfig {
                 .with_provider_name("GroupDescription"),
         )
         .attribute(
-            AttributeSchema::new("group_id", super::security_group_id())
+            AttributeSchema::new("group_id", AttributeType::String)
                 .read_only()
                 .with_description("The group ID of the specified security group. (read-only)")
                 .with_provider_name("GroupId"),
@@ -81,7 +81,9 @@ pub fn ec2_security_group_config() -> AwsccSchemaConfig {
                     StructField::new("destination_prefix_list_id", super::prefix_list_id()).with_provider_name("DestinationPrefixListId"),
                     StructField::new("destination_security_group_id", super::security_group_id()).with_provider_name("DestinationSecurityGroupId"),
                     StructField::new("from_port", AttributeType::Custom {
-                name: "Int(-1..=65535)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: None,
                 base: Box::new(AttributeType::Int),
                 validate: validate_from_port_range,
                 namespace: None,
@@ -94,7 +96,9 @@ pub fn ec2_security_group_config() -> AwsccSchemaConfig {
                 to_dsl: Some(|s: &str| match s { "-1" => "all".to_string(), _ => s.replace('-', "_") }),
             }).required().with_provider_name("IpProtocol"),
                     StructField::new("to_port", AttributeType::Custom {
-                name: "Int(-1..=65535)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: None,
                 base: Box::new(AttributeType::Int),
                 validate: validate_to_port_range,
                 namespace: None,
@@ -114,7 +118,9 @@ pub fn ec2_security_group_config() -> AwsccSchemaConfig {
                     StructField::new("cidr_ipv6", types::ipv6_cidr()).with_provider_name("CidrIpv6"),
                     StructField::new("description", AttributeType::String).with_provider_name("Description"),
                     StructField::new("from_port", AttributeType::Custom {
-                name: "Int(-1..=65535)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: None,
                 base: Box::new(AttributeType::Int),
                 validate: validate_from_port_range,
                 namespace: None,
@@ -131,7 +137,9 @@ pub fn ec2_security_group_config() -> AwsccSchemaConfig {
                     StructField::new("source_security_group_name", AttributeType::String).with_provider_name("SourceSecurityGroupName"),
                     StructField::new("source_security_group_owner_id", super::aws_account_id()).with_provider_name("SourceSecurityGroupOwnerId"),
                     StructField::new("to_port", AttributeType::Custom {
-                name: "Int(-1..=65535)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: None,
                 base: Box::new(AttributeType::Int),
                 validate: validate_to_port_range,
                 namespace: None,

--- a/carina-provider-awscc/src/schemas/generated/ec2/security_group_egress.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/security_group_egress.rs
@@ -73,7 +73,9 @@ pub fn ec2_security_group_egress_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("from_port", AttributeType::Custom {
-                name: "Int(-1..=65535)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: None,
                 base: Box::new(AttributeType::Int),
                 validate: validate_from_port_range,
                 namespace: None,
@@ -84,7 +86,7 @@ pub fn ec2_security_group_egress_config() -> AwsccSchemaConfig {
                 .with_provider_name("FromPort"),
         )
         .attribute(
-            AttributeSchema::new("group_id", super::security_group_id())
+            AttributeSchema::new("group_id", AttributeType::String)
                 .required()
                 .create_only()
                 .with_description("The ID of the security group. You must specify either the security group ID or the security group name in the request. For security groups in a nondefault VPC, you must specify the security group ID.")
@@ -110,7 +112,9 @@ pub fn ec2_security_group_egress_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("to_port", AttributeType::Custom {
-                name: "Int(-1..=65535)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: None,
                 base: Box::new(AttributeType::Int),
                 validate: validate_to_port_range,
                 namespace: None,

--- a/carina-provider-awscc/src/schemas/generated/ec2/security_group_ingress.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/security_group_ingress.rs
@@ -61,7 +61,9 @@ pub fn ec2_security_group_ingress_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("from_port", AttributeType::Custom {
-                name: "Int(-1..=65535)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: None,
                 base: Box::new(AttributeType::Int),
                 validate: validate_from_port_range,
                 namespace: None,
@@ -72,7 +74,7 @@ pub fn ec2_security_group_ingress_config() -> AwsccSchemaConfig {
                 .with_provider_name("FromPort"),
         )
         .attribute(
-            AttributeSchema::new("group_id", super::security_group_id())
+            AttributeSchema::new("group_id", AttributeType::String)
                 .create_only()
                 .with_description("The ID of the security group. You must specify either the security group ID or the security group name in the request. For security groups in a nondefault VPC, you must specify the security group ID. You must specify the GroupName property or the GroupId property. For security groups that are in a VPC, you must use the GroupId property.")
                 .with_provider_name("GroupId"),
@@ -127,7 +129,9 @@ pub fn ec2_security_group_ingress_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("to_port", AttributeType::Custom {
-                name: "Int(-1..=65535)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: None,
                 base: Box::new(AttributeType::Int),
                 validate: validate_to_port_range,
                 namespace: None,

--- a/carina-provider-awscc/src/schemas/generated/ec2/subnet.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/subnet.rs
@@ -101,7 +101,9 @@ pub fn ec2_subnet_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("ipv4_netmask_length", AttributeType::Custom {
-                name: "Int(0..=32)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: None,
                 base: Box::new(AttributeType::Int),
                 validate: validate_ipv4_netmask_length_range,
                 namespace: None,
@@ -138,7 +140,9 @@ pub fn ec2_subnet_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("ipv6_netmask_length", AttributeType::Custom {
-                name: "Int(0..=128)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: None,
                 base: Box::new(AttributeType::Int),
                 validate: validate_ipv6_netmask_length_range,
                 namespace: None,

--- a/carina-provider-awscc/src/schemas/generated/ec2/transit_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/transit_gateway.rs
@@ -52,7 +52,9 @@ pub fn ec2_transit_gateway_config() -> AwsccSchemaConfig {
                 AttributeSchema::new(
                     "amazon_side_asn",
                     AttributeType::Custom {
-                        name: "Int(1..=4294967294)".to_string(),
+                        semantic_name: None,
+                        pattern: None,
+                        length: None,
                         base: Box::new(AttributeType::Int),
                         validate: validate_amazon_side_asn_range,
                         namespace: None,

--- a/carina-provider-awscc/src/schemas/generated/ec2/vpc.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/vpc.rs
@@ -85,7 +85,9 @@ pub fn ec2_vpc_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("ipv4_netmask_length", AttributeType::Custom {
-                name: "Int(0..=32)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: None,
                 base: Box::new(AttributeType::Int),
                 validate: validate_ipv4_netmask_length_range,
                 namespace: None,

--- a/carina-provider-awscc/src/schemas/generated/ec2/vpc_endpoint.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/vpc_endpoint.rs
@@ -108,9 +108,13 @@ pub fn ec2_vpc_endpoint_config() -> AwsccSchemaConfig {
                 to_dsl: None,
             }).with_description("The preference for which private domains have a private hosted zone created for and associated with the specified VPC. Only supported when private DNS is enabled and when the VPC endpoint type is ServiceNetwork or Resource.").with_provider_name("PrivateDnsPreference"),
                     StructField::new("private_dns_specified_domains", AttributeType::Custom {
-                name: "List(1..=10)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: None,
                 base: Box::new(AttributeType::list(AttributeType::Custom {
-                name: "String(len: 1..=255)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: Some((Some(1), Some(255))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_length_1_255,
                 namespace: None,

--- a/carina-provider-awscc/src/schemas/generated/ec2/vpn_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/vpn_gateway.rs
@@ -34,7 +34,9 @@ pub fn ec2_vpn_gateway_config() -> AwsccSchemaConfig {
         .with_description("Specifies a virtual private gateway. A virtual private gateway is the endpoint on the VPC side of your VPN connection. You can create a virtual private gateway before creating the VPC itself.  For more information, see [](https://docs.aws.amazon.com/vpn/latest/s2svpn/VPC_VPN.html) in the *User Guide*.")
         .attribute(
             AttributeSchema::new("amazon_side_asn", AttributeType::Custom {
-                name: "Int(1..=4294967294)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: None,
                 base: Box::new(AttributeType::Int),
                 validate: validate_amazon_side_asn_range,
                 namespace: None,

--- a/carina-provider-awscc/src/schemas/generated/iam/oidc_provider.rs
+++ b/carina-provider-awscc/src/schemas/generated/iam/oidc_provider.rs
@@ -78,7 +78,9 @@ pub fn iam_oidc_provider_config() -> AwsccSchemaConfig {
                 AttributeSchema::new(
                     "client_id_list",
                     AttributeType::unordered_list(AttributeType::Custom {
-                        name: "String(len: 1..=255)".to_string(),
+                        semantic_name: None,
+                        pattern: None,
+                        length: Some((Some(1), Some(255))),
                         base: Box::new(AttributeType::String),
                         validate: validate_string_length_1_255,
                         namespace: None,
@@ -92,9 +94,13 @@ pub fn iam_oidc_provider_config() -> AwsccSchemaConfig {
                 AttributeSchema::new(
                     "thumbprint_list",
                     AttributeType::Custom {
-                        name: "List(..=5)".to_string(),
+                        semantic_name: None,
+                        pattern: None,
+                        length: None,
                         base: Box::new(AttributeType::unordered_list(AttributeType::Custom {
-                            name: "String(pattern, len: 40..=40)".to_string(),
+                            semantic_name: None,
+                            pattern: None,
+                            length: Some((Some(40), Some(40))),
                             base: Box::new(AttributeType::String),
                             validate: validate_string_pattern_57ee0c44b504b839_len_40_40,
                             namespace: None,
@@ -111,7 +117,9 @@ pub fn iam_oidc_provider_config() -> AwsccSchemaConfig {
                 AttributeSchema::new(
                     "url",
                     AttributeType::Custom {
-                        name: "String(len: 1..=255)".to_string(),
+                        semantic_name: None,
+                        pattern: None,
+                        length: Some((Some(1), Some(255))),
                         base: Box::new(AttributeType::String),
                         validate: validate_string_length_1_255,
                         namespace: None,

--- a/carina-provider-awscc/src/schemas/generated/iam/role.rs
+++ b/carina-provider-awscc/src/schemas/generated/iam/role.rs
@@ -54,7 +54,9 @@ pub fn iam_role_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("max_session_duration", AttributeType::Custom {
-                name: "Int(3600..=43200)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: None,
                 base: Box::new(AttributeType::Int),
                 validate: validate_max_session_duration_range,
                 namespace: None,

--- a/carina-provider-awscc/src/schemas/generated/identitystore/group.rs
+++ b/carina-provider-awscc/src/schemas/generated/identitystore/group.rs
@@ -112,7 +112,9 @@ pub fn identitystore_group_config() -> AwsccSchemaConfig {
         .with_description("Resource Type definition for AWS::IdentityStore::Group")
         .attribute(
             AttributeSchema::new("description", AttributeType::Custom {
-                name: "String(pattern, len: 1..=1024)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: Some((Some(1), Some(1024))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_3e29f1c0497511f3_len_1_1024,
                 namespace: None,
@@ -123,7 +125,9 @@ pub fn identitystore_group_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("display_name", AttributeType::Custom {
-                name: "String(pattern, len: 1..=1024)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: Some((Some(1), Some(1024))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_a301e45ae2f7df12_len_1_1024,
                 namespace: None,
@@ -135,7 +139,9 @@ pub fn identitystore_group_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("group_id", AttributeType::Custom {
-                name: "String(pattern, len: 1..=47)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: Some((Some(1), Some(47))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_2a77a2e32f71b5f3_len_1_47,
                 namespace: None,
@@ -147,7 +153,9 @@ pub fn identitystore_group_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("identity_store_id", AttributeType::Custom {
-                name: "String(pattern, len: 1..=36)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: Some((Some(1), Some(36))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_135f0b126ef95449_len_1_36,
                 namespace: None,

--- a/carina-provider-awscc/src/schemas/generated/identitystore/group_membership.rs
+++ b/carina-provider-awscc/src/schemas/generated/identitystore/group_membership.rs
@@ -68,7 +68,9 @@ pub fn identitystore_group_membership_config() -> AwsccSchemaConfig {
                 AttributeSchema::new(
                     "group_id",
                     AttributeType::Custom {
-                        name: "String(pattern, len: 1..=47)".to_string(),
+                        semantic_name: None,
+                        pattern: None,
+                        length: Some((Some(1), Some(47))),
                         base: Box::new(AttributeType::String),
                         validate: validate_string_pattern_2a77a2e32f71b5f3_len_1_47,
                         namespace: None,
@@ -84,7 +86,9 @@ pub fn identitystore_group_membership_config() -> AwsccSchemaConfig {
                 AttributeSchema::new(
                     "identity_store_id",
                     AttributeType::Custom {
-                        name: "String(pattern, len: 1..=36)".to_string(),
+                        semantic_name: None,
+                        pattern: None,
+                        length: Some((Some(1), Some(36))),
                         base: Box::new(AttributeType::String),
                         validate: validate_string_pattern_135f0b126ef95449_len_1_36,
                         namespace: None,
@@ -105,7 +109,9 @@ pub fn identitystore_group_membership_config() -> AwsccSchemaConfig {
                             StructField::new(
                                 "user_id",
                                 AttributeType::Custom {
-                                    name: "String(pattern, len: 1..=47)".to_string(),
+                                    semantic_name: None,
+                                    pattern: None,
+                                    length: Some((Some(1), Some(47))),
                                     base: Box::new(AttributeType::String),
                                     validate: validate_string_pattern_2a77a2e32f71b5f3_len_1_47,
                                     namespace: None,
@@ -127,7 +133,9 @@ pub fn identitystore_group_membership_config() -> AwsccSchemaConfig {
                 AttributeSchema::new(
                     "membership_id",
                     AttributeType::Custom {
-                        name: "String(pattern, len: 1..=47)".to_string(),
+                        semantic_name: None,
+                        pattern: None,
+                        length: Some((Some(1), Some(47))),
                         base: Box::new(AttributeType::String),
                         validate: validate_string_pattern_2a77a2e32f71b5f3_len_1_47,
                         namespace: None,

--- a/carina-provider-awscc/src/schemas/generated/logs/log_group.rs
+++ b/carina-provider-awscc/src/schemas/generated/logs/log_group.rs
@@ -106,7 +106,9 @@ pub fn logs_log_group_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("log_group_name", AttributeType::Custom {
-                name: "String(pattern, len: 1..=512)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: Some((Some(1), Some(512))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_b6dfbc56753dfe38_len_1_512,
                 namespace: None,
@@ -123,7 +125,9 @@ pub fn logs_log_group_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("retention_in_days", AttributeType::Custom {
-                name: "IntEnum([1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653])".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: None,
                 base: Box::new(AttributeType::Int),
                 validate: validate_retention_in_days_int_enum,
                 namespace: None,

--- a/carina-provider-awscc/src/schemas/generated/organizations/account.rs
+++ b/carina-provider-awscc/src/schemas/generated/organizations/account.rs
@@ -161,7 +161,9 @@ pub fn organizations_account_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("account_name", AttributeType::Custom {
-                name: "String(pattern, len: 1..=50)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: Some((Some(1), Some(50))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_3af299ea99241fab_len_1_50,
                 namespace: None,
@@ -179,7 +181,9 @@ pub fn organizations_account_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("email", AttributeType::Custom {
-                name: "String(pattern, len: 6..=64)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: Some((Some(6), Some(64))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_ec4d9bee0dcd262b_len_6_64,
                 namespace: None,
@@ -208,7 +212,9 @@ pub fn organizations_account_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("parent_ids", AttributeType::unordered_list(AttributeType::Custom {
-                name: "String(pattern)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: None,
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_6fa92970742ee8e6,
                 namespace: None,
@@ -219,7 +225,9 @@ pub fn organizations_account_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("role_name", AttributeType::Custom {
-                name: "String(pattern, len: 1..=64)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: Some((Some(1), Some(64))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_253e7eb79a4beec5_len_1_64,
                 namespace: None,

--- a/carina-provider-awscc/src/schemas/generated/organizations/organization.rs
+++ b/carina-provider-awscc/src/schemas/generated/organizations/organization.rs
@@ -101,7 +101,9 @@ pub fn organizations_organization_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("id", AttributeType::Custom {
-                name: "String(pattern)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: None,
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_2fd01fd52b67fc75,
                 namespace: None,
@@ -119,7 +121,9 @@ pub fn organizations_organization_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("management_account_email", AttributeType::Custom {
-                name: "String(pattern, len: 6..=64)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: Some((Some(6), Some(64))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_ec4d9bee0dcd262b_len_6_64,
                 namespace: None,
@@ -137,7 +141,9 @@ pub fn organizations_organization_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("root_id", AttributeType::Custom {
-                name: "String(pattern, len: ..=64)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: Some((None, Some(64))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_0cb01cbc89d38ae3_len_max_64,
                 namespace: None,

--- a/carina-provider-awscc/src/schemas/generated/route53/hosted_zone.rs
+++ b/carina-provider-awscc/src/schemas/generated/route53/hosted_zone.rs
@@ -61,7 +61,9 @@ pub fn route53_hosted_zone_config() -> AwsccSchemaConfig {
                     name: "HostedZoneConfig".to_string(),
                     fields: vec![
                     StructField::new("comment", AttributeType::Custom {
-                name: "String(len: ..=256)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: Some((None, Some(256))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_length_max_256,
                 namespace: None,
@@ -87,14 +89,18 @@ pub fn route53_hosted_zone_config() -> AwsccSchemaConfig {
                     name: "HostedZoneTag".to_string(),
                     fields: vec![
                     StructField::new("key", AttributeType::Custom {
-                name: "String(len: ..=128)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: Some((None, Some(128))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_length_max_128,
                 namespace: None,
                 to_dsl: None,
             }).required().with_description("The value of ``Key`` depends on the operation that you want to perform: + *Add a tag to a health check or hosted zone*: ``Key`` is the name that you want to give the new tag. + *Edit a tag*: ``Key`` is the name of the tag that you want to change the ``Value`` for. + *Delete a key*: ``Key`` is the name of the tag you want to remove. + *Give a name to a health check*: Edit the default ``Name`` tag. In the Amazon Route 53 console, the list of your health checks includes a *Name* column that lets you see the name that you've given to each health check.").with_provider_name("Key"),
                     StructField::new("value", AttributeType::Custom {
-                name: "String(len: ..=256)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: Some((None, Some(256))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_length_max_256,
                 namespace: None,
@@ -114,7 +120,9 @@ pub fn route53_hosted_zone_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("name", AttributeType::Custom {
-                name: "String(len: ..=1024)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: Some((None, Some(1024))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_length_max_1024,
                 namespace: None,

--- a/carina-provider-awscc/src/schemas/generated/s3/bucket.rs
+++ b/carina-provider-awscc/src/schemas/generated/s3/bucket.rs
@@ -30,8 +30,6 @@ const VALID_ACCESS_CONTROL_TRANSLATION_OWNER: &[&str] = &["Destination"];
 
 const VALID_BLOCKED_ENCRYPTION_TYPES_ENCRYPTION_TYPE: &[&str] = &["NONE", "SSE-C"];
 
-const VALID_BUCKET_NAMESPACE: &[&str] = &["global", "account-regional"];
-
 const VALID_CORS_RULE_ALLOWED_METHODS: &[&str] = &["GET", "PUT", "HEAD", "POST", "DELETE"];
 
 const VALID_DATA_EXPORT_OUTPUT_SCHEMA_VERSION: &[&str] = &["V_1"];
@@ -366,25 +364,6 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 .with_provider_name("BucketName"),
         )
         .attribute(
-            AttributeSchema::new("bucket_name_prefix", AttributeType::String)
-                .create_only()
-                .write_only()
-                .with_description("")
-                .with_provider_name("BucketNamePrefix"),
-        )
-        .attribute(
-            AttributeSchema::new("bucket_namespace", AttributeType::StringEnum {
-                name: "BucketNamespace".to_string(),
-                values: vec!["global".to_string(), "account-regional".to_string()],
-                namespace: Some("awscc.s3.bucket".to_string()),
-                to_dsl: Some(|s: &str| s.replace('-', "_")),
-            })
-                .create_only()
-                .write_only()
-                .with_description("")
-                .with_provider_name("BucketNamespace"),
-        )
-        .attribute(
             AttributeSchema::new("cors_configuration", AttributeType::Struct {
                     name: "CorsConfiguration".to_string(),
                     fields: vec![
@@ -401,14 +380,18 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("allowed_origins", AttributeType::list(AttributeType::String)).required().with_description("One or more origins you want customers to be able to access the bucket from.").with_provider_name("AllowedOrigins"),
                     StructField::new("exposed_headers", AttributeType::list(AttributeType::String)).with_description("One or more headers in the response that you want customers to be able to access from their applications (for example, from a JavaScript ``XMLHttpRequest`` object).").with_provider_name("ExposedHeaders"),
                     StructField::new("id", AttributeType::Custom {
-                name: "String(len: ..=255)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: Some((None, Some(255))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_length_max_255,
                 namespace: None,
                 to_dsl: None,
             }).with_description("A unique identifier for this rule. The value must be no more than 255 characters.").with_provider_name("Id"),
                     StructField::new("max_age", AttributeType::Custom {
-                name: "Int(0..)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: None,
                 base: Box::new(AttributeType::Int),
                 validate: validate_max_age_range,
                 namespace: None,
@@ -521,7 +504,9 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     name: "AbortIncompleteMultipartUpload".to_string(),
                     fields: vec![
                     StructField::new("days_after_initiation", AttributeType::Custom {
-                name: "Int(0..)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: None,
                 base: Box::new(AttributeType::Int),
                 validate: validate_days_after_initiation_range,
                 namespace: None,
@@ -530,7 +515,9 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     ],
                 }).with_description("Specifies a lifecycle rule that stops incomplete multipart uploads to an Amazon S3 bucket.").with_provider_name("AbortIncompleteMultipartUpload"),
                     StructField::new("expiration_date", AttributeType::Custom {
-                name: "String(pattern)".to_string(),
+                semantic_name: None,
+                pattern: Some("^(\\d{4})-(0[0-9]|1[0-2])-([0-2]\\d|3[01])T([01]\\d|2[0-4]):([0-5]\\d):([0-6]\\d)((\\.\\d{3})?)Z$".to_string()),
+                length: None,
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_cc806c69dc4cdaf7,
                 namespace: None,
@@ -539,7 +526,9 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("expiration_in_days", AttributeType::Int).with_description("Indicates the number of days after creation when objects are deleted from Amazon S3 and Amazon S3 Glacier. If you specify an expiration and transition time, you must use the same time unit for both properties (either in days or by date). The expiration time must also be later than the transition time.").with_provider_name("ExpirationInDays"),
                     StructField::new("expired_object_delete_marker", AttributeType::Bool).with_description("Indicates whether Amazon S3 will remove a delete marker without any noncurrent versions. If set to true, the delete marker will be removed if there are no noncurrent versions. This cannot be specified with ``ExpirationInDays``, ``ExpirationDate``, or ``TagFilters``.").with_provider_name("ExpiredObjectDeleteMarker"),
                     StructField::new("id", AttributeType::Custom {
-                name: "String(len: ..=255)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: Some((None, Some(255))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_length_max_255,
                 namespace: None,
@@ -580,14 +569,18 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     ],
                 })).with_description("For buckets with versioning enabled (or suspended), one or more transition rules that specify when non-current objects transition to a specified storage class. If you specify a transition and expiration time, the expiration time must be later than the transition time. If you specify this property, don't specify the ``NoncurrentVersionTransition`` property.").with_provider_name("NoncurrentVersionTransitions").with_block_name("noncurrent_version_transition"),
                     StructField::new("object_size_greater_than", AttributeType::Custom {
-                name: "NumericString(len: ..=20)".to_string(),
+                semantic_name: None,
+                pattern: Some("[0-9]+".to_string()),
+                length: Some((None, Some(20))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_3ee03875337c12ab_len_max_20,
                 namespace: None,
                 to_dsl: None,
             }).with_description("Specifies the minimum object size in bytes for this rule to apply to. Objects must be larger than this value in bytes. For more information about size based rules, see [Lifecycle configuration using size-based rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/lifecycle-configuration-examples.html#lc-size-rules) in the *Amazon S3 User Guide*.").with_provider_name("ObjectSizeGreaterThan"),
                     StructField::new("object_size_less_than", AttributeType::Custom {
-                name: "NumericString(len: ..=20)".to_string(),
+                semantic_name: None,
+                pattern: Some("[0-9]+".to_string()),
+                length: Some((None, Some(20))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_3ee03875337c12ab_len_max_20,
                 namespace: None,
@@ -611,7 +604,9 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 to_dsl: None,
             }).required().with_description("The storage class to which you want the object to transition.").with_provider_name("StorageClass"),
                     StructField::new("transition_date", AttributeType::Custom {
-                name: "String(pattern)".to_string(),
+                semantic_name: None,
+                pattern: Some("^(\\d{4})-(0[0-9]|1[0-2])-([0-2]\\d|3[01])T([01]\\d|2[0-4]):([0-5]\\d):([0-6]\\d)((\\.\\d{3})?)Z$".to_string()),
+                length: None,
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_cc806c69dc4cdaf7,
                 namespace: None,
@@ -630,7 +625,9 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 to_dsl: None,
             }).required().with_description("The storage class to which you want the object to transition.").with_provider_name("StorageClass"),
                     StructField::new("transition_date", AttributeType::Custom {
-                name: "String(pattern)".to_string(),
+                semantic_name: None,
+                pattern: Some("^(\\d{4})-(0[0-9]|1[0-2])-([0-2]\\d|3[01])T([01]\\d|2[0-4]):([0-5]\\d):([0-6]\\d)((\\.\\d{3})?)Z$".to_string()),
+                length: None,
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_cc806c69dc4cdaf7,
                 namespace: None,
@@ -818,7 +815,9 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     name: "FilterRule".to_string(),
                     fields: vec![
                     StructField::new("name", AttributeType::Custom {
-                name: "String(len: ..=1024)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: Some((None, Some(1024))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_length_max_1024,
                 namespace: None,
@@ -848,7 +847,9 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     name: "FilterRule".to_string(),
                     fields: vec![
                     StructField::new("name", AttributeType::Custom {
-                name: "String(len: ..=1024)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: Some((None, Some(1024))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_length_max_1024,
                 namespace: None,
@@ -878,7 +879,9 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     name: "FilterRule".to_string(),
                     fields: vec![
                     StructField::new("name", AttributeType::Custom {
-                name: "String(len: ..=1024)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: Some((None, Some(1024))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_length_max_1024,
                 namespace: None,
@@ -1076,14 +1079,18 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     ],
                 }).with_description("A filter that identifies the subset of objects to which the replication rule applies. A ``Filter`` must specify exactly one ``Prefix``, ``TagFilter``, or an ``And`` child element. The use of the filter field indicates that this is a V2 replication configuration. This field isn't supported in a V1 replication configuration. V1 replication configuration only supports filtering by key prefix. To filter using a V1 replication configuration, add the ``Prefix`` directly as a child element of the ``Rule`` element.").with_provider_name("Filter"),
                     StructField::new("id", AttributeType::Custom {
-                name: "String(len: ..=255)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: Some((None, Some(255))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_length_max_255,
                 namespace: None,
                 to_dsl: None,
             }).with_description("A unique identifier for the rule. The maximum value is 255 characters. If you don't specify a value, AWS CloudFormation generates a random ID. When using a V2 replication configuration this property is capitalized as \"ID\".").with_provider_name("Id"),
                     StructField::new("prefix", AttributeType::Custom {
-                name: "String(len: ..=1024)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: Some((None, Some(1024))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_length_max_1024,
                 namespace: None,
@@ -1204,7 +1211,9 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("website_url", AttributeType::Custom {
-                name: "String(uri)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: None,
                 base: Box::new(AttributeType::String),
                 validate: |_| Ok(()),
                 namespace: None,
@@ -1244,7 +1253,6 @@ pub fn enum_valid_values() -> (
                 "encryption_type",
                 VALID_BLOCKED_ENCRYPTION_TYPES_ENCRYPTION_TYPE,
             ),
-            ("bucket_namespace", VALID_BUCKET_NAMESPACE),
             ("allowed_methods", VALID_CORS_RULE_ALLOWED_METHODS),
             (
                 "output_schema_version",
@@ -1324,15 +1332,11 @@ pub fn enum_valid_values() -> (
 pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
     match (attr_name, value) {
         ("encryption_type", "SSE_C") => Some("SSE-C"),
-        ("bucket_namespace", "account_regional") => Some("account-regional"),
         _ => None,
     }
 }
 
 /// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
 pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
-    &[
-        ("encryption_type", "SSE_C", "SSE-C"),
-        ("bucket_namespace", "account_regional", "account-regional"),
-    ]
+    &[("encryption_type", "SSE_C", "SSE-C")]
 }

--- a/carina-provider-awscc/src/schemas/generated/sso/assignment.rs
+++ b/carina-provider-awscc/src/schemas/generated/sso/assignment.rs
@@ -76,7 +76,9 @@ pub fn sso_assignment_config() -> AwsccSchemaConfig {
                 AttributeSchema::new(
                     "principal_id",
                     AttributeType::Custom {
-                        name: "String(pattern, len: 1..=47)".to_string(),
+                        semantic_name: None,
+                        pattern: None,
+                        length: Some((Some(1), Some(47))),
                         base: Box::new(AttributeType::String),
                         validate: validate_string_pattern_2a77a2e32f71b5f3_len_1_47,
                         namespace: None,
@@ -107,7 +109,9 @@ pub fn sso_assignment_config() -> AwsccSchemaConfig {
                 AttributeSchema::new(
                     "target_id",
                     AttributeType::Custom {
-                        name: "String(pattern)".to_string(),
+                        semantic_name: None,
+                        pattern: None,
+                        length: None,
                         base: Box::new(AttributeType::String),
                         validate: validate_string_pattern_fd8ddd3f8bec29c4,
                         namespace: None,

--- a/carina-provider-awscc/src/schemas/generated/sso/instance.rs
+++ b/carina-provider-awscc/src/schemas/generated/sso/instance.rs
@@ -117,7 +117,9 @@ pub fn sso_instance_config() -> AwsccSchemaConfig {
         .with_description("Resource Type definition for Identity Center (SSO) Instance")
         .attribute(
             AttributeSchema::new("identity_store_id", AttributeType::Custom {
-                name: "String(pattern, len: 1..=64)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: Some((Some(1), Some(64))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_52730ac83148124e_len_1_64,
                 namespace: None,
@@ -135,7 +137,9 @@ pub fn sso_instance_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("name", AttributeType::Custom {
-                name: "String(pattern, len: 1..=32)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: Some((Some(1), Some(32))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_5a2bd7daee6344f1_len_1_32,
                 namespace: None,

--- a/carina-provider-awscc/src/schemas/generated/sso/permission_set.rs
+++ b/carina-provider-awscc/src/schemas/generated/sso/permission_set.rs
@@ -189,19 +189,25 @@ pub fn sso_permission_set_config() -> AwsccSchemaConfig {
         .with_description("Resource Type definition for SSO PermissionSet")
         .attribute(
             AttributeSchema::new("customer_managed_policy_references", AttributeType::Custom {
-                name: "List(..=20)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: None,
                 base: Box::new(AttributeType::unordered_list(AttributeType::Struct {
                     name: "CustomerManagedPolicyReference".to_string(),
                     fields: vec![
                     StructField::new("name", AttributeType::Custom {
-                name: "String(pattern, len: 1..=128)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: Some((Some(1), Some(128))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_9b83f4f8f3673df5_len_1_128,
                 namespace: None,
                 to_dsl: None,
             }).required().with_provider_name("Name"),
                     StructField::new("path", AttributeType::Custom {
-                name: "String(pattern, len: 1..=512)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: Some((Some(1), Some(512))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_b84fa12576539ca9_len_1_512,
                 namespace: None,
@@ -218,7 +224,9 @@ pub fn sso_permission_set_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("description", AttributeType::Custom {
-                name: "String(pattern, len: 1..=700)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: Some((Some(1), Some(700))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_9863be410e005e12_len_1_700,
                 namespace: None,
@@ -241,7 +249,9 @@ pub fn sso_permission_set_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("managed_policies", AttributeType::Custom {
-                name: "List(..=20)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: None,
                 base: Box::new(AttributeType::unordered_list(AttributeType::String)),
                 validate: validate_list_items_max_20,
                 namespace: None,
@@ -251,7 +261,9 @@ pub fn sso_permission_set_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("name", AttributeType::Custom {
-                name: "String(pattern, len: 1..=32)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: Some((Some(1), Some(32))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_9b83f4f8f3673df5_len_1_32,
                 namespace: None,
@@ -276,14 +288,18 @@ pub fn sso_permission_set_config() -> AwsccSchemaConfig {
                     name: "CustomerManagedPolicyReference".to_string(),
                     fields: vec![
                     StructField::new("name", AttributeType::Custom {
-                name: "String(pattern, len: 1..=128)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: Some((Some(1), Some(128))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_9b83f4f8f3673df5_len_1_128,
                 namespace: None,
                 to_dsl: None,
             }).required().with_provider_name("Name"),
                     StructField::new("path", AttributeType::Custom {
-                name: "String(pattern, len: 1..=512)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: Some((Some(1), Some(512))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_b84fa12576539ca9_len_1_512,
                 namespace: None,
@@ -298,7 +314,9 @@ pub fn sso_permission_set_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("relay_state_type", AttributeType::Custom {
-                name: "String(pattern, len: 1..=240)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: Some((Some(1), Some(240))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_4d6d630589930649_len_1_240,
                 namespace: None,
@@ -309,7 +327,9 @@ pub fn sso_permission_set_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("session_duration", AttributeType::Custom {
-                name: "String(pattern, len: 1..=100)".to_string(),
+                semantic_name: None,
+                pattern: None,
+                length: Some((Some(1), Some(100))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_1e58d8243b46a2f1_len_1_100,
                 namespace: None,


### PR DESCRIPTION
## Summary

- Adopts the redesigned `AttributeType::Custom { semantic_name, pattern, length, ... }` from carina-core PRs #2090/#2091.
- Adds `sso_principal_id()` and `sso_instance_arn()` helpers in the local `carina-aws-types` crate.
- Codegen now routes `AWS::SSO::Assignment` (`TargetId`/`PrincipalId`/`InstanceArn`) and `AWS::SSO::PermissionSet` (`InstanceArn`) through semantic helpers.
- Codegen emission templates updated to produce the new `Custom` shape with structured pattern/length fields.
- Regenerated 24 resources (EC2/S3/IAM::Role/Logs) from cached CFN schemas; in-place migrated 9 resources whose CFN schemas are not in the local cache (SSO/IdentityStore/Organizations/Route53/IAM::OIDCProvider).

Closes #139, #140, #141, #142.

## Notes

The SSO/IdentityStore/Organizations/Route53/OIDCProvider schemas need a full regen with AWS credentials to realize the new SSO override mappings — I couldn't run `aws cloudformation describe-type` during this PR. Rerun `aws-vault exec <profile> -- ./carina-provider-awscc/scripts/generate-schemas.sh` to materialize them. The current generated files compile and validate; only the SSO-specific semantic typing is deferred until the next regen.

## Test plan

- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build --workspace`
- [x] `cargo build -p carina-provider-awscc --target wasm32-wasip2 --release`
- [x] `cargo test -p carina-aws-types` (covers new SSO helpers)