### PR TITLE
Regenerate schemas with AWS creds: SSO overrides now applied

### DIFF
--- a/carina-provider-awscc/src/schemas/generated/iam/oidc_provider.rs
+++ b/carina-provider-awscc/src/schemas/generated/iam/oidc_provider.rs
@@ -99,7 +99,7 @@ pub fn iam_oidc_provider_config() -> AwsccSchemaConfig {
                         length: None,
                         base: Box::new(AttributeType::unordered_list(AttributeType::Custom {
                             semantic_name: None,
-                            pattern: None,
+                            pattern: Some("[0-9A-Fa-f]{40}".to_string()),
                             length: Some((Some(40), Some(40))),
                             base: Box::new(AttributeType::String),
                             validate: validate_string_pattern_57ee0c44b504b839_len_40_40,

--- a/carina-provider-awscc/src/schemas/generated/identitystore/group.rs
+++ b/carina-provider-awscc/src/schemas/generated/identitystore/group.rs
@@ -113,7 +113,7 @@ pub fn identitystore_group_config() -> AwsccSchemaConfig {
         .attribute(
             AttributeSchema::new("description", AttributeType::Custom {
                 semantic_name: None,
-                pattern: None,
+                pattern: Some("^[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}\\t\\n\\r  　]+$".to_string()),
                 length: Some((Some(1), Some(1024))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_3e29f1c0497511f3_len_1_1024,
@@ -126,7 +126,7 @@ pub fn identitystore_group_config() -> AwsccSchemaConfig {
         .attribute(
             AttributeSchema::new("display_name", AttributeType::Custom {
                 semantic_name: None,
-                pattern: None,
+                pattern: Some("^[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}\\t\\n\\r  ]+$".to_string()),
                 length: Some((Some(1), Some(1024))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_a301e45ae2f7df12_len_1_1024,
@@ -140,7 +140,7 @@ pub fn identitystore_group_config() -> AwsccSchemaConfig {
         .attribute(
             AttributeSchema::new("group_id", AttributeType::Custom {
                 semantic_name: None,
-                pattern: None,
+                pattern: Some("^([0-9a-f]{10}-|)[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$".to_string()),
                 length: Some((Some(1), Some(47))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_2a77a2e32f71b5f3_len_1_47,
@@ -154,7 +154,7 @@ pub fn identitystore_group_config() -> AwsccSchemaConfig {
         .attribute(
             AttributeSchema::new("identity_store_id", AttributeType::Custom {
                 semantic_name: None,
-                pattern: None,
+                pattern: Some("^d-[0-9a-f]{10}$|^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$".to_string()),
                 length: Some((Some(1), Some(36))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_135f0b126ef95449_len_1_36,

--- a/carina-provider-awscc/src/schemas/generated/identitystore/group_membership.rs
+++ b/carina-provider-awscc/src/schemas/generated/identitystore/group_membership.rs
@@ -63,91 +63,71 @@ pub fn identitystore_group_membership_config() -> AwsccSchemaConfig {
         resource_type_name: "identitystore.group_membership",
         has_tags: false,
         schema: ResourceSchema::new("awscc.identitystore.group_membership")
-            .with_description("Resource Type Definition for AWS:IdentityStore::GroupMembership")
-            .attribute(
-                AttributeSchema::new(
-                    "group_id",
-                    AttributeType::Custom {
-                        semantic_name: None,
-                        pattern: None,
-                        length: Some((Some(1), Some(47))),
-                        base: Box::new(AttributeType::String),
-                        validate: validate_string_pattern_2a77a2e32f71b5f3_len_1_47,
-                        namespace: None,
-                        to_dsl: None,
-                    },
-                )
+        .with_description("Resource Type Definition for AWS:IdentityStore::GroupMembership")
+        .attribute(
+            AttributeSchema::new("group_id", AttributeType::Custom {
+                semantic_name: None,
+                pattern: Some("^([0-9a-f]{10}-|)[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$".to_string()),
+                length: Some((Some(1), Some(47))),
+                base: Box::new(AttributeType::String),
+                validate: validate_string_pattern_2a77a2e32f71b5f3_len_1_47,
+                namespace: None,
+                to_dsl: None,
+            })
                 .required()
                 .create_only()
                 .with_description("The unique identifier for a group in the identity store.")
                 .with_provider_name("GroupId"),
-            )
-            .attribute(
-                AttributeSchema::new(
-                    "identity_store_id",
-                    AttributeType::Custom {
-                        semantic_name: None,
-                        pattern: None,
-                        length: Some((Some(1), Some(36))),
-                        base: Box::new(AttributeType::String),
-                        validate: validate_string_pattern_135f0b126ef95449_len_1_36,
-                        namespace: None,
-                        to_dsl: None,
-                    },
-                )
+        )
+        .attribute(
+            AttributeSchema::new("identity_store_id", AttributeType::Custom {
+                semantic_name: None,
+                pattern: Some("^d-[0-9a-f]{10}$|^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$".to_string()),
+                length: Some((Some(1), Some(36))),
+                base: Box::new(AttributeType::String),
+                validate: validate_string_pattern_135f0b126ef95449_len_1_36,
+                namespace: None,
+                to_dsl: None,
+            })
                 .required()
                 .create_only()
                 .with_description("The globally unique identifier for the identity store.")
                 .with_provider_name("IdentityStoreId"),
-            )
-            .attribute(
-                AttributeSchema::new(
-                    "member_id",
-                    AttributeType::Struct {
-                        name: "MemberId".to_string(),
-                        fields: vec![
-                            StructField::new(
-                                "user_id",
-                                AttributeType::Custom {
-                                    semantic_name: None,
-                                    pattern: None,
-                                    length: Some((Some(1), Some(47))),
-                                    base: Box::new(AttributeType::String),
-                                    validate: validate_string_pattern_2a77a2e32f71b5f3_len_1_47,
-                                    namespace: None,
-                                    to_dsl: None,
-                                },
-                            )
-                            .required()
-                            .with_description("The identifier for a user in the identity store.")
-                            .with_provider_name("UserId"),
-                        ],
-                    },
-                )
+        )
+        .attribute(
+            AttributeSchema::new("member_id", AttributeType::Struct {
+                    name: "MemberId".to_string(),
+                    fields: vec![
+                    StructField::new("user_id", AttributeType::Custom {
+                semantic_name: None,
+                pattern: Some("^([0-9a-f]{10}-|)[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$".to_string()),
+                length: Some((Some(1), Some(47))),
+                base: Box::new(AttributeType::String),
+                validate: validate_string_pattern_2a77a2e32f71b5f3_len_1_47,
+                namespace: None,
+                to_dsl: None,
+            }).required().with_description("The identifier for a user in the identity store.").with_provider_name("UserId")
+                    ],
+                })
                 .required()
                 .create_only()
                 .with_description("An object containing the identifier of a group member.")
                 .with_provider_name("MemberId"),
-            )
-            .attribute(
-                AttributeSchema::new(
-                    "membership_id",
-                    AttributeType::Custom {
-                        semantic_name: None,
-                        pattern: None,
-                        length: Some((Some(1), Some(47))),
-                        base: Box::new(AttributeType::String),
-                        validate: validate_string_pattern_2a77a2e32f71b5f3_len_1_47,
-                        namespace: None,
-                        to_dsl: None,
-                    },
-                )
+        )
+        .attribute(
+            AttributeSchema::new("membership_id", AttributeType::Custom {
+                semantic_name: None,
+                pattern: Some("^([0-9a-f]{10}-|)[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$".to_string()),
+                length: Some((Some(1), Some(47))),
+                base: Box::new(AttributeType::String),
+                validate: validate_string_pattern_2a77a2e32f71b5f3_len_1_47,
+                namespace: None,
+                to_dsl: None,
+            })
                 .read_only()
-                .with_description(
-                    "The identifier for a GroupMembership in the identity store. (read-only)",
-                )
+                .with_description("The identifier for a GroupMembership in the identity store. (read-only)")
                 .with_provider_name("MembershipId"),
-            ),
+        )
     }
 }
 

--- a/carina-provider-awscc/src/schemas/generated/logs/log_group.rs
+++ b/carina-provider-awscc/src/schemas/generated/logs/log_group.rs
@@ -107,7 +107,7 @@ pub fn logs_log_group_config() -> AwsccSchemaConfig {
         .attribute(
             AttributeSchema::new("log_group_name", AttributeType::Custom {
                 semantic_name: None,
-                pattern: None,
+                pattern: Some("^[.\\-_/#A-Za-z0-9]{1,512}\\Z".to_string()),
                 length: Some((Some(1), Some(512))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_b6dfbc56753dfe38_len_1_512,

--- a/carina-provider-awscc/src/schemas/generated/organizations/account.rs
+++ b/carina-provider-awscc/src/schemas/generated/organizations/account.rs
@@ -44,6 +44,25 @@ fn validate_string_pattern_6fa92970742ee8e6(value: &Value) -> Result<(), String>
 }
 
 #[allow(dead_code)]
+fn validate_string_pattern_f777bea2efc17af6(value: &Value) -> Result<(), String> {
+    if let Value::String(s) = value {
+        static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+            Regex::new("^(o-[a-z0-9]{10,32}/r-[0-9a-z]{4,32}(/ou-[0-9a-z]{4,32}-[a-z0-9]{8,32})*(/\\d{12})*)/").expect("invalid pattern regex")
+        });
+        if RE.is_match(s) {
+            Ok(())
+        } else {
+            Err(format!(
+                "Value '{}' does not match pattern ^(o-[a-z0-9]{{10,32}}/r-[0-9a-z]{{4,32}}(/ou-[0-9a-z]{{4,32}}-[a-z0-9]{{8,32}})*(/\\d{{12}})*)/",
+                s
+            ))
+        }
+    } else {
+        Err("Expected string".to_string())
+    }
+}
+
+#[allow(dead_code)]
 fn validate_string_pattern_9329bdea96a93739_len_max_256(value: &Value) -> Result<(), String> {
     if let Value::String(s) = value {
         static RE: std::sync::LazyLock<Regex> =
@@ -162,7 +181,7 @@ pub fn organizations_account_config() -> AwsccSchemaConfig {
         .attribute(
             AttributeSchema::new("account_name", AttributeType::Custom {
                 semantic_name: None,
-                pattern: None,
+                pattern: Some("[\\u0020-\\u007E]+".to_string()),
                 length: Some((Some(1), Some(50))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_3af299ea99241fab_len_1_50,
@@ -182,7 +201,7 @@ pub fn organizations_account_config() -> AwsccSchemaConfig {
         .attribute(
             AttributeSchema::new("email", AttributeType::Custom {
                 semantic_name: None,
-                pattern: None,
+                pattern: Some("[^\\s@]+@[^\\s@]+\\.[^\\s@]+".to_string()),
                 length: Some((Some(6), Some(64))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_ec4d9bee0dcd262b_len_6_64,
@@ -213,7 +232,7 @@ pub fn organizations_account_config() -> AwsccSchemaConfig {
         .attribute(
             AttributeSchema::new("parent_ids", AttributeType::unordered_list(AttributeType::Custom {
                 semantic_name: None,
-                pattern: None,
+                pattern: Some("^(r-[0-9a-z]{4,32})|(ou-[0-9a-z]{4,32}-[a-z0-9]{8,32})$".to_string()),
                 length: None,
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_6fa92970742ee8e6,
@@ -224,9 +243,23 @@ pub fn organizations_account_config() -> AwsccSchemaConfig {
                 .with_provider_name("ParentIds"),
         )
         .attribute(
+            AttributeSchema::new("paths", AttributeType::list(AttributeType::Custom {
+                semantic_name: None,
+                pattern: Some("^(o-[a-z0-9]{10,32}/r-[0-9a-z]{4,32}(/ou-[0-9a-z]{4,32}-[a-z0-9]{8,32})*(/\\d{12})*)/".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: validate_string_pattern_f777bea2efc17af6,
+                namespace: None,
+                to_dsl: None,
+            }))
+                .read_only()
+                .with_description("The paths in the organization where the account exists. (read-only)")
+                .with_provider_name("Paths"),
+        )
+        .attribute(
             AttributeSchema::new("role_name", AttributeType::Custom {
                 semantic_name: None,
-                pattern: None,
+                pattern: Some("[\\w+=,.@-]{1,64}".to_string()),
                 length: Some((Some(1), Some(64))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_253e7eb79a4beec5_len_1_64,

--- a/carina-provider-awscc/src/schemas/generated/organizations/organization.rs
+++ b/carina-provider-awscc/src/schemas/generated/organizations/organization.rs
@@ -102,7 +102,7 @@ pub fn organizations_organization_config() -> AwsccSchemaConfig {
         .attribute(
             AttributeSchema::new("id", AttributeType::Custom {
                 semantic_name: None,
-                pattern: None,
+                pattern: Some("^o-[a-z0-9]{10,32}$".to_string()),
                 length: None,
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_2fd01fd52b67fc75,
@@ -122,7 +122,7 @@ pub fn organizations_organization_config() -> AwsccSchemaConfig {
         .attribute(
             AttributeSchema::new("management_account_email", AttributeType::Custom {
                 semantic_name: None,
-                pattern: None,
+                pattern: Some("[^\\s@]+@[^\\s@]+\\.[^\\s@]+".to_string()),
                 length: Some((Some(6), Some(64))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_ec4d9bee0dcd262b_len_6_64,
@@ -142,7 +142,7 @@ pub fn organizations_organization_config() -> AwsccSchemaConfig {
         .attribute(
             AttributeSchema::new("root_id", AttributeType::Custom {
                 semantic_name: None,
-                pattern: None,
+                pattern: Some("^r-[0-9a-z]{4,32}$".to_string()),
                 length: Some((None, Some(64))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_0cb01cbc89d38ae3_len_max_64,

--- a/carina-provider-awscc/src/schemas/generated/s3/bucket.rs
+++ b/carina-provider-awscc/src/schemas/generated/s3/bucket.rs
@@ -30,6 +30,8 @@ const VALID_ACCESS_CONTROL_TRANSLATION_OWNER: &[&str] = &["Destination"];
 
 const VALID_BLOCKED_ENCRYPTION_TYPES_ENCRYPTION_TYPE: &[&str] = &["NONE", "SSE-C"];
 
+const VALID_BUCKET_NAMESPACE: &[&str] = &["global", "account-regional"];
+
 const VALID_CORS_RULE_ALLOWED_METHODS: &[&str] = &["GET", "PUT", "HEAD", "POST", "DELETE"];
 
 const VALID_DATA_EXPORT_OUTPUT_SCHEMA_VERSION: &[&str] = &["V_1"];
@@ -362,6 +364,25 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 .create_only()
                 .with_description("A name for the bucket. If you don't specify a name, AWS CloudFormation generates a unique ID and uses that ID for the bucket name. The bucket name must contain only lowercase letters, numbers, periods (.), and dashes (-) and must follow [Amazon S3 bucket restrictions and limitations](https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html). For more information, see [Rules for naming Amazon S3 buckets](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html) in the *Amazon S3 User Guide*. If you specify a name, you can't perform updates that require replacement of this resource. You can perform updates that require no or some interruption. If you need to replace the resource, specify a new name.")
                 .with_provider_name("BucketName"),
+        )
+        .attribute(
+            AttributeSchema::new("bucket_name_prefix", AttributeType::String)
+                .create_only()
+                .write_only()
+                .with_description("")
+                .with_provider_name("BucketNamePrefix"),
+        )
+        .attribute(
+            AttributeSchema::new("bucket_namespace", AttributeType::StringEnum {
+                name: "BucketNamespace".to_string(),
+                values: vec!["global".to_string(), "account-regional".to_string()],
+                namespace: Some("awscc.s3.bucket".to_string()),
+                to_dsl: Some(|s: &str| s.replace('-', "_")),
+            })
+                .create_only()
+                .write_only()
+                .with_description("")
+                .with_provider_name("BucketNamespace"),
         )
         .attribute(
             AttributeSchema::new("cors_configuration", AttributeType::Struct {
@@ -1253,6 +1274,7 @@ pub fn enum_valid_values() -> (
                 "encryption_type",
                 VALID_BLOCKED_ENCRYPTION_TYPES_ENCRYPTION_TYPE,
             ),
+            ("bucket_namespace", VALID_BUCKET_NAMESPACE),
             ("allowed_methods", VALID_CORS_RULE_ALLOWED_METHODS),
             (
                 "output_schema_version",
@@ -1332,11 +1354,15 @@ pub fn enum_valid_values() -> (
 pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
     match (attr_name, value) {
         ("encryption_type", "SSE_C") => Some("SSE-C"),
+        ("bucket_namespace", "account_regional") => Some("account-regional"),
         _ => None,
     }
 }
 
 /// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
 pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
-    &[("encryption_type", "SSE_C", "SSE-C")]
+    &[
+        ("encryption_type", "SSE_C", "SSE-C"),
+        ("bucket_namespace", "account_regional", "account-regional"),
+    ]
 }

--- a/carina-provider-awscc/src/schemas/generated/sso/assignment.rs
+++ b/carina-provider-awscc/src/schemas/generated/sso/assignment.rs
@@ -5,50 +5,11 @@
 //! DO NOT EDIT MANUALLY - regenerate with carina-codegen
 
 use super::AwsccSchemaConfig;
-use carina_core::resource::Value;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
-use regex::Regex;
 
 const VALID_PRINCIPAL_TYPE: &[&str] = &["USER", "GROUP"];
 
 const VALID_TARGET_TYPE: &[&str] = &["AWS_ACCOUNT"];
-
-#[allow(dead_code)]
-fn validate_string_pattern_fd8ddd3f8bec29c4(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
-        static RE: std::sync::LazyLock<Regex> =
-            std::sync::LazyLock::new(|| Regex::new("\\d{12}").expect("invalid pattern regex"));
-        if RE.is_match(s) {
-            Ok(())
-        } else {
-            Err(format!("Value '{}' does not match pattern \\d{{12}}", s))
-        }
-    } else {
-        Err("Expected string".to_string())
-    }
-}
-
-#[allow(dead_code)]
-fn validate_string_pattern_2a77a2e32f71b5f3_len_1_47(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
-        static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-            Regex::new("^([0-9a-f]{10}-|)[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$").expect("invalid pattern regex")
-        });
-        if !RE.is_match(s) {
-            return Err(format!(
-                "Value '{}' does not match pattern ^([0-9a-f]{{10}}-|)[A-Fa-f0-9]{{8}}-[A-Fa-f0-9]{{4}}-[A-Fa-f0-9]{{4}}-[A-Fa-f0-9]{{4}}-[A-Fa-f0-9]{{12}}$",
-                s
-            ));
-        }
-        let len = s.chars().count();
-        if !(1..=47).contains(&len) {
-            return Err(format!("String length {} is out of range 1..=47", len));
-        }
-        Ok(())
-    } else {
-        Err("Expected string".to_string())
-    }
-}
 
 /// Returns the schema config for sso_assignment (AWS::SSO::Assignment)
 pub fn sso_assignment_config() -> AwsccSchemaConfig {
@@ -59,7 +20,7 @@ pub fn sso_assignment_config() -> AwsccSchemaConfig {
         schema: ResourceSchema::new("awscc.sso.assignment")
             .with_description("Resource Type definition for SSO assignmet")
             .attribute(
-                AttributeSchema::new("instance_arn", super::arn())
+                AttributeSchema::new("instance_arn", super::sso_instance_arn())
                     .required()
                     .create_only()
                     .with_description("The sso instance that the permission set is owned.")
@@ -73,22 +34,11 @@ pub fn sso_assignment_config() -> AwsccSchemaConfig {
                     .with_provider_name("PermissionSetArn"),
             )
             .attribute(
-                AttributeSchema::new(
-                    "principal_id",
-                    AttributeType::Custom {
-                        semantic_name: None,
-                        pattern: None,
-                        length: Some((Some(1), Some(47))),
-                        base: Box::new(AttributeType::String),
-                        validate: validate_string_pattern_2a77a2e32f71b5f3_len_1_47,
-                        namespace: None,
-                        to_dsl: None,
-                    },
-                )
-                .required()
-                .create_only()
-                .with_description("The assignee's identifier, user id/group id")
-                .with_provider_name("PrincipalId"),
+                AttributeSchema::new("principal_id", super::sso_principal_id())
+                    .required()
+                    .create_only()
+                    .with_description("The assignee's identifier, user id/group id")
+                    .with_provider_name("PrincipalId"),
             )
             .attribute(
                 AttributeSchema::new(
@@ -106,22 +56,11 @@ pub fn sso_assignment_config() -> AwsccSchemaConfig {
                 .with_provider_name("PrincipalType"),
             )
             .attribute(
-                AttributeSchema::new(
-                    "target_id",
-                    AttributeType::Custom {
-                        semantic_name: None,
-                        pattern: None,
-                        length: None,
-                        base: Box::new(AttributeType::String),
-                        validate: validate_string_pattern_fd8ddd3f8bec29c4,
-                        namespace: None,
-                        to_dsl: None,
-                    },
-                )
-                .required()
-                .create_only()
-                .with_description("The account id to be provisioned.")
-                .with_provider_name("TargetId"),
+                AttributeSchema::new("target_id", super::aws_account_id())
+                    .required()
+                    .create_only()
+                    .with_description("The account id to be provisioned.")
+                    .with_provider_name("TargetId"),
             )
             .attribute(
                 AttributeSchema::new(

--- a/carina-provider-awscc/src/schemas/generated/sso/instance.rs
+++ b/carina-provider-awscc/src/schemas/generated/sso/instance.rs
@@ -118,7 +118,7 @@ pub fn sso_instance_config() -> AwsccSchemaConfig {
         .attribute(
             AttributeSchema::new("identity_store_id", AttributeType::Custom {
                 semantic_name: None,
-                pattern: None,
+                pattern: Some("^[a-zA-Z0-9-]*$".to_string()),
                 length: Some((Some(1), Some(64))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_52730ac83148124e_len_1_64,
@@ -138,7 +138,7 @@ pub fn sso_instance_config() -> AwsccSchemaConfig {
         .attribute(
             AttributeSchema::new("name", AttributeType::Custom {
                 semantic_name: None,
-                pattern: None,
+                pattern: Some("^[\\w+=,.@-]+$".to_string()),
                 length: Some((Some(1), Some(32))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_5a2bd7daee6344f1_len_1_32,

--- a/carina-provider-awscc/src/schemas/generated/sso/permission_set.rs
+++ b/carina-provider-awscc/src/schemas/generated/sso/permission_set.rs
@@ -197,7 +197,7 @@ pub fn sso_permission_set_config() -> AwsccSchemaConfig {
                     fields: vec![
                     StructField::new("name", AttributeType::Custom {
                 semantic_name: None,
-                pattern: None,
+                pattern: Some("[\\w+=,.@-]+".to_string()),
                 length: Some((Some(1), Some(128))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_9b83f4f8f3673df5_len_1_128,
@@ -206,7 +206,7 @@ pub fn sso_permission_set_config() -> AwsccSchemaConfig {
             }).required().with_provider_name("Name"),
                     StructField::new("path", AttributeType::Custom {
                 semantic_name: None,
-                pattern: None,
+                pattern: Some("((/[A-Za-z0-9\\.,\\+@=_-]+)*)/".to_string()),
                 length: Some((Some(1), Some(512))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_b84fa12576539ca9_len_1_512,
@@ -225,7 +225,7 @@ pub fn sso_permission_set_config() -> AwsccSchemaConfig {
         .attribute(
             AttributeSchema::new("description", AttributeType::Custom {
                 semantic_name: None,
-                pattern: None,
+                pattern: Some("[\\u0009\\u000A\\u000D\\u0020-\\u007E\\u00A1-\\u00FF]*".to_string()),
                 length: Some((Some(1), Some(700))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_9863be410e005e12_len_1_700,
@@ -241,7 +241,7 @@ pub fn sso_permission_set_config() -> AwsccSchemaConfig {
                 .with_provider_name("InlinePolicy"),
         )
         .attribute(
-            AttributeSchema::new("instance_arn", super::arn())
+            AttributeSchema::new("instance_arn", super::sso_instance_arn())
                 .required()
                 .create_only()
                 .with_description("The sso instance arn that the permission set is owned.")
@@ -262,7 +262,7 @@ pub fn sso_permission_set_config() -> AwsccSchemaConfig {
         .attribute(
             AttributeSchema::new("name", AttributeType::Custom {
                 semantic_name: None,
-                pattern: None,
+                pattern: Some("[\\w+=,.@-]+".to_string()),
                 length: Some((Some(1), Some(32))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_9b83f4f8f3673df5_len_1_32,
@@ -289,7 +289,7 @@ pub fn sso_permission_set_config() -> AwsccSchemaConfig {
                     fields: vec![
                     StructField::new("name", AttributeType::Custom {
                 semantic_name: None,
-                pattern: None,
+                pattern: Some("[\\w+=,.@-]+".to_string()),
                 length: Some((Some(1), Some(128))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_9b83f4f8f3673df5_len_1_128,
@@ -298,7 +298,7 @@ pub fn sso_permission_set_config() -> AwsccSchemaConfig {
             }).required().with_provider_name("Name"),
                     StructField::new("path", AttributeType::Custom {
                 semantic_name: None,
-                pattern: None,
+                pattern: Some("((/[A-Za-z0-9\\.,\\+@=_-]+)*)/".to_string()),
                 length: Some((Some(1), Some(512))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_b84fa12576539ca9_len_1_512,
@@ -315,7 +315,7 @@ pub fn sso_permission_set_config() -> AwsccSchemaConfig {
         .attribute(
             AttributeSchema::new("relay_state_type", AttributeType::Custom {
                 semantic_name: None,
-                pattern: None,
+                pattern: Some("[a-zA-Z0-9&amp;$@#\\/%?=~\\-_'&quot;|!:,.;*+\\[\\]\\ \\(\\)\\{\\}]+".to_string()),
                 length: Some((Some(1), Some(240))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_4d6d630589930649_len_1_240,
@@ -328,7 +328,7 @@ pub fn sso_permission_set_config() -> AwsccSchemaConfig {
         .attribute(
             AttributeSchema::new("session_duration", AttributeType::Custom {
                 semantic_name: None,
-                pattern: None,
+                pattern: Some("^(-?)P(?=\\d|T\\d)(?:(\\d+)Y)?(?:(\\d+)M)?(?:(\\d+)([DW]))?(?:T(?:(\\d+)H)?(?:(\\d+)M)?(?:(\\d+(?:\\.\\d+)?)S)?)?$".to_string()),
                 length: Some((Some(1), Some(100))),
                 base: Box::new(AttributeType::String),
                 validate: validate_string_pattern_1e58d8243b46a2f1_len_1_100,


### PR DESCRIPTION
## Summary

Follow-up to #144. The previous codegen pass migrated SSO/IdentityStore/Organizations/Route53/OIDCProvider files in-place via perl because the CFN schema cache was unavailable in the agent sandbox. This PR re-runs \`generate-schemas.sh\` with AWS credentials so those resources are freshly re-emitted from upstream CFN schemas, picking up the SSO \`resource_type_overrides\` in their canonical form.

## Why this matters for #2079

Without this regen, the semantic overrides added in #144 weren't present in the generated schemas — \`AWS::SSO::Assignment.target_id\` was still emitted as anonymous \`String(pattern)\`. That makes \`target_id = sso.identity_store_id\` silently valid, which is precisely the bug #2079 set out to fix.

With this PR merged:

- \`AWS::SSO::Assignment.target_id\` → \`super::aws_account_id()\` (semantic: AwsAccountId)
- \`AWS::SSO::Assignment.principal_id\` → \`super::sso_principal_id()\`
- \`AWS::SSO::Assignment.instance_arn\` → \`super::sso_instance_arn()\`
- \`AWS::SSO::PermissionSet.instance_arn\` → \`super::sso_instance_arn()\`

Now \`target_id = sso.identity_store_id\` is a type error at \`carina validate\` time (IdentityStoreId → AwsAccountId, distinct semantic names rejected).

## Other drift

The regen also updates OIDC provider, identity store, organizations, S3 bucket etc. to reflect upstream CFN schema drift since the last regen. The structural shape remains the new Custom shape introduced in #144.

Refs #2079

## Test plan

- [x] \`aws-vault exec mizzy -- ./carina-provider-awscc/scripts/generate-schemas.sh\` regenerates cleanly
- [x] \`cargo build --workspace\`
- [x] \`cargo test --workspace\` (165 provider tests, 134 codegen, 85+5 others pass)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean