### PR TITLE
Release 0.5.0: type-compat redesign migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "carina-aws-types"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "carina-core",
 ]
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "carina-provider-awscc"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,4 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "carina-aws-types"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 license = "MIT"
 description = "AWS type definitions for Carina infrastructure management tool"


### PR DESCRIPTION
## Summary

- Bumps `carina-provider-awscc` to 0.5.0 and the local `carina-aws-types` crate to 0.4.0 to publish the new `Custom` shape (semantic_name/pattern/length) and the SSO helpers (`sso_principal_id`, `sso_instance_arn`).

Closes #143.

## Test plan

- [x] `cargo check --workspace`
- [ ] CI passes
- [ ] After merge, tag `v0.5.0` on main and push.