### PR TITLE
Extend SSO/IdentityStore semantic overrides to producer side

### DIFF
--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -879,6 +879,76 @@ pub fn sso_instance_arn() -> AttributeType {
     }
 }
 
+/// Validate an IdentityStore id (`d-<10-hex>` or a 36-char UUID).
+pub fn validate_identity_store_id(id: &str) -> Result<(), String> {
+    let looks_like_d = id
+        .strip_prefix("d-")
+        .is_some_and(|rest| rest.len() == 10 && rest.chars().all(|c| c.is_ascii_hexdigit()));
+    let looks_like_uuid = id.len() == 36
+        && id.chars().enumerate().all(|(i, c)| match i {
+            8 | 13 | 18 | 23 => c == '-',
+            _ => c.is_ascii_hexdigit(),
+        });
+    if looks_like_d || looks_like_uuid {
+        Ok(())
+    } else {
+        Err("must be d-<10 hex> or a 36-char UUID".to_string())
+    }
+}
+
+/// IdentityStore identity store id (`d-...` or UUID).
+pub fn identity_store_id() -> AttributeType {
+    AttributeType::Custom {
+        semantic_name: Some("IdentityStoreId".to_string()),
+        pattern: None,
+        length: None,
+        base: Box::new(AttributeType::String),
+        validate: |value| {
+            if let Value::String(s) = value {
+                validate_identity_store_id(s)
+                    .map_err(|reason| format!("Invalid IdentityStore id '{}': {}", s, reason))
+            } else {
+                Err("Expected string".to_string())
+            }
+        },
+        namespace: None,
+        to_dsl: None,
+    }
+}
+
+/// Validate an SSO PermissionSet ARN (`arn:aws:sso:::permissionSet/ssoins-<hex>/ps-<hex>`).
+pub fn validate_sso_permission_set_arn(arn: &str) -> Result<(), String> {
+    validate_arn(arn)?;
+    let parts: Vec<&str> = arn.splitn(6, ':').collect();
+    if parts[2] != "sso" {
+        return Err(format!("expected service 'sso', got '{}'", parts[2]));
+    }
+    if !parts[5].starts_with("permissionSet/") {
+        return Err("resource must start with 'permissionSet/'".to_string());
+    }
+    Ok(())
+}
+
+/// SSO PermissionSet ARN type.
+pub fn sso_permission_set_arn() -> AttributeType {
+    AttributeType::Custom {
+        semantic_name: Some("SsoPermissionSetArn".to_string()),
+        pattern: None,
+        length: None,
+        base: Box::new(arn()),
+        validate: |value| {
+            if let Value::String(s) = value {
+                validate_sso_permission_set_arn(s)
+                    .map_err(|reason| format!("Invalid SSO permission set ARN '{}': {}", s, reason))
+            } else {
+                Err("Expected string".to_string())
+            }
+        },
+        namespace: None,
+        to_dsl: None,
+    }
+}
+
 // ========== ARN validators ==========
 
 /// Valid AWS partition values.

--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -3108,7 +3108,9 @@ fn resource_type_overrides() -> &'static HashMap<(&'static str, &'static str), T
                 TypeOverride::StringType("AttributeType::String"),
             );
 
-            // SSO Assignment identity semantics
+            // SSO / IdentityStore identity semantics
+            //
+            // Sinks (consumers in assignments, permission sets):
             m.insert(
                 ("AWS::SSO::Assignment", "TargetId"),
                 TypeOverride::StringType("super::aws_account_id()"),
@@ -3124,6 +3126,43 @@ fn resource_type_overrides() -> &'static HashMap<(&'static str, &'static str), T
             m.insert(
                 ("AWS::SSO::PermissionSet", "InstanceArn"),
                 TypeOverride::StringType("super::sso_instance_arn()"),
+            );
+            //
+            // Sources (produced by SSO/IdentityStore resources themselves).
+            // Without these, the sinks above can only accept values from
+            // hand-typed literals — references to the canonical producers
+            // fail with "expected SsoInstanceArn, got Arn".
+            m.insert(
+                ("AWS::SSO::Instance", "InstanceArn"),
+                TypeOverride::StringType("super::sso_instance_arn()"),
+            );
+            m.insert(
+                ("AWS::SSO::Instance", "IdentityStoreId"),
+                TypeOverride::StringType("super::identity_store_id()"),
+            );
+            m.insert(
+                ("AWS::SSO::PermissionSet", "PermissionSetArn"),
+                TypeOverride::StringType("super::sso_permission_set_arn()"),
+            );
+            m.insert(
+                ("AWS::SSO::Assignment", "PermissionSetArn"),
+                TypeOverride::StringType("super::sso_permission_set_arn()"),
+            );
+            m.insert(
+                ("AWS::IdentityStore::Group", "GroupId"),
+                TypeOverride::StringType("super::sso_principal_id()"),
+            );
+            m.insert(
+                ("AWS::IdentityStore::Group", "IdentityStoreId"),
+                TypeOverride::StringType("super::identity_store_id()"),
+            );
+            m.insert(
+                ("AWS::IdentityStore::GroupMembership", "IdentityStoreId"),
+                TypeOverride::StringType("super::identity_store_id()"),
+            );
+            m.insert(
+                ("AWS::IdentityStore::GroupMembership", "GroupId"),
+                TypeOverride::StringType("super::sso_principal_id()"),
             );
 
             // === Enum overrides ===

--- a/carina-provider-awscc/src/schemas/generated/identitystore/group.rs
+++ b/carina-provider-awscc/src/schemas/generated/identitystore/group.rs
@@ -10,28 +10,6 @@ use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
 use regex::Regex;
 
 #[allow(dead_code)]
-fn validate_string_pattern_2a77a2e32f71b5f3_len_1_47(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
-        static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-            Regex::new("^([0-9a-f]{10}-|)[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$").expect("invalid pattern regex")
-        });
-        if !RE.is_match(s) {
-            return Err(format!(
-                "Value '{}' does not match pattern ^([0-9a-f]{{10}}-|)[A-Fa-f0-9]{{8}}-[A-Fa-f0-9]{{4}}-[A-Fa-f0-9]{{4}}-[A-Fa-f0-9]{{4}}-[A-Fa-f0-9]{{12}}$",
-                s
-            ));
-        }
-        let len = s.chars().count();
-        if !(1..=47).contains(&len) {
-            return Err(format!("String length {} is out of range 1..=47", len));
-        }
-        Ok(())
-    } else {
-        Err("Expected string".to_string())
-    }
-}
-
-#[allow(dead_code)]
 fn validate_string_pattern_a301e45ae2f7df12_len_1_1024(value: &Value) -> Result<(), String> {
     if let Value::String(s) = value {
         static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
@@ -77,31 +55,6 @@ fn validate_string_pattern_3e29f1c0497511f3_len_1_1024(value: &Value) -> Result<
     }
 }
 
-#[allow(dead_code)]
-fn validate_string_pattern_135f0b126ef95449_len_1_36(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
-        static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-            Regex::new(
-                "^d-[0-9a-f]{10}$|^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
-            )
-            .expect("invalid pattern regex")
-        });
-        if !RE.is_match(s) {
-            return Err(format!(
-                "Value '{}' does not match pattern ^d-[0-9a-f]{{10}}$|^[0-9a-f]{{8}}-[0-9a-f]{{4}}-[0-9a-f]{{4}}-[0-9a-f]{{4}}-[0-9a-f]{{12}}$",
-                s
-            ));
-        }
-        let len = s.chars().count();
-        if !(1..=36).contains(&len) {
-            return Err(format!("String length {} is out of range 1..=36", len));
-        }
-        Ok(())
-    } else {
-        Err("Expected string".to_string())
-    }
-}
-
 /// Returns the schema config for identitystore_group (AWS::IdentityStore::Group)
 pub fn identitystore_group_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
@@ -138,29 +91,13 @@ pub fn identitystore_group_config() -> AwsccSchemaConfig {
                 .with_provider_name("DisplayName"),
         )
         .attribute(
-            AttributeSchema::new("group_id", AttributeType::Custom {
-                semantic_name: None,
-                pattern: Some("^([0-9a-f]{10}-|)[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$".to_string()),
-                length: Some((Some(1), Some(47))),
-                base: Box::new(AttributeType::String),
-                validate: validate_string_pattern_2a77a2e32f71b5f3_len_1_47,
-                namespace: None,
-                to_dsl: None,
-            })
+            AttributeSchema::new("group_id", super::sso_principal_id())
                 .read_only()
                 .with_description("The unique identifier for a group in the identity store. (read-only)")
                 .with_provider_name("GroupId"),
         )
         .attribute(
-            AttributeSchema::new("identity_store_id", AttributeType::Custom {
-                semantic_name: None,
-                pattern: Some("^d-[0-9a-f]{10}$|^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$".to_string()),
-                length: Some((Some(1), Some(36))),
-                base: Box::new(AttributeType::String),
-                validate: validate_string_pattern_135f0b126ef95449_len_1_36,
-                namespace: None,
-                to_dsl: None,
-            })
+            AttributeSchema::new("identity_store_id", super::identity_store_id())
                 .required()
                 .create_only()
                 .with_description("The globally unique identifier for the identity store.")

--- a/carina-provider-awscc/src/schemas/generated/identitystore/group_membership.rs
+++ b/carina-provider-awscc/src/schemas/generated/identitystore/group_membership.rs
@@ -31,31 +31,6 @@ fn validate_string_pattern_2a77a2e32f71b5f3_len_1_47(value: &Value) -> Result<()
     }
 }
 
-#[allow(dead_code)]
-fn validate_string_pattern_135f0b126ef95449_len_1_36(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
-        static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-            Regex::new(
-                "^d-[0-9a-f]{10}$|^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
-            )
-            .expect("invalid pattern regex")
-        });
-        if !RE.is_match(s) {
-            return Err(format!(
-                "Value '{}' does not match pattern ^d-[0-9a-f]{{10}}$|^[0-9a-f]{{8}}-[0-9a-f]{{4}}-[0-9a-f]{{4}}-[0-9a-f]{{4}}-[0-9a-f]{{12}}$",
-                s
-            ));
-        }
-        let len = s.chars().count();
-        if !(1..=36).contains(&len) {
-            return Err(format!("String length {} is out of range 1..=36", len));
-        }
-        Ok(())
-    } else {
-        Err("Expected string".to_string())
-    }
-}
-
 /// Returns the schema config for identitystore_group_membership (AWS::IdentityStore::GroupMembership)
 pub fn identitystore_group_membership_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
@@ -65,30 +40,14 @@ pub fn identitystore_group_membership_config() -> AwsccSchemaConfig {
         schema: ResourceSchema::new("awscc.identitystore.group_membership")
         .with_description("Resource Type Definition for AWS:IdentityStore::GroupMembership")
         .attribute(
-            AttributeSchema::new("group_id", AttributeType::Custom {
-                semantic_name: None,
-                pattern: Some("^([0-9a-f]{10}-|)[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$".to_string()),
-                length: Some((Some(1), Some(47))),
-                base: Box::new(AttributeType::String),
-                validate: validate_string_pattern_2a77a2e32f71b5f3_len_1_47,
-                namespace: None,
-                to_dsl: None,
-            })
+            AttributeSchema::new("group_id", super::sso_principal_id())
                 .required()
                 .create_only()
                 .with_description("The unique identifier for a group in the identity store.")
                 .with_provider_name("GroupId"),
         )
         .attribute(
-            AttributeSchema::new("identity_store_id", AttributeType::Custom {
-                semantic_name: None,
-                pattern: Some("^d-[0-9a-f]{10}$|^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$".to_string()),
-                length: Some((Some(1), Some(36))),
-                base: Box::new(AttributeType::String),
-                validate: validate_string_pattern_135f0b126ef95449_len_1_36,
-                namespace: None,
-                to_dsl: None,
-            })
+            AttributeSchema::new("identity_store_id", super::identity_store_id())
                 .required()
                 .create_only()
                 .with_description("The globally unique identifier for the identity store.")

--- a/carina-provider-awscc/src/schemas/generated/sso/assignment.rs
+++ b/carina-provider-awscc/src/schemas/generated/sso/assignment.rs
@@ -27,7 +27,7 @@ pub fn sso_assignment_config() -> AwsccSchemaConfig {
                     .with_provider_name("InstanceArn"),
             )
             .attribute(
-                AttributeSchema::new("permission_set_arn", super::arn())
+                AttributeSchema::new("permission_set_arn", super::sso_permission_set_arn())
                     .required()
                     .create_only()
                     .with_description("The permission set that the assignment will be assigned")

--- a/carina-provider-awscc/src/schemas/generated/sso/instance.rs
+++ b/carina-provider-awscc/src/schemas/generated/sso/instance.rs
@@ -85,28 +85,6 @@ fn validate_string_pattern_5a2bd7daee6344f1_len_1_32(value: &Value) -> Result<()
     }
 }
 
-#[allow(dead_code)]
-fn validate_string_pattern_52730ac83148124e_len_1_64(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
-        static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-            Regex::new("^[a-zA-Z0-9-]*$").expect("invalid pattern regex")
-        });
-        if !RE.is_match(s) {
-            return Err(format!(
-                "Value '{}' does not match pattern ^[a-zA-Z0-9-]*$",
-                s
-            ));
-        }
-        let len = s.chars().count();
-        if !(1..=64).contains(&len) {
-            return Err(format!("String length {} is out of range 1..=64", len));
-        }
-        Ok(())
-    } else {
-        Err("Expected string".to_string())
-    }
-}
-
 /// Returns the schema config for sso_instance (AWS::SSO::Instance)
 pub fn sso_instance_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
@@ -116,21 +94,13 @@ pub fn sso_instance_config() -> AwsccSchemaConfig {
         schema: ResourceSchema::new("awscc.sso.instance")
         .with_description("Resource Type definition for Identity Center (SSO) Instance")
         .attribute(
-            AttributeSchema::new("identity_store_id", AttributeType::Custom {
-                semantic_name: None,
-                pattern: Some("^[a-zA-Z0-9-]*$".to_string()),
-                length: Some((Some(1), Some(64))),
-                base: Box::new(AttributeType::String),
-                validate: validate_string_pattern_52730ac83148124e_len_1_64,
-                namespace: None,
-                to_dsl: None,
-            })
+            AttributeSchema::new("identity_store_id", super::identity_store_id())
                 .read_only()
                 .with_description("The ID of the identity store associated with the created Identity Center (SSO) Instance (read-only)")
                 .with_provider_name("IdentityStoreId"),
         )
         .attribute(
-            AttributeSchema::new("instance_arn", super::arn())
+            AttributeSchema::new("instance_arn", super::sso_instance_arn())
                 .read_only()
                 .with_description("The SSO Instance ARN that is returned upon creation of the Identity Center (SSO) Instance (read-only)")
                 .with_provider_name("InstanceArn"),

--- a/carina-provider-awscc/src/schemas/generated/sso/permission_set.rs
+++ b/carina-provider-awscc/src/schemas/generated/sso/permission_set.rs
@@ -275,7 +275,7 @@ pub fn sso_permission_set_config() -> AwsccSchemaConfig {
                 .with_provider_name("Name"),
         )
         .attribute(
-            AttributeSchema::new("permission_set_arn", super::arn())
+            AttributeSchema::new("permission_set_arn", super::sso_permission_set_arn())
                 .read_only()
                 .with_description("The permission set that the policy will be attached to (read-only)")
                 .with_provider_name("PermissionSetArn"),


### PR DESCRIPTION
## Summary

Follow-up to #144 and #146. The previous overrides covered only the consumer side (Assignment, PermissionSet attributes accepting values). The producer side (SSO::Instance, IdentityStore::Group) still emitted `String(pattern)`, so legitimate references like `target_id = caller.account_id` or `instance_arn = sso.instance_arn` failed the new directional check with "anonymous source → semantic sink".

This PR:

- Adds `identity_store_id()` and `sso_permission_set_arn()` helpers in carina-aws-types (semantic Custom types with validators)
- Extends `resource_type_overrides`:
  - `AWS::SSO::Instance.{InstanceArn, IdentityStoreId}`
  - `AWS::SSO::PermissionSet.PermissionSetArn`
  - `AWS::IdentityStore::Group.{GroupId, IdentityStoreId}`
  - `AWS::IdentityStore::GroupMembership.{GroupId, IdentityStoreId}`
  - `AWS::SSO::Assignment.PermissionSetArn` (was plain `arn()`)

## End-to-end verification on infra/aws/management/identity-center

- With these in place + the main-repo directional `is_assignable_to`:
  - `target_id = caller.account_id` validates ✓ (both AwsAccountId)
  - `target_id = account_id` (from `for _, account_id in orgs.accounts`) validates ✓
  - `principal_id = admins.group_id` validates ✓ (both SsoPrincipalId)
  - `instance_arn = sso.instance_arn` validates ✓ (both SsoInstanceArn)
- The bug case `target_id = sso.identity_store_id` is correctly rejected:
  `cannot assign IdentityStoreId to 'target_id': expected AwsAccountId, got IdentityStoreId (from sso.identity_store_id)`

Refs #2079

## Test plan

- [x] \`cargo test --workspace\`
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean
- [x] \`aws-vault exec mizzy -- ./carina-provider-awscc/scripts/generate-schemas.sh\`
- [x] Manual \`carina validate .\` on infra/aws/management/identity-center