### PR TITLE
codegen+fixtures: migrate provider-awscc to Strategy Y casing

### DIFF
--- a/acceptance-tests/attribute_removal/ec2_vpc_endpoint_step1.crn
+++ b/acceptance-tests/attribute_removal/ec2_vpc_endpoint_step1.crn
@@ -6,15 +6,15 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.108.0.0/16'
 }
 
-let rt = awscc.ec2.route_table {
+let rt = awscc.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 }
 
-awscc.ec2.vpc_endpoint {
+awscc.ec2.VpcEndpoint {
   vpc_id            = vpc.vpc_id
   service_name      = 'com.amazonaws.ap-northeast-1.s3'
   vpc_endpoint_type = Gateway

--- a/acceptance-tests/attribute_removal/ec2_vpc_endpoint_step2.crn
+++ b/acceptance-tests/attribute_removal/ec2_vpc_endpoint_step2.crn
@@ -6,15 +6,15 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.108.0.0/16'
 }
 
-let rt = awscc.ec2.route_table {
+let rt = awscc.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 }
 
-awscc.ec2.vpc_endpoint {
+awscc.ec2.VpcEndpoint {
   vpc_id            = vpc.vpc_id
   service_name      = 'com.amazonaws.ap-northeast-1.s3'
   vpc_endpoint_type = Gateway

--- a/acceptance-tests/attribute_removal/logs_log_group_step1.crn
+++ b/acceptance-tests/attribute_removal/logs_log_group_step1.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.logs.log_group {
+awscc.logs.LogGroup {
   log_group_name    = '/carina/acc-test-attr-removal'
   retention_in_days = 7
 }

--- a/acceptance-tests/attribute_removal/logs_log_group_step2.crn
+++ b/acceptance-tests/attribute_removal/logs_log_group_step2.crn
@@ -6,6 +6,6 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.logs.log_group {
+awscc.logs.LogGroup {
   log_group_name = '/carina/acc-test-attr-removal'
 }

--- a/acceptance-tests/builtin_functions/cidr_subnet.crn
+++ b/acceptance-tests/builtin_functions/cidr_subnet.crn
@@ -4,7 +4,7 @@ provider awscc {
 
 let base_cidr = '10.0.0.0/16'
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = base_cidr
 
   tags = {
@@ -12,7 +12,7 @@ let vpc = awscc.ec2.vpc {
   }
 }
 
-awscc.ec2.subnet {
+awscc.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = cidr_subnet(base_cidr, 8, 1)
   availability_zone = 'ap-northeast-1a'

--- a/acceptance-tests/builtin_functions/concat.crn
+++ b/acceptance-tests/builtin_functions/concat.crn
@@ -6,7 +6,7 @@ let parts1 = ['web', 'test']
 
 let parts2 = ['vpc']
 
-awscc.ec2.vpc {
+awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {

--- a/acceptance-tests/builtin_functions/flatten.crn
+++ b/acceptance-tests/builtin_functions/flatten.crn
@@ -4,7 +4,7 @@ provider awscc {
 
 let parts = [['flat', 'test'], ['vpc']]
 
-awscc.ec2.vpc {
+awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {

--- a/acceptance-tests/builtin_functions/join.crn
+++ b/acceptance-tests/builtin_functions/join.crn
@@ -6,7 +6,7 @@ let env = 'test'
 
 let app = 'web'
 
-awscc.ec2.vpc {
+awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {

--- a/acceptance-tests/builtin_functions/keys_values.crn
+++ b/acceptance-tests/builtin_functions/keys_values.crn
@@ -8,7 +8,7 @@ let config = {
   team = 'infra'
 }
 
-awscc.ec2.vpc {
+awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {

--- a/acceptance-tests/builtin_functions/length.crn
+++ b/acceptance-tests/builtin_functions/length.crn
@@ -4,7 +4,7 @@ provider awscc {
 
 let items = ['a', 'b', 'c']
 
-awscc.ec2.vpc {
+awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {

--- a/acceptance-tests/builtin_functions/local_let.crn
+++ b/acceptance-tests/builtin_functions/local_let.crn
@@ -2,7 +2,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.ec2.vpc {
+awscc.ec2.Vpc {
   let env = 'production'
   let name = "local-let-${env}"
   cidr_block = '10.0.0.0/16'

--- a/acceptance-tests/builtin_functions/lookup.crn
+++ b/acceptance-tests/builtin_functions/lookup.crn
@@ -8,7 +8,7 @@ let env_names = {
   dev  = 'development'
 }
 
-awscc.ec2.vpc {
+awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {

--- a/acceptance-tests/builtin_functions/min_max.crn
+++ b/acceptance-tests/builtin_functions/min_max.crn
@@ -2,7 +2,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.ec2.vpc {
+awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {

--- a/acceptance-tests/builtin_functions/replace.crn
+++ b/acceptance-tests/builtin_functions/replace.crn
@@ -4,7 +4,7 @@ provider awscc {
 
 let name = replace('-', '_', 'web-test-vpc')
 
-awscc.ec2.vpc {
+awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {

--- a/acceptance-tests/builtin_functions/split.crn
+++ b/acceptance-tests/builtin_functions/split.crn
@@ -4,7 +4,7 @@ provider awscc {
 
 let parts = split('-', 'web-test-vpc')
 
-awscc.ec2.vpc {
+awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {

--- a/acceptance-tests/builtin_functions/trim.crn
+++ b/acceptance-tests/builtin_functions/trim.crn
@@ -2,7 +2,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.ec2.vpc {
+awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {

--- a/acceptance-tests/builtin_functions/upper_lower.crn
+++ b/acceptance-tests/builtin_functions/upper_lower.crn
@@ -6,7 +6,7 @@ let env = 'Production'
 
 let app = 'WebApp'
 
-awscc.ec2.vpc {
+awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {

--- a/acceptance-tests/cascade_without_cbd/step1.crn
+++ b/acceptance-tests/cascade_without_cbd/step1.crn
@@ -8,7 +8,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.220.0.0/16'
 
   tags = {
@@ -17,7 +17,7 @@ let vpc = awscc.ec2.vpc {
   }
 }
 
-awscc.ec2.subnet {
+awscc.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.220.1.0/24'
   availability_zone = 'ap-northeast-1a'

--- a/acceptance-tests/cascade_without_cbd/step2.crn
+++ b/acceptance-tests/cascade_without_cbd/step2.crn
@@ -8,7 +8,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.221.0.0/16'
 
   tags = {
@@ -17,7 +17,7 @@ let vpc = awscc.ec2.vpc {
   }
 }
 
-awscc.ec2.subnet {
+awscc.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.221.1.0/24'
   availability_zone = 'ap-northeast-1c'

--- a/acceptance-tests/create_before_destroy/ec2_transit_gateway_attachment_step1.crn
+++ b/acceptance-tests/create_before_destroy/ec2_transit_gateway_attachment_step1.crn
@@ -8,7 +8,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.210.0.0/16'
 
   tags = {
@@ -17,7 +17,7 @@ let vpc = awscc.ec2.vpc {
   }
 }
 
-let subnet = awscc.ec2.subnet {
+let subnet = awscc.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.210.1.0/24'
   availability_zone = 'ap-northeast-1a'
@@ -28,7 +28,7 @@ let subnet = awscc.ec2.subnet {
   }
 }
 
-let tgw_a = awscc.ec2.transit_gateway {
+let tgw_a = awscc.ec2.TransitGateway {
   description = 'carina-acc-test-cbd-tgw-attach-a'
 
   tags = {
@@ -37,7 +37,7 @@ let tgw_a = awscc.ec2.transit_gateway {
   }
 }
 
-awscc.ec2.transit_gateway {
+awscc.ec2.TransitGateway {
   description = 'carina-acc-test-cbd-tgw-attach-b'
 
   tags = {
@@ -46,7 +46,7 @@ awscc.ec2.transit_gateway {
   }
 }
 
-awscc.ec2.transit_gateway_attachment {
+awscc.ec2.TransitGatewayAttachment {
   subnet_ids         = [subnet.subnet_id]
   transit_gateway_id = tgw_a.id
   vpc_id             = vpc.vpc_id

--- a/acceptance-tests/create_before_destroy/ec2_transit_gateway_attachment_step2.crn
+++ b/acceptance-tests/create_before_destroy/ec2_transit_gateway_attachment_step2.crn
@@ -9,7 +9,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.210.0.0/16'
 
   tags = {
@@ -18,7 +18,7 @@ let vpc = awscc.ec2.vpc {
   }
 }
 
-let subnet = awscc.ec2.subnet {
+let subnet = awscc.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.210.1.0/24'
   availability_zone = 'ap-northeast-1a'
@@ -29,7 +29,7 @@ let subnet = awscc.ec2.subnet {
   }
 }
 
-awscc.ec2.transit_gateway {
+awscc.ec2.TransitGateway {
   description = 'carina-acc-test-cbd-tgw-attach-a'
 
   tags = {
@@ -38,7 +38,7 @@ awscc.ec2.transit_gateway {
   }
 }
 
-let tgw_b = awscc.ec2.transit_gateway {
+let tgw_b = awscc.ec2.TransitGateway {
   description = 'carina-acc-test-cbd-tgw-attach-b'
 
   tags = {
@@ -47,7 +47,7 @@ let tgw_b = awscc.ec2.transit_gateway {
   }
 }
 
-awscc.ec2.transit_gateway_attachment {
+awscc.ec2.TransitGatewayAttachment {
   subnet_ids         = [subnet.subnet_id]
   transit_gateway_id = tgw_b.id
   vpc_id             = vpc.vpc_id

--- a/acceptance-tests/create_before_destroy/ec2_vpc_step1.crn
+++ b/acceptance-tests/create_before_destroy/ec2_vpc_step1.crn
@@ -7,7 +7,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.ec2.vpc {
+awscc.ec2.Vpc {
   cidr_block           = '10.200.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true

--- a/acceptance-tests/create_before_destroy/ec2_vpc_step2.crn
+++ b/acceptance-tests/create_before_destroy/ec2_vpc_step2.crn
@@ -8,7 +8,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.ec2.vpc {
+awscc.ec2.Vpc {
   cidr_block           = '10.201.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true

--- a/acceptance-tests/create_before_destroy/iam_role_step1.crn
+++ b/acceptance-tests/create_before_destroy/iam_role_step1.crn
@@ -8,7 +8,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.iam.role {
+awscc.iam.Role {
   role_name = 'carina-acc-test-cbd-role'
   path      = '/'
 

--- a/acceptance-tests/create_before_destroy/iam_role_step2.crn
+++ b/acceptance-tests/create_before_destroy/iam_role_step2.crn
@@ -11,7 +11,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.iam.role {
+awscc.iam.Role {
   role_name = 'carina-acc-test-cbd-role'
   path      = '/carina/'
 

--- a/acceptance-tests/ec2_egress_only_internet_gateway/basic.crn
+++ b/acceptance-tests/ec2_egress_only_internet_gateway/basic.crn
@@ -6,11 +6,11 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-awscc.ec2.egress_only_internet_gateway {
+awscc.ec2.EgressOnlyInternetGateway {
   vpc_id = vpc.vpc_id
 
   tags = {

--- a/acceptance-tests/ec2_eip/basic.crn
+++ b/acceptance-tests/ec2_eip/basic.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.ec2.eip {
+awscc.ec2.Eip {
   domain = 'vpc'
 
   tags = {

--- a/acceptance-tests/ec2_flow_log/cloudwatch.crn
+++ b/acceptance-tests/ec2_flow_log/cloudwatch.crn
@@ -7,16 +7,16 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-let log_group = awscc.logs.log_group {
+let log_group = awscc.logs.LogGroup {
   log_group_name    = '/acceptance-test/vpc-flow-logs'
   retention_in_days = 1
 }
 
-let flow_log_role = awscc.iam.role {
+let flow_log_role = awscc.iam.Role {
   role_name = 'acceptance-test-flow-log-role'
 
   assume_role_policy_document = {
@@ -33,7 +33,7 @@ let flow_log_role = awscc.iam.role {
   }
 }
 
-awscc.ec2.flow_log {
+awscc.ec2.FlowLog {
   resource_id                 = vpc.vpc_id
   resource_type               = VPC
   traffic_type                = ALL

--- a/acceptance-tests/ec2_flow_log/s3.crn
+++ b/acceptance-tests/ec2_flow_log/s3.crn
@@ -7,17 +7,17 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-let bucket = awscc.s3.bucket {
+let bucket = awscc.s3.Bucket {
   lifecycle {
     force_delete = true
   }
 }
 
-awscc.ec2.flow_log {
+awscc.ec2.FlowLog {
   resource_id          = vpc.vpc_id
   resource_type        = VPC
   traffic_type         = ALL

--- a/acceptance-tests/ec2_internet_gateway/basic.crn
+++ b/acceptance-tests/ec2_internet_gateway/basic.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.ec2.internet_gateway {
+awscc.ec2.InternetGateway {
   tags = {
     Environment = 'acceptance-test'
   }

--- a/acceptance-tests/ec2_ipam/basic.crn
+++ b/acceptance-tests/ec2_ipam/basic.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.ec2.ipam {
+awscc.ec2.Ipam {
   tier        = advanced
   description = 'Acceptance test IPAM'
 

--- a/acceptance-tests/ec2_ipam_pool/basic.crn
+++ b/acceptance-tests/ec2_ipam_pool/basic.crn
@@ -7,7 +7,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let ipam = awscc.ec2.ipam {
+let ipam = awscc.ec2.Ipam {
   tier = advanced
 
   operating_region {
@@ -15,7 +15,7 @@ let ipam = awscc.ec2.ipam {
   }
 }
 
-awscc.ec2.ipam_pool {
+awscc.ec2.IpamPool {
   ipam_scope_id  = ipam.private_default_scope_id
   address_family = 'IPv4'
   locale         = 'ap-northeast-1'

--- a/acceptance-tests/ec2_nat_gateway/private.crn
+++ b/acceptance-tests/ec2_nat_gateway/private.crn
@@ -6,17 +6,17 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-let private_subnet = awscc.ec2.subnet {
+let private_subnet = awscc.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.1.0/24'
   availability_zone = 'ap-northeast-1a'
 }
 
-awscc.ec2.nat_gateway {
+awscc.ec2.NatGateway {
   subnet_id          = private_subnet.subnet_id
   connectivity_type  = private
   private_ip_address = '10.0.1.100'

--- a/acceptance-tests/ec2_nat_gateway/public.crn
+++ b/acceptance-tests/ec2_nat_gateway/public.crn
@@ -6,31 +6,31 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
-let igw = awscc.ec2.internet_gateway {}
+let igw = awscc.ec2.InternetGateway {}
 
-awscc.ec2.vpc_gateway_attachment {
+awscc.ec2.VpcGatewayAttachment {
   vpc_id              = vpc.vpc_id
   internet_gateway_id = igw.internet_gateway_id
 }
 
-let public_subnet = awscc.ec2.subnet {
+let public_subnet = awscc.ec2.Subnet {
   vpc_id                  = vpc.vpc_id
   cidr_block              = '10.0.1.0/24'
   availability_zone       = 'ap-northeast-1a'
   map_public_ip_on_launch = true
 }
 
-let eip = awscc.ec2.eip {
+let eip = awscc.ec2.Eip {
   domain = 'vpc'
 }
 
-awscc.ec2.nat_gateway {
+awscc.ec2.NatGateway {
   allocation_id = eip.allocation_id
   subnet_id     = public_subnet.subnet_id
 

--- a/acceptance-tests/ec2_route/igw.crn
+++ b/acceptance-tests/ec2_route/igw.crn
@@ -6,22 +6,22 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-let igw = awscc.ec2.internet_gateway {}
+let igw = awscc.ec2.InternetGateway {}
 
-let igw_attachment = awscc.ec2.vpc_gateway_attachment {
+let igw_attachment = awscc.ec2.VpcGatewayAttachment {
   vpc_id              = vpc.vpc_id
   internet_gateway_id = igw.internet_gateway_id
 }
 
-let rt = awscc.ec2.route_table {
+let rt = awscc.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 }
 
-awscc.ec2.route {
+awscc.ec2.Route {
   route_table_id         = rt.route_table_id
   destination_cidr_block = '0.0.0.0/0'
   gateway_id             = igw_attachment.internet_gateway_id

--- a/acceptance-tests/ec2_route/ipv6.crn
+++ b/acceptance-tests/ec2_route/ipv6.crn
@@ -7,19 +7,19 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-let eoigw = awscc.ec2.egress_only_internet_gateway {
+let eoigw = awscc.ec2.EgressOnlyInternetGateway {
   vpc_id = vpc.vpc_id
 }
 
-let rt = awscc.ec2.route_table {
+let rt = awscc.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 }
 
-awscc.ec2.route {
+awscc.ec2.Route {
   route_table_id                  = rt.route_table_id
   destination_ipv6_cidr_block     = '::/0'
   egress_only_internet_gateway_id = eoigw.id

--- a/acceptance-tests/ec2_route/nat_gateway.crn
+++ b/acceptance-tests/ec2_route/nat_gateway.crn
@@ -6,40 +6,40 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
-let igw = awscc.ec2.internet_gateway {}
+let igw = awscc.ec2.InternetGateway {}
 
-awscc.ec2.vpc_gateway_attachment {
+awscc.ec2.VpcGatewayAttachment {
   vpc_id              = vpc.vpc_id
   internet_gateway_id = igw.internet_gateway_id
 }
 
-let public_subnet = awscc.ec2.subnet {
+let public_subnet = awscc.ec2.Subnet {
   vpc_id                  = vpc.vpc_id
   cidr_block              = '10.0.1.0/24'
   availability_zone       = 'ap-northeast-1a'
   map_public_ip_on_launch = true
 }
 
-let eip = awscc.ec2.eip {
+let eip = awscc.ec2.Eip {
   domain = 'vpc'
 }
 
-let nat_gw = awscc.ec2.nat_gateway {
+let nat_gw = awscc.ec2.NatGateway {
   allocation_id = eip.allocation_id
   subnet_id     = public_subnet.subnet_id
 }
 
-let rt = awscc.ec2.route_table {
+let rt = awscc.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 }
 
-awscc.ec2.route {
+awscc.ec2.Route {
   route_table_id         = rt.route_table_id
   destination_cidr_block = '0.0.0.0/0'
   nat_gateway_id         = nat_gw.nat_gateway_id

--- a/acceptance-tests/ec2_route/transit_gateway.crn
+++ b/acceptance-tests/ec2_route/transit_gateway.crn
@@ -7,31 +7,31 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-let subnet = awscc.ec2.subnet {
+let subnet = awscc.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.1.0/24'
   availability_zone = 'ap-northeast-1a'
 }
 
-let tgw = awscc.ec2.transit_gateway {
+let tgw = awscc.ec2.TransitGateway {
   description = 'Transit Gateway for route test'
 }
 
-let tgw_attach = awscc.ec2.transit_gateway_attachment {
+let tgw_attach = awscc.ec2.TransitGatewayAttachment {
   transit_gateway_id = tgw.id
   vpc_id             = vpc.vpc_id
   subnet_ids         = [subnet.subnet_id]
 }
 
-let rt = awscc.ec2.route_table {
+let rt = awscc.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 }
 
-awscc.ec2.route {
+awscc.ec2.Route {
   route_table_id         = rt.route_table_id
   destination_cidr_block = '10.1.0.0/16'
   transit_gateway_id     = tgw_attach.transit_gateway_id

--- a/acceptance-tests/ec2_route/vpc_peering.crn
+++ b/acceptance-tests/ec2_route/vpc_peering.crn
@@ -7,24 +7,24 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc1 = awscc.ec2.vpc {
+let vpc1 = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-let vpc2 = awscc.ec2.vpc {
+let vpc2 = awscc.ec2.Vpc {
   cidr_block = '10.1.0.0/16'
 }
 
-let peering = awscc.ec2.vpc_peering_connection {
+let peering = awscc.ec2.VpcPeeringConnection {
   vpc_id      = vpc1.vpc_id
   peer_vpc_id = vpc2.vpc_id
 }
 
-let rt = awscc.ec2.route_table {
+let rt = awscc.ec2.RouteTable {
   vpc_id = vpc1.vpc_id
 }
 
-awscc.ec2.route {
+awscc.ec2.Route {
   route_table_id            = rt.route_table_id
   destination_cidr_block    = '10.1.0.0/16'
   vpc_peering_connection_id = peering.id

--- a/acceptance-tests/ec2_route_table/basic.crn
+++ b/acceptance-tests/ec2_route_table/basic.crn
@@ -6,11 +6,11 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-awscc.ec2.route_table {
+awscc.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 
   tags = {

--- a/acceptance-tests/ec2_security_group/ipv6_rules.crn
+++ b/acceptance-tests/ec2_security_group/ipv6_rules.crn
@@ -6,11 +6,11 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-awscc.ec2.security_group {
+awscc.ec2.SecurityGroup {
   vpc_id            = vpc.vpc_id
   group_description = 'Acceptance test - IPv6 rules'
 

--- a/acceptance-tests/ec2_security_group/prefix.crn
+++ b/acceptance-tests/ec2_security_group/prefix.crn
@@ -8,11 +8,11 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-awscc.ec2.security_group {
+awscc.ec2.SecurityGroup {
   vpc_id            = vpc.vpc_id
   group_description = 'Acceptance test - group_name_prefix'
   group_name_prefix = 'carina-acc-test-'

--- a/acceptance-tests/ec2_security_group/with_egress.crn
+++ b/acceptance-tests/ec2_security_group/with_egress.crn
@@ -6,11 +6,11 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-awscc.ec2.security_group {
+awscc.ec2.SecurityGroup {
   vpc_id            = vpc.vpc_id
   group_description = 'Acceptance test - egress rules'
 

--- a/acceptance-tests/ec2_security_group/with_ingress.crn
+++ b/acceptance-tests/ec2_security_group/with_ingress.crn
@@ -6,11 +6,11 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-awscc.ec2.security_group {
+awscc.ec2.SecurityGroup {
   vpc_id            = vpc.vpc_id
   group_description = 'Acceptance test - ingress rules'
 

--- a/acceptance-tests/ec2_security_group_egress/basic.crn
+++ b/acceptance-tests/ec2_security_group_egress/basic.crn
@@ -6,16 +6,16 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-let sg = awscc.ec2.security_group {
+let sg = awscc.ec2.SecurityGroup {
   vpc_id            = vpc.vpc_id
   group_description = 'SG for egress rule test'
 }
 
-awscc.ec2.security_group_egress {
+awscc.ec2.SecurityGroupEgress {
   group_id    = sg.group_id
   description = 'Allow all outbound'
   ip_protocol = all

--- a/acceptance-tests/ec2_security_group_egress/dest_sg.crn
+++ b/acceptance-tests/ec2_security_group_egress/dest_sg.crn
@@ -6,21 +6,21 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-let source_sg = awscc.ec2.security_group {
+let source_sg = awscc.ec2.SecurityGroup {
   vpc_id            = vpc.vpc_id
   group_description = 'Source security group'
 }
 
-let dest_sg = awscc.ec2.security_group {
+let dest_sg = awscc.ec2.SecurityGroup {
   vpc_id            = vpc.vpc_id
   group_description = 'Destination security group'
 }
 
-awscc.ec2.security_group_egress {
+awscc.ec2.SecurityGroupEgress {
   group_id                      = source_sg.group_id
   description                   = 'Allow HTTPS to destination SG'
   ip_protocol                   = 'tcp'

--- a/acceptance-tests/ec2_security_group_egress/ipv6.crn
+++ b/acceptance-tests/ec2_security_group_egress/ipv6.crn
@@ -6,16 +6,16 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-let sg = awscc.ec2.security_group {
+let sg = awscc.ec2.SecurityGroup {
   vpc_id            = vpc.vpc_id
   group_description = 'SG for IPv6 egress rule test'
 }
 
-awscc.ec2.security_group_egress {
+awscc.ec2.SecurityGroupEgress {
   group_id    = sg.group_id
   description = 'Allow all IPv6 outbound'
   ip_protocol = all

--- a/acceptance-tests/ec2_security_group_ingress/basic.crn
+++ b/acceptance-tests/ec2_security_group_ingress/basic.crn
@@ -6,16 +6,16 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-let sg = awscc.ec2.security_group {
+let sg = awscc.ec2.SecurityGroup {
   vpc_id            = vpc.vpc_id
   group_description = 'SG for ingress rule test'
 }
 
-awscc.ec2.security_group_ingress {
+awscc.ec2.SecurityGroupIngress {
   group_id    = sg.group_id
   description = 'Allow HTTPS from VPC'
   ip_protocol = 'tcp'

--- a/acceptance-tests/ec2_security_group_ingress/ipv6.crn
+++ b/acceptance-tests/ec2_security_group_ingress/ipv6.crn
@@ -6,16 +6,16 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-let sg = awscc.ec2.security_group {
+let sg = awscc.ec2.SecurityGroup {
   vpc_id            = vpc.vpc_id
   group_description = 'SG for IPv6 ingress rule test'
 }
 
-awscc.ec2.security_group_ingress {
+awscc.ec2.SecurityGroupIngress {
   group_id    = sg.group_id
   description = 'Allow HTTPS from IPv6'
   ip_protocol = 'tcp'

--- a/acceptance-tests/ec2_security_group_ingress/source_sg.crn
+++ b/acceptance-tests/ec2_security_group_ingress/source_sg.crn
@@ -6,21 +6,21 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-let source_sg = awscc.ec2.security_group {
+let source_sg = awscc.ec2.SecurityGroup {
   vpc_id            = vpc.vpc_id
   group_description = 'Source security group'
 }
 
-let dest_sg = awscc.ec2.security_group {
+let dest_sg = awscc.ec2.SecurityGroup {
   vpc_id            = vpc.vpc_id
   group_description = 'Destination security group'
 }
 
-awscc.ec2.security_group_ingress {
+awscc.ec2.SecurityGroupIngress {
   group_id                 = dest_sg.group_id
   description              = 'Allow HTTPS from source SG'
   ip_protocol              = 'tcp'

--- a/acceptance-tests/ec2_subnet/basic.crn
+++ b/acceptance-tests/ec2_subnet/basic.crn
@@ -6,11 +6,11 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-awscc.ec2.subnet {
+awscc.ec2.Subnet {
   vpc_id                  = vpc.vpc_id
   cidr_block              = '10.0.1.0/24'
   availability_zone       = 'ap-northeast-1a'

--- a/acceptance-tests/ec2_subnet/ipv6.crn
+++ b/acceptance-tests/ec2_subnet/ipv6.crn
@@ -6,11 +6,11 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-awscc.ec2.subnet {
+awscc.ec2.Subnet {
   vpc_id                          = vpc.vpc_id
   cidr_block                      = '10.0.1.0/24'
   availability_zone               = 'ap-northeast-1a'

--- a/acceptance-tests/ec2_subnet/with_dns_options.crn
+++ b/acceptance-tests/ec2_subnet/with_dns_options.crn
@@ -6,13 +6,13 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
-awscc.ec2.subnet {
+awscc.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.1.0/24'
   availability_zone = 'ap-northeast-1a'

--- a/acceptance-tests/ec2_subnet/with_ipam.crn
+++ b/acceptance-tests/ec2_subnet/with_ipam.crn
@@ -24,7 +24,7 @@ provider aws {
 
 let identity = read aws.sts.caller_identity {}
 
-let ipam = awscc.ec2.ipam {
+let ipam = awscc.ec2.Ipam {
   tier = advanced
 
   operating_region {
@@ -32,7 +32,7 @@ let ipam = awscc.ec2.ipam {
   }
 }
 
-let top_pool = awscc.ec2.ipam_pool {
+let top_pool = awscc.ec2.IpamPool {
   ipam_scope_id  = ipam.private_default_scope_id
   address_family = 'IPv4'
   locale         = 'ap-northeast-1'
@@ -42,12 +42,12 @@ let top_pool = awscc.ec2.ipam_pool {
   }
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   ipv4_ipam_pool_id   = top_pool.ipam_pool_id
   ipv4_netmask_length = 16
 }
 
-let vpc_pool = awscc.ec2.ipam_pool {
+let vpc_pool = awscc.ec2.IpamPool {
   ipam_scope_id       = ipam.private_default_scope_id
   address_family      = 'IPv4'
   locale              = 'ap-northeast-1'
@@ -65,7 +65,7 @@ let vpc_pool = awscc.ec2.ipam_pool {
   }
 }
 
-awscc.ec2.subnet {
+awscc.ec2.Subnet {
   vpc_id              = vpc.vpc_id
   ipv4_ipam_pool_id   = vpc_pool.ipam_pool_id
   ipv4_netmask_length = 24

--- a/acceptance-tests/ec2_subnet_route_table_association/basic.crn
+++ b/acceptance-tests/ec2_subnet_route_table_association/basic.crn
@@ -6,21 +6,21 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-let subnet = awscc.ec2.subnet {
+let subnet = awscc.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.1.0/24'
   availability_zone = 'ap-northeast-1a'
 }
 
-let rt = awscc.ec2.route_table {
+let rt = awscc.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 }
 
-awscc.ec2.subnet_route_table_association {
+awscc.ec2.SubnetRouteTableAssociation {
   subnet_id      = subnet.subnet_id
   route_table_id = rt.route_table_id
 }

--- a/acceptance-tests/ec2_transit_gateway/basic.crn
+++ b/acceptance-tests/ec2_transit_gateway/basic.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.ec2.transit_gateway {
+awscc.ec2.TransitGateway {
   description = 'Acceptance test Transit Gateway'
 
   tags = {

--- a/acceptance-tests/ec2_transit_gateway_attachment/basic.crn
+++ b/acceptance-tests/ec2_transit_gateway_attachment/basic.crn
@@ -6,21 +6,21 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-let subnet = awscc.ec2.subnet {
+let subnet = awscc.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.1.0/24'
   availability_zone = 'ap-northeast-1a'
 }
 
-let tgw = awscc.ec2.transit_gateway {
+let tgw = awscc.ec2.TransitGateway {
   description = 'Acceptance test Transit Gateway'
 }
 
-awscc.ec2.transit_gateway_attachment {
+awscc.ec2.TransitGatewayAttachment {
   subnet_ids         = [subnet.subnet_id]
   transit_gateway_id = tgw.id
   vpc_id             = vpc.vpc_id

--- a/acceptance-tests/ec2_vpc/basic.crn
+++ b/acceptance-tests/ec2_vpc/basic.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.ec2.vpc {
+awscc.ec2.Vpc {
   cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true

--- a/acceptance-tests/ec2_vpc_endpoint/gateway.crn
+++ b/acceptance-tests/ec2_vpc_endpoint/gateway.crn
@@ -6,15 +6,15 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-let rt = awscc.ec2.route_table {
+let rt = awscc.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 }
 
-awscc.ec2.vpc_endpoint {
+awscc.ec2.VpcEndpoint {
   vpc_id            = vpc.vpc_id
   service_name      = 'com.amazonaws.ap-northeast-1.s3'
   vpc_endpoint_type = Gateway

--- a/acceptance-tests/ec2_vpc_endpoint/interface.crn
+++ b/acceptance-tests/ec2_vpc_endpoint/interface.crn
@@ -7,24 +7,24 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
-let subnet = awscc.ec2.subnet {
+let subnet = awscc.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.100.0/24'
   availability_zone = 'ap-northeast-1a'
 }
 
-let sg = awscc.ec2.security_group {
+let sg = awscc.ec2.SecurityGroup {
   vpc_id            = vpc.vpc_id
   group_description = 'SG for VPC Endpoint'
 }
 
-awscc.ec2.security_group_ingress {
+awscc.ec2.SecurityGroupIngress {
   group_id    = sg.group_id
   description = 'Allow HTTPS from VPC'
   ip_protocol = 'tcp'
@@ -33,7 +33,7 @@ awscc.ec2.security_group_ingress {
   cidr_ip     = '10.0.0.0/16'
 }
 
-awscc.ec2.vpc_endpoint {
+awscc.ec2.VpcEndpoint {
   vpc_id              = vpc.vpc_id
   service_name        = 'com.amazonaws.ap-northeast-1.ecr.dkr'
   vpc_endpoint_type   = Interface

--- a/acceptance-tests/ec2_vpc_gateway_attachment/igw.crn
+++ b/acceptance-tests/ec2_vpc_gateway_attachment/igw.crn
@@ -6,13 +6,13 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-let igw = awscc.ec2.internet_gateway {}
+let igw = awscc.ec2.InternetGateway {}
 
-awscc.ec2.vpc_gateway_attachment {
+awscc.ec2.VpcGatewayAttachment {
   vpc_id              = vpc.vpc_id
   internet_gateway_id = igw.internet_gateway_id
 }

--- a/acceptance-tests/ec2_vpc_gateway_attachment/vpn.crn
+++ b/acceptance-tests/ec2_vpc_gateway_attachment/vpn.crn
@@ -7,15 +7,15 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-let vpn_gw = awscc.ec2.vpn_gateway {
-  type = awscc.ec2.vpn_gateway.Type.ipsec.1
+let vpn_gw = awscc.ec2.VpnGateway {
+  type = awscc.ec2.VpnGateway.Type.ipsec.1
 }
 
-awscc.ec2.vpc_gateway_attachment {
+awscc.ec2.VpcGatewayAttachment {
   vpc_id         = vpc.vpc_id
   vpn_gateway_id = vpn_gw.vpn_gateway_id
 }

--- a/acceptance-tests/ec2_vpc_peering_connection/basic.crn
+++ b/acceptance-tests/ec2_vpc_peering_connection/basic.crn
@@ -6,15 +6,15 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc1 = awscc.ec2.vpc {
+let vpc1 = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-let vpc2 = awscc.ec2.vpc {
+let vpc2 = awscc.ec2.Vpc {
   cidr_block = '10.1.0.0/16'
 }
 
-awscc.ec2.vpc_peering_connection {
+awscc.ec2.VpcPeeringConnection {
   vpc_id      = vpc1.vpc_id
   peer_vpc_id = vpc2.vpc_id
 

--- a/acceptance-tests/ec2_vpn_gateway/basic.crn
+++ b/acceptance-tests/ec2_vpn_gateway/basic.crn
@@ -6,8 +6,8 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.ec2.vpn_gateway {
-  type = awscc.ec2.vpn_gateway.Type.ipsec.1
+awscc.ec2.VpnGateway {
+  type = awscc.ec2.VpnGateway.Type.ipsec.1
 
   tags = {
     Environment = 'acceptance-test'

--- a/acceptance-tests/for_expression/for_list.crn
+++ b/acceptance-tests/for_expression/for_list.crn
@@ -3,7 +3,7 @@ provider awscc {
 }
 
 let vpcs = for (i, env) in ['dev', 'stg'] {
-  awscc.ec2.vpc {
+  awscc.ec2.Vpc {
     cidr_block = cidr_subnet('10.0.0.0/8', 8, i)
 
     tags = {

--- a/acceptance-tests/for_expression/for_map.crn
+++ b/acceptance-tests/for_expression/for_map.crn
@@ -8,7 +8,7 @@ let cidrs = {
 }
 
 let vpcs = for name, cidr in cidrs {
-  awscc.ec2.vpc {
+  awscc.ec2.Vpc {
     cidr_block = cidr
 
     tags = {

--- a/acceptance-tests/for_expression/index_access.crn
+++ b/acceptance-tests/for_expression/index_access.crn
@@ -3,7 +3,7 @@ provider awscc {
 }
 
 let vpcs = for env in ['dev', 'stg'] {
-  awscc.ec2.vpc {
+  awscc.ec2.Vpc {
     cidr_block = '10.0.0.0/16'
 
     tags = {
@@ -14,7 +14,7 @@ let vpcs = for env in ['dev', 'stg'] {
 }
 
 # Use index access to reference for expression result
-awscc.ec2.subnet {
+awscc.ec2.Subnet {
   vpc_id            = vpcs[0].vpc_id
   cidr_block        = '10.0.1.0/24'
   availability_zone = 'ap-northeast-1a'

--- a/acceptance-tests/for_expression/modules/network/main.crn
+++ b/acceptance-tests/for_expression/modules/network/main.crn
@@ -3,12 +3,12 @@
 # Creates a VPC and subnet. Demonstrates intra-module resource references.
 
 arguments {
-  cidr_block : string
-  subnet_cidr: string
-  az         : string
+  cidr_block : String
+  subnet_cidr: String
+  az         : String
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = cidr_block
 
   tags = {
@@ -16,7 +16,7 @@ let vpc = awscc.ec2.vpc {
   }
 }
 
-let subnet = awscc.ec2.subnet {
+let subnet = awscc.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = subnet_cidr
   availability_zone = az
@@ -27,6 +27,6 @@ let subnet = awscc.ec2.subnet {
 }
 
 attributes {
-  vpc_id   : awscc.ec2.vpc = vpc.vpc_id
-  subnet_id: awscc.ec2.subnet = subnet.subnet_id
+  vpc_id   : awscc.ec2.Vpc = vpc.vpc_id
+  subnet_id: awscc.ec2.Subnet = subnet.subnet_id
 }

--- a/acceptance-tests/for_expression/modules/vpc_only/main.crn
+++ b/acceptance-tests/for_expression/modules/vpc_only/main.crn
@@ -1,9 +1,9 @@
 arguments {
-  cidr_block: string
-  env_name  : string
+  cidr_block: String
+  env_name  : String
 }
 
-awscc.ec2.vpc {
+awscc.ec2.Vpc {
   cidr_block = cidr_block
 
   tags = {

--- a/acceptance-tests/iam_role/managed_policy.crn
+++ b/acceptance-tests/iam_role/managed_policy.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.iam.role {
+awscc.iam.Role {
   role_name_prefix = 'carina-acc-test-'
 
   assume_role_policy_document = {

--- a/acceptance-tests/iam_role/prefix.crn
+++ b/acceptance-tests/iam_role/prefix.crn
@@ -8,7 +8,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.iam.role {
+awscc.iam.Role {
   role_name_prefix = 'carina-acc-test-'
 
   assume_role_policy_document = {

--- a/acceptance-tests/iam_role/with_path.crn
+++ b/acceptance-tests/iam_role/with_path.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.iam.role {
+awscc.iam.Role {
   role_name_prefix = 'carina-acc-test-'
   path             = '/carina/acceptance-test/'
 

--- a/acceptance-tests/iam_role/with_policy.crn
+++ b/acceptance-tests/iam_role/with_policy.crn
@@ -7,7 +7,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.iam.role {
+awscc.iam.Role {
   role_name_prefix     = 'carina-acc-test-'
   description          = 'Carina acceptance test role with inline policy'
   max_session_duration = 7200

--- a/acceptance-tests/if_expression/if_else_value.crn
+++ b/acceptance-tests/if_expression/if_else_value.crn
@@ -4,7 +4,7 @@ provider awscc {
 
 let is_production = true
 
-awscc.ec2.vpc {
+awscc.ec2.Vpc {
   cidr_block = if is_production { '10.0.0.0/16' } else { '172.16.0.0/16' }
 
   tags = {

--- a/acceptance-tests/if_expression/if_false.crn
+++ b/acceptance-tests/if_expression/if_false.crn
@@ -5,7 +5,7 @@ provider awscc {
 let enabled = false
 
 let vpc = if enabled {
-  awscc.ec2.vpc {
+  awscc.ec2.Vpc {
     cidr_block = '10.0.0.0/16'
 
     tags = {

--- a/acceptance-tests/if_expression/if_true.crn
+++ b/acceptance-tests/if_expression/if_true.crn
@@ -5,7 +5,7 @@ provider awscc {
 let enabled = true
 
 let vpc = if enabled {
-  awscc.ec2.vpc {
+  awscc.ec2.Vpc {
     cidr_block = '10.0.0.0/16'
 
     tags = {

--- a/acceptance-tests/in_place_update/ec2_egress_only_internet_gateway_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_egress_only_internet_gateway_step1.crn
@@ -6,11 +6,11 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.106.0.0/16'
 }
 
-awscc.ec2.egress_only_internet_gateway {
+awscc.ec2.EgressOnlyInternetGateway {
   vpc_id = vpc.vpc_id
 
   tags = {

--- a/acceptance-tests/in_place_update/ec2_egress_only_internet_gateway_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_egress_only_internet_gateway_step2.crn
@@ -6,11 +6,11 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.106.0.0/16'
 }
 
-awscc.ec2.egress_only_internet_gateway {
+awscc.ec2.EgressOnlyInternetGateway {
   vpc_id = vpc.vpc_id
 
   tags = {

--- a/acceptance-tests/in_place_update/ec2_eip_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_eip_step1.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.ec2.eip {
+awscc.ec2.Eip {
   domain = 'vpc'
 
   tags = {

--- a/acceptance-tests/in_place_update/ec2_eip_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_eip_step2.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.ec2.eip {
+awscc.ec2.Eip {
   domain = 'vpc'
 
   tags = {

--- a/acceptance-tests/in_place_update/ec2_flow_log_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_flow_log_step1.crn
@@ -6,16 +6,16 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.104.0.0/16'
 }
 
-let log_group = awscc.logs.log_group {
+let log_group = awscc.logs.LogGroup {
   log_group_name    = '/carina/acc-test-update-flow-log'
   retention_in_days = 1
 }
 
-let flow_log_role = awscc.iam.role {
+let flow_log_role = awscc.iam.Role {
   role_name = 'carina-acc-test-update-flow-log-role'
 
   assume_role_policy_document = {
@@ -32,7 +32,7 @@ let flow_log_role = awscc.iam.role {
   }
 }
 
-awscc.ec2.flow_log {
+awscc.ec2.FlowLog {
   resource_id                 = vpc.vpc_id
   resource_type               = VPC
   traffic_type                = ALL

--- a/acceptance-tests/in_place_update/ec2_flow_log_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_flow_log_step2.crn
@@ -6,16 +6,16 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.104.0.0/16'
 }
 
-let log_group = awscc.logs.log_group {
+let log_group = awscc.logs.LogGroup {
   log_group_name    = '/carina/acc-test-update-flow-log'
   retention_in_days = 1
 }
 
-let flow_log_role = awscc.iam.role {
+let flow_log_role = awscc.iam.Role {
   role_name = 'carina-acc-test-update-flow-log-role'
 
   assume_role_policy_document = {
@@ -32,7 +32,7 @@ let flow_log_role = awscc.iam.role {
   }
 }
 
-awscc.ec2.flow_log {
+awscc.ec2.FlowLog {
   resource_id                 = vpc.vpc_id
   resource_type               = VPC
   traffic_type                = ALL

--- a/acceptance-tests/in_place_update/ec2_ipam_pool_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_ipam_pool_step1.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let ipam = awscc.ec2.ipam {
+let ipam = awscc.ec2.Ipam {
   tier = advanced
 
   operating_region {
@@ -14,7 +14,7 @@ let ipam = awscc.ec2.ipam {
   }
 }
 
-awscc.ec2.ipam_pool {
+awscc.ec2.IpamPool {
   ipam_scope_id  = ipam.private_default_scope_id
   address_family = 'IPv4'
   locale         = 'ap-northeast-1'

--- a/acceptance-tests/in_place_update/ec2_ipam_pool_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_ipam_pool_step2.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let ipam = awscc.ec2.ipam {
+let ipam = awscc.ec2.Ipam {
   tier = advanced
 
   operating_region {
@@ -14,7 +14,7 @@ let ipam = awscc.ec2.ipam {
   }
 }
 
-awscc.ec2.ipam_pool {
+awscc.ec2.IpamPool {
   ipam_scope_id  = ipam.private_default_scope_id
   address_family = 'IPv4'
   locale         = 'ap-northeast-1'

--- a/acceptance-tests/in_place_update/ec2_nat_gateway_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_nat_gateway_step1.crn
@@ -6,31 +6,31 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block           = '10.105.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
-let igw = awscc.ec2.internet_gateway {}
+let igw = awscc.ec2.InternetGateway {}
 
-awscc.ec2.vpc_gateway_attachment {
+awscc.ec2.VpcGatewayAttachment {
   vpc_id              = vpc.vpc_id
   internet_gateway_id = igw.internet_gateway_id
 }
 
-let public_subnet = awscc.ec2.subnet {
+let public_subnet = awscc.ec2.Subnet {
   vpc_id                  = vpc.vpc_id
   cidr_block              = '10.105.1.0/24'
   availability_zone       = 'ap-northeast-1a'
   map_public_ip_on_launch = true
 }
 
-let eip = awscc.ec2.eip {
+let eip = awscc.ec2.Eip {
   domain = 'vpc'
 }
 
-awscc.ec2.nat_gateway {
+awscc.ec2.NatGateway {
   allocation_id = eip.allocation_id
   subnet_id     = public_subnet.subnet_id
 

--- a/acceptance-tests/in_place_update/ec2_nat_gateway_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_nat_gateway_step2.crn
@@ -6,31 +6,31 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block           = '10.105.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
-let igw = awscc.ec2.internet_gateway {}
+let igw = awscc.ec2.InternetGateway {}
 
-awscc.ec2.vpc_gateway_attachment {
+awscc.ec2.VpcGatewayAttachment {
   vpc_id              = vpc.vpc_id
   internet_gateway_id = igw.internet_gateway_id
 }
 
-let public_subnet = awscc.ec2.subnet {
+let public_subnet = awscc.ec2.Subnet {
   vpc_id                  = vpc.vpc_id
   cidr_block              = '10.105.1.0/24'
   availability_zone       = 'ap-northeast-1a'
   map_public_ip_on_launch = true
 }
 
-let eip = awscc.ec2.eip {
+let eip = awscc.ec2.Eip {
   domain = 'vpc'
 }
 
-awscc.ec2.nat_gateway {
+awscc.ec2.NatGateway {
   allocation_id = eip.allocation_id
   subnet_id     = public_subnet.subnet_id
 

--- a/acceptance-tests/in_place_update/ec2_route_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_route_step1.crn
@@ -6,40 +6,40 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block           = '10.110.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
-let igw = awscc.ec2.internet_gateway {}
+let igw = awscc.ec2.InternetGateway {}
 
-let igw_attachment = awscc.ec2.vpc_gateway_attachment {
+let igw_attachment = awscc.ec2.VpcGatewayAttachment {
   vpc_id              = vpc.vpc_id
   internet_gateway_id = igw.internet_gateway_id
 }
 
-let public_subnet = awscc.ec2.subnet {
+let public_subnet = awscc.ec2.Subnet {
   vpc_id                  = vpc.vpc_id
   cidr_block              = '10.110.1.0/24'
   availability_zone       = 'ap-northeast-1a'
   map_public_ip_on_launch = true
 }
 
-let eip = awscc.ec2.eip {
+let eip = awscc.ec2.Eip {
   domain = 'vpc'
 }
 
-awscc.ec2.nat_gateway {
+awscc.ec2.NatGateway {
   allocation_id = eip.allocation_id
   subnet_id     = public_subnet.subnet_id
 }
 
-let rt = awscc.ec2.route_table {
+let rt = awscc.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 }
 
-awscc.ec2.route {
+awscc.ec2.Route {
   route_table_id         = rt.route_table_id
   destination_cidr_block = '10.1.0.0/16'
   gateway_id             = igw_attachment.internet_gateway_id

--- a/acceptance-tests/in_place_update/ec2_route_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_route_step2.crn
@@ -6,40 +6,40 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block           = '10.110.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
-let igw = awscc.ec2.internet_gateway {}
+let igw = awscc.ec2.InternetGateway {}
 
-awscc.ec2.vpc_gateway_attachment {
+awscc.ec2.VpcGatewayAttachment {
   vpc_id              = vpc.vpc_id
   internet_gateway_id = igw.internet_gateway_id
 }
 
-let public_subnet = awscc.ec2.subnet {
+let public_subnet = awscc.ec2.Subnet {
   vpc_id                  = vpc.vpc_id
   cidr_block              = '10.110.1.0/24'
   availability_zone       = 'ap-northeast-1a'
   map_public_ip_on_launch = true
 }
 
-let eip = awscc.ec2.eip {
+let eip = awscc.ec2.Eip {
   domain = 'vpc'
 }
 
-let nat_gw = awscc.ec2.nat_gateway {
+let nat_gw = awscc.ec2.NatGateway {
   allocation_id = eip.allocation_id
   subnet_id     = public_subnet.subnet_id
 }
 
-let rt = awscc.ec2.route_table {
+let rt = awscc.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 }
 
-awscc.ec2.route {
+awscc.ec2.Route {
   route_table_id         = rt.route_table_id
   destination_cidr_block = '10.1.0.0/16'
   nat_gateway_id         = nat_gw.nat_gateway_id

--- a/acceptance-tests/in_place_update/ec2_route_table_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_route_table_step1.crn
@@ -6,11 +6,11 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.103.0.0/16'
 }
 
-awscc.ec2.route_table {
+awscc.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 
   tags = {

--- a/acceptance-tests/in_place_update/ec2_route_table_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_route_table_step2.crn
@@ -6,11 +6,11 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.103.0.0/16'
 }
 
-awscc.ec2.route_table {
+awscc.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 
   tags = {

--- a/acceptance-tests/in_place_update/ec2_security_group_egress_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_security_group_egress_step1.crn
@@ -6,16 +6,16 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-let sg = awscc.ec2.security_group {
+let sg = awscc.ec2.SecurityGroup {
   vpc_id            = vpc.vpc_id
   group_description = 'carina acceptance test - egress in-place update'
 }
 
-awscc.ec2.security_group_egress {
+awscc.ec2.SecurityGroupEgress {
   group_id    = sg.group_id
   description = 'Allow all outbound'
   ip_protocol = all

--- a/acceptance-tests/in_place_update/ec2_security_group_egress_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_security_group_egress_step2.crn
@@ -6,16 +6,16 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-let sg = awscc.ec2.security_group {
+let sg = awscc.ec2.SecurityGroup {
   vpc_id            = vpc.vpc_id
   group_description = 'carina acceptance test - egress in-place update'
 }
 
-awscc.ec2.security_group_egress {
+awscc.ec2.SecurityGroupEgress {
   group_id    = sg.group_id
   description = 'Allow all outbound (updated)'
   ip_protocol = all

--- a/acceptance-tests/in_place_update/ec2_security_group_ingress_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_security_group_ingress_step1.crn
@@ -6,16 +6,16 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-let sg = awscc.ec2.security_group {
+let sg = awscc.ec2.SecurityGroup {
   vpc_id            = vpc.vpc_id
   group_description = 'carina acceptance test - ingress in-place update'
 }
 
-awscc.ec2.security_group_ingress {
+awscc.ec2.SecurityGroupIngress {
   group_id    = sg.group_id
   description = 'Allow HTTPS from VPC'
   ip_protocol = 'tcp'

--- a/acceptance-tests/in_place_update/ec2_security_group_ingress_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_security_group_ingress_step2.crn
@@ -6,16 +6,16 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-let sg = awscc.ec2.security_group {
+let sg = awscc.ec2.SecurityGroup {
   vpc_id            = vpc.vpc_id
   group_description = 'carina acceptance test - ingress in-place update'
 }
 
-awscc.ec2.security_group_ingress {
+awscc.ec2.SecurityGroupIngress {
   group_id    = sg.group_id
   description = 'Allow HTTPS from VPC (updated)'
   ip_protocol = 'tcp'

--- a/acceptance-tests/in_place_update/ec2_security_group_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_security_group_step1.crn
@@ -6,11 +6,11 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.102.0.0/16'
 }
 
-awscc.ec2.security_group {
+awscc.ec2.SecurityGroup {
   vpc_id            = vpc.vpc_id
   group_description = 'carina acceptance test - in-place update'
 

--- a/acceptance-tests/in_place_update/ec2_security_group_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_security_group_step2.crn
@@ -6,11 +6,11 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.102.0.0/16'
 }
 
-awscc.ec2.security_group {
+awscc.ec2.SecurityGroup {
   vpc_id            = vpc.vpc_id
   group_description = 'carina acceptance test - in-place update'
 

--- a/acceptance-tests/in_place_update/ec2_subnet_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_subnet_step1.crn
@@ -6,11 +6,11 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.101.0.0/16'
 }
 
-awscc.ec2.subnet {
+awscc.ec2.Subnet {
   vpc_id                  = vpc.vpc_id
   cidr_block              = '10.101.1.0/24'
   availability_zone       = 'ap-northeast-1a'

--- a/acceptance-tests/in_place_update/ec2_subnet_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_subnet_step2.crn
@@ -6,11 +6,11 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.101.0.0/16'
 }
 
-awscc.ec2.subnet {
+awscc.ec2.Subnet {
   vpc_id                  = vpc.vpc_id
   cidr_block              = '10.101.1.0/24'
   availability_zone       = 'ap-northeast-1a'

--- a/acceptance-tests/in_place_update/ec2_transit_gateway_attachment_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_transit_gateway_attachment_step1.crn
@@ -6,21 +6,21 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-let subnet = awscc.ec2.subnet {
+let subnet = awscc.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.1.0/24'
   availability_zone = 'ap-northeast-1a'
 }
 
-let tgw = awscc.ec2.transit_gateway {
+let tgw = awscc.ec2.TransitGateway {
   description = 'carina acceptance test - tgw attachment update'
 }
 
-awscc.ec2.transit_gateway_attachment {
+awscc.ec2.TransitGatewayAttachment {
   subnet_ids         = [subnet.subnet_id]
   transit_gateway_id = tgw.id
   vpc_id             = vpc.vpc_id

--- a/acceptance-tests/in_place_update/ec2_transit_gateway_attachment_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_transit_gateway_attachment_step2.crn
@@ -6,21 +6,21 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-let subnet = awscc.ec2.subnet {
+let subnet = awscc.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.1.0/24'
   availability_zone = 'ap-northeast-1a'
 }
 
-let tgw = awscc.ec2.transit_gateway {
+let tgw = awscc.ec2.TransitGateway {
   description = 'carina acceptance test - tgw attachment update'
 }
 
-awscc.ec2.transit_gateway_attachment {
+awscc.ec2.TransitGatewayAttachment {
   subnet_ids         = [subnet.subnet_id]
   transit_gateway_id = tgw.id
   vpc_id             = vpc.vpc_id

--- a/acceptance-tests/in_place_update/ec2_transit_gateway_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_transit_gateway_step1.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.ec2.transit_gateway {
+awscc.ec2.TransitGateway {
   description = 'carina acceptance test - step 1'
 
   tags = {

--- a/acceptance-tests/in_place_update/ec2_transit_gateway_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_transit_gateway_step2.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.ec2.transit_gateway {
+awscc.ec2.TransitGateway {
   description = 'carina acceptance test - step 2 updated'
 
   tags = {

--- a/acceptance-tests/in_place_update/ec2_vpc_endpoint_interface_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_vpc_endpoint_interface_step1.crn
@@ -6,18 +6,18 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block           = '10.108.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
-let sg = awscc.ec2.security_group {
+let sg = awscc.ec2.SecurityGroup {
   vpc_id            = vpc.vpc_id
   group_description = 'SG for interface endpoint test'
 }
 
-awscc.ec2.vpc_endpoint {
+awscc.ec2.VpcEndpoint {
   vpc_id              = vpc.vpc_id
   service_name        = 'com.amazonaws.ap-northeast-1.sts'
   vpc_endpoint_type   = Interface

--- a/acceptance-tests/in_place_update/ec2_vpc_endpoint_interface_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_vpc_endpoint_interface_step2.crn
@@ -6,18 +6,18 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block           = '10.108.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
-let sg = awscc.ec2.security_group {
+let sg = awscc.ec2.SecurityGroup {
   vpc_id            = vpc.vpc_id
   group_description = 'SG for interface endpoint test'
 }
 
-awscc.ec2.vpc_endpoint {
+awscc.ec2.VpcEndpoint {
   vpc_id              = vpc.vpc_id
   service_name        = 'com.amazonaws.ap-northeast-1.sts'
   vpc_endpoint_type   = Interface

--- a/acceptance-tests/in_place_update/ec2_vpc_endpoint_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_vpc_endpoint_step1.crn
@@ -6,15 +6,15 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.107.0.0/16'
 }
 
-let rt = awscc.ec2.route_table {
+let rt = awscc.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 }
 
-awscc.ec2.vpc_endpoint {
+awscc.ec2.VpcEndpoint {
   vpc_id            = vpc.vpc_id
   service_name      = 'com.amazonaws.ap-northeast-1.s3'
   vpc_endpoint_type = Gateway

--- a/acceptance-tests/in_place_update/ec2_vpc_endpoint_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_vpc_endpoint_step2.crn
@@ -6,15 +6,15 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.107.0.0/16'
 }
 
-let rt = awscc.ec2.route_table {
+let rt = awscc.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 }
 
-awscc.ec2.vpc_endpoint {
+awscc.ec2.VpcEndpoint {
   vpc_id            = vpc.vpc_id
   service_name      = 'com.amazonaws.ap-northeast-1.s3'
   vpc_endpoint_type = Gateway

--- a/acceptance-tests/in_place_update/ec2_vpc_peering_connection_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_vpc_peering_connection_step1.crn
@@ -6,15 +6,15 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc1 = awscc.ec2.vpc {
+let vpc1 = awscc.ec2.Vpc {
   cidr_block = '10.108.0.0/16'
 }
 
-let vpc2 = awscc.ec2.vpc {
+let vpc2 = awscc.ec2.Vpc {
   cidr_block = '10.109.0.0/16'
 }
 
-awscc.ec2.vpc_peering_connection {
+awscc.ec2.VpcPeeringConnection {
   vpc_id      = vpc1.vpc_id
   peer_vpc_id = vpc2.vpc_id
 

--- a/acceptance-tests/in_place_update/ec2_vpc_peering_connection_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_vpc_peering_connection_step2.crn
@@ -6,15 +6,15 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc1 = awscc.ec2.vpc {
+let vpc1 = awscc.ec2.Vpc {
   cidr_block = '10.108.0.0/16'
 }
 
-let vpc2 = awscc.ec2.vpc {
+let vpc2 = awscc.ec2.Vpc {
   cidr_block = '10.109.0.0/16'
 }
 
-awscc.ec2.vpc_peering_connection {
+awscc.ec2.VpcPeeringConnection {
   vpc_id      = vpc1.vpc_id
   peer_vpc_id = vpc2.vpc_id
 

--- a/acceptance-tests/in_place_update/ec2_vpc_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_vpc_step1.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.ec2.vpc {
+awscc.ec2.Vpc {
   cidr_block           = '10.100.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = false

--- a/acceptance-tests/in_place_update/ec2_vpc_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_vpc_step2.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.ec2.vpc {
+awscc.ec2.Vpc {
   cidr_block           = '10.100.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true

--- a/acceptance-tests/in_place_update/iam_role_step1.crn
+++ b/acceptance-tests/in_place_update/iam_role_step1.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.iam.role {
+awscc.iam.Role {
   role_name_prefix = 'carina-acc-test-update-'
 
   assume_role_policy_document = {

--- a/acceptance-tests/in_place_update/iam_role_step2.crn
+++ b/acceptance-tests/in_place_update/iam_role_step2.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.iam.role {
+awscc.iam.Role {
   role_name_prefix = 'carina-acc-test-update-'
 
   assume_role_policy_document = {

--- a/acceptance-tests/in_place_update/logs_log_group_step1.crn
+++ b/acceptance-tests/in_place_update/logs_log_group_step1.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.logs.log_group {
+awscc.logs.LogGroup {
   log_group_name_prefix = '/carina/acc-test-update-'
   retention_in_days     = 7
 

--- a/acceptance-tests/in_place_update/logs_log_group_step2.crn
+++ b/acceptance-tests/in_place_update/logs_log_group_step2.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.logs.log_group {
+awscc.logs.LogGroup {
   log_group_name_prefix = '/carina/acc-test-update-'
   retention_in_days     = 14
 

--- a/acceptance-tests/in_place_update/s3_bucket_step1.crn
+++ b/acceptance-tests/in_place_update/s3_bucket_step1.crn
@@ -6,11 +6,11 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.s3.bucket {
+awscc.s3.Bucket {
   bucket_name_prefix = 'carina-acc-test-update-'
 
   versioning_configuration = {
-    status = awscc.s3.bucket.VersioningConfigurationStatus.Enabled
+    status = awscc.s3.Bucket.VersioningConfigurationStatus.Enabled
   }
 
   lifecycle {

--- a/acceptance-tests/in_place_update/s3_bucket_step2.crn
+++ b/acceptance-tests/in_place_update/s3_bucket_step2.crn
@@ -6,11 +6,11 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.s3.bucket {
+awscc.s3.Bucket {
   bucket_name_prefix = 'carina-acc-test-update-'
 
   versioning_configuration = {
-    status = awscc.s3.bucket.VersioningConfigurationStatus.Suspended
+    status = awscc.s3.Bucket.VersioningConfigurationStatus.Suspended
   }
 
   lifecycle {

--- a/acceptance-tests/logs_log_group/infrequent_access.crn
+++ b/acceptance-tests/logs_log_group/infrequent_access.crn
@@ -6,8 +6,8 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.logs.log_group {
+awscc.logs.LogGroup {
   log_group_name_prefix = '/carina/acc-test-'
-  log_group_class       = awscc.logs.log_group.LogGroupClass.INFREQUENT_ACCESS
+  log_group_class       = awscc.logs.LogGroup.LogGroupClass.INFREQUENT_ACCESS
   retention_in_days     = 1
 }

--- a/acceptance-tests/logs_log_group/prefix.crn
+++ b/acceptance-tests/logs_log_group/prefix.crn
@@ -8,7 +8,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.logs.log_group {
+awscc.logs.LogGroup {
   log_group_name_prefix = '/carina/acc-test-'
   retention_in_days     = 1
 }

--- a/acceptance-tests/logs_log_group/retention.crn
+++ b/acceptance-tests/logs_log_group/retention.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.logs.log_group {
+awscc.logs.LogGroup {
   log_group_name_prefix = '/carina/acc-test-'
   retention_in_days     = 7
 

--- a/acceptance-tests/module/attributes_access.crn
+++ b/acceptance-tests/module/attributes_access.crn
@@ -15,7 +15,7 @@ let net = network {
 }
 
 # Use module attributes to create a resource that depends on module output
-awscc.ec2.route_table {
+awscc.ec2.RouteTable {
   vpc_id = net.vpc_id
   tags   = { Name = 'module-attr-test' }
 }

--- a/acceptance-tests/module/modules/network/main.crn
+++ b/acceptance-tests/module/modules/network/main.crn
@@ -3,12 +3,12 @@
 # Creates a VPC and subnet. Demonstrates intra-module resource references.
 
 arguments {
-  cidr_block : string
-  subnet_cidr: string
-  az         : string
+  cidr_block : String
+  subnet_cidr: String
+  az         : String
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = cidr_block
 
   tags = {
@@ -16,7 +16,7 @@ let vpc = awscc.ec2.vpc {
   }
 }
 
-let subnet = awscc.ec2.subnet {
+let subnet = awscc.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = subnet_cidr
   availability_zone = az
@@ -27,6 +27,6 @@ let subnet = awscc.ec2.subnet {
 }
 
 attributes {
-  vpc_id   : awscc.ec2.vpc = vpc.vpc_id
-  subnet_id: awscc.ec2.subnet = subnet.subnet_id
+  vpc_id   : awscc.ec2.Vpc = vpc.vpc_id
+  subnet_id: awscc.ec2.Subnet = subnet.subnet_id
 }

--- a/acceptance-tests/module/modules/network_with_rt/main.crn
+++ b/acceptance-tests/module/modules/network_with_rt/main.crn
@@ -6,9 +6,9 @@
 let network = import '../network'
 
 arguments {
-  cidr_block : string
-  subnet_cidr: string
-  az         : string
+  cidr_block : String
+  subnet_cidr: String
+  az         : String
 }
 
 let net = network {
@@ -17,7 +17,7 @@ let net = network {
   az          = az
 }
 
-let rt = awscc.ec2.route_table {
+let rt = awscc.ec2.RouteTable {
   vpc_id = net.vpc_id
 
   tags = {
@@ -26,6 +26,6 @@ let rt = awscc.ec2.route_table {
 }
 
 attributes {
-  vpc_id        : awscc.ec2.vpc = net.vpc_id
-  route_table_id: awscc.ec2.route_table = rt.route_table_id
+  vpc_id        : awscc.ec2.Vpc = net.vpc_id
+  route_table_id: awscc.ec2.RouteTable = rt.route_table_id
 }

--- a/acceptance-tests/s3_bucket/encryption.crn
+++ b/acceptance-tests/s3_bucket/encryption.crn
@@ -9,7 +9,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.s3.bucket {
+awscc.s3.Bucket {
   bucket_name_prefix = 'carina-acc-test-'
 
   bucket_encryption = {

--- a/acceptance-tests/s3_bucket/kms_encryption.crn
+++ b/acceptance-tests/s3_bucket/kms_encryption.crn
@@ -10,7 +10,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.s3.bucket {
+awscc.s3.Bucket {
   bucket_name_prefix = 'carina-acc-test-'
 
   bucket_encryption = {

--- a/acceptance-tests/s3_bucket/lifecycle.crn
+++ b/acceptance-tests/s3_bucket/lifecycle.crn
@@ -10,20 +10,20 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.s3.bucket {
+awscc.s3.Bucket {
   bucket_name_prefix = 'carina-acc-test-'
 
   lifecycle_configuration = {
     rule {
       id                 = 'expire-old-objects'
-      status             = awscc.s3.bucket.RuleStatus.Enabled
+      status             = awscc.s3.Bucket.RuleStatus.Enabled
       expiration_in_days = 90
     }
     rule {
       id     = 'transition-to-glacier'
-      status = awscc.s3.bucket.RuleStatus.Enabled
+      status = awscc.s3.Bucket.RuleStatus.Enabled
       transition {
-        storage_class      = awscc.s3.bucket.TransitionStorageClass.GLACIER
+        storage_class      = awscc.s3.Bucket.TransitionStorageClass.GLACIER
         transition_in_days = 30
       }
     }

--- a/acceptance-tests/s3_bucket/logging.crn
+++ b/acceptance-tests/s3_bucket/logging.crn
@@ -9,7 +9,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let log_bucket = awscc.s3.bucket {
+let log_bucket = awscc.s3.Bucket {
   bucket_name_prefix = 'carina-acc-test-log-'
 
   lifecycle {
@@ -17,7 +17,7 @@ let log_bucket = awscc.s3.bucket {
   }
 }
 
-awscc.s3.bucket {
+awscc.s3.Bucket {
   bucket_name_prefix = 'carina-acc-test-src-'
 
   logging_configuration = {

--- a/acceptance-tests/s3_bucket/prefix.crn
+++ b/acceptance-tests/s3_bucket/prefix.crn
@@ -8,7 +8,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.s3.bucket {
+awscc.s3.Bucket {
   bucket_name_prefix = 'carina-acc-test-'
 
   lifecycle {

--- a/acceptance-tests/s3_bucket/public_access_block.crn
+++ b/acceptance-tests/s3_bucket/public_access_block.crn
@@ -8,7 +8,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.s3.bucket {
+awscc.s3.Bucket {
   bucket_name_prefix = 'carina-acc-test-'
 
   public_access_block_configuration = {

--- a/acceptance-tests/s3_bucket/versioning.crn
+++ b/acceptance-tests/s3_bucket/versioning.crn
@@ -8,11 +8,11 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.s3.bucket {
+awscc.s3.Bucket {
   bucket_name_prefix = 'carina-acc-test-'
 
   versioning_configuration = {
-    status = awscc.s3.bucket.VersioningConfigurationStatus.Enabled
+    status = awscc.s3.Bucket.VersioningConfigurationStatus.Enabled
   }
 
   lifecycle {

--- a/acceptance-tests/s3_bucket/website.crn
+++ b/acceptance-tests/s3_bucket/website.crn
@@ -8,7 +8,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.s3.bucket {
+awscc.s3.Bucket {
   bucket_name_prefix = 'carina-acc-test-'
 
   website_configuration = {

--- a/acceptance-tests/secret_env/decrypt_tag.crn
+++ b/acceptance-tests/secret_env/decrypt_tag.crn
@@ -6,7 +6,7 @@ provider awscc {
 # Plaintext: "decrypt-test-value"
 let encrypted = 'AQICAHiUU4BhXxV/24kFblvFgRinfx00Rva9nBXHESKU/n2W1QHeJgFItWvJdpm6QXmCH3s7AAAAajBoBgkqhkiG9w0BBwagWzBZAgEAMFQGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMdsKc/QPUdhV6Uy4dAgEQgCeZSRW3iwDwiszbvKUyTpsZRQZdGQzY9M94i6ZO70MQdiy8wEi+DEs='
 
-awscc.ec2.vpc {
+awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {

--- a/acceptance-tests/secret_env/env_tag.crn
+++ b/acceptance-tests/secret_env/env_tag.crn
@@ -2,7 +2,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.ec2.vpc {
+awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {

--- a/acceptance-tests/secret_env/secret_tag.crn
+++ b/acceptance-tests/secret_env/secret_tag.crn
@@ -2,7 +2,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.ec2.vpc {
+awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {

--- a/acceptance-tests/simhash_update/ec2_eip_step1.crn
+++ b/acceptance-tests/simhash_update/ec2_eip_step1.crn
@@ -7,7 +7,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.ec2.eip {
+awscc.ec2.Eip {
   domain = 'vpc'
 
   tags = {

--- a/acceptance-tests/simhash_update/ec2_eip_step2.crn
+++ b/acceptance-tests/simhash_update/ec2_eip_step2.crn
@@ -7,7 +7,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.ec2.eip {
+awscc.ec2.Eip {
   domain = 'vpc'
 
   tags = {

--- a/acceptance-tests/simhash_update/ec2_ipam_step1.crn
+++ b/acceptance-tests/simhash_update/ec2_ipam_step1.crn
@@ -7,9 +7,9 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.ec2.ipam {
+awscc.ec2.Ipam {
   description = 'simhash acceptance test'
-  tier        = awscc.ec2.ipam.Tier.free
+  tier        = awscc.ec2.Ipam.Tier.free
 
   tags = {
     Environment = 'acceptance-test'

--- a/acceptance-tests/simhash_update/ec2_ipam_step2.crn
+++ b/acceptance-tests/simhash_update/ec2_ipam_step2.crn
@@ -7,9 +7,9 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.ec2.ipam {
+awscc.ec2.Ipam {
   description = 'simhash acceptance test updated'
-  tier        = awscc.ec2.ipam.Tier.free
+  tier        = awscc.ec2.Ipam.Tier.free
 
   tags = {
     Environment = 'acceptance-test'

--- a/acceptance-tests/state_blocks/step1_create.crn
+++ b/acceptance-tests/state_blocks/step1_create.crn
@@ -2,7 +2,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.ec2.vpc {
+awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {

--- a/acceptance-tests/state_blocks/step2_moved.crn
+++ b/acceptance-tests/state_blocks/step2_moved.crn
@@ -3,11 +3,11 @@ provider awscc {
 }
 
 moved {
-  from = awscc.ec2.vpc 'vpc'
-  to   = awscc.ec2.vpc 'main_vpc'
+  from = awscc.ec2.Vpc 'vpc'
+  to   = awscc.ec2.Vpc 'main_vpc'
 }
 
-awscc.ec2.vpc {
+awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {

--- a/acceptance-tests/state_blocks/step3_removed.crn
+++ b/acceptance-tests/state_blocks/step3_removed.crn
@@ -3,5 +3,5 @@ provider awscc {
 }
 
 removed {
-  from = awscc.ec2.vpc 'main_vpc'
+  from = awscc.ec2.Vpc 'main_vpc'
 }

--- a/acceptance-tests/state_blocks/step4_import.crn
+++ b/acceptance-tests/state_blocks/step4_import.crn
@@ -3,11 +3,11 @@ provider awscc {
 }
 
 import {
-  to = awscc.ec2.vpc 'imported_vpc'
+  to = awscc.ec2.Vpc 'imported_vpc'
   id = 'PLACEHOLDER'
 }
 
-awscc.ec2.vpc {
+awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {

--- a/acceptance-tests/string_interpolation/basic.crn
+++ b/acceptance-tests/string_interpolation/basic.crn
@@ -4,7 +4,7 @@ provider awscc {
 
 let env = 'test'
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {
@@ -13,7 +13,7 @@ let vpc = awscc.ec2.vpc {
   }
 }
 
-awscc.ec2.subnet {
+awscc.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.1.0/24'
   availability_zone = 'ap-northeast-1a'

--- a/acceptance-tests/tag_deletion/ec2_nat_gateway_step1.crn
+++ b/acceptance-tests/tag_deletion/ec2_nat_gateway_step1.crn
@@ -8,31 +8,31 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block           = '10.112.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
-let igw = awscc.ec2.internet_gateway {}
+let igw = awscc.ec2.InternetGateway {}
 
-awscc.ec2.vpc_gateway_attachment {
+awscc.ec2.VpcGatewayAttachment {
   vpc_id              = vpc.vpc_id
   internet_gateway_id = igw.internet_gateway_id
 }
 
-let public_subnet = awscc.ec2.subnet {
+let public_subnet = awscc.ec2.Subnet {
   vpc_id                  = vpc.vpc_id
   cidr_block              = '10.112.1.0/24'
   availability_zone       = 'ap-northeast-1a'
   map_public_ip_on_launch = true
 }
 
-let eip = awscc.ec2.eip {
+let eip = awscc.ec2.Eip {
   domain = 'vpc'
 }
 
-awscc.ec2.nat_gateway {
+awscc.ec2.NatGateway {
   allocation_id = eip.allocation_id
   subnet_id     = public_subnet.subnet_id
 

--- a/acceptance-tests/tag_deletion/ec2_nat_gateway_step2.crn
+++ b/acceptance-tests/tag_deletion/ec2_nat_gateway_step2.crn
@@ -8,31 +8,31 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block           = '10.112.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
-let igw = awscc.ec2.internet_gateway {}
+let igw = awscc.ec2.InternetGateway {}
 
-awscc.ec2.vpc_gateway_attachment {
+awscc.ec2.VpcGatewayAttachment {
   vpc_id              = vpc.vpc_id
   internet_gateway_id = igw.internet_gateway_id
 }
 
-let public_subnet = awscc.ec2.subnet {
+let public_subnet = awscc.ec2.Subnet {
   vpc_id                  = vpc.vpc_id
   cidr_block              = '10.112.1.0/24'
   availability_zone       = 'ap-northeast-1a'
   map_public_ip_on_launch = true
 }
 
-let eip = awscc.ec2.eip {
+let eip = awscc.ec2.Eip {
   domain = 'vpc'
 }
 
-awscc.ec2.nat_gateway {
+awscc.ec2.NatGateway {
   allocation_id = eip.allocation_id
   subnet_id     = public_subnet.subnet_id
 

--- a/acceptance-tests/tag_deletion/ec2_nat_gateway_step3.crn
+++ b/acceptance-tests/tag_deletion/ec2_nat_gateway_step3.crn
@@ -8,31 +8,31 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block           = '10.112.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
-let igw = awscc.ec2.internet_gateway {}
+let igw = awscc.ec2.InternetGateway {}
 
-awscc.ec2.vpc_gateway_attachment {
+awscc.ec2.VpcGatewayAttachment {
   vpc_id              = vpc.vpc_id
   internet_gateway_id = igw.internet_gateway_id
 }
 
-let public_subnet = awscc.ec2.subnet {
+let public_subnet = awscc.ec2.Subnet {
   vpc_id                  = vpc.vpc_id
   cidr_block              = '10.112.1.0/24'
   availability_zone       = 'ap-northeast-1a'
   map_public_ip_on_launch = true
 }
 
-let eip = awscc.ec2.eip {
+let eip = awscc.ec2.Eip {
   domain = 'vpc'
 }
 
-awscc.ec2.nat_gateway {
+awscc.ec2.NatGateway {
   allocation_id = eip.allocation_id
   subnet_id     = public_subnet.subnet_id
 }

--- a/acceptance-tests/tag_deletion/ec2_vpc_step1.crn
+++ b/acceptance-tests/tag_deletion/ec2_vpc_step1.crn
@@ -7,7 +7,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.ec2.vpc {
+awscc.ec2.Vpc {
   cidr_block           = '10.100.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true

--- a/acceptance-tests/tag_deletion/ec2_vpc_step2.crn
+++ b/acceptance-tests/tag_deletion/ec2_vpc_step2.crn
@@ -8,7 +8,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.ec2.vpc {
+awscc.ec2.Vpc {
   cidr_block           = '10.100.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true

--- a/acceptance-tests/tag_deletion/ec2_vpc_step3.crn
+++ b/acceptance-tests/tag_deletion/ec2_vpc_step3.crn
@@ -8,7 +8,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.ec2.vpc {
+awscc.ec2.Vpc {
   cidr_block           = '10.100.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true

--- a/acceptance-tests/tag_deletion/iam_role_step1.crn
+++ b/acceptance-tests/tag_deletion/iam_role_step1.crn
@@ -7,7 +7,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.iam.role {
+awscc.iam.Role {
   role_name_prefix = 'carina-acc-test-tag-del-'
 
   assume_role_policy_document = {

--- a/acceptance-tests/tag_deletion/iam_role_step2.crn
+++ b/acceptance-tests/tag_deletion/iam_role_step2.crn
@@ -8,7 +8,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.iam.role {
+awscc.iam.Role {
   role_name_prefix = 'carina-acc-test-tag-del-'
 
   assume_role_policy_document = {

--- a/acceptance-tests/tag_deletion/iam_role_step3.crn
+++ b/acceptance-tests/tag_deletion/iam_role_step3.crn
@@ -8,7 +8,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.iam.role {
+awscc.iam.Role {
   role_name_prefix = 'carina-acc-test-tag-del-'
 
   assume_role_policy_document = {

--- a/acceptance-tests/tag_deletion/s3_bucket_step1.crn
+++ b/acceptance-tests/tag_deletion/s3_bucket_step1.crn
@@ -7,7 +7,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.s3.bucket {
+awscc.s3.Bucket {
   bucket_name_prefix = 'carina-acc-test-tag-del-'
 
   tags = {

--- a/acceptance-tests/tag_deletion/s3_bucket_step2.crn
+++ b/acceptance-tests/tag_deletion/s3_bucket_step2.crn
@@ -8,7 +8,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.s3.bucket {
+awscc.s3.Bucket {
   bucket_name_prefix = 'carina-acc-test-tag-del-'
 
   tags = {

--- a/acceptance-tests/tag_deletion/s3_bucket_step3.crn
+++ b/acceptance-tests/tag_deletion/s3_bucket_step3.crn
@@ -8,7 +8,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.s3.bucket {
+awscc.s3.Bucket {
   bucket_name_prefix = 'carina-acc-test-tag-del-'
 
   lifecycle {

--- a/acceptance-tests/user_functions/value_fn.crn
+++ b/acceptance-tests/user_functions/value_fn.crn
@@ -2,11 +2,11 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-fn tag_name(env: string, service: string): string {
+fn tag_name(env: String, service: String): String {
   join('-', [env, service, 'vpc'])
 }
 
-awscc.ec2.vpc {
+awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {

--- a/acceptance-tests/vpc_full/basic.crn
+++ b/acceptance-tests/vpc_full/basic.crn
@@ -19,7 +19,7 @@ provider awscc {
 
 # --- VPC and Internet Gateway ---
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
@@ -29,20 +29,20 @@ let vpc = awscc.ec2.vpc {
   }
 }
 
-let igw = awscc.ec2.internet_gateway {
+let igw = awscc.ec2.InternetGateway {
   tags = {
     Name = 'main'
   }
 }
 
-let igw_attachment = awscc.ec2.vpc_gateway_attachment {
+let igw_attachment = awscc.ec2.VpcGatewayAttachment {
   vpc_id              = vpc.vpc_id
   internet_gateway_id = igw.internet_gateway_id
 }
 
 # --- Public Subnets ---
 
-let public_subnet_1a = awscc.ec2.subnet {
+let public_subnet_1a = awscc.ec2.Subnet {
   vpc_id                  = vpc.vpc_id
   cidr_block              = '10.0.0.0/24'
   availability_zone       = 'ap-northeast-1a'
@@ -53,7 +53,7 @@ let public_subnet_1a = awscc.ec2.subnet {
   }
 }
 
-let public_subnet_1c = awscc.ec2.subnet {
+let public_subnet_1c = awscc.ec2.Subnet {
   vpc_id                  = vpc.vpc_id
   cidr_block              = '10.0.1.0/24'
   availability_zone       = 'ap-northeast-1c'
@@ -64,7 +64,7 @@ let public_subnet_1c = awscc.ec2.subnet {
   }
 }
 
-let public_subnet_1d = awscc.ec2.subnet {
+let public_subnet_1d = awscc.ec2.Subnet {
   vpc_id                  = vpc.vpc_id
   cidr_block              = '10.0.2.0/24'
   availability_zone       = 'ap-northeast-1d'
@@ -77,7 +77,7 @@ let public_subnet_1d = awscc.ec2.subnet {
 
 # --- Public Route Table ---
 
-let public_rt = awscc.ec2.route_table {
+let public_rt = awscc.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 
   tags = {
@@ -85,30 +85,30 @@ let public_rt = awscc.ec2.route_table {
   }
 }
 
-awscc.ec2.route {
+awscc.ec2.Route {
   route_table_id         = public_rt.route_table_id
   destination_cidr_block = '0.0.0.0/0'
   gateway_id             = igw_attachment.internet_gateway_id
 }
 
-awscc.ec2.subnet_route_table_association {
+awscc.ec2.SubnetRouteTableAssociation {
   subnet_id      = public_subnet_1a.subnet_id
   route_table_id = public_rt.route_table_id
 }
 
-awscc.ec2.subnet_route_table_association {
+awscc.ec2.SubnetRouteTableAssociation {
   subnet_id      = public_subnet_1c.subnet_id
   route_table_id = public_rt.route_table_id
 }
 
-awscc.ec2.subnet_route_table_association {
+awscc.ec2.SubnetRouteTableAssociation {
   subnet_id      = public_subnet_1d.subnet_id
   route_table_id = public_rt.route_table_id
 }
 
 # --- Elastic IPs and NAT Gateways ---
 
-let eip_1a = awscc.ec2.eip {
+let eip_1a = awscc.ec2.Eip {
   domain = 'vpc'
 
   tags = {
@@ -116,7 +116,7 @@ let eip_1a = awscc.ec2.eip {
   }
 }
 
-let eip_1c = awscc.ec2.eip {
+let eip_1c = awscc.ec2.Eip {
   domain = 'vpc'
 
   tags = {
@@ -124,7 +124,7 @@ let eip_1c = awscc.ec2.eip {
   }
 }
 
-let eip_1d = awscc.ec2.eip {
+let eip_1d = awscc.ec2.Eip {
   domain = 'vpc'
 
   tags = {
@@ -132,7 +132,7 @@ let eip_1d = awscc.ec2.eip {
   }
 }
 
-let nat_gw_1a = awscc.ec2.nat_gateway {
+let nat_gw_1a = awscc.ec2.NatGateway {
   allocation_id = eip_1a.allocation_id
   subnet_id     = public_subnet_1a.subnet_id
 
@@ -141,7 +141,7 @@ let nat_gw_1a = awscc.ec2.nat_gateway {
   }
 }
 
-let nat_gw_1c = awscc.ec2.nat_gateway {
+let nat_gw_1c = awscc.ec2.NatGateway {
   allocation_id = eip_1c.allocation_id
   subnet_id     = public_subnet_1c.subnet_id
 
@@ -150,7 +150,7 @@ let nat_gw_1c = awscc.ec2.nat_gateway {
   }
 }
 
-let nat_gw_1d = awscc.ec2.nat_gateway {
+let nat_gw_1d = awscc.ec2.NatGateway {
   allocation_id = eip_1d.allocation_id
   subnet_id     = public_subnet_1d.subnet_id
 
@@ -161,7 +161,7 @@ let nat_gw_1d = awscc.ec2.nat_gateway {
 
 # --- Private Subnets ---
 
-let private_subnet_1a = awscc.ec2.subnet {
+let private_subnet_1a = awscc.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.100.0/24'
   availability_zone = 'ap-northeast-1a'
@@ -171,7 +171,7 @@ let private_subnet_1a = awscc.ec2.subnet {
   }
 }
 
-let private_subnet_1c = awscc.ec2.subnet {
+let private_subnet_1c = awscc.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.101.0/24'
   availability_zone = 'ap-northeast-1c'
@@ -181,7 +181,7 @@ let private_subnet_1c = awscc.ec2.subnet {
   }
 }
 
-let private_subnet_1d = awscc.ec2.subnet {
+let private_subnet_1d = awscc.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.102.0/24'
   availability_zone = 'ap-northeast-1d'
@@ -193,7 +193,7 @@ let private_subnet_1d = awscc.ec2.subnet {
 
 # --- Private Route Tables ---
 
-let private_rt_1a = awscc.ec2.route_table {
+let private_rt_1a = awscc.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 
   tags = {
@@ -201,7 +201,7 @@ let private_rt_1a = awscc.ec2.route_table {
   }
 }
 
-let private_rt_1c = awscc.ec2.route_table {
+let private_rt_1c = awscc.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 
   tags = {
@@ -209,7 +209,7 @@ let private_rt_1c = awscc.ec2.route_table {
   }
 }
 
-let private_rt_1d = awscc.ec2.route_table {
+let private_rt_1d = awscc.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 
   tags = {
@@ -217,42 +217,42 @@ let private_rt_1d = awscc.ec2.route_table {
   }
 }
 
-awscc.ec2.route {
+awscc.ec2.Route {
   route_table_id         = private_rt_1a.route_table_id
   destination_cidr_block = '0.0.0.0/0'
   nat_gateway_id         = nat_gw_1a.nat_gateway_id
 }
 
-awscc.ec2.route {
+awscc.ec2.Route {
   route_table_id         = private_rt_1c.route_table_id
   destination_cidr_block = '0.0.0.0/0'
   nat_gateway_id         = nat_gw_1c.nat_gateway_id
 }
 
-awscc.ec2.route {
+awscc.ec2.Route {
   route_table_id         = private_rt_1d.route_table_id
   destination_cidr_block = '0.0.0.0/0'
   nat_gateway_id         = nat_gw_1d.nat_gateway_id
 }
 
-awscc.ec2.subnet_route_table_association {
+awscc.ec2.SubnetRouteTableAssociation {
   subnet_id      = private_subnet_1a.subnet_id
   route_table_id = private_rt_1a.route_table_id
 }
 
-awscc.ec2.subnet_route_table_association {
+awscc.ec2.SubnetRouteTableAssociation {
   subnet_id      = private_subnet_1c.subnet_id
   route_table_id = private_rt_1c.route_table_id
 }
 
-awscc.ec2.subnet_route_table_association {
+awscc.ec2.SubnetRouteTableAssociation {
   subnet_id      = private_subnet_1d.subnet_id
   route_table_id = private_rt_1d.route_table_id
 }
 
 # --- Database Subnets ---
 
-let database_subnet_1a = awscc.ec2.subnet {
+let database_subnet_1a = awscc.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.200.0/24'
   availability_zone = 'ap-northeast-1a'
@@ -262,7 +262,7 @@ let database_subnet_1a = awscc.ec2.subnet {
   }
 }
 
-let database_subnet_1c = awscc.ec2.subnet {
+let database_subnet_1c = awscc.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.201.0/24'
   availability_zone = 'ap-northeast-1c'
@@ -272,7 +272,7 @@ let database_subnet_1c = awscc.ec2.subnet {
   }
 }
 
-let database_subnet_1d = awscc.ec2.subnet {
+let database_subnet_1d = awscc.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.202.0/24'
   availability_zone = 'ap-northeast-1d'
@@ -284,7 +284,7 @@ let database_subnet_1d = awscc.ec2.subnet {
 
 # --- Database Route Table ---
 
-let database_rt = awscc.ec2.route_table {
+let database_rt = awscc.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 
   tags = {
@@ -292,24 +292,24 @@ let database_rt = awscc.ec2.route_table {
   }
 }
 
-awscc.ec2.subnet_route_table_association {
+awscc.ec2.SubnetRouteTableAssociation {
   subnet_id      = database_subnet_1a.subnet_id
   route_table_id = database_rt.route_table_id
 }
 
-awscc.ec2.subnet_route_table_association {
+awscc.ec2.SubnetRouteTableAssociation {
   subnet_id      = database_subnet_1c.subnet_id
   route_table_id = database_rt.route_table_id
 }
 
-awscc.ec2.subnet_route_table_association {
+awscc.ec2.SubnetRouteTableAssociation {
   subnet_id      = database_subnet_1d.subnet_id
   route_table_id = database_rt.route_table_id
 }
 
 # --- Security Group for VPC Endpoints ---
 
-let endpoint_sg = awscc.ec2.security_group {
+let endpoint_sg = awscc.ec2.SecurityGroup {
   vpc_id            = vpc.vpc_id
   group_description = 'SG for VPC Endpoint'
 
@@ -318,7 +318,7 @@ let endpoint_sg = awscc.ec2.security_group {
   }
 }
 
-awscc.ec2.security_group_ingress {
+awscc.ec2.SecurityGroupIngress {
   group_id    = endpoint_sg.group_id
   description = 'Allow HTTPS from VPC'
   ip_protocol = 'tcp'
@@ -329,7 +329,7 @@ awscc.ec2.security_group_ingress {
 
 # --- VPC Endpoints (Interface type) ---
 
-awscc.ec2.vpc_endpoint {
+awscc.ec2.VpcEndpoint {
   vpc_id              = vpc.vpc_id
   service_name        = 'com.amazonaws.ap-northeast-1.ecr.dkr'
   vpc_endpoint_type   = 'Interface'
@@ -338,7 +338,7 @@ awscc.ec2.vpc_endpoint {
   private_dns_enabled = true
 }
 
-awscc.ec2.vpc_endpoint {
+awscc.ec2.VpcEndpoint {
   vpc_id              = vpc.vpc_id
   service_name        = 'com.amazonaws.ap-northeast-1.ecr.api'
   vpc_endpoint_type   = 'Interface'
@@ -347,7 +347,7 @@ awscc.ec2.vpc_endpoint {
   private_dns_enabled = true
 }
 
-awscc.ec2.vpc_endpoint {
+awscc.ec2.VpcEndpoint {
   vpc_id              = vpc.vpc_id
   service_name        = 'com.amazonaws.ap-northeast-1.logs'
   vpc_endpoint_type   = 'Interface'
@@ -356,7 +356,7 @@ awscc.ec2.vpc_endpoint {
   private_dns_enabled = true
 }
 
-awscc.ec2.vpc_endpoint {
+awscc.ec2.VpcEndpoint {
   vpc_id              = vpc.vpc_id
   service_name        = 'com.amazonaws.ap-northeast-1.ssm'
   vpc_endpoint_type   = 'Interface'
@@ -365,7 +365,7 @@ awscc.ec2.vpc_endpoint {
   private_dns_enabled = true
 }
 
-awscc.ec2.vpc_endpoint {
+awscc.ec2.VpcEndpoint {
   vpc_id              = vpc.vpc_id
   service_name        = 'com.amazonaws.ap-northeast-1.ssmmessages'
   vpc_endpoint_type   = 'Interface'
@@ -376,7 +376,7 @@ awscc.ec2.vpc_endpoint {
 
 # --- VPC Endpoint (Gateway type) ---
 
-awscc.ec2.vpc_endpoint {
+awscc.ec2.VpcEndpoint {
   vpc_id            = vpc.vpc_id
   service_name      = 'com.amazonaws.ap-northeast-1.s3'
   vpc_endpoint_type = 'Gateway'

--- a/acceptance-tests/write_only_attrs/step1_create.crn
+++ b/acceptance-tests/write_only_attrs/step1_create.crn
@@ -2,7 +2,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {
@@ -10,7 +10,7 @@ let vpc = awscc.ec2.vpc {
   }
 }
 
-let subnet = awscc.ec2.subnet {
+let subnet = awscc.ec2.Subnet {
   vpc_id                  = vpc.vpc_id
   cidr_block              = '10.0.1.0/24'
   availability_zone       = 'ap-northeast-1a'
@@ -21,18 +21,18 @@ let subnet = awscc.ec2.subnet {
   }
 }
 
-let igw = awscc.ec2.internet_gateway {
+let igw = awscc.ec2.InternetGateway {
   tags = {
     Name = 'write-only-test'
   }
 }
 
-awscc.ec2.vpc_gateway_attachment {
+awscc.ec2.VpcGatewayAttachment {
   vpc_id              = vpc.vpc_id
   internet_gateway_id = igw.internet_gateway_id
 }
 
-let eip = awscc.ec2.eip {
+let eip = awscc.ec2.Eip {
   domain = 'vpc'
 
   tags = {
@@ -40,7 +40,7 @@ let eip = awscc.ec2.eip {
   }
 }
 
-awscc.ec2.nat_gateway {
+awscc.ec2.NatGateway {
   allocation_id            = eip.allocation_id
   subnet_id                = subnet.subnet_id
   max_drain_duration_seconds = 120

--- a/acceptance-tests/write_only_attrs/step2_change.crn
+++ b/acceptance-tests/write_only_attrs/step2_change.crn
@@ -2,7 +2,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {
@@ -10,7 +10,7 @@ let vpc = awscc.ec2.vpc {
   }
 }
 
-let subnet = awscc.ec2.subnet {
+let subnet = awscc.ec2.Subnet {
   vpc_id                  = vpc.vpc_id
   cidr_block              = '10.0.1.0/24'
   availability_zone       = 'ap-northeast-1a'
@@ -21,18 +21,18 @@ let subnet = awscc.ec2.subnet {
   }
 }
 
-let igw = awscc.ec2.internet_gateway {
+let igw = awscc.ec2.InternetGateway {
   tags = {
     Name = 'write-only-test'
   }
 }
 
-awscc.ec2.vpc_gateway_attachment {
+awscc.ec2.VpcGatewayAttachment {
   vpc_id              = vpc.vpc_id
   internet_gateway_id = igw.internet_gateway_id
 }
 
-let eip = awscc.ec2.eip {
+let eip = awscc.ec2.Eip {
   domain = 'vpc'
 
   tags = {
@@ -40,7 +40,7 @@ let eip = awscc.ec2.eip {
   }
 }
 
-awscc.ec2.nat_gateway {
+awscc.ec2.NatGateway {
   allocation_id            = eip.allocation_id
   subnet_id                = subnet.subnet_id
   max_drain_duration_seconds = 240

--- a/acceptance-tests/write_only_attrs/step3_remove.crn
+++ b/acceptance-tests/write_only_attrs/step3_remove.crn
@@ -2,7 +2,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 
   tags = {
@@ -10,7 +10,7 @@ let vpc = awscc.ec2.vpc {
   }
 }
 
-let subnet = awscc.ec2.subnet {
+let subnet = awscc.ec2.Subnet {
   vpc_id                  = vpc.vpc_id
   cidr_block              = '10.0.1.0/24'
   availability_zone       = 'ap-northeast-1a'
@@ -21,18 +21,18 @@ let subnet = awscc.ec2.subnet {
   }
 }
 
-let igw = awscc.ec2.internet_gateway {
+let igw = awscc.ec2.InternetGateway {
   tags = {
     Name = 'write-only-test'
   }
 }
 
-awscc.ec2.vpc_gateway_attachment {
+awscc.ec2.VpcGatewayAttachment {
   vpc_id              = vpc.vpc_id
   internet_gateway_id = igw.internet_gateway_id
 }
 
-let eip = awscc.ec2.eip {
+let eip = awscc.ec2.Eip {
   domain = 'vpc'
 
   tags = {
@@ -41,7 +41,7 @@ let eip = awscc.ec2.eip {
 }
 
 # max_drain_duration_seconds removed
-awscc.ec2.nat_gateway {
+awscc.ec2.NatGateway {
   allocation_id = eip.allocation_id
   subnet_id     = subnet.subnet_id
 

--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -287,16 +287,55 @@ fn full_resource_name_from_type(type_name: &str) -> Result<String> {
 }
 
 /// Compute DSL resource name (service.resource) from CloudFormation type name
-/// e.g., "AWS::EC2::SecurityGroupEgress" -> "ec2.security_group_egress"
-/// Used for DSL-facing strings (resource_type_name, namespace, display).
+/// e.g., "AWS::EC2::SecurityGroupEgress" -> "ec2.SecurityGroupEgress"
+/// and "AWS::EC2::VPC" -> "ec2.Vpc" (acronyms normalised via snake -> pascal).
+/// The service segment is lowercase (a namespace); the resource segment is
+/// PascalCase with acronyms treated as single words, matching carina-core's
+/// `snake_to_pascal` round-trip (design D2).
 fn dsl_resource_name_from_type(type_name: &str) -> Result<String> {
     let parts: Vec<&str> = type_name.split("::").collect();
     if parts.len() != 3 {
         anyhow::bail!("Invalid type name format: {}", type_name);
     }
     let service = parts[1].to_lowercase();
-    let resource = parts[2].to_snake_case();
+    // Route through snake_case first so CloudFormation-style acronyms
+    // ("VPC", "IPAM", "EIP") become single Pascal tokens ("Vpc", "Ipam",
+    // "Eip") rather than shouty residue.
+    let resource = parts[2].to_snake_case().to_pascal_case();
     Ok(format!("{}.{}", service, resource))
+}
+
+/// Convert a CloudFormation-side enum value to its DSL (snake_case) form.
+///
+/// Per naming-conventions design D7:
+/// - SHOUTY_SNAKE (`GROUP`, `AWS_ACCOUNT`) → lowercase (`group`, `aws_account`)
+/// - PascalCase (`Enabled`, `VersioningStatus`) → snake_case (`enabled`,
+///   `versioning_status`)
+/// - Already kebab/snake (`ap-northeast-1`, `ipsec.1`) → `-` to `_` if present
+///   (`ap_northeast_1`), leave `.`-containing values verbatim so they round-trip
+/// - Numeric values pass through unchanged.
+fn dsl_enum_value(value: &str) -> String {
+    if value.is_empty() {
+        return String::new();
+    }
+    // Passthrough for already-numeric or dotted values (e.g. "ipsec.1").
+    if value.chars().all(|c| c.is_ascii_digit() || c == '.') {
+        return value.to_string();
+    }
+    // SHOUTY_SNAKE: uppercase ASCII letters + underscores + optional digits.
+    if value
+        .chars()
+        .all(|c| c.is_ascii_uppercase() || c == '_' || c.is_ascii_digit())
+        && value.chars().any(|c| c.is_ascii_uppercase())
+    {
+        return value.to_ascii_lowercase();
+    }
+    // Already snake / kebab (no uppercase): just normalize hyphens.
+    if !value.chars().any(|c| c.is_ascii_uppercase()) {
+        return value.replace('-', "_");
+    }
+    // PascalCase (or anything else mixed): route through heck's ToSnakeCase.
+    value.to_snake_case()
 }
 
 fn main() -> Result<()> {
@@ -1203,7 +1242,7 @@ fn generate_schema_code(schema: &CfnSchema, type_name: &str) -> Result<String> {
     let resource = parts[2].to_snake_case();
     let full_resource = full_resource_name_from_type(type_name)?;
     let dsl_resource = dsl_resource_name_from_type(type_name)?;
-    // Namespace for enums: awscc.ec2.vpc
+    // Namespace for enums: awscc.ec2.Vpc
     let namespace = format!("awscc.{}", dsl_resource);
 
     // Build read-only properties set
@@ -1917,7 +1956,7 @@ fn {fn_name}(value: &Value) -> Result<(), String> {{
 
     // Generate config function
     let config_fn_name = format!("{}_config", full_resource);
-    // Use awscc.service.resource format (e.g., awscc.ec2.vpc)
+    // Use awscc.service.resource format (e.g., awscc.ec2.Vpc)
     let schema_name = format!("awscc.{}", dsl_resource);
 
     code.push_str(&format!(
@@ -2230,13 +2269,14 @@ pub fn {}() -> AwsccSchemaConfig {{
                 }
             }
 
-            // Add to_dsl reverse mappings for values containing hyphens.
+            // Auto-generate DSL aliases for every enum value so the user-facing
+            // DSL form is always snake_case (naming-conventions design D3). The
+            // alias maps the snake_case DSL form back to the canonical AWS API
+            // value (PascalCase, SHOUTY_SNAKE, or already-kebab/snake).
             for value in &enum_info.values {
-                if value.contains('-') {
-                    let dsl_form = value.replace('-', "_");
-                    if dsl_form != *value && seen.insert((attr_name.clone(), dsl_form.clone())) {
-                        alias_entries.push((attr_name.clone(), dsl_form, value.clone()));
-                    }
+                let dsl_form = dsl_enum_value(value);
+                if dsl_form != *value && seen.insert((attr_name.clone(), dsl_form.clone())) {
+                    alias_entries.push((attr_name.clone(), dsl_form, value.clone()));
                 }
             }
         }
@@ -6974,7 +7014,7 @@ mod tests {
             &prop,
             "OutputSchemaVersion",
             &schema,
-            "awscc.s3.bucket",
+            "awscc.s3.Bucket",
             &enums,
         );
         assert!(enum_info.is_some(), "const value should produce enum info");
@@ -7020,7 +7060,7 @@ mod tests {
             &prop,
             "AllowedMethods",
             &schema,
-            "awscc.s3.bucket",
+            "awscc.s3.Bucket",
             &enums,
         );
         assert!(
@@ -7080,7 +7120,7 @@ mod tests {
             &prop,
             "HttpMethod",
             &schema,
-            "awscc.s3.bucket",
+            "awscc.s3.Bucket",
             &enums,
         );
         assert!(
@@ -7142,7 +7182,7 @@ mod tests {
             &prop,
             "BlockedEncryptionTypes",
             &schema,
-            "awscc.s3.bucket",
+            "awscc.s3.Bucket",
             &enums,
         );
         assert!(
@@ -7582,11 +7622,11 @@ mod tests {
 
         // DSL identifiers should also be disambiguated
         assert!(
-            md.contains("awscc.test.resource.ConfigAStatus.Disabled"),
+            md.contains("awscc.test.Resource.ConfigAStatus.Disabled"),
             "Expected disambiguated DSL identifier for ConfigA"
         );
         assert!(
-            md.contains("awscc.test.resource.ConfigBStatus.Suspended"),
+            md.contains("awscc.test.Resource.ConfigBStatus.Suspended"),
             "Expected disambiguated DSL identifier for ConfigB"
         );
 
@@ -8039,7 +8079,7 @@ mod tests {
             &prop,
             "LogGroupName",
             &schema,
-            "awscc.logs.log_group",
+            "awscc.logs.LogGroup",
             &BTreeMap::new(),
         );
         assert!(
@@ -8082,7 +8122,7 @@ mod tests {
             &prop,
             "KmsKeyId",
             &schema,
-            "awscc.logs.log_group",
+            "awscc.logs.LogGroup",
             &BTreeMap::new(),
         );
         // KmsKeyId should be resolved to a specific ARN type, not pattern-validated
@@ -8168,7 +8208,7 @@ mod tests {
             &prop,
             "PrivateDnsSpecifiedDomains",
             &schema,
-            "awscc.ec2.vpc_endpoint",
+            "awscc.ec2.VpcEndpoint",
             &enums,
         );
         assert!(
@@ -8217,7 +8257,7 @@ mod tests {
             &prop,
             "SomeArray",
             &schema,
-            "awscc.ec2.vpc_endpoint",
+            "awscc.ec2.VpcEndpoint",
             &enums,
         );
         assert!(
@@ -8262,7 +8302,7 @@ mod tests {
             &prop,
             "SomeArray",
             &schema,
-            "awscc.ec2.vpc_endpoint",
+            "awscc.ec2.VpcEndpoint",
             &enums,
         );
         assert!(
@@ -8525,7 +8565,7 @@ mod tests {
             &prop,
             "ExpirationDate",
             &schema,
-            "awscc.s3.bucket",
+            "awscc.s3.Bucket",
             &BTreeMap::new(),
         );
         assert!(

--- a/carina-provider-awscc/src/convert.rs
+++ b/carina-provider-awscc/src/convert.rs
@@ -357,7 +357,7 @@ mod tests {
         let core_type = CoreAttributeType::StringEnum {
             name: "VersioningStatus".to_string(),
             values: vec!["Enabled".to_string(), "Suspended".to_string()],
-            namespace: Some("awscc.s3.bucket".to_string()),
+            namespace: Some("awscc.s3.Bucket".to_string()),
             to_dsl: None,
         };
 
@@ -372,7 +372,7 @@ mod tests {
             } => {
                 assert_eq!(name, "VersioningStatus");
                 assert_eq!(values.len(), 2);
-                assert_eq!(namespace.as_deref(), Some("awscc.s3.bucket"));
+                assert_eq!(namespace.as_deref(), Some("awscc.s3.Bucket"));
             }
             _ => panic!("Expected StringEnum"),
         }
@@ -390,7 +390,7 @@ mod tests {
 
     #[test]
     fn core_to_proto_schema_initializes_empty_validators() {
-        let schema = CoreResourceSchema::new("awscc.s3.bucket");
+        let schema = CoreResourceSchema::new("awscc.s3.Bucket");
         let proto = core_to_proto_schema(&schema);
         assert!(proto.validators.is_empty());
     }

--- a/carina-provider-awscc/src/lib.rs
+++ b/carina-provider-awscc/src/lib.rs
@@ -233,7 +233,7 @@ mod tests {
         let schemas = build_schemas();
         let normalizer = AwsccNormalizer;
 
-        let mut resource = Resource::with_provider("awscc", "ec2.vpc", "test-vpc");
+        let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "test-vpc");
         resource.set_attr(
             "cidr_block".to_string(),
             Value::String("10.0.0.0/16".to_string()),
@@ -289,7 +289,7 @@ mod tests {
         let schemas = build_schemas();
         let normalizer = AwsccNormalizer;
 
-        let mut resource = Resource::with_provider("awscc", "ec2.vpc", "test-vpc");
+        let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "test-vpc");
         resource.set_attr(
             "cidr_block".to_string(),
             Value::String("10.0.0.0/16".to_string()),
@@ -332,7 +332,7 @@ mod tests {
         let schemas = build_schemas();
         let normalizer = AwsccNormalizer;
 
-        let mut resource = Resource::with_provider("awscc", "ec2.route", "test-route");
+        let mut resource = Resource::with_provider("awscc", "ec2.Route", "test-route");
         resource.set_attr(
             "route_table_id".to_string(),
             Value::String("rtb-123".to_string()),
@@ -356,7 +356,7 @@ mod tests {
         let schemas = build_schemas();
         let normalizer = AwsccNormalizer;
 
-        let mut resource = Resource::with_provider("awscc", "ec2.vpc", "test-vpc");
+        let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "test-vpc");
         resource.set_attr(
             "cidr_block".to_string(),
             Value::String("10.0.0.0/16".to_string()),

--- a/carina-provider-awscc/src/main.rs
+++ b/carina-provider-awscc/src/main.rs
@@ -338,7 +338,7 @@ mod tests {
         let schemas = provider.schemas();
         let bucket = schemas
             .iter()
-            .find(|s| s.resource_type == "awscc.s3.bucket")
+            .find(|s| s.resource_type == "awscc.s3.Bucket")
             .expect("s3.bucket schema should exist");
         assert!(
             bucket
@@ -370,14 +370,14 @@ mod tests {
     /// Regression for carina-rs/carina#2025: the VPC schema must carry the
     /// `cidr_block` / `ipv4_ipam_pool_id` oneOf constraint as serializable
     /// data, so it survives the WASM plugin boundary and validate/plan can
-    /// reject `awscc.ec2.vpc {}` before any provider call.
+    /// reject `awscc.ec2.Vpc {}` before any provider call.
     #[test]
     fn vpc_schema_carries_cidr_block_exclusive_group_across_proto() {
         let provider = AwsccProcessProvider::new();
         let schemas = provider.schemas();
         let vpc = schemas
             .iter()
-            .find(|s| s.resource_type == "awscc.ec2.vpc")
+            .find(|s| s.resource_type == "awscc.ec2.Vpc")
             .expect("ec2.vpc schema should exist");
         assert!(
             vpc.exclusive_required

--- a/carina-provider-awscc/src/provider/conversion.rs
+++ b/carina-provider-awscc/src/provider/conversion.rs
@@ -199,7 +199,7 @@ pub(crate) fn dsl_value_to_aws(
             Value::String(s) => {
                 // Extract the raw enum value from the namespaced identifier, using
                 // known valid values for disambiguation when enum values contain dots
-                // (e.g., "ipsec.1" in "awscc.ec2.vpn_gateway.Type.ipsec.1").
+                // (e.g., "ipsec.1" in "awscc.ec2.VpnGateway.Type.ipsec.1").
                 let raw = if let Some((_, values, _, _)) = attr_type.string_enum_parts() {
                     let valid: Vec<&str> = values.iter().map(String::as_str).collect();
                     let raw_extracted = extract_enum_value_with_values(s, &valid);
@@ -523,7 +523,7 @@ mod tests {
 
         // 1. DSL side: resolve_enum_identifiers_impl converts bare `Gateway` ident
         let mut resource =
-            carina_core::resource::Resource::with_provider("awscc", "ec2.vpc_endpoint", "test");
+            carina_core::resource::Resource::with_provider("awscc", "ec2.VpcEndpoint", "test");
         resource.set_attr("vpc_id".to_string(), Value::String("vpc-123".to_string()));
         resource.set_attr(
             "vpc_endpoint_type".to_string(),
@@ -536,7 +536,7 @@ mod tests {
         let dsl_resolved = &resources[0].attributes["vpc_endpoint_type"];
         assert_eq!(
             dsl_resolved,
-            &Value::String("awscc.ec2.vpc_endpoint.VpcEndpointType.Gateway".to_string()),
+            &Value::String("awscc.ec2.VpcEndpoint.VpcEndpointType.Gateway".to_string()),
             "DSL bare ident `Gateway` should resolve to namespaced form"
         );
 
@@ -546,13 +546,13 @@ mod tests {
             "vpc_endpoint_type",
             &aws_json,
             &attr_schema.attr_type,
-            "ec2.vpc_endpoint",
+            "ec2.VpcEndpoint",
         )
         .expect("aws_value_to_dsl should return Some");
 
         assert_eq!(
             aws_dsl,
-            Value::String("awscc.ec2.vpc_endpoint.VpcEndpointType.Gateway".to_string()),
+            Value::String("awscc.ec2.VpcEndpoint.VpcEndpointType.Gateway".to_string()),
             "AWS read-back 'Gateway' should normalize to namespaced form"
         );
 
@@ -572,12 +572,12 @@ mod tests {
                 "INFREQUENT_ACCESS".to_string(),
                 "DELIVERY".to_string(),
             ],
-            namespace: Some("awscc.logs.log_group".to_string()),
+            namespace: Some("awscc.logs.LogGroup".to_string()),
             to_dsl: None,
         };
         let value =
-            Value::String("awscc.logs.log_group.LogGroupClass.INFREQUENT_ACCESS".to_string());
-        let result = dsl_value_to_aws(&value, &attr_type, "logs.log_group", "log_group_class");
+            Value::String("awscc.logs.LogGroup.LogGroupClass.INFREQUENT_ACCESS".to_string());
+        let result = dsl_value_to_aws(&value, &attr_type, "logs.LogGroup", "log_group_class");
         assert_eq!(result, Some(json!("INFREQUENT_ACCESS")));
     }
 
@@ -593,7 +593,7 @@ mod tests {
             to_dsl: None,
         };
         let value = Value::String("awscc.Region.ap_northeast_1".to_string());
-        let result = dsl_value_to_aws(&value, &attr_type, "logs.log_group", "region");
+        let result = dsl_value_to_aws(&value, &attr_type, "logs.LogGroup", "region");
         assert_eq!(result, Some(json!("ap-northeast-1")));
     }
 
@@ -602,15 +602,15 @@ mod tests {
         let inner = AttributeType::StringEnum {
             name: "AllowedMethod".to_string(),
             values: vec!["GET".to_string(), "PUT".to_string(), "DELETE".to_string()],
-            namespace: Some("awscc.s3.bucket".to_string()),
+            namespace: Some("awscc.s3.Bucket".to_string()),
             to_dsl: None,
         };
         let attr_type = AttributeType::list(inner);
         let value = Value::List(vec![
-            Value::String("awscc.s3.bucket.AllowedMethod.GET".to_string()),
-            Value::String("awscc.s3.bucket.AllowedMethod.PUT".to_string()),
+            Value::String("awscc.s3.Bucket.AllowedMethod.GET".to_string()),
+            Value::String("awscc.s3.Bucket.AllowedMethod.PUT".to_string()),
         ]);
-        let result = dsl_value_to_aws(&value, &attr_type, "s3.bucket", "allowed_methods");
+        let result = dsl_value_to_aws(&value, &attr_type, "s3.Bucket", "allowed_methods");
         assert_eq!(result, Some(json!(["GET", "PUT"])));
     }
 
@@ -619,17 +619,17 @@ mod tests {
         let inner = AttributeType::StringEnum {
             name: "AllowedMethod".to_string(),
             values: vec!["GET".to_string(), "PUT".to_string(), "DELETE".to_string()],
-            namespace: Some("awscc.s3.bucket".to_string()),
+            namespace: Some("awscc.s3.Bucket".to_string()),
             to_dsl: None,
         };
         let attr_type = AttributeType::list(inner);
         let json_val = json!(["GET", "PUT"]);
-        let result = aws_value_to_dsl("allowed_methods", &json_val, &attr_type, "s3.bucket");
+        let result = aws_value_to_dsl("allowed_methods", &json_val, &attr_type, "s3.Bucket");
         assert_eq!(
             result,
             Some(Value::List(vec![
-                Value::String("awscc.s3.bucket.AllowedMethod.GET".to_string()),
-                Value::String("awscc.s3.bucket.AllowedMethod.PUT".to_string()),
+                Value::String("awscc.s3.Bucket.AllowedMethod.GET".to_string()),
+                Value::String("awscc.s3.Bucket.AllowedMethod.PUT".to_string()),
             ]))
         );
     }
@@ -639,15 +639,15 @@ mod tests {
         let inner = AttributeType::StringEnum {
             name: "AllowedMethod".to_string(),
             values: vec!["GET".to_string(), "PUT".to_string()],
-            namespace: Some("awscc.s3.bucket".to_string()),
+            namespace: Some("awscc.s3.Bucket".to_string()),
             to_dsl: None,
         };
         let attr_type = AttributeType::list(inner);
 
         let aws_json = json!(["GET", "PUT"]);
-        let dsl = aws_value_to_dsl("allowed_methods", &aws_json, &attr_type, "s3.bucket")
+        let dsl = aws_value_to_dsl("allowed_methods", &aws_json, &attr_type, "s3.Bucket")
             .expect("read should succeed");
-        let written = dsl_value_to_aws(&dsl, &attr_type, "s3.bucket", "allowed_methods")
+        let written = dsl_value_to_aws(&dsl, &attr_type, "s3.Bucket", "allowed_methods")
             .expect("write should succeed");
         assert_eq!(written, aws_json, "Round-trip should produce original JSON");
     }
@@ -658,13 +658,13 @@ mod tests {
             AttributeType::StringEnum {
                 name: "Protocol".to_string(),
                 values: vec!["tcp".to_string(), "udp".to_string()],
-                namespace: Some("awscc.ec2.sg".to_string()),
+                namespace: Some("awscc.ec2.Sg".to_string()),
                 to_dsl: None,
             },
             AttributeType::String,
         ]);
-        let value = Value::String("awscc.ec2.sg.Protocol.tcp".to_string());
-        let result = dsl_value_to_aws(&value, &attr_type, "ec2.sg", "protocol");
+        let value = Value::String("awscc.ec2.Sg.Protocol.tcp".to_string());
+        let result = dsl_value_to_aws(&value, &attr_type, "ec2.Sg", "protocol");
         assert_eq!(result, Some(json!("tcp")));
     }
 
@@ -683,7 +683,7 @@ mod tests {
         );
         let dsl_value = Value::Map(map);
 
-        let result = dsl_value_to_aws(&dsl_value, &attr_type, "s3.bucket", "tags");
+        let result = dsl_value_to_aws(&dsl_value, &attr_type, "s3.Bucket", "tags");
         let result = result.expect("Should return Some");
 
         if let serde_json::Value::Object(obj) = &result {
@@ -732,7 +732,7 @@ mod tests {
             "another-key": "value2"
         });
 
-        let result = aws_value_to_dsl("tags", &aws_json, &attr_type, "s3.bucket");
+        let result = aws_value_to_dsl("tags", &aws_json, &attr_type, "s3.Bucket");
         let result = result.expect("Should return Some");
 
         if let Value::Map(map) = &result {
@@ -756,16 +756,16 @@ mod tests {
             AttributeType::StringEnum {
                 name: "Protocol".to_string(),
                 values: vec!["tcp".to_string(), "udp".to_string()],
-                namespace: Some("awscc.ec2.sg".to_string()),
+                namespace: Some("awscc.ec2.Sg".to_string()),
                 to_dsl: None,
             },
             AttributeType::String,
         ]);
         let json_val = json!("tcp");
-        let result = aws_value_to_dsl("protocol", &json_val, &attr_type, "ec2.sg");
+        let result = aws_value_to_dsl("protocol", &json_val, &attr_type, "ec2.Sg");
         assert_eq!(
             result,
-            Some(Value::String("awscc.ec2.sg.Protocol.tcp".to_string()))
+            Some(Value::String("awscc.ec2.Sg.Protocol.tcp".to_string()))
         );
     }
 
@@ -775,13 +775,13 @@ mod tests {
             AttributeType::StringEnum {
                 name: "Protocol".to_string(),
                 values: vec!["tcp".to_string(), "udp".to_string()],
-                namespace: Some("awscc.ec2.sg".to_string()),
+                namespace: Some("awscc.ec2.Sg".to_string()),
                 to_dsl: None,
             },
             AttributeType::Int,
         ]);
         let json_val = json!(42);
-        let result = aws_value_to_dsl("protocol", &json_val, &attr_type, "ec2.sg");
+        let result = aws_value_to_dsl("protocol", &json_val, &attr_type, "ec2.Sg");
         assert_eq!(result, Some(Value::Int(42)));
     }
 
@@ -829,7 +829,7 @@ mod tests {
         let result = dsl_value_to_aws(
             &value,
             &attr_type,
-            "iam.role",
+            "iam.Role",
             "assume_role_policy_document",
         );
         let result = result.expect("Should return Some");
@@ -884,7 +884,7 @@ mod tests {
             "assume_role_policy_document",
             &aws_json,
             &attr_type,
-            "iam.role",
+            "iam.Role",
         );
         let result = result.expect("Should return Some");
 
@@ -942,7 +942,7 @@ mod tests {
         });
         let json_val = json!([{"RegionName": "ap-northeast-1"}]);
 
-        let result = aws_value_to_dsl("operating_regions", &json_val, &attr_type, "ec2.ipam");
+        let result = aws_value_to_dsl("operating_regions", &json_val, &attr_type, "ec2.Ipam");
         let expected = Value::List(vec![Value::Map(HashMap::from([(
             "region_name".to_string(),
             Value::String("awscc.Region.ap_northeast_1".to_string()),
@@ -955,16 +955,16 @@ mod tests {
         let attr_type = AttributeType::StringEnum {
             name: "Type".to_string(),
             values: vec!["ipsec.1".to_string()],
-            namespace: Some("awscc.ec2.vpn_gateway".to_string()),
+            namespace: Some("awscc.ec2.VpnGateway".to_string()),
             to_dsl: None,
         };
         let json_val = json!("ipsec.1");
 
-        let result = aws_value_to_dsl("type", &json_val, &attr_type, "ec2.vpn_gateway");
+        let result = aws_value_to_dsl("type", &json_val, &attr_type, "ec2.VpnGateway");
         assert_eq!(
             result,
             Some(Value::String(
-                "awscc.ec2.vpn_gateway.Type.ipsec.1".to_string()
+                "awscc.ec2.VpnGateway.Type.ipsec.1".to_string()
             ))
         );
     }
@@ -974,12 +974,12 @@ mod tests {
         let attr_type = AttributeType::StringEnum {
             name: "Type".to_string(),
             values: vec!["ipsec.1".to_string()],
-            namespace: Some("awscc.ec2.vpn_gateway".to_string()),
+            namespace: Some("awscc.ec2.VpnGateway".to_string()),
             to_dsl: None,
         };
-        let value = Value::String("awscc.ec2.vpn_gateway.Type.ipsec.1".to_string());
+        let value = Value::String("awscc.ec2.VpnGateway.Type.ipsec.1".to_string());
 
-        let result = dsl_value_to_aws(&value, &attr_type, "ec2.vpn_gateway", "type");
+        let result = dsl_value_to_aws(&value, &attr_type, "ec2.VpnGateway", "type");
         assert_eq!(result, Some(json!("ipsec.1")));
     }
 
@@ -988,12 +988,12 @@ mod tests {
         let attr_type = AttributeType::StringEnum {
             name: "Type".to_string(),
             values: vec!["ipsec.1".to_string()],
-            namespace: Some("awscc.ec2.vpn_gateway".to_string()),
+            namespace: Some("awscc.ec2.VpnGateway".to_string()),
             to_dsl: None,
         };
         let value = Value::String("ipsec.1".to_string());
 
-        let result = dsl_value_to_aws(&value, &attr_type, "ec2.vpn_gateway", "type");
+        let result = dsl_value_to_aws(&value, &attr_type, "ec2.VpnGateway", "type");
         assert_eq!(result, Some(json!("ipsec.1")));
     }
 
@@ -1002,21 +1002,20 @@ mod tests {
         let attr_type = AttributeType::StringEnum {
             name: "Type".to_string(),
             values: vec!["ipsec.1".to_string()],
-            namespace: Some("awscc.ec2.vpn_gateway".to_string()),
+            namespace: Some("awscc.ec2.VpnGateway".to_string()),
             to_dsl: None,
         };
 
         let aws_val = json!("ipsec.1");
-        let dsl_val = aws_value_to_dsl("type", &aws_val, &attr_type, "ec2.vpn_gateway");
+        let dsl_val = aws_value_to_dsl("type", &aws_val, &attr_type, "ec2.VpnGateway");
         assert_eq!(
             dsl_val,
             Some(Value::String(
-                "awscc.ec2.vpn_gateway.Type.ipsec.1".to_string()
+                "awscc.ec2.VpnGateway.Type.ipsec.1".to_string()
             ))
         );
 
-        let back_to_aws =
-            dsl_value_to_aws(&dsl_val.unwrap(), &attr_type, "ec2.vpn_gateway", "type");
+        let back_to_aws = dsl_value_to_aws(&dsl_val.unwrap(), &attr_type, "ec2.VpnGateway", "type");
         assert_eq!(back_to_aws, Some(json!("ipsec.1")));
     }
 
@@ -1142,7 +1141,7 @@ mod tests {
             "lifecycle_configuration",
             &aws_json,
             &attr_schema.attr_type,
-            "s3.bucket",
+            "s3.Bucket",
         )
         .expect("aws_value_to_dsl should succeed for lifecycle_configuration");
 
@@ -1160,7 +1159,7 @@ mod tests {
             assert_eq!(
                 rule0.get("status"),
                 Some(&Value::String(
-                    "awscc.s3.bucket.RuleStatus.Enabled".to_string()
+                    "awscc.s3.Bucket.RuleStatus.Enabled".to_string()
                 )),
                 "status should be namespaced enum"
             );
@@ -1181,7 +1180,7 @@ mod tests {
             assert_eq!(
                 rule1.get("status"),
                 Some(&Value::String(
-                    "awscc.s3.bucket.RuleStatus.Enabled".to_string()
+                    "awscc.s3.Bucket.RuleStatus.Enabled".to_string()
                 )),
             );
             if let Some(Value::List(transitions)) = rule1.get("transitions") {
@@ -1190,7 +1189,7 @@ mod tests {
                     assert_eq!(
                         t.get("storage_class"),
                         Some(&Value::String(
-                            "awscc.s3.bucket.TransitionStorageClass.GLACIER".to_string()
+                            "awscc.s3.Bucket.TransitionStorageClass.GLACIER".to_string()
                         )),
                     );
                     assert_eq!(t.get("transition_in_days"), Some(&Value::Int(30)),);
@@ -1208,7 +1207,7 @@ mod tests {
         let written_json = dsl_value_to_aws(
             &dsl_value,
             &attr_schema.attr_type,
-            "s3.bucket",
+            "s3.Bucket",
             "lifecycle_configuration",
         )
         .expect("dsl_value_to_aws should succeed");
@@ -1244,7 +1243,7 @@ mod tests {
             to_dsl: Some(|s: &str| s.strip_suffix('.').unwrap_or(s).to_string()),
         };
         let json_val = serde_json::json!("carina-rs.dev.");
-        let result = aws_value_to_dsl("name", &json_val, &attr_type, "route53.hosted_zone");
+        let result = aws_value_to_dsl("name", &json_val, &attr_type, "route53.HostedZone");
         assert_eq!(result, Some(Value::String("carina-rs.dev".to_string())));
     }
 
@@ -1260,7 +1259,7 @@ mod tests {
             to_dsl: None,
         };
         let json_val = serde_json::json!("carina-rs.dev.");
-        let result = aws_value_to_dsl("name", &json_val, &attr_type, "route53.hosted_zone");
+        let result = aws_value_to_dsl("name", &json_val, &attr_type, "route53.HostedZone");
         assert_eq!(result, Some(Value::String("carina-rs.dev.".to_string())));
     }
 }

--- a/carina-provider-awscc/src/provider/normalizer.rs
+++ b/carina-provider-awscc/src/provider/normalizer.rs
@@ -12,7 +12,7 @@ use carina_core::schema::{AttributeType, StructField};
 ///
 /// For each awscc resource, looks up the schema and resolves bare identifiers
 /// (e.g., `advanced`) or TypeName.value identifiers (e.g., `Tier.advanced`)
-/// into fully-qualified namespaced strings (e.g., `awscc.ec2.ipam.Tier.advanced`).
+/// into fully-qualified namespaced strings (e.g., `awscc.ec2.Ipam.Tier.advanced`).
 pub fn resolve_enum_identifiers_impl(resources: &mut [Resource]) {
     for resource in resources.iter_mut() {
         // Only handle awscc resources
@@ -141,7 +141,7 @@ fn resolve_struct_enum_values(value: &Value, fields: &[StructField]) -> Value {
 ///
 /// State files store raw AWS values (e.g., `"ap-northeast-1a"`, `"default"`).
 /// After `normalize_desired()` converts desired values to DSL enum format
-/// (e.g., `"awscc.ec2.subnet.AvailabilityZone.ap_northeast_1a"`), the differ
+/// (e.g., `"awscc.ec2.Subnet.AvailabilityZone.ap_northeast_1a"`), the differ
 /// would see a false diff. This function normalizes state values the same way
 /// so that both sides use the same representation.
 pub fn normalize_state_enums_impl(current_states: &mut HashMap<ResourceId, State>) {
@@ -235,7 +235,7 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_bare_ident() {
-        let mut resource = Resource::with_provider("awscc", "ec2.vpc", "test");
+        let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "test");
         resource.set_attr(
             "instance_tenancy".to_string(),
             Value::String("dedicated".to_string()),
@@ -255,7 +255,7 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_typename_value() {
-        let mut resource = Resource::with_provider("awscc", "ec2.vpc", "test");
+        let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "test");
         resource.set_attr(
             "instance_tenancy".to_string(),
             Value::String("InstanceTenancy.dedicated".to_string()),
@@ -275,7 +275,7 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_skips_non_awscc() {
-        let mut resource = Resource::with_provider("aws", "s3.bucket", "test");
+        let mut resource = Resource::with_provider("aws", "s3.Bucket", "test");
         resource.set_attr(
             "instance_tenancy".to_string(),
             Value::String("dedicated".to_string()),
@@ -291,7 +291,7 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_hyphen_to_underscore() {
-        let mut resource = Resource::with_provider("awscc", "ec2.flow_log", "test");
+        let mut resource = Resource::with_provider("awscc", "ec2.FlowLog", "test");
         resource.set_attr(
             "log_destination_type".to_string(),
             Value::String("cloud_watch_logs".to_string()),
@@ -302,7 +302,7 @@ mod tests {
         match resources[0].get_attr("log_destination_type").unwrap() {
             Value::String(s) => {
                 assert_eq!(
-                    s, "awscc.ec2.flow_log.LogDestinationType.cloud_watch_logs",
+                    s, "awscc.ec2.FlowLog.LogDestinationType.cloud_watch_logs",
                     "Expected underscored namespaced enum, got: {}",
                     s
                 );
@@ -313,7 +313,7 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_hyphen_string_to_underscore() {
-        let mut resource = Resource::with_provider("awscc", "ec2.flow_log", "test");
+        let mut resource = Resource::with_provider("awscc", "ec2.FlowLog", "test");
         resource.set_attr(
             "log_destination_type".to_string(),
             Value::String("cloud-watch-logs".to_string()),
@@ -324,7 +324,7 @@ mod tests {
         match resources[0].get_attr("log_destination_type").unwrap() {
             Value::String(s) => {
                 assert_eq!(
-                    s, "awscc.ec2.flow_log.LogDestinationType.cloud_watch_logs",
+                    s, "awscc.ec2.FlowLog.LogDestinationType.cloud_watch_logs",
                     "Hyphenated string should be converted to underscore form, got: {}",
                     s
                 );
@@ -335,7 +335,7 @@ mod tests {
 
     #[test]
     fn test_restore_unreturned_attrs_impl_create_only() {
-        let id = ResourceId::with_provider("awscc", "ec2.nat_gateway", "test");
+        let id = ResourceId::with_provider("awscc", "ec2.NatGateway", "test");
         let mut state = State::existing(id.clone(), HashMap::new());
         state.attributes.insert(
             "nat_gateway_id".to_string(),
@@ -363,7 +363,7 @@ mod tests {
 
     #[test]
     fn test_restore_unreturned_attrs_skips_non_awscc() {
-        let id = ResourceId::with_provider("aws", "s3.bucket", "test");
+        let id = ResourceId::with_provider("aws", "s3.Bucket", "test");
         let state = State::existing(id.clone(), HashMap::new());
 
         let mut current_states = HashMap::new();
@@ -381,7 +381,7 @@ mod tests {
 
     #[test]
     fn test_restore_unreturned_attrs_skips_already_present() {
-        let id = ResourceId::with_provider("awscc", "ec2.nat_gateway", "test");
+        let id = ResourceId::with_provider("awscc", "ec2.NatGateway", "test");
         let mut attrs = HashMap::new();
         attrs.insert(
             "subnet_id".to_string(),
@@ -410,11 +410,11 @@ mod tests {
 
     #[test]
     fn test_restore_unreturned_attrs_impl_non_create_only() {
-        let id = ResourceId::with_provider("awscc", "ec2.security_group_egress", "test");
+        let id = ResourceId::with_provider("awscc", "ec2.SecurityGroupEgress", "test");
         let mut state = State::existing(id.clone(), HashMap::new());
         state.attributes.insert(
             "ip_protocol".to_string(),
-            Value::String("awscc.ec2.security_group_egress.IpProtocol.all".to_string()),
+            Value::String("awscc.ec2.SecurityGroupEgress.IpProtocol.all".to_string()),
         );
 
         let mut current_states = HashMap::new();
@@ -438,7 +438,7 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_ip_protocol_all_alias() {
-        let mut resource = Resource::with_provider("awscc", "ec2.security_group_egress", "test");
+        let mut resource = Resource::with_provider("awscc", "ec2.SecurityGroupEgress", "test");
         resource.set_attr("ip_protocol".to_string(), Value::String("all".to_string()));
 
         let mut resources = vec![resource];
@@ -446,7 +446,7 @@ mod tests {
         match resources[0].get_attr("ip_protocol").unwrap() {
             Value::String(s) => {
                 assert_eq!(
-                    s, "awscc.ec2.security_group_egress.IpProtocol.all",
+                    s, "awscc.ec2.SecurityGroupEgress.IpProtocol.all",
                     "Expected namespaced IpProtocol.all, got: {}",
                     s
                 );
@@ -457,7 +457,7 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_ip_protocol_tcp() {
-        let mut resource = Resource::with_provider("awscc", "ec2.security_group_egress", "test");
+        let mut resource = Resource::with_provider("awscc", "ec2.SecurityGroupEgress", "test");
         resource.set_attr("ip_protocol".to_string(), Value::String("tcp".to_string()));
 
         let mut resources = vec![resource];
@@ -465,7 +465,7 @@ mod tests {
         match resources[0].get_attr("ip_protocol").unwrap() {
             Value::String(s) => {
                 assert_eq!(
-                    s, "awscc.ec2.security_group_egress.IpProtocol.tcp",
+                    s, "awscc.ec2.SecurityGroupEgress.IpProtocol.tcp",
                     "Expected namespaced IpProtocol.tcp, got: {}",
                     s
                 );
@@ -485,7 +485,7 @@ mod tests {
                     length: None,
                     base: Box::new(AttributeType::String),
                     validate: |_| Ok(()),
-                    namespace: Some("awscc.ec2.security_group".to_string()),
+                    namespace: Some("awscc.ec2.SecurityGroup".to_string()),
                     to_dsl: Some(|s: &str| match s {
                         "-1" => "all".to_string(),
                         _ => s.to_string(),
@@ -511,7 +511,7 @@ mod tests {
             if let Value::Map(m) = &items[0] {
                 match &m["ip_protocol"] {
                     Value::String(s) => {
-                        assert_eq!(s, "awscc.ec2.security_group.IpProtocol.all");
+                        assert_eq!(s, "awscc.ec2.SecurityGroup.IpProtocol.all");
                     }
                     other => panic!("Expected String, got: {:?}", other),
                 }
@@ -539,7 +539,7 @@ mod tests {
             if let Value::Map(m) = &items[0] {
                 match &m["ip_protocol"] {
                     Value::String(s) => {
-                        assert_eq!(s, "awscc.ec2.security_group.IpProtocol.tcp");
+                        assert_eq!(s, "awscc.ec2.SecurityGroup.IpProtocol.tcp");
                     }
                     other => panic!("Expected String, got: {:?}", other),
                 }
@@ -557,7 +557,7 @@ mod tests {
         let mut map = HashMap::new();
         map.insert(
             "ip_protocol".to_string(),
-            Value::String("awscc.ec2.security_group.IpProtocol.tcp".to_string()),
+            Value::String("awscc.ec2.SecurityGroup.IpProtocol.tcp".to_string()),
         );
         let value = Value::List(vec![Value::Map(map)]);
 
@@ -566,7 +566,7 @@ mod tests {
             if let Value::Map(m) = &items[0] {
                 match &m["ip_protocol"] {
                     Value::String(s) => {
-                        assert_eq!(s, "awscc.ec2.security_group.IpProtocol.tcp");
+                        assert_eq!(s, "awscc.ec2.SecurityGroup.IpProtocol.tcp");
                     }
                     other => panic!("Expected String, got: {:?}", other),
                 }
@@ -580,7 +580,7 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_impl_struct_field() {
-        let mut resource = Resource::with_provider("awscc", "ec2.security_group", "test-sg");
+        let mut resource = Resource::with_provider("awscc", "ec2.SecurityGroup", "test-sg");
         resource.set_attr(
             "group_description".to_string(),
             Value::String("test".to_string()),
@@ -604,7 +604,7 @@ mod tests {
                 match &m["ip_protocol"] {
                     Value::String(s) => {
                         assert_eq!(
-                            s, "awscc.ec2.security_group.IpProtocol.all",
+                            s, "awscc.ec2.SecurityGroup.IpProtocol.all",
                             "Expected namespaced IpProtocol.all in struct field, got: {}",
                             s
                         );
@@ -746,7 +746,7 @@ mod tests {
             AttributeType::list(AttributeType::StringEnum {
                 name: "EncryptionType".to_string(),
                 values: vec!["NONE".to_string(), "SSE-C".to_string()],
-                namespace: Some("awscc.s3.bucket".to_string()),
+                namespace: Some("awscc.s3.Bucket".to_string()),
                 to_dsl: Some(|s: &str| s.replace('-', "_")),
             }),
         )];
@@ -769,7 +769,7 @@ mod tests {
                         AttributeType::StringEnum {
                             name: "SseAlgorithm".to_string(),
                             values: vec!["AES256".to_string()],
-                            namespace: Some("awscc.s3.bucket".to_string()),
+                            namespace: Some("awscc.s3.Bucket".to_string()),
                             to_dsl: None,
                         },
                     )],
@@ -808,7 +808,7 @@ mod tests {
                     if let Value::List(types) = &blocked["encryption_type"] {
                         assert_eq!(
                             types[0],
-                            Value::String("awscc.s3.bucket.EncryptionType.SSE_C".to_string()),
+                            Value::String("awscc.s3.Bucket.EncryptionType.SSE_C".to_string()),
                             "Nested struct enum should be resolved to DSL format"
                         );
                     } else {
@@ -821,7 +821,7 @@ mod tests {
                 if let Value::Map(sse) = &m["server_side_encryption_by_default"] {
                     assert_eq!(
                         sse["sse_algorithm"],
-                        Value::String("awscc.s3.bucket.SseAlgorithm.AES256".to_string()),
+                        Value::String("awscc.s3.Bucket.SseAlgorithm.AES256".to_string()),
                         "Sibling struct enum should also be resolved"
                     );
                 } else {

--- a/carina-provider-awscc/src/provider/operations.rs
+++ b/carina-provider-awscc/src/provider/operations.rs
@@ -218,7 +218,7 @@ impl AwsccProvider {
         self.pre_delete_operations(id, config, identifier).await?;
 
         // Handle force_delete for S3 buckets: empty the bucket before deletion
-        if lifecycle.force_delete && id.resource_type == "s3.bucket" {
+        if lifecycle.force_delete && id.resource_type == "s3.Bucket" {
             self.empty_s3_bucket(identifier).await.map_err(|e| {
                 ProviderError::new("Failed to empty S3 bucket before deletion")
                     .with_cause(e)

--- a/carina-provider-awscc/src/provider/special_cases.rs
+++ b/carina-provider-awscc/src/provider/special_cases.rs
@@ -22,7 +22,7 @@ impl AwsccProvider {
         attributes: &mut HashMap<String, Value>,
     ) {
         match resource_type {
-            "ec2.internet_gateway" => {
+            "ec2.InternetGateway" => {
                 // Get VPC attachment
                 if let Some(attachments) = props.get("Attachments").and_then(|v| v.as_array())
                     && let Some(first) = attachments.first()
@@ -31,7 +31,7 @@ impl AwsccProvider {
                     attributes.insert("vpc_id".to_string(), Value::String(vpc_id.to_string()));
                 }
             }
-            "ec2.vpc_endpoint" => {
+            "ec2.VpcEndpoint" => {
                 // Handle route_table_ids list
                 if let Some(rt_ids) = props.get("RouteTableIds").and_then(|v| v.as_array()) {
                     let ids: Vec<Value> = rt_ids
@@ -61,7 +61,7 @@ impl AwsccProvider {
         resource_type: &str,
         desired_state: &mut serde_json::Map<String, serde_json::Value>,
     ) {
-        if resource_type == "ec2.eip" && !desired_state.contains_key("Domain") {
+        if resource_type == "ec2.Eip" && !desired_state.contains_key("Domain") {
             desired_state.insert("Domain".to_string(), json!("vpc"));
         }
     }
@@ -73,7 +73,7 @@ impl AwsccProvider {
         config: &AwsccSchemaConfig,
         identifier: &str,
     ) -> ProviderResult<()> {
-        if id.resource_type == "ec2.internet_gateway" {
+        if id.resource_type == "ec2.InternetGateway" {
             // Detach from VPC first
             if let Some(props) = self
                 .cc_get_resource(config.aws_type_name, identifier)

--- a/carina-provider-awscc/src/provider/update.rs
+++ b/carina-provider-awscc/src/provider/update.rs
@@ -129,7 +129,7 @@ mod tests {
     }
 
     fn get_vpc_config() -> &'static AwsccSchemaConfig {
-        get_schema_config("ec2.vpc").expect("ec2.vpc schema should exist")
+        get_schema_config("ec2.Vpc").expect("ec2.vpc schema should exist")
     }
 
     #[test]
@@ -164,7 +164,7 @@ mod tests {
     #[test]
     fn test_build_update_patches_remove_attribute_absent_in_to() {
         let config = get_vpc_config();
-        let id = ResourceId::with_provider("awscc", "ec2.vpc", "test");
+        let id = ResourceId::with_provider("awscc", "ec2.Vpc", "test");
 
         let mut from_attrs = HashMap::new();
         from_attrs.insert(
@@ -173,11 +173,11 @@ mod tests {
         );
         from_attrs.insert(
             "instance_tenancy".to_string(),
-            Value::String("awscc.ec2.vpc.InstanceTenancy.default".to_string()),
+            Value::String("awscc.ec2.Vpc.InstanceTenancy.default".to_string()),
         );
         let from = State::existing(id.clone(), from_attrs);
 
-        let mut to = Resource::new("ec2.vpc", "test");
+        let mut to = Resource::new("ec2.Vpc", "test");
         to.set_attr(
             "cidr_block".to_string(),
             Value::String("10.0.0.0/16".to_string()),
@@ -199,7 +199,7 @@ mod tests {
     #[test]
     fn test_build_update_patches_remove_tags_absent_in_to() {
         let config = get_vpc_config();
-        let id = ResourceId::with_provider("awscc", "ec2.vpc", "test");
+        let id = ResourceId::with_provider("awscc", "ec2.Vpc", "test");
 
         let mut from_attrs = HashMap::new();
         from_attrs.insert(
@@ -211,7 +211,7 @@ mod tests {
         from_attrs.insert("tags".to_string(), Value::Map(tags));
         let from = State::existing(id.clone(), from_attrs);
 
-        let mut to = Resource::new("ec2.vpc", "test");
+        let mut to = Resource::new("ec2.Vpc", "test");
         to.set_attr(
             "cidr_block".to_string(),
             Value::String("10.0.0.0/16".to_string()),
@@ -233,7 +233,7 @@ mod tests {
     #[test]
     fn test_build_update_patches_no_remove_for_required_attribute() {
         let config = get_vpc_config();
-        let id = ResourceId::with_provider("awscc", "ec2.vpc", "test");
+        let id = ResourceId::with_provider("awscc", "ec2.Vpc", "test");
 
         let mut from_attrs = HashMap::new();
         from_attrs.insert(
@@ -242,7 +242,7 @@ mod tests {
         );
         let from = State::existing(id.clone(), from_attrs);
 
-        let to = Resource::new("ec2.vpc", "test");
+        let to = Resource::new("ec2.Vpc", "test");
 
         let patches = build_update_patches(config, &from, &to);
 
@@ -260,7 +260,7 @@ mod tests {
     #[test]
     fn test_build_update_patches_no_remove_when_both_present() {
         let config = get_vpc_config();
-        let id = ResourceId::with_provider("awscc", "ec2.vpc", "test");
+        let id = ResourceId::with_provider("awscc", "ec2.Vpc", "test");
 
         let mut from_attrs = HashMap::new();
         from_attrs.insert(
@@ -269,18 +269,18 @@ mod tests {
         );
         from_attrs.insert(
             "instance_tenancy".to_string(),
-            Value::String("awscc.ec2.vpc.InstanceTenancy.default".to_string()),
+            Value::String("awscc.ec2.Vpc.InstanceTenancy.default".to_string()),
         );
         let from = State::existing(id.clone(), from_attrs);
 
-        let mut to = Resource::new("ec2.vpc", "test");
+        let mut to = Resource::new("ec2.Vpc", "test");
         to.set_attr(
             "cidr_block".to_string(),
             Value::String("10.0.0.0/16".to_string()),
         );
         to.set_attr(
             "instance_tenancy".to_string(),
-            Value::String("awscc.ec2.vpc.InstanceTenancy.dedicated".to_string()),
+            Value::String("awscc.ec2.Vpc.InstanceTenancy.dedicated".to_string()),
         );
 
         let patches = build_update_patches(config, &from, &to);
@@ -298,7 +298,7 @@ mod tests {
     #[test]
     fn test_build_update_patches_skip_unchanged_attributes() {
         let config = get_vpc_config();
-        let id = ResourceId::with_provider("awscc", "ec2.vpc", "test");
+        let id = ResourceId::with_provider("awscc", "ec2.Vpc", "test");
 
         let mut from_attrs = HashMap::new();
         from_attrs.insert(
@@ -307,18 +307,18 @@ mod tests {
         );
         from_attrs.insert(
             "instance_tenancy".to_string(),
-            Value::String("awscc.ec2.vpc.InstanceTenancy.default".to_string()),
+            Value::String("awscc.ec2.Vpc.InstanceTenancy.default".to_string()),
         );
         let from = State::existing(id.clone(), from_attrs);
 
-        let mut to = Resource::new("ec2.vpc", "test");
+        let mut to = Resource::new("ec2.Vpc", "test");
         to.set_attr(
             "cidr_block".to_string(),
             Value::String("10.0.0.0/16".to_string()),
         );
         to.set_attr(
             "instance_tenancy".to_string(),
-            Value::String("awscc.ec2.vpc.InstanceTenancy.dedicated".to_string()),
+            Value::String("awscc.ec2.Vpc.InstanceTenancy.dedicated".to_string()),
         );
 
         let patches = build_update_patches(config, &from, &to);
@@ -347,7 +347,7 @@ mod tests {
     #[test]
     fn test_build_update_patches_no_patches_when_identical() {
         let config = get_vpc_config();
-        let id = ResourceId::with_provider("awscc", "ec2.vpc", "test");
+        let id = ResourceId::with_provider("awscc", "ec2.Vpc", "test");
 
         let mut from_attrs = HashMap::new();
         from_attrs.insert(
@@ -356,7 +356,7 @@ mod tests {
         );
         let from = State::existing(id.clone(), from_attrs);
 
-        let mut to = Resource::new("ec2.vpc", "test");
+        let mut to = Resource::new("ec2.Vpc", "test");
         to.set_attr(
             "cidr_block".to_string(),
             Value::String("10.0.0.0/16".to_string()),
@@ -374,7 +374,7 @@ mod tests {
     #[test]
     fn test_build_update_patches_skip_unchanged_tags() {
         let config = get_vpc_config();
-        let id = ResourceId::with_provider("awscc", "ec2.vpc", "test");
+        let id = ResourceId::with_provider("awscc", "ec2.Vpc", "test");
 
         let mut from_attrs = HashMap::new();
         from_attrs.insert(
@@ -386,7 +386,7 @@ mod tests {
         from_attrs.insert("tags".to_string(), Value::Map(tags.clone()));
         let from = State::existing(id.clone(), from_attrs);
 
-        let mut to = Resource::new("ec2.vpc", "test");
+        let mut to = Resource::new("ec2.Vpc", "test");
         to.set_attr(
             "cidr_block".to_string(),
             Value::String("10.0.0.0/16".to_string()),
@@ -408,7 +408,7 @@ mod tests {
         // while "replace" fails if the property doesn't exist in the model.
         // Using "add" is more robust and matches the AWS AWSCC Terraform provider behavior.
         let config = get_vpc_config();
-        let id = ResourceId::with_provider("awscc", "ec2.vpc", "test");
+        let id = ResourceId::with_provider("awscc", "ec2.Vpc", "test");
 
         let mut from_attrs = HashMap::new();
         from_attrs.insert(
@@ -417,18 +417,18 @@ mod tests {
         );
         from_attrs.insert(
             "instance_tenancy".to_string(),
-            Value::String("awscc.ec2.vpc.InstanceTenancy.default".to_string()),
+            Value::String("awscc.ec2.Vpc.InstanceTenancy.default".to_string()),
         );
         let from = State::existing(id.clone(), from_attrs);
 
-        let mut to = Resource::new("ec2.vpc", "test");
+        let mut to = Resource::new("ec2.Vpc", "test");
         to.set_attr(
             "cidr_block".to_string(),
             Value::String("10.0.0.0/16".to_string()),
         );
         to.set_attr(
             "instance_tenancy".to_string(),
-            Value::String("awscc.ec2.vpc.InstanceTenancy.dedicated".to_string()),
+            Value::String("awscc.ec2.Vpc.InstanceTenancy.dedicated".to_string()),
         );
 
         let patches = build_update_patches(config, &from, &to);
@@ -452,8 +452,8 @@ mod tests {
         // because "replace" op fails when the property path doesn't exist in
         // the CloudControl model.
         let config =
-            get_schema_config("logs.log_group").expect("logs.log_group schema should exist");
-        let id = ResourceId::with_provider("awscc", "logs.log_group", "test");
+            get_schema_config("logs.LogGroup").expect("logs.log_group schema should exist");
+        let id = ResourceId::with_provider("awscc", "logs.LogGroup", "test");
 
         let mut from_attrs = HashMap::new();
         from_attrs.insert("retention_in_days".to_string(), Value::Int(7));
@@ -463,7 +463,7 @@ mod tests {
         );
         let from = State::existing(id.clone(), from_attrs);
 
-        let mut to = Resource::new("logs.log_group", "test");
+        let mut to = Resource::new("logs.LogGroup", "test");
         to.set_attr("retention_in_days".to_string(), Value::Int(14));
         to.set_attr(
             "log_group_name".to_string(),
@@ -496,8 +496,8 @@ mod tests {
         // Regression test for issue #806: update patch includes readOnly property Arn
         // CloudFormation rejects patches that include read-only properties like Arn.
         let config =
-            get_schema_config("logs.log_group").expect("logs.log_group schema should exist");
-        let id = ResourceId::with_provider("awscc", "logs.log_group", "test");
+            get_schema_config("logs.LogGroup").expect("logs.log_group schema should exist");
+        let id = ResourceId::with_provider("awscc", "logs.LogGroup", "test");
 
         let mut from_attrs = HashMap::new();
         from_attrs.insert("retention_in_days".to_string(), Value::Int(7));
@@ -515,7 +515,7 @@ mod tests {
         );
         let from = State::existing(id.clone(), from_attrs);
 
-        let mut to = Resource::new("logs.log_group", "test");
+        let mut to = Resource::new("logs.LogGroup", "test");
         to.set_attr("retention_in_days".to_string(), Value::Int(14));
         to.set_attr(
             "log_group_name".to_string(),
@@ -551,8 +551,8 @@ mod tests {
         // When DnsOptions has nested create-only sub-properties (PrivateDnsPreference,
         // PrivateDnsSpecifiedDomains), the whole DnsOptions should be excluded from patches.
         let config =
-            get_schema_config("ec2.vpc_endpoint").expect("ec2.vpc_endpoint schema should exist");
-        let id = ResourceId::with_provider("awscc", "ec2.vpc_endpoint", "test");
+            get_schema_config("ec2.VpcEndpoint").expect("ec2.vpc_endpoint schema should exist");
+        let id = ResourceId::with_provider("awscc", "ec2.VpcEndpoint", "test");
 
         let mut from_attrs = HashMap::new();
         from_attrs.insert("vpc_id".to_string(), Value::String("vpc-123".to_string()));
@@ -568,13 +568,13 @@ mod tests {
         let mut dns_options = HashMap::new();
         dns_options.insert(
             "dns_record_ip_type".to_string(),
-            Value::String("awscc.ec2.vpc_endpoint.DnsRecordIpType.ipv4".to_string()),
+            Value::String("awscc.ec2.VpcEndpoint.DnsRecordIpType.ipv4".to_string()),
         );
         from_attrs.insert("dns_options".to_string(), Value::Map(dns_options));
         let from = State::existing(id.clone(), from_attrs);
 
         // User only specifies policy_document change, no dns_options
-        let mut to = Resource::new("ec2.vpc_endpoint", "test");
+        let mut to = Resource::new("ec2.VpcEndpoint", "test");
         to.set_attr("vpc_id".to_string(), Value::String("vpc-123".to_string()));
         to.set_attr(
             "service_name".to_string(),

--- a/carina-provider-awscc/src/resources.rs
+++ b/carina-provider-awscc/src/resources.rs
@@ -11,23 +11,23 @@ mod tests {
 
     #[test]
     fn test_get_schema_config() {
-        assert!(get_config("ec2.vpc").is_some());
-        assert!(get_config("ec2.subnet").is_some());
+        assert!(get_config("ec2.Vpc").is_some());
+        assert!(get_config("ec2.Subnet").is_some());
         assert!(get_config("unknown").is_none());
     }
 
     #[test]
     fn test_schema_config_aws_type() {
         assert_eq!(
-            get_config("ec2.vpc").unwrap().aws_type_name,
+            get_config("ec2.Vpc").unwrap().aws_type_name,
             "AWS::EC2::VPC"
         );
         assert_eq!(
-            get_config("ec2.subnet").unwrap().aws_type_name,
+            get_config("ec2.Subnet").unwrap().aws_type_name,
             "AWS::EC2::Subnet"
         );
         assert_eq!(
-            get_config("ec2.security_group_ingress")
+            get_config("ec2.SecurityGroupIngress")
                 .unwrap()
                 .aws_type_name,
             "AWS::EC2::SecurityGroupIngress"
@@ -36,15 +36,15 @@ mod tests {
 
     #[test]
     fn test_schema_config_has_tags() {
-        assert!(get_config("ec2.vpc").unwrap().has_tags);
-        assert!(get_config("ec2.subnet").unwrap().has_tags);
-        assert!(!get_config("ec2.route").unwrap().has_tags);
-        assert!(!get_config("ec2.vpc_gateway_attachment").unwrap().has_tags);
+        assert!(get_config("ec2.Vpc").unwrap().has_tags);
+        assert!(get_config("ec2.Subnet").unwrap().has_tags);
+        assert!(!get_config("ec2.Route").unwrap().has_tags);
+        assert!(!get_config("ec2.VpcGatewayAttachment").unwrap().has_tags);
     }
 
     #[test]
     fn test_schema_config_provider_name() {
-        let vpc_config = get_config("ec2.vpc").unwrap();
+        let vpc_config = get_config("ec2.Vpc").unwrap();
         let cidr_attr = vpc_config.schema.attributes.get("cidr_block").unwrap();
         assert_eq!(cidr_attr.provider_name.as_deref(), Some("CidrBlock"));
         let vpc_id_attr = vpc_config.schema.attributes.get("vpc_id").unwrap();
@@ -124,8 +124,7 @@ mod tests {
 
     #[test]
     fn test_iam_oidc_provider_config() {
-        let config =
-            get_config("iam.oidc_provider").expect("iam.oidc_provider config should exist");
+        let config = get_config("iam.OidcProvider").expect("iam.oidc_provider config should exist");
         assert_eq!(config.aws_type_name, "AWS::IAM::OIDCProvider");
         assert!(config.has_tags, "OIDCProvider should support tags");
     }
@@ -138,7 +137,7 @@ mod tests {
         use carina_core::resource::Value;
         use std::collections::HashMap;
 
-        let config = get_config("ec2.vpc_gateway_attachment").unwrap();
+        let config = get_config("ec2.VpcGatewayAttachment").unwrap();
         let schema = &config.schema;
 
         // Providing both internet_gateway_id and vpn_gateway_id should fail validation
@@ -180,7 +179,7 @@ mod tests {
         use carina_core::resource::Value;
         use std::collections::HashMap;
 
-        let config = get_config("ec2.vpc_gateway_attachment").unwrap();
+        let config = get_config("ec2.VpcGatewayAttachment").unwrap();
         let schema = &config.schema;
 
         // Only internet_gateway_id - should pass
@@ -221,7 +220,7 @@ mod tests {
         use carina_core::resource::Value;
         use std::collections::HashMap;
 
-        let config = get_config("ec2.vpc_gateway_attachment").unwrap();
+        let config = get_config("ec2.VpcGatewayAttachment").unwrap();
         let schema = &config.schema;
 
         // Neither gateway specified - should fail

--- a/carina-provider-awscc/src/schemas/awscc_types.rs
+++ b/carina-provider-awscc/src/schemas/awscc_types.rs
@@ -20,7 +20,7 @@ use carina_core::utils::{extract_enum_value, validate_enum_namespace};
 pub struct AwsccSchemaConfig {
     /// AWS CloudFormation type name (e.g., "AWS::EC2::VPC")
     pub aws_type_name: &'static str,
-    /// Resource type name used in DSL (e.g., "ec2.vpc")
+    /// Resource type name used in DSL (e.g., "ec2.Vpc")
     pub resource_type_name: &'static str,
     /// Whether this resource type uses tags
     pub has_tags: bool,
@@ -268,9 +268,9 @@ mod tests {
     #[test]
     fn validate_namespaced_enum_basic() {
         let result = validate_namespaced_enum(
-            &Value::String("awscc.ec2.vpc.InstanceTenancy.default".to_string()),
+            &Value::String("awscc.ec2.Vpc.InstanceTenancy.default".to_string()),
             "InstanceTenancy",
-            "awscc.ec2.vpc",
+            "awscc.ec2.Vpc",
             &["default", "dedicated", "host"],
         );
         assert!(result.is_ok());

--- a/carina-provider-awscc/src/schemas/generated/ec2/egress_only_internet_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/egress_only_internet_gateway.rs
@@ -13,9 +13,9 @@ use carina_core::schema::{AttributeSchema, ResourceSchema};
 pub fn ec2_egress_only_internet_gateway_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::EC2::EgressOnlyInternetGateway",
-        resource_type_name: "ec2.egress_only_internet_gateway",
+        resource_type_name: "ec2.EgressOnlyInternetGateway",
         has_tags: true,
-        schema: ResourceSchema::new("awscc.ec2.egress_only_internet_gateway")
+        schema: ResourceSchema::new("awscc.ec2.EgressOnlyInternetGateway")
             .with_description("Resource Type definition for AWS::EC2::EgressOnlyInternetGateway")
             .attribute(
                 AttributeSchema::new("id", super::egress_only_internet_gateway_id())
@@ -58,7 +58,7 @@ pub fn enum_valid_values() -> (
     &'static str,
     &'static [(&'static str, &'static [&'static str])],
 ) {
-    ("ec2.egress_only_internet_gateway", &[])
+    ("ec2.EgressOnlyInternetGateway", &[])
 }
 
 /// Maps DSL alias values back to canonical AWS values for this module.

--- a/carina-provider-awscc/src/schemas/generated/ec2/eip.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/eip.rs
@@ -15,9 +15,9 @@ const VALID_DOMAIN: &[&str] = &["vpc", "standard"];
 pub fn ec2_eip_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::EC2::EIP",
-        resource_type_name: "ec2.eip",
+        resource_type_name: "ec2.Eip",
         has_tags: true,
-        schema: ResourceSchema::new("awscc.ec2.eip")
+        schema: ResourceSchema::new("awscc.ec2.Eip")
         .with_description("Specifies an Elastic IP (EIP) address and can, optionally, associate it with an Amazon EC2 instance.  You can allocate an Elastic IP address from an address pool owned by AWS or from an address pool created from a public IPv4 address range that you have brought to AWS for use with your AWS resources using bring your own IP addresses (BYOIP). For more information, see [Bring Your Own IP Addresses (BYOIP)](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-byoip.html) in the *Amazon EC2 User Guide*.  For more information, see [Elastic IP Addresses](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-ip-addresses-eip.html) in the *Amazon EC2 User Guide*.")
         .attribute(
             AttributeSchema::new("address", types::ipv4_address())
@@ -36,7 +36,7 @@ pub fn ec2_eip_config() -> AwsccSchemaConfig {
             AttributeSchema::new("domain", AttributeType::StringEnum {
                 name: "Domain".to_string(),
                 values: vec!["vpc".to_string(), "standard".to_string()],
-                namespace: Some("awscc.ec2.eip".to_string()),
+                namespace: Some("awscc.ec2.Eip".to_string()),
                 to_dsl: None,
             })
                 .with_description("The network (``vpc``). If you define an Elastic IP address and associate it with a VPC that is defined in the same template, you must declare a dependency on the VPC-gateway attachment by using the [DependsOn Attribute](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html) on this resource.")
@@ -98,7 +98,7 @@ pub fn enum_valid_values() -> (
     &'static str,
     &'static [(&'static str, &'static [&'static str])],
 ) {
-    ("ec2.eip", &[("domain", VALID_DOMAIN)])
+    ("ec2.Eip", &[("domain", VALID_DOMAIN)])
 }
 
 /// Maps DSL alias values back to canonical AWS values for this module.

--- a/carina-provider-awscc/src/schemas/generated/ec2/flow_log.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/flow_log.rs
@@ -41,9 +41,9 @@ fn validate_max_aggregation_interval_int_enum(value: &Value) -> Result<(), Strin
 pub fn ec2_flow_log_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::EC2::FlowLog",
-        resource_type_name: "ec2.flow_log",
+        resource_type_name: "ec2.FlowLog",
         has_tags: true,
-        schema: ResourceSchema::new("awscc.ec2.flow_log")
+        schema: ResourceSchema::new("awscc.ec2.FlowLog")
         .with_description("Specifies a VPC flow log, which enables you to capture IP traffic for a specific network interface, subnet, or VPC.")
         .attribute(
             AttributeSchema::new("deliver_cross_account_role", super::iam_role_arn())
@@ -64,7 +64,7 @@ pub fn ec2_flow_log_config() -> AwsccSchemaConfig {
                     StructField::new("file_format", AttributeType::StringEnum {
                 name: "FileFormat".to_string(),
                 values: vec!["plain-text".to_string(), "parquet".to_string()],
-                namespace: Some("awscc.ec2.flow_log".to_string()),
+                namespace: Some("awscc.ec2.FlowLog".to_string()),
                 to_dsl: Some(|s: &str| s.replace('-', "_")),
             }).required().with_provider_name("FileFormat"),
                     StructField::new("hive_compatible_partitions", AttributeType::Bool).required().with_provider_name("HiveCompatiblePartitions"),
@@ -90,7 +90,7 @@ pub fn ec2_flow_log_config() -> AwsccSchemaConfig {
             AttributeSchema::new("log_destination_type", AttributeType::StringEnum {
                 name: "LogDestinationType".to_string(),
                 values: vec!["cloud-watch-logs".to_string(), "s3".to_string(), "kinesis-data-firehose".to_string()],
-                namespace: Some("awscc.ec2.flow_log".to_string()),
+                namespace: Some("awscc.ec2.FlowLog".to_string()),
                 to_dsl: Some(|s: &str| s.replace('-', "_")),
             })
                 .create_only()
@@ -134,7 +134,7 @@ pub fn ec2_flow_log_config() -> AwsccSchemaConfig {
             AttributeSchema::new("resource_type", AttributeType::StringEnum {
                 name: "ResourceType".to_string(),
                 values: vec!["NetworkInterface".to_string(), "Subnet".to_string(), "VPC".to_string(), "TransitGateway".to_string(), "TransitGatewayAttachment".to_string(), "RegionalNatGateway".to_string()],
-                namespace: Some("awscc.ec2.flow_log".to_string()),
+                namespace: Some("awscc.ec2.FlowLog".to_string()),
                 to_dsl: None,
             })
                 .required()
@@ -151,7 +151,7 @@ pub fn ec2_flow_log_config() -> AwsccSchemaConfig {
             AttributeSchema::new("traffic_type", AttributeType::StringEnum {
                 name: "TrafficType".to_string(),
                 values: vec!["ACCEPT".to_string(), "ALL".to_string(), "REJECT".to_string()],
-                namespace: Some("awscc.ec2.flow_log".to_string()),
+                namespace: Some("awscc.ec2.FlowLog".to_string()),
                 to_dsl: None,
             })
                 .create_only()
@@ -174,7 +174,7 @@ pub fn enum_valid_values() -> (
     &'static [(&'static str, &'static [&'static str])],
 ) {
     (
-        "ec2.flow_log",
+        "ec2.FlowLog",
         &[
             ("log_destination_type", VALID_LOG_DESTINATION_TYPE),
             ("resource_type", VALID_RESOURCE_TYPE),
@@ -189,6 +189,15 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     match (attr_name, value) {
         ("log_destination_type", "cloud_watch_logs") => Some("cloud-watch-logs"),
         ("log_destination_type", "kinesis_data_firehose") => Some("kinesis-data-firehose"),
+        ("resource_type", "network_interface") => Some("NetworkInterface"),
+        ("resource_type", "subnet") => Some("Subnet"),
+        ("resource_type", "vpc") => Some("VPC"),
+        ("resource_type", "transit_gateway") => Some("TransitGateway"),
+        ("resource_type", "transit_gateway_attachment") => Some("TransitGatewayAttachment"),
+        ("resource_type", "regional_nat_gateway") => Some("RegionalNatGateway"),
+        ("traffic_type", "accept") => Some("ACCEPT"),
+        ("traffic_type", "all") => Some("ALL"),
+        ("traffic_type", "reject") => Some("REJECT"),
         _ => None,
     }
 }
@@ -206,5 +215,22 @@ pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static s
             "kinesis_data_firehose",
             "kinesis-data-firehose",
         ),
+        ("resource_type", "network_interface", "NetworkInterface"),
+        ("resource_type", "subnet", "Subnet"),
+        ("resource_type", "vpc", "VPC"),
+        ("resource_type", "transit_gateway", "TransitGateway"),
+        (
+            "resource_type",
+            "transit_gateway_attachment",
+            "TransitGatewayAttachment",
+        ),
+        (
+            "resource_type",
+            "regional_nat_gateway",
+            "RegionalNatGateway",
+        ),
+        ("traffic_type", "accept", "ACCEPT"),
+        ("traffic_type", "all", "ALL"),
+        ("traffic_type", "reject", "REJECT"),
     ]
 }

--- a/carina-provider-awscc/src/schemas/generated/ec2/internet_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/internet_gateway.rs
@@ -13,9 +13,9 @@ use carina_core::schema::{AttributeSchema, ResourceSchema};
 pub fn ec2_internet_gateway_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::EC2::InternetGateway",
-        resource_type_name: "ec2.internet_gateway",
+        resource_type_name: "ec2.InternetGateway",
         has_tags: true,
-        schema: ResourceSchema::new("awscc.ec2.internet_gateway")
+        schema: ResourceSchema::new("awscc.ec2.InternetGateway")
         .with_description("Allocates an internet gateway for use with a VPC. After creating the Internet gateway, you then attach it to a VPC.")
         .attribute(
             AttributeSchema::new("internet_gateway_id", super::internet_gateway_id())
@@ -44,7 +44,7 @@ pub fn enum_valid_values() -> (
     &'static str,
     &'static [(&'static str, &'static [&'static str])],
 ) {
-    ("ec2.internet_gateway", &[])
+    ("ec2.InternetGateway", &[])
 }
 
 /// Maps DSL alias values back to canonical AWS values for this module.

--- a/carina-provider-awscc/src/schemas/generated/ec2/ipam.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/ipam.rs
@@ -46,9 +46,9 @@ fn validate_string_length_max_255(value: &Value) -> Result<(), String> {
 pub fn ec2_ipam_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::EC2::IPAM",
-        resource_type_name: "ec2.ipam",
+        resource_type_name: "ec2.Ipam",
         has_tags: true,
-        schema: ResourceSchema::new("awscc.ec2.ipam")
+        schema: ResourceSchema::new("awscc.ec2.Ipam")
         .with_description("Resource Schema of AWS::EC2::IPAM Type")
         .attribute(
             AttributeSchema::new("arn", super::arn())
@@ -106,7 +106,7 @@ pub fn ec2_ipam_config() -> AwsccSchemaConfig {
             AttributeSchema::new("metered_account", AttributeType::StringEnum {
                 name: "MeteredAccount".to_string(),
                 values: vec!["ipam-owner".to_string(), "resource-owner".to_string()],
-                namespace: Some("awscc.ec2.ipam".to_string()),
+                namespace: Some("awscc.ec2.Ipam".to_string()),
                 to_dsl: Some(|s: &str| s.replace('-', "_")),
             })
                 .with_description("A metered account is an account that is charged for active IP addresses managed in IPAM")
@@ -164,7 +164,7 @@ pub fn ec2_ipam_config() -> AwsccSchemaConfig {
             AttributeSchema::new("tier", AttributeType::StringEnum {
                 name: "Tier".to_string(),
                 values: vec!["free".to_string(), "advanced".to_string()],
-                namespace: Some("awscc.ec2.ipam".to_string()),
+                namespace: Some("awscc.ec2.Ipam".to_string()),
                 to_dsl: None,
             })
                 .with_description("The tier of the IPAM.")
@@ -193,7 +193,7 @@ pub fn enum_valid_values() -> (
     &'static [(&'static str, &'static [&'static str])],
 ) {
     (
-        "ec2.ipam",
+        "ec2.Ipam",
         &[
             ("metered_account", VALID_METERED_ACCOUNT),
             ("tier", VALID_TIER),

--- a/carina-provider-awscc/src/schemas/generated/ec2/ipam_pool.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/ipam_pool.rs
@@ -32,15 +32,15 @@ const VALID_STATE: &[&str] = &[
 pub fn ec2_ipam_pool_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::EC2::IPAMPool",
-        resource_type_name: "ec2.ipam_pool",
+        resource_type_name: "ec2.IpamPool",
         has_tags: true,
-        schema: ResourceSchema::new("awscc.ec2.ipam_pool")
+        schema: ResourceSchema::new("awscc.ec2.IpamPool")
         .with_description("Resource Schema of AWS::EC2::IPAMPool Type")
         .attribute(
             AttributeSchema::new("address_family", AttributeType::StringEnum {
                 name: "AddressFamily".to_string(),
                 values: vec!["IPv4".to_string(), "IPv6".to_string()],
-                namespace: Some("awscc.ec2.ipam_pool".to_string()),
+                namespace: Some("awscc.ec2.IpamPool".to_string()),
                 to_dsl: None,
             })
                 .required()
@@ -83,7 +83,7 @@ pub fn ec2_ipam_pool_config() -> AwsccSchemaConfig {
             AttributeSchema::new("aws_service", AttributeType::StringEnum {
                 name: "AwsService".to_string(),
                 values: vec!["ec2".to_string(), "global-services".to_string()],
-                namespace: Some("awscc.ec2.ipam_pool".to_string()),
+                namespace: Some("awscc.ec2.IpamPool".to_string()),
                 to_dsl: Some(|s: &str| s.replace('-', "_")),
             })
                 .create_only()
@@ -123,7 +123,7 @@ pub fn ec2_ipam_pool_config() -> AwsccSchemaConfig {
             AttributeSchema::new("ipam_scope_type", AttributeType::StringEnum {
                 name: "IpamScopeType".to_string(),
                 values: vec!["public".to_string(), "private".to_string()],
-                namespace: Some("awscc.ec2.ipam_pool".to_string()),
+                namespace: Some("awscc.ec2.IpamPool".to_string()),
                 to_dsl: None,
             })
                 .read_only()
@@ -157,7 +157,7 @@ pub fn ec2_ipam_pool_config() -> AwsccSchemaConfig {
             AttributeSchema::new("public_ip_source", AttributeType::StringEnum {
                 name: "PublicIpSource".to_string(),
                 values: vec!["byoip".to_string(), "amazon".to_string()],
-                namespace: Some("awscc.ec2.ipam_pool".to_string()),
+                namespace: Some("awscc.ec2.IpamPool".to_string()),
                 to_dsl: None,
             })
                 .create_only()
@@ -193,7 +193,7 @@ pub fn ec2_ipam_pool_config() -> AwsccSchemaConfig {
             AttributeSchema::new("state", AttributeType::StringEnum {
                 name: "State".to_string(),
                 values: vec!["create-in-progress".to_string(), "create-complete".to_string(), "modify-in-progress".to_string(), "modify-complete".to_string(), "delete-in-progress".to_string(), "delete-complete".to_string()],
-                namespace: Some("awscc.ec2.ipam_pool".to_string()),
+                namespace: Some("awscc.ec2.IpamPool".to_string()),
                 to_dsl: Some(|s: &str| s.replace('-', "_")),
             })
                 .read_only()
@@ -233,7 +233,7 @@ pub fn enum_valid_values() -> (
     &'static [(&'static str, &'static [&'static str])],
 ) {
     (
-        "ec2.ipam_pool",
+        "ec2.IpamPool",
         &[
             ("address_family", VALID_ADDRESS_FAMILY),
             ("aws_service", VALID_AWS_SERVICE),
@@ -248,6 +248,8 @@ pub fn enum_valid_values() -> (
 /// e.g., ("ip_protocol", "all") -> Some("-1")
 pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
     match (attr_name, value) {
+        ("address_family", "i_pv4") => Some("IPv4"),
+        ("address_family", "i_pv6") => Some("IPv6"),
         ("aws_service", "global_services") => Some("global-services"),
         ("state", "create_in_progress") => Some("create-in-progress"),
         ("state", "create_complete") => Some("create-complete"),
@@ -262,6 +264,8 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
 /// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
 pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
     &[
+        ("address_family", "i_pv4", "IPv4"),
+        ("address_family", "i_pv6", "IPv6"),
         ("aws_service", "global_services", "global-services"),
         ("state", "create_in_progress", "create-in-progress"),
         ("state", "create_complete", "create-complete"),

--- a/carina-provider-awscc/src/schemas/generated/ec2/nat_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/nat_gateway.rs
@@ -32,9 +32,9 @@ fn validate_secondary_private_ip_address_count_range(value: &Value) -> Result<()
 pub fn ec2_nat_gateway_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::EC2::NatGateway",
-        resource_type_name: "ec2.nat_gateway",
+        resource_type_name: "ec2.NatGateway",
         has_tags: true,
-        schema: ResourceSchema::new("awscc.ec2.nat_gateway")
+        schema: ResourceSchema::new("awscc.ec2.NatGateway")
         .with_description("Specifies a network address translation (NAT) gateway in the specified subnet. You can create either a public NAT gateway or a private NAT gateway. The default is a public NAT gateway. If you create a public NAT gateway, you must specify an elastic IP address.  With a NAT gateway, instances in a private subnet can connect to the internet, other AWS services, or an on-premises network using the IP address of the NAT gateway. For more information, see [NAT gateways](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-nat-gateway.html) in the *Amazon VPC User Guide*.  If you add a default route (``AWS::EC2::Route`` resource) that points to a NAT gateway, specify the NAT gateway ID for the route's ``NatGatewayId`` property.   When you associate an Elastic IP address or secondary Elastic IP address with a public NAT gateway, the network border group of the Elastic IP address must match the network border group of the Availability Zone (AZ) that the public NAT gateway is in. Otherwise, the NAT gateway fails to launch. You can see the network border group for the AZ by viewing the details of the subnet. Similarly, you can view the network border group for the Elastic IP address by viewing its details. For more information, see [Allocate an Elastic IP address](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-eips.html#allocate-eip) in the *Amazon VPC User Guide*.")
         .attribute(
             AttributeSchema::new("allocation_id", super::allocation_id())
@@ -58,7 +58,7 @@ pub fn ec2_nat_gateway_config() -> AwsccSchemaConfig {
             AttributeSchema::new("availability_mode", AttributeType::StringEnum {
                 name: "AvailabilityMode".to_string(),
                 values: vec!["zonal".to_string(), "regional".to_string()],
-                namespace: Some("awscc.ec2.nat_gateway".to_string()),
+                namespace: Some("awscc.ec2.NatGateway".to_string()),
                 to_dsl: None,
             })
                 .create_only()
@@ -82,7 +82,7 @@ pub fn ec2_nat_gateway_config() -> AwsccSchemaConfig {
             AttributeSchema::new("connectivity_type", AttributeType::StringEnum {
                 name: "ConnectivityType".to_string(),
                 values: vec!["public".to_string(), "private".to_string()],
-                namespace: Some("awscc.ec2.nat_gateway".to_string()),
+                namespace: Some("awscc.ec2.NatGateway".to_string()),
                 to_dsl: None,
             })
                 .create_only()
@@ -181,7 +181,7 @@ pub fn enum_valid_values() -> (
     &'static [(&'static str, &'static [&'static str])],
 ) {
     (
-        "ec2.nat_gateway",
+        "ec2.NatGateway",
         &[
             ("availability_mode", VALID_AVAILABILITY_MODE),
             ("connectivity_type", VALID_CONNECTIVITY_TYPE),

--- a/carina-provider-awscc/src/schemas/generated/ec2/route.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/route.rs
@@ -11,9 +11,9 @@ use carina_core::schema::{AttributeSchema, ResourceSchema, types};
 pub fn ec2_route_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::EC2::Route",
-        resource_type_name: "ec2.route",
+        resource_type_name: "ec2.Route",
         has_tags: false,
-        schema: ResourceSchema::new("awscc.ec2.route")
+        schema: ResourceSchema::new("awscc.ec2.Route")
         .with_description("Specifies a route in a route table. For more information, see [Routes](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Route_Tables.html#route-table-routes) in the *Amazon VPC User Guide*.  You must specify either a destination CIDR block or prefix list ID. You must also specify exactly one of the resources as the target.  If you create a route that references a transit gateway in the same template where you create the transit gateway, you must declare a dependency on the transit gateway attachment. The route table cannot use the transit gateway until it has successfully attached to the VPC. Add a [DependsOn Attribute](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html) in the ``AWS::EC2::Route`` resource to explicitly declare a dependency on the ``AWS::EC2::TransitGatewayAttachment`` resource.")
         .attribute(
             AttributeSchema::new("carrier_gateway_id", super::carrier_gateway_id())
@@ -109,7 +109,7 @@ pub fn enum_valid_values() -> (
     &'static str,
     &'static [(&'static str, &'static [&'static str])],
 ) {
-    ("ec2.route", &[])
+    ("ec2.Route", &[])
 }
 
 /// Maps DSL alias values back to canonical AWS values for this module.

--- a/carina-provider-awscc/src/schemas/generated/ec2/route_table.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/route_table.rs
@@ -13,9 +13,9 @@ use carina_core::schema::{AttributeSchema, ResourceSchema};
 pub fn ec2_route_table_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::EC2::RouteTable",
-        resource_type_name: "ec2.route_table",
+        resource_type_name: "ec2.RouteTable",
         has_tags: true,
-        schema: ResourceSchema::new("awscc.ec2.route_table")
+        schema: ResourceSchema::new("awscc.ec2.RouteTable")
         .with_description("Specifies a route table for the specified VPC. After you create a route table, you can add routes and associate the table with a subnet.  For more information, see [Route tables](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Route_Tables.html) in the *Amazon VPC User Guide*.")
         .attribute(
             AttributeSchema::new("route_table_id", super::route_table_id())
@@ -50,7 +50,7 @@ pub fn enum_valid_values() -> (
     &'static str,
     &'static [(&'static str, &'static [&'static str])],
 ) {
-    ("ec2.route_table", &[])
+    ("ec2.RouteTable", &[])
 }
 
 /// Maps DSL alias values back to canonical AWS values for this module.

--- a/carina-provider-awscc/src/schemas/generated/ec2/security_group.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/security_group.rs
@@ -42,9 +42,9 @@ fn validate_to_port_range(value: &Value) -> Result<(), String> {
 pub fn ec2_security_group_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::EC2::SecurityGroup",
-        resource_type_name: "ec2.security_group",
+        resource_type_name: "ec2.SecurityGroup",
         has_tags: true,
-        schema: ResourceSchema::new("awscc.ec2.security_group")
+        schema: ResourceSchema::new("awscc.ec2.SecurityGroup")
         .with_description("Resource Type definition for AWS::EC2::SecurityGroup")
         .attribute(
             AttributeSchema::new("group_description", AttributeType::String)
@@ -92,7 +92,7 @@ pub fn ec2_security_group_config() -> AwsccSchemaConfig {
                     StructField::new("ip_protocol", AttributeType::StringEnum {
                 name: "IpProtocol".to_string(),
                 values: vec!["tcp".to_string(), "udp".to_string(), "icmp".to_string(), "icmpv6".to_string(), "-1".to_string(), "all".to_string()],
-                namespace: Some("awscc.ec2.security_group".to_string()),
+                namespace: Some("awscc.ec2.SecurityGroup".to_string()),
                 to_dsl: Some(|s: &str| match s { "-1" => "all".to_string(), _ => s.replace('-', "_") }),
             }).required().with_provider_name("IpProtocol"),
                     StructField::new("to_port", AttributeType::Custom {
@@ -129,7 +129,7 @@ pub fn ec2_security_group_config() -> AwsccSchemaConfig {
                     StructField::new("ip_protocol", AttributeType::StringEnum {
                 name: "IpProtocol".to_string(),
                 values: vec!["tcp".to_string(), "udp".to_string(), "icmp".to_string(), "icmpv6".to_string(), "-1".to_string(), "all".to_string()],
-                namespace: Some("awscc.ec2.security_group".to_string()),
+                namespace: Some("awscc.ec2.SecurityGroup".to_string()),
                 to_dsl: Some(|s: &str| match s { "-1" => "all".to_string(), _ => s.replace('-', "_") }),
             }).required().with_provider_name("IpProtocol"),
                     StructField::new("source_prefix_list_id", super::prefix_list_id()).with_provider_name("SourcePrefixListId"),
@@ -178,7 +178,7 @@ pub fn enum_valid_values() -> (
     &'static [(&'static str, &'static [&'static str])],
 ) {
     (
-        "ec2.security_group",
+        "ec2.SecurityGroup",
         &[
             ("ip_protocol", VALID_EGRESS_IP_PROTOCOL),
             ("ip_protocol", VALID_INGRESS_IP_PROTOCOL),

--- a/carina-provider-awscc/src/schemas/generated/ec2/security_group_egress.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/security_group_egress.rs
@@ -38,9 +38,9 @@ fn validate_to_port_range(value: &Value) -> Result<(), String> {
 pub fn ec2_security_group_egress_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::EC2::SecurityGroupEgress",
-        resource_type_name: "ec2.security_group_egress",
+        resource_type_name: "ec2.SecurityGroupEgress",
         has_tags: false,
-        schema: ResourceSchema::new("awscc.ec2.security_group_egress")
+        schema: ResourceSchema::new("awscc.ec2.SecurityGroupEgress")
         .with_description("Adds the specified outbound (egress) rule to a security group.  An outbound rule permits instances to send traffic to the specified IPv4 or IPv6 address range, the IP addresses that are specified by a prefix list, or the instances that are associated with a destination security group. For more information, see [Security group rules](https://docs.aws.amazon.com/vpc/latest/userguide/security-group-rules.html).  You must specify exactly one of the following destinations: an IPv4 address range, an IPv6 address range, a prefix list, or a security group.  You must specify a protocol for each rule (for example, TCP). If the protocol is TCP or UDP, you must also specify a port or port range. If the protocol is ICMP or ICMPv6, you must also specify the ICMP/ICMPv6 type and code. To specify all types or all codes, use -1.  Rule changes are propagated to instances associated with the security group as quickly as possible. However, a small delay might occur.")
         .attribute(
             AttributeSchema::new("cidr_ip", types::ipv4_cidr())
@@ -102,7 +102,7 @@ pub fn ec2_security_group_egress_config() -> AwsccSchemaConfig {
             AttributeSchema::new("ip_protocol", AttributeType::StringEnum {
                 name: "IpProtocol".to_string(),
                 values: vec!["tcp".to_string(), "udp".to_string(), "icmp".to_string(), "icmpv6".to_string(), "-1".to_string(), "all".to_string()],
-                namespace: Some("awscc.ec2.security_group_egress".to_string()),
+                namespace: Some("awscc.ec2.SecurityGroupEgress".to_string()),
                 to_dsl: Some(|s: &str| match s { "-1" => "all".to_string(), _ => s.replace('-', "_") }),
             })
                 .required()
@@ -133,7 +133,7 @@ pub fn enum_valid_values() -> (
     &'static [(&'static str, &'static [&'static str])],
 ) {
     (
-        "ec2.security_group_egress",
+        "ec2.SecurityGroupEgress",
         &[("ip_protocol", VALID_IP_PROTOCOL)],
     )
 }

--- a/carina-provider-awscc/src/schemas/generated/ec2/security_group_ingress.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/security_group_ingress.rs
@@ -38,9 +38,9 @@ fn validate_to_port_range(value: &Value) -> Result<(), String> {
 pub fn ec2_security_group_ingress_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::EC2::SecurityGroupIngress",
-        resource_type_name: "ec2.security_group_ingress",
+        resource_type_name: "ec2.SecurityGroupIngress",
         has_tags: false,
-        schema: ResourceSchema::new("awscc.ec2.security_group_ingress")
+        schema: ResourceSchema::new("awscc.ec2.SecurityGroupIngress")
         .with_description("Resource Type definition for AWS::EC2::SecurityGroupIngress")
         .attribute(
             AttributeSchema::new("cidr_ip", types::ipv4_cidr())
@@ -95,7 +95,7 @@ pub fn ec2_security_group_ingress_config() -> AwsccSchemaConfig {
             AttributeSchema::new("ip_protocol", AttributeType::StringEnum {
                 name: "IpProtocol".to_string(),
                 values: vec!["tcp".to_string(), "udp".to_string(), "icmp".to_string(), "icmpv6".to_string(), "-1".to_string(), "all".to_string()],
-                namespace: Some("awscc.ec2.security_group_ingress".to_string()),
+                namespace: Some("awscc.ec2.SecurityGroupIngress".to_string()),
                 to_dsl: Some(|s: &str| match s { "-1" => "all".to_string(), _ => s.replace('-', "_") }),
             })
                 .required()
@@ -150,7 +150,7 @@ pub fn enum_valid_values() -> (
     &'static [(&'static str, &'static [&'static str])],
 ) {
     (
-        "ec2.security_group_ingress",
+        "ec2.SecurityGroupIngress",
         &[("ip_protocol", VALID_IP_PROTOCOL)],
     )
 }

--- a/carina-provider-awscc/src/schemas/generated/ec2/subnet.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/subnet.rs
@@ -38,9 +38,9 @@ fn validate_ipv6_netmask_length_range(value: &Value) -> Result<(), String> {
 pub fn ec2_subnet_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::EC2::Subnet",
-        resource_type_name: "ec2.subnet",
+        resource_type_name: "ec2.Subnet",
         has_tags: true,
-        schema: ResourceSchema::new("awscc.ec2.subnet")
+        schema: ResourceSchema::new("awscc.ec2.Subnet")
         .with_description("Specifies a subnet for the specified VPC.  For an IPv4 only subnet, specify an IPv4 CIDR block. If the VPC has an IPv6 CIDR block, you can create an IPv6 only subnet or a dual stack subnet instead. For an IPv6 only subnet, specify an IPv6 CIDR block. For a dual stack subnet, specify both an IPv4 CIDR block and an IPv6 CIDR block.  For more information, see [Subnets for your VPC](https://docs.aws.amazon.com/vpc/latest/userguide/configure-subnets.html) in the *Amazon VPC User Guide*.")
         .attribute(
             AttributeSchema::new("assign_ipv6_address_on_creation", AttributeType::Bool)
@@ -66,7 +66,7 @@ pub fn ec2_subnet_config() -> AwsccSchemaConfig {
                     StructField::new("internet_gateway_block_mode", AttributeType::StringEnum {
                 name: "InternetGatewayBlockMode".to_string(),
                 values: vec!["off".to_string(), "block-bidirectional".to_string(), "block-ingress".to_string()],
-                namespace: Some("awscc.ec2.subnet".to_string()),
+                namespace: Some("awscc.ec2.Subnet".to_string()),
                 to_dsl: Some(|s: &str| s.replace('-', "_")),
             }).with_description("The mode of VPC BPA. Options here are off, block-bidirectional, block-ingress ").with_provider_name("InternetGatewayBlockMode")
                     ],
@@ -179,7 +179,7 @@ pub fn ec2_subnet_config() -> AwsccSchemaConfig {
                     StructField::new("hostname_type", AttributeType::StringEnum {
                 name: "HostnameType".to_string(),
                 values: vec!["ip-name".to_string(), "resource-name".to_string()],
-                namespace: Some("awscc.ec2.subnet".to_string()),
+                namespace: Some("awscc.ec2.Subnet".to_string()),
                 to_dsl: Some(|s: &str| s.replace('-', "_")),
             }).with_provider_name("HostnameType")
                     ],
@@ -220,7 +220,7 @@ pub fn enum_valid_values() -> (
     &'static str,
     &'static [(&'static str, &'static [&'static str])],
 ) {
-    ("ec2.subnet", &[])
+    ("ec2.Subnet", &[])
 }
 
 /// Maps DSL alias values back to canonical AWS values for this module.

--- a/carina-provider-awscc/src/schemas/generated/ec2/subnet_route_table_association.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/subnet_route_table_association.rs
@@ -11,9 +11,9 @@ use carina_core::schema::{AttributeSchema, ResourceSchema};
 pub fn ec2_subnet_route_table_association_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::EC2::SubnetRouteTableAssociation",
-        resource_type_name: "ec2.subnet_route_table_association",
+        resource_type_name: "ec2.SubnetRouteTableAssociation",
         has_tags: false,
-        schema: ResourceSchema::new("awscc.ec2.subnet_route_table_association")
+        schema: ResourceSchema::new("awscc.ec2.SubnetRouteTableAssociation")
         .with_description("Associates a subnet with a route table. The subnet and route table must be in the same VPC. This association causes traffic originating from the subnet to be routed according to the routes in the route table. A route table can be associated with multiple subnets. To create a route table, see [AWS::EC2::RouteTable](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-routetable.html).")
         .attribute(
             AttributeSchema::new("id", super::subnet_route_table_association_id())
@@ -43,7 +43,7 @@ pub fn enum_valid_values() -> (
     &'static str,
     &'static [(&'static str, &'static [&'static str])],
 ) {
-    ("ec2.subnet_route_table_association", &[])
+    ("ec2.SubnetRouteTableAssociation", &[])
 }
 
 /// Maps DSL alias values back to canonical AWS values for this module.

--- a/carina-provider-awscc/src/schemas/generated/ec2/transit_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/transit_gateway.rs
@@ -44,9 +44,9 @@ fn validate_amazon_side_asn_range(value: &Value) -> Result<(), String> {
 pub fn ec2_transit_gateway_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::EC2::TransitGateway",
-        resource_type_name: "ec2.transit_gateway",
+        resource_type_name: "ec2.TransitGateway",
         has_tags: true,
-        schema: ResourceSchema::new("awscc.ec2.transit_gateway")
+        schema: ResourceSchema::new("awscc.ec2.TransitGateway")
             .with_description("Resource Type definition for AWS::EC2::TransitGateway")
             .attribute(
                 AttributeSchema::new(
@@ -77,7 +77,7 @@ pub fn ec2_transit_gateway_config() -> AwsccSchemaConfig {
                     AttributeType::StringEnum {
                         name: "AutoAcceptSharedAttachments".to_string(),
                         values: vec!["enable".to_string(), "disable".to_string()],
-                        namespace: Some("awscc.ec2.transit_gateway".to_string()),
+                        namespace: Some("awscc.ec2.TransitGateway".to_string()),
                         to_dsl: None,
                     },
                 )
@@ -89,7 +89,7 @@ pub fn ec2_transit_gateway_config() -> AwsccSchemaConfig {
                     AttributeType::StringEnum {
                         name: "DefaultRouteTableAssociation".to_string(),
                         values: vec!["enable".to_string(), "disable".to_string()],
-                        namespace: Some("awscc.ec2.transit_gateway".to_string()),
+                        namespace: Some("awscc.ec2.TransitGateway".to_string()),
                         to_dsl: None,
                     },
                 )
@@ -101,7 +101,7 @@ pub fn ec2_transit_gateway_config() -> AwsccSchemaConfig {
                     AttributeType::StringEnum {
                         name: "DefaultRouteTablePropagation".to_string(),
                         values: vec!["enable".to_string(), "disable".to_string()],
-                        namespace: Some("awscc.ec2.transit_gateway".to_string()),
+                        namespace: Some("awscc.ec2.TransitGateway".to_string()),
                         to_dsl: None,
                     },
                 )
@@ -117,7 +117,7 @@ pub fn ec2_transit_gateway_config() -> AwsccSchemaConfig {
                     AttributeType::StringEnum {
                         name: "DnsSupport".to_string(),
                         values: vec!["enable".to_string(), "disable".to_string()],
-                        namespace: Some("awscc.ec2.transit_gateway".to_string()),
+                        namespace: Some("awscc.ec2.TransitGateway".to_string()),
                         to_dsl: None,
                     },
                 )
@@ -129,7 +129,7 @@ pub fn ec2_transit_gateway_config() -> AwsccSchemaConfig {
                     AttributeType::StringEnum {
                         name: "EncryptionSupport".to_string(),
                         values: vec!["disable".to_string(), "enable".to_string()],
-                        namespace: Some("awscc.ec2.transit_gateway".to_string()),
+                        namespace: Some("awscc.ec2.TransitGateway".to_string()),
                         to_dsl: None,
                     },
                 )
@@ -142,7 +142,7 @@ pub fn ec2_transit_gateway_config() -> AwsccSchemaConfig {
                     AttributeType::StringEnum {
                         name: "EncryptionSupportState".to_string(),
                         values: vec!["disable".to_string(), "enable".to_string()],
-                        namespace: Some("awscc.ec2.transit_gateway".to_string()),
+                        namespace: Some("awscc.ec2.TransitGateway".to_string()),
                         to_dsl: None,
                     },
                 )
@@ -160,7 +160,7 @@ pub fn ec2_transit_gateway_config() -> AwsccSchemaConfig {
                     AttributeType::StringEnum {
                         name: "MulticastSupport".to_string(),
                         values: vec!["enable".to_string(), "disable".to_string()],
-                        namespace: Some("awscc.ec2.transit_gateway".to_string()),
+                        namespace: Some("awscc.ec2.TransitGateway".to_string()),
                         to_dsl: None,
                     },
                 )
@@ -180,7 +180,7 @@ pub fn ec2_transit_gateway_config() -> AwsccSchemaConfig {
                     AttributeType::StringEnum {
                         name: "SecurityGroupReferencingSupport".to_string(),
                         values: vec!["enable".to_string(), "disable".to_string()],
-                        namespace: Some("awscc.ec2.transit_gateway".to_string()),
+                        namespace: Some("awscc.ec2.TransitGateway".to_string()),
                         to_dsl: None,
                     },
                 )
@@ -205,7 +205,7 @@ pub fn ec2_transit_gateway_config() -> AwsccSchemaConfig {
                     AttributeType::StringEnum {
                         name: "VpnEcmpSupport".to_string(),
                         values: vec!["enable".to_string(), "disable".to_string()],
-                        namespace: Some("awscc.ec2.transit_gateway".to_string()),
+                        namespace: Some("awscc.ec2.TransitGateway".to_string()),
                         to_dsl: None,
                     },
                 )
@@ -237,7 +237,7 @@ pub fn enum_valid_values() -> (
     &'static [(&'static str, &'static [&'static str])],
 ) {
     (
-        "ec2.transit_gateway",
+        "ec2.TransitGateway",
         &[
             (
                 "auto_accept_shared_attachments",

--- a/carina-provider-awscc/src/schemas/generated/ec2/transit_gateway_attachment.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/transit_gateway_attachment.rs
@@ -15,9 +15,9 @@ use carina_core::schema::{
 pub fn ec2_transit_gateway_attachment_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::EC2::TransitGatewayAttachment",
-        resource_type_name: "ec2.transit_gateway_attachment",
+        resource_type_name: "ec2.TransitGatewayAttachment",
         has_tags: true,
-        schema: ResourceSchema::new("awscc.ec2.transit_gateway_attachment")
+        schema: ResourceSchema::new("awscc.ec2.TransitGatewayAttachment")
         .with_description("Resource Type definition for AWS::EC2::TransitGatewayAttachment")
         .attribute(
             AttributeSchema::new("id", super::transit_gateway_attachment_id())
@@ -31,25 +31,25 @@ pub fn ec2_transit_gateway_attachment_config() -> AwsccSchemaConfig {
                     StructField::new("appliance_mode_support", AttributeType::StringEnum {
                 name: "ApplianceModeSupport".to_string(),
                 values: vec!["enable".to_string(), "disable".to_string()],
-                namespace: Some("awscc.ec2.transit_gateway_attachment".to_string()),
+                namespace: Some("awscc.ec2.TransitGatewayAttachment".to_string()),
                 to_dsl: None,
             }).with_description("Indicates whether to enable Ipv6 Support for Vpc Attachment. Valid Values: enable | disable").with_provider_name("ApplianceModeSupport"),
                     StructField::new("dns_support", AttributeType::StringEnum {
                 name: "DnsSupport".to_string(),
                 values: vec!["enable".to_string(), "disable".to_string()],
-                namespace: Some("awscc.ec2.transit_gateway_attachment".to_string()),
+                namespace: Some("awscc.ec2.TransitGatewayAttachment".to_string()),
                 to_dsl: None,
             }).with_description("Indicates whether to enable DNS Support for Vpc Attachment. Valid Values: enable | disable").with_provider_name("DnsSupport"),
                     StructField::new("ipv6_support", AttributeType::StringEnum {
                 name: "Ipv6Support".to_string(),
                 values: vec!["enable".to_string(), "disable".to_string()],
-                namespace: Some("awscc.ec2.transit_gateway_attachment".to_string()),
+                namespace: Some("awscc.ec2.TransitGatewayAttachment".to_string()),
                 to_dsl: None,
             }).with_description("Indicates whether to enable Ipv6 Support for Vpc Attachment. Valid Values: enable | disable").with_provider_name("Ipv6Support"),
                     StructField::new("security_group_referencing_support", AttributeType::StringEnum {
                 name: "SecurityGroupReferencingSupport".to_string(),
                 values: vec!["enable".to_string(), "disable".to_string()],
-                namespace: Some("awscc.ec2.transit_gateway_attachment".to_string()),
+                namespace: Some("awscc.ec2.TransitGatewayAttachment".to_string()),
                 to_dsl: None,
             }).with_description("Indicates whether to enable Security Group referencing support for Vpc Attachment. Valid Values: enable | disable").with_provider_name("SecurityGroupReferencingSupport")
                     ],
@@ -99,7 +99,7 @@ pub fn enum_valid_values() -> (
     &'static str,
     &'static [(&'static str, &'static [&'static str])],
 ) {
-    ("ec2.transit_gateway_attachment", &[])
+    ("ec2.TransitGatewayAttachment", &[])
 }
 
 /// Maps DSL alias values back to canonical AWS values for this module.

--- a/carina-provider-awscc/src/schemas/generated/ec2/vpc.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/vpc.rs
@@ -28,9 +28,9 @@ fn validate_ipv4_netmask_length_range(value: &Value) -> Result<(), String> {
 pub fn ec2_vpc_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::EC2::VPC",
-        resource_type_name: "ec2.vpc",
+        resource_type_name: "ec2.Vpc",
         has_tags: true,
-        schema: ResourceSchema::new("awscc.ec2.vpc")
+        schema: ResourceSchema::new("awscc.ec2.Vpc")
         .with_description("Specifies a virtual private cloud (VPC).  To add an IPv6 CIDR block to the VPC, see [AWS::EC2::VPCCidrBlock](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-vpccidrblock.html).  For more information, see [Virtual private clouds (VPC)](https://docs.aws.amazon.com/vpc/latest/userguide/configure-your-vpc.html) in the *Amazon VPC User Guide*.")
         .attribute(
             AttributeSchema::new("cidr_block", types::ipv4_cidr())
@@ -70,7 +70,7 @@ pub fn ec2_vpc_config() -> AwsccSchemaConfig {
             AttributeSchema::new("instance_tenancy", AttributeType::StringEnum {
                 name: "InstanceTenancy".to_string(),
                 values: vec!["default".to_string(), "dedicated".to_string(), "host".to_string()],
-                namespace: Some("awscc.ec2.vpc".to_string()),
+                namespace: Some("awscc.ec2.Vpc".to_string()),
                 to_dsl: None,
             })
                 .with_description("The allowed tenancy of instances launched into the VPC. + ``default``: An instance launched into the VPC runs on shared hardware by default, unless you explicitly specify a different tenancy during instance launch. + ``dedicated``: An instance launched into the VPC runs on dedicated hardware by default, unless you explicitly specify a tenancy of ``host`` during instance launch. You cannot specify a tenancy of ``default`` during instance launch. Updating ``InstanceTenancy`` requires no replacement only if you are updating its value from ``dedicated`` to ``default``. Updating ``InstanceTenancy`` from ``default`` to ``dedicated`` requires replacement.")
@@ -131,7 +131,7 @@ pub fn enum_valid_values() -> (
     &'static str,
     &'static [(&'static str, &'static [&'static str])],
 ) {
-    ("ec2.vpc", &[("instance_tenancy", VALID_INSTANCE_TENANCY)])
+    ("ec2.Vpc", &[("instance_tenancy", VALID_INSTANCE_TENANCY)])
 }
 
 /// Maps DSL alias values back to canonical AWS values for this module.

--- a/carina-provider-awscc/src/schemas/generated/ec2/vpc_endpoint.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/vpc_endpoint.rs
@@ -69,9 +69,9 @@ fn validate_string_length_1_255(value: &Value) -> Result<(), String> {
 pub fn ec2_vpc_endpoint_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::EC2::VPCEndpoint",
-        resource_type_name: "ec2.vpc_endpoint",
+        resource_type_name: "ec2.VpcEndpoint",
         has_tags: true,
-        schema: ResourceSchema::new("awscc.ec2.vpc_endpoint")
+        schema: ResourceSchema::new("awscc.ec2.VpcEndpoint")
         .with_description("Specifies a VPC endpoint. A VPC endpoint provides a private connection between your VPC and an endpoint service. You can use an endpoint service provided by AWS, an MKT Partner, or another AWS accounts in your organization. For more information, see the [User Guide](https://docs.aws.amazon.com/vpc/latest/privatelink/).  An endpoint of type ``Interface`` establishes connections between the subnets in your VPC and an AWS-service, your own service, or a service hosted by another AWS-account. With an interface VPC endpoint, you specify the subnets in which to create the endpoint and the security groups to associate with the endpoint network interfaces.  An endpoint of type ``gateway`` serves as a target for a route in your route table for traffic destined for S3 or DDB. You can specify an endpoint policy for the endpoint, which controls access to the service from your VPC. You can also specify the VPC route tables that use the endpoint. For more information about connectivity to S3, see [Why can't I connect to an S3 bucket using a gateway VPC endpoint?](https://docs.aws.amazon.com/premiumsupport/knowledge-center/connect-s3-vpc-endpoint)  An endpoint of type ``GatewayLoadBalancer`` provides private connectivity between your VPC and virtual appliances from a service provider.")
         .attribute(
             AttributeSchema::new("creation_timestamp", AttributeType::String)
@@ -92,19 +92,19 @@ pub fn ec2_vpc_endpoint_config() -> AwsccSchemaConfig {
                     StructField::new("dns_record_ip_type", AttributeType::StringEnum {
                 name: "DnsRecordIpType".to_string(),
                 values: vec!["ipv4".to_string(), "ipv6".to_string(), "dualstack".to_string(), "service-defined".to_string(), "not-specified".to_string()],
-                namespace: Some("awscc.ec2.vpc_endpoint".to_string()),
+                namespace: Some("awscc.ec2.VpcEndpoint".to_string()),
                 to_dsl: Some(|s: &str| s.replace('-', "_")),
             }).with_description("The DNS records created for the endpoint.").with_provider_name("DnsRecordIpType"),
                     StructField::new("private_dns_only_for_inbound_resolver_endpoint", AttributeType::StringEnum {
                 name: "PrivateDnsOnlyForInboundResolverEndpoint".to_string(),
                 values: vec!["OnlyInboundResolver".to_string(), "AllResolvers".to_string(), "NotSpecified".to_string()],
-                namespace: Some("awscc.ec2.vpc_endpoint".to_string()),
+                namespace: Some("awscc.ec2.VpcEndpoint".to_string()),
                 to_dsl: None,
             }).with_description("Indicates whether to enable private DNS only for inbound endpoints. This option is available only for services that support both gateway and interface endpoints. It routes traffic that originates from the VPC to the gateway endpoint and traffic that originates from on-premises to the interface endpoint.").with_provider_name("PrivateDnsOnlyForInboundResolverEndpoint"),
                     StructField::new("private_dns_preference", AttributeType::StringEnum {
                 name: "PrivateDnsPreference".to_string(),
                 values: vec!["VERIFIED_DOMAINS_ONLY".to_string(), "ALL_DOMAINS".to_string(), "VERIFIED_DOMAINS_AND_SPECIFIED_DOMAINS".to_string(), "SPECIFIED_DOMAINS_ONLY".to_string()],
-                namespace: Some("awscc.ec2.vpc_endpoint".to_string()),
+                namespace: Some("awscc.ec2.VpcEndpoint".to_string()),
                 to_dsl: None,
             }).with_description("The preference for which private domains have a private hosted zone created for and associated with the specified VPC. Only supported when private DNS is enabled and when the VPC endpoint type is ServiceNetwork or Resource.").with_provider_name("PrivateDnsPreference"),
                     StructField::new("private_dns_specified_domains", AttributeType::Custom {
@@ -140,7 +140,7 @@ pub fn ec2_vpc_endpoint_config() -> AwsccSchemaConfig {
             AttributeSchema::new("ip_address_type", AttributeType::StringEnum {
                 name: "IpAddressType".to_string(),
                 values: vec!["ipv4".to_string(), "ipv6".to_string(), "dualstack".to_string(), "not-specified".to_string()],
-                namespace: Some("awscc.ec2.vpc_endpoint".to_string()),
+                namespace: Some("awscc.ec2.VpcEndpoint".to_string()),
                 to_dsl: Some(|s: &str| s.replace('-', "_")),
             })
                 .with_description("The supported IP address types.")
@@ -210,7 +210,7 @@ pub fn ec2_vpc_endpoint_config() -> AwsccSchemaConfig {
             AttributeSchema::new("vpc_endpoint_type", AttributeType::StringEnum {
                 name: "VpcEndpointType".to_string(),
                 values: vec!["Interface".to_string(), "Gateway".to_string(), "GatewayLoadBalancer".to_string(), "ServiceNetwork".to_string(), "Resource".to_string()],
-                namespace: Some("awscc.ec2.vpc_endpoint".to_string()),
+                namespace: Some("awscc.ec2.VpcEndpoint".to_string()),
                 to_dsl: None,
             })
                 .create_only()
@@ -240,7 +240,7 @@ pub fn enum_valid_values() -> (
     &'static [(&'static str, &'static [&'static str])],
 ) {
     (
-        "ec2.vpc_endpoint",
+        "ec2.VpcEndpoint",
         &[
             (
                 "dns_record_ip_type",
@@ -266,7 +266,23 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
     match (attr_name, value) {
         ("dns_record_ip_type", "service_defined") => Some("service-defined"),
         ("dns_record_ip_type", "not_specified") => Some("not-specified"),
+        ("private_dns_only_for_inbound_resolver_endpoint", "only_inbound_resolver") => {
+            Some("OnlyInboundResolver")
+        }
+        ("private_dns_only_for_inbound_resolver_endpoint", "all_resolvers") => Some("AllResolvers"),
+        ("private_dns_only_for_inbound_resolver_endpoint", "not_specified") => Some("NotSpecified"),
+        ("private_dns_preference", "verified_domains_only") => Some("VERIFIED_DOMAINS_ONLY"),
+        ("private_dns_preference", "all_domains") => Some("ALL_DOMAINS"),
+        ("private_dns_preference", "verified_domains_and_specified_domains") => {
+            Some("VERIFIED_DOMAINS_AND_SPECIFIED_DOMAINS")
+        }
+        ("private_dns_preference", "specified_domains_only") => Some("SPECIFIED_DOMAINS_ONLY"),
         ("ip_address_type", "not_specified") => Some("not-specified"),
+        ("vpc_endpoint_type", "interface") => Some("Interface"),
+        ("vpc_endpoint_type", "gateway") => Some("Gateway"),
+        ("vpc_endpoint_type", "gateway_load_balancer") => Some("GatewayLoadBalancer"),
+        ("vpc_endpoint_type", "service_network") => Some("ServiceNetwork"),
+        ("vpc_endpoint_type", "resource") => Some("Resource"),
         _ => None,
     }
 }
@@ -276,6 +292,46 @@ pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static s
     &[
         ("dns_record_ip_type", "service_defined", "service-defined"),
         ("dns_record_ip_type", "not_specified", "not-specified"),
+        (
+            "private_dns_only_for_inbound_resolver_endpoint",
+            "only_inbound_resolver",
+            "OnlyInboundResolver",
+        ),
+        (
+            "private_dns_only_for_inbound_resolver_endpoint",
+            "all_resolvers",
+            "AllResolvers",
+        ),
+        (
+            "private_dns_only_for_inbound_resolver_endpoint",
+            "not_specified",
+            "NotSpecified",
+        ),
+        (
+            "private_dns_preference",
+            "verified_domains_only",
+            "VERIFIED_DOMAINS_ONLY",
+        ),
+        ("private_dns_preference", "all_domains", "ALL_DOMAINS"),
+        (
+            "private_dns_preference",
+            "verified_domains_and_specified_domains",
+            "VERIFIED_DOMAINS_AND_SPECIFIED_DOMAINS",
+        ),
+        (
+            "private_dns_preference",
+            "specified_domains_only",
+            "SPECIFIED_DOMAINS_ONLY",
+        ),
         ("ip_address_type", "not_specified", "not-specified"),
+        ("vpc_endpoint_type", "interface", "Interface"),
+        ("vpc_endpoint_type", "gateway", "Gateway"),
+        (
+            "vpc_endpoint_type",
+            "gateway_load_balancer",
+            "GatewayLoadBalancer",
+        ),
+        ("vpc_endpoint_type", "service_network", "ServiceNetwork"),
+        ("vpc_endpoint_type", "resource", "Resource"),
     ]
 }

--- a/carina-provider-awscc/src/schemas/generated/ec2/vpc_gateway_attachment.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/vpc_gateway_attachment.rs
@@ -11,9 +11,9 @@ use carina_core::schema::{AttributeSchema, AttributeType, OperationConfig, Resou
 pub fn ec2_vpc_gateway_attachment_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::EC2::VPCGatewayAttachment",
-        resource_type_name: "ec2.vpc_gateway_attachment",
+        resource_type_name: "ec2.VpcGatewayAttachment",
         has_tags: false,
-        schema: ResourceSchema::new("awscc.ec2.vpc_gateway_attachment")
+        schema: ResourceSchema::new("awscc.ec2.VpcGatewayAttachment")
         .with_description("Resource Type definition for AWS::EC2::VPCGatewayAttachment")
         .attribute(
             AttributeSchema::new("attachment_type", AttributeType::String)
@@ -53,7 +53,7 @@ pub fn enum_valid_values() -> (
     &'static str,
     &'static [(&'static str, &'static [&'static str])],
 ) {
-    ("ec2.vpc_gateway_attachment", &[])
+    ("ec2.VpcGatewayAttachment", &[])
 }
 
 /// Maps DSL alias values back to canonical AWS values for this module.

--- a/carina-provider-awscc/src/schemas/generated/ec2/vpc_peering_connection.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/vpc_peering_connection.rs
@@ -13,9 +13,9 @@ use carina_core::schema::{AttributeSchema, ResourceSchema};
 pub fn ec2_vpc_peering_connection_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::EC2::VPCPeeringConnection",
-        resource_type_name: "ec2.vpc_peering_connection",
+        resource_type_name: "ec2.VpcPeeringConnection",
         has_tags: true,
-        schema: ResourceSchema::new("awscc.ec2.vpc_peering_connection")
+        schema: ResourceSchema::new("awscc.ec2.VpcPeeringConnection")
         .with_description("Resource Type definition for AWS::EC2::VPCPeeringConnection")
         .attribute(
             AttributeSchema::new("assume_role_region", super::awscc_region())
@@ -81,7 +81,7 @@ pub fn enum_valid_values() -> (
     &'static str,
     &'static [(&'static str, &'static [&'static str])],
 ) {
-    ("ec2.vpc_peering_connection", &[])
+    ("ec2.VpcPeeringConnection", &[])
 }
 
 /// Maps DSL alias values back to canonical AWS values for this module.

--- a/carina-provider-awscc/src/schemas/generated/ec2/vpn_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/vpn_gateway.rs
@@ -28,9 +28,9 @@ fn validate_amazon_side_asn_range(value: &Value) -> Result<(), String> {
 pub fn ec2_vpn_gateway_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::EC2::VPNGateway",
-        resource_type_name: "ec2.vpn_gateway",
+        resource_type_name: "ec2.VpnGateway",
         has_tags: true,
-        schema: ResourceSchema::new("awscc.ec2.vpn_gateway")
+        schema: ResourceSchema::new("awscc.ec2.VpnGateway")
         .with_description("Specifies a virtual private gateway. A virtual private gateway is the endpoint on the VPC side of your VPN connection. You can create a virtual private gateway before creating the VPC itself.  For more information, see [](https://docs.aws.amazon.com/vpn/latest/s2svpn/VPC_VPN.html) in the *User Guide*.")
         .attribute(
             AttributeSchema::new("amazon_side_asn", AttributeType::Custom {
@@ -55,7 +55,7 @@ pub fn ec2_vpn_gateway_config() -> AwsccSchemaConfig {
             AttributeSchema::new("type", AttributeType::StringEnum {
                 name: "Type".to_string(),
                 values: vec!["ipsec.1".to_string()],
-                namespace: Some("awscc.ec2.vpn_gateway".to_string()),
+                namespace: Some("awscc.ec2.VpnGateway".to_string()),
                 to_dsl: None,
             })
                 .required()
@@ -84,7 +84,7 @@ pub fn enum_valid_values() -> (
     &'static str,
     &'static [(&'static str, &'static [&'static str])],
 ) {
-    ("ec2.vpn_gateway", &[("type", VALID_TYPE)])
+    ("ec2.VpnGateway", &[("type", VALID_TYPE)])
 }
 
 /// Maps DSL alias values back to canonical AWS values for this module.

--- a/carina-provider-awscc/src/schemas/generated/iam/oidc_provider.rs
+++ b/carina-provider-awscc/src/schemas/generated/iam/oidc_provider.rs
@@ -64,7 +64,7 @@ fn validate_string_pattern_57ee0c44b504b839_len_40_40(value: &Value) -> Result<(
 pub fn iam_oidc_provider_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::IAM::OIDCProvider",
-        resource_type_name: "iam.oidc_provider",
+        resource_type_name: "iam.OidcProvider",
         has_tags: true,
         schema: ResourceSchema::new("awscc.iam.oidc_provider")
             .with_description("Resource Type definition for AWS::IAM::OIDCProvider")
@@ -148,7 +148,7 @@ pub fn enum_valid_values() -> (
     &'static str,
     &'static [(&'static str, &'static [&'static str])],
 ) {
-    ("iam.oidc_provider", &[])
+    ("iam.OidcProvider", &[])
 }
 
 /// Maps DSL alias values back to canonical AWS values for this module.

--- a/carina-provider-awscc/src/schemas/generated/iam/role.rs
+++ b/carina-provider-awscc/src/schemas/generated/iam/role.rs
@@ -26,9 +26,9 @@ fn validate_max_session_duration_range(value: &Value) -> Result<(), String> {
 pub fn iam_role_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::IAM::Role",
-        resource_type_name: "iam.role",
+        resource_type_name: "iam.Role",
         has_tags: true,
-        schema: ResourceSchema::new("awscc.iam.role")
+        schema: ResourceSchema::new("awscc.iam.Role")
         .with_description("Creates a new role for your AWS-account.   For more information about roles, see [IAM roles](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html) in the *IAM User Guide*. For information about quotas for role names and the number of roles you can create, see [IAM and quotas](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html) in the *IAM User Guide*.")
         .attribute(
             AttributeSchema::new("arn", super::iam_role_arn())
@@ -122,7 +122,7 @@ pub fn enum_valid_values() -> (
     &'static str,
     &'static [(&'static str, &'static [&'static str])],
 ) {
-    ("iam.role", &[])
+    ("iam.Role", &[])
 }
 
 /// Maps DSL alias values back to canonical AWS values for this module.

--- a/carina-provider-awscc/src/schemas/generated/logs/log_group.rs
+++ b/carina-provider-awscc/src/schemas/generated/logs/log_group.rs
@@ -56,21 +56,15 @@ fn validate_string_pattern_b6dfbc56753dfe38_len_1_512(value: &Value) -> Result<(
 pub fn logs_log_group_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::Logs::LogGroup",
-        resource_type_name: "logs.log_group",
+        resource_type_name: "logs.LogGroup",
         has_tags: true,
-        schema: ResourceSchema::new("awscc.logs.log_group")
+        schema: ResourceSchema::new("awscc.logs.LogGroup")
         .with_description("The ``AWS::Logs::LogGroup`` resource specifies a log group. A log group defines common properties for log streams, such as their retention and access control rules. Each log stream must belong to one log group.  You can create up to 1,000,000 log groups per Region per account. You must use the following guidelines when naming a log group:   +  Log group names must be unique within a Region for an AWS account.   +  Log group names can be between 1 and 512 characters long.   +  Log group names consist of the following characters: a-z, A-Z, 0-9, '_' (underscore), '-' (hyphen), '/' (forward slash), and '.' (period).")
         .attribute(
             AttributeSchema::new("arn", super::arn())
                 .read_only()
                 .with_description(" (read-only)")
                 .with_provider_name("Arn"),
-        )
-        .attribute(
-            AttributeSchema::new("bearer_token_authentication_enabled", AttributeType::Bool)
-                .with_description("")
-                .with_provider_name("BearerTokenAuthenticationEnabled")
-                .with_default(Value::Bool(false)),
         )
         .attribute(
             AttributeSchema::new("data_protection_policy", AttributeType::map(AttributeType::String))
@@ -97,7 +91,7 @@ pub fn logs_log_group_config() -> AwsccSchemaConfig {
             AttributeSchema::new("log_group_class", AttributeType::StringEnum {
                 name: "LogGroupClass".to_string(),
                 values: vec!["STANDARD".to_string(), "INFREQUENT_ACCESS".to_string(), "DELIVERY".to_string()],
-                namespace: Some("awscc.logs.log_group".to_string()),
+                namespace: Some("awscc.logs.LogGroup".to_string()),
                 to_dsl: None,
             })
                 .with_description("Specifies the log group class for this log group. There are two classes: + The ``Standard`` log class supports all CWL features. + The ``Infrequent Access`` log class supports a subset of CWL features and incurs lower costs. For details about the features supported by each class, see [Log classes](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CloudWatch_Logs_Log_Classes.html)")
@@ -158,7 +152,7 @@ pub fn enum_valid_values() -> (
     &'static [(&'static str, &'static [&'static str])],
 ) {
     (
-        "logs.log_group",
+        "logs.LogGroup",
         &[("log_group_class", VALID_LOG_GROUP_CLASS)],
     )
 }
@@ -166,11 +160,19 @@ pub fn enum_valid_values() -> (
 /// Maps DSL alias values back to canonical AWS values for this module.
 /// e.g., ("ip_protocol", "all") -> Some("-1")
 pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
-    let _ = (attr_name, value);
-    None
+    match (attr_name, value) {
+        ("log_group_class", "standard") => Some("STANDARD"),
+        ("log_group_class", "infrequent_access") => Some("INFREQUENT_ACCESS"),
+        ("log_group_class", "delivery") => Some("DELIVERY"),
+        _ => None,
+    }
 }
 
 /// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
 pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
-    &[]
+    &[
+        ("log_group_class", "standard", "STANDARD"),
+        ("log_group_class", "infrequent_access", "INFREQUENT_ACCESS"),
+        ("log_group_class", "delivery", "DELIVERY"),
+    ]
 }

--- a/carina-provider-awscc/src/schemas/generated/organizations/account.rs
+++ b/carina-provider-awscc/src/schemas/generated/organizations/account.rs
@@ -168,7 +168,7 @@ fn validate_string_pattern_ec4d9bee0dcd262b_len_6_64(value: &Value) -> Result<()
 pub fn organizations_account_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::Organizations::Account",
-        resource_type_name: "organizations.account",
+        resource_type_name: "organizations.Account",
         has_tags: true,
         schema: ResourceSchema::new("awscc.organizations.account")
         .with_description("You can use AWS::Organizations::Account to manage accounts in organization.")
@@ -314,7 +314,7 @@ pub fn enum_valid_values() -> (
     &'static [(&'static str, &'static [&'static str])],
 ) {
     (
-        "organizations.account",
+        "organizations.Account",
         &[
             ("joined_method", VALID_JOINED_METHOD),
             ("state", VALID_STATE),

--- a/carina-provider-awscc/src/schemas/generated/organizations/organization.rs
+++ b/carina-provider-awscc/src/schemas/generated/organizations/organization.rs
@@ -78,7 +78,7 @@ fn validate_string_pattern_0cb01cbc89d38ae3_len_max_64(value: &Value) -> Result<
 pub fn organizations_organization_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::Organizations::Organization",
-        resource_type_name: "organizations.organization",
+        resource_type_name: "organizations.Organization",
         has_tags: false,
         schema: ResourceSchema::new("awscc.organizations.organization")
         .with_description("Resource schema for AWS::Organizations::Organization")
@@ -162,7 +162,7 @@ pub fn enum_valid_values() -> (
     &'static [(&'static str, &'static [&'static str])],
 ) {
     (
-        "organizations.organization",
+        "organizations.Organization",
         &[("feature_set", VALID_FEATURE_SET)],
     )
 }

--- a/carina-provider-awscc/src/schemas/generated/s3/bucket.rs
+++ b/carina-provider-awscc/src/schemas/generated/s3/bucket.rs
@@ -30,8 +30,6 @@ const VALID_ACCESS_CONTROL_TRANSLATION_OWNER: &[&str] = &["Destination"];
 
 const VALID_BLOCKED_ENCRYPTION_TYPES_ENCRYPTION_TYPE: &[&str] = &["NONE", "SSE-C"];
 
-const VALID_BUCKET_NAMESPACE: &[&str] = &["global", "account-regional"];
-
 const VALID_CORS_RULE_ALLOWED_METHODS: &[&str] = &["GET", "PUT", "HEAD", "POST", "DELETE"];
 
 const VALID_DATA_EXPORT_OUTPUT_SCHEMA_VERSION: &[&str] = &["V_1"];
@@ -231,15 +229,15 @@ fn validate_string_pattern_3ee03875337c12ab_len_max_20(value: &Value) -> Result<
 pub fn s3_bucket_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::S3::Bucket",
-        resource_type_name: "s3.bucket",
+        resource_type_name: "s3.Bucket",
         has_tags: true,
-        schema: ResourceSchema::new("awscc.s3.bucket")
+        schema: ResourceSchema::new("awscc.s3.Bucket")
         .with_description("The ``AWS::S3::Bucket`` resource creates an Amazon S3 bucket in the same AWS Region where you create the AWS CloudFormation stack.  To control how AWS CloudFormation handles the bucket when the stack is deleted, you can set a deletion policy for your bucket. You can choose to *retain* the bucket or to *delete* the bucket. For more information, see [DeletionPolicy Attribute](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html).   You can only delete empty buckets. Deletion fails for buckets that have contents.")
         .attribute(
             AttributeSchema::new("abac_status", AttributeType::StringEnum {
                 name: "AbacStatus".to_string(),
                 values: vec!["Enabled".to_string(), "Disabled".to_string()],
-                namespace: Some("awscc.s3.bucket".to_string()),
+                namespace: Some("awscc.s3.Bucket".to_string()),
                 to_dsl: None,
             })
                 .with_description("The ABAC status of the general purpose bucket. When ABAC is enabled for the general purpose bucket, you can use tags to manage access to the general purpose buckets as well as for cost tracking purposes. When ABAC is disabled for the general purpose buckets, you can only use tags for cost tracking purposes. For more information, see [Using tags with S3 general purpose buckets](https://docs.aws.amazon.com/AmazonS3/latest/userguide/buckets-tagging.html).")
@@ -252,7 +250,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("acceleration_status", AttributeType::StringEnum {
                 name: "AccelerationStatus".to_string(),
                 values: vec!["Enabled".to_string(), "Suspended".to_string()],
-                namespace: Some("awscc.s3.bucket".to_string()),
+                namespace: Some("awscc.s3.Bucket".to_string()),
                 to_dsl: None,
             }).required().with_description("Specifies the transfer acceleration status of the bucket.").with_provider_name("AccelerationStatus")
                     ],
@@ -264,7 +262,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
             AttributeSchema::new("access_control", AttributeType::StringEnum {
                 name: "AccessControl".to_string(),
                 values: vec!["AuthenticatedRead".to_string(), "AwsExecRead".to_string(), "BucketOwnerFullControl".to_string(), "BucketOwnerRead".to_string(), "LogDeliveryWrite".to_string(), "Private".to_string(), "PublicRead".to_string(), "PublicReadWrite".to_string()],
-                namespace: Some("awscc.s3.bucket".to_string()),
+                namespace: Some("awscc.s3.Bucket".to_string()),
                 to_dsl: None,
             })
                 .write_only()
@@ -291,7 +289,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("format", AttributeType::StringEnum {
                 name: "Format".to_string(),
                 values: vec!["CSV".to_string(), "ORC".to_string(), "Parquet".to_string()],
-                namespace: Some("awscc.s3.bucket".to_string()),
+                namespace: Some("awscc.s3.Bucket".to_string()),
                 to_dsl: None,
             }).required().with_description("Specifies the file format used when exporting data to Amazon S3. *Allowed values*: ``CSV`` | ``ORC`` | ``Parquet``").with_provider_name("Format"),
                     StructField::new("prefix", AttributeType::String).with_description("The prefix to use when exporting data. The prefix is prepended to all results.").with_provider_name("Prefix")
@@ -300,7 +298,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("output_schema_version", AttributeType::StringEnum {
                 name: "OutputSchemaVersion".to_string(),
                 values: vec!["V_1".to_string()],
-                namespace: Some("awscc.s3.bucket".to_string()),
+                namespace: Some("awscc.s3.Bucket".to_string()),
                 to_dsl: None,
             }).required().with_description("The version of the output schema to use when exporting data. Must be ``V_1``.").with_provider_name("OutputSchemaVersion")
                     ],
@@ -333,7 +331,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("encryption_type", AttributeType::list(AttributeType::StringEnum {
                 name: "EncryptionType".to_string(),
                 values: vec!["NONE".to_string(), "SSE-C".to_string()],
-                namespace: Some("awscc.s3.bucket".to_string()),
+                namespace: Some("awscc.s3.Bucket".to_string()),
                 to_dsl: Some(|s: &str| s.replace('-', "_")),
             })).with_description("The object encryption type that you want to block or unblock for an Amazon S3 general purpose bucket. Currently, this parameter only supports blocking or unblocking server side encryption with customer-provided keys (SSE-C). For more information about SSE-C, see [Using server-side encryption with customer-provided keys (SSE-C)](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerSideEncryptionCustomerKeys.html).").with_provider_name("EncryptionType")
                     ],
@@ -346,7 +344,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("sse_algorithm", AttributeType::StringEnum {
                 name: "ServerSideEncryptionByDefaultSseAlgorithm".to_string(),
                 values: vec!["aws:kms".to_string(), "AES256".to_string(), "aws:kms:dsse".to_string()],
-                namespace: Some("awscc.s3.bucket".to_string()),
+                namespace: Some("awscc.s3.Bucket".to_string()),
                 to_dsl: None,
             }).required().with_description("Server-side encryption algorithm to use for the default encryption. For directory buckets, there are only two supported values for server-side encryption: ``AES256`` and ``aws:kms``.").with_provider_name("SSEAlgorithm")
                     ],
@@ -366,25 +364,6 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 .with_provider_name("BucketName"),
         )
         .attribute(
-            AttributeSchema::new("bucket_name_prefix", AttributeType::String)
-                .create_only()
-                .write_only()
-                .with_description("")
-                .with_provider_name("BucketNamePrefix"),
-        )
-        .attribute(
-            AttributeSchema::new("bucket_namespace", AttributeType::StringEnum {
-                name: "BucketNamespace".to_string(),
-                values: vec!["global".to_string(), "account-regional".to_string()],
-                namespace: Some("awscc.s3.bucket".to_string()),
-                to_dsl: Some(|s: &str| s.replace('-', "_")),
-            })
-                .create_only()
-                .write_only()
-                .with_description("")
-                .with_provider_name("BucketNamespace"),
-        )
-        .attribute(
             AttributeSchema::new("cors_configuration", AttributeType::Struct {
                     name: "CorsConfiguration".to_string(),
                     fields: vec![
@@ -395,7 +374,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("allowed_methods", AttributeType::list(AttributeType::StringEnum {
                 name: "AllowedMethods".to_string(),
                 values: vec!["GET".to_string(), "PUT".to_string(), "HEAD".to_string(), "POST".to_string(), "DELETE".to_string()],
-                namespace: Some("awscc.s3.bucket".to_string()),
+                namespace: Some("awscc.s3.Bucket".to_string()),
                 to_dsl: None,
             })).required().with_description("An HTTP method that you allow the origin to run. *Allowed values*: ``GET`` | ``PUT`` | ``HEAD`` | ``POST`` | ``DELETE``").with_provider_name("AllowedMethods"),
                     StructField::new("allowed_origins", AttributeType::list(AttributeType::String)).required().with_description("One or more origins you want customers to be able to access the bucket from.").with_provider_name("AllowedOrigins"),
@@ -447,7 +426,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("status", AttributeType::StringEnum {
                 name: "IntelligentTieringConfigurationStatus".to_string(),
                 values: vec!["Disabled".to_string(), "Enabled".to_string()],
-                namespace: Some("awscc.s3.bucket".to_string()),
+                namespace: Some("awscc.s3.Bucket".to_string()),
                 to_dsl: None,
             }).required().with_description("Specifies the status of the configuration.").with_provider_name("Status"),
                     StructField::new("tag_filters", AttributeType::list(tags_type())).with_description("A container for a key-value pair.").with_provider_name("TagFilters"),
@@ -457,7 +436,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("access_tier", AttributeType::StringEnum {
                 name: "AccessTier".to_string(),
                 values: vec!["ARCHIVE_ACCESS".to_string(), "DEEP_ARCHIVE_ACCESS".to_string()],
-                namespace: Some("awscc.s3.bucket".to_string()),
+                namespace: Some("awscc.s3.Bucket".to_string()),
                 to_dsl: None,
             }).required().with_description("S3 Intelligent-Tiering access tier. See [Storage class for automatically optimizing frequently and infrequently accessed objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html#sc-dynamic-data-access) for a list of access tiers in the S3 Intelligent-Tiering storage class.").with_provider_name("AccessTier"),
                     StructField::new("days", AttributeType::Int).required().with_description("The number of consecutive days of no access after which an object will be eligible to be transitioned to the corresponding tier. The minimum number of days specified for Archive Access tier must be at least 90 days and Deep Archive Access tier must be at least 180 days. The maximum can be up to 2 years (730 days).").with_provider_name("Days")
@@ -481,7 +460,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("format", AttributeType::StringEnum {
                 name: "Format".to_string(),
                 values: vec!["CSV".to_string(), "ORC".to_string(), "Parquet".to_string()],
-                namespace: Some("awscc.s3.bucket".to_string()),
+                namespace: Some("awscc.s3.Bucket".to_string()),
                 to_dsl: None,
             }).required().with_description("Specifies the file format used when exporting data to Amazon S3. *Allowed values*: ``CSV`` | ``ORC`` | ``Parquet``").with_provider_name("Format"),
                     StructField::new("prefix", AttributeType::String).with_description("The prefix to use when exporting data. The prefix is prepended to all results.").with_provider_name("Prefix")
@@ -492,20 +471,20 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("included_object_versions", AttributeType::StringEnum {
                 name: "IncludedObjectVersions".to_string(),
                 values: vec!["All".to_string(), "Current".to_string()],
-                namespace: Some("awscc.s3.bucket".to_string()),
+                namespace: Some("awscc.s3.Bucket".to_string()),
                 to_dsl: None,
             }).required().with_description("Object versions to include in the inventory list. If set to ``All``, the list includes all the object versions, which adds the version-related fields ``VersionId``, ``IsLatest``, and ``DeleteMarker`` to the list. If set to ``Current``, the list does not contain these version-related fields.").with_provider_name("IncludedObjectVersions"),
                     StructField::new("optional_fields", AttributeType::list(AttributeType::StringEnum {
                 name: "OptionalFields".to_string(),
                 values: vec!["Size".to_string(), "LastModifiedDate".to_string(), "StorageClass".to_string(), "ETag".to_string(), "IsMultipartUploaded".to_string(), "ReplicationStatus".to_string(), "EncryptionStatus".to_string(), "ObjectLockRetainUntilDate".to_string(), "ObjectLockMode".to_string(), "ObjectLockLegalHoldStatus".to_string(), "IntelligentTieringAccessTier".to_string(), "BucketKeyStatus".to_string(), "ChecksumAlgorithm".to_string(), "ObjectAccessControlList".to_string(), "ObjectOwner".to_string(), "LifecycleExpirationDate".to_string()],
-                namespace: Some("awscc.s3.bucket".to_string()),
+                namespace: Some("awscc.s3.Bucket".to_string()),
                 to_dsl: None,
             })).with_description("Contains the optional fields that are included in the inventory results.").with_provider_name("OptionalFields"),
                     StructField::new("prefix", AttributeType::String).with_description("Specifies the inventory filter prefix.").with_provider_name("Prefix"),
                     StructField::new("schedule_frequency", AttributeType::StringEnum {
                 name: "ScheduleFrequency".to_string(),
                 values: vec!["Daily".to_string(), "Weekly".to_string()],
-                namespace: Some("awscc.s3.bucket".to_string()),
+                namespace: Some("awscc.s3.Bucket".to_string()),
                 to_dsl: None,
             }).required().with_description("Specifies the schedule for generating inventory results.").with_provider_name("ScheduleFrequency")
                     ],
@@ -570,7 +549,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("storage_class", AttributeType::StringEnum {
                 name: "NoncurrentVersionTransitionStorageClass".to_string(),
                 values: vec!["DEEP_ARCHIVE".to_string(), "GLACIER".to_string(), "GLACIER_IR".to_string(), "INTELLIGENT_TIERING".to_string(), "ONEZONE_IA".to_string(), "STANDARD_IA".to_string()],
-                namespace: Some("awscc.s3.bucket".to_string()),
+                namespace: Some("awscc.s3.Bucket".to_string()),
                 to_dsl: None,
             }).required().with_description("The class of storage used to store the object.").with_provider_name("StorageClass"),
                     StructField::new("transition_in_days", AttributeType::Int).required().with_description("Specifies the number of days an object is noncurrent before Amazon S3 can perform the associated action. For information about the noncurrent days calculations, see [How Amazon S3 Calculates How Long an Object Has Been Noncurrent](https://docs.aws.amazon.com/AmazonS3/latest/dev/intro-lifecycle-rules.html#non-current-days-calculations) in the *Amazon S3 User Guide*.").with_provider_name("TransitionInDays")
@@ -583,7 +562,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("storage_class", AttributeType::StringEnum {
                 name: "NoncurrentVersionTransitionStorageClass".to_string(),
                 values: vec!["DEEP_ARCHIVE".to_string(), "GLACIER".to_string(), "GLACIER_IR".to_string(), "INTELLIGENT_TIERING".to_string(), "ONEZONE_IA".to_string(), "STANDARD_IA".to_string()],
-                namespace: Some("awscc.s3.bucket".to_string()),
+                namespace: Some("awscc.s3.Bucket".to_string()),
                 to_dsl: None,
             }).required().with_description("The class of storage used to store the object.").with_provider_name("StorageClass"),
                     StructField::new("transition_in_days", AttributeType::Int).required().with_description("Specifies the number of days an object is noncurrent before Amazon S3 can perform the associated action. For information about the noncurrent days calculations, see [How Amazon S3 Calculates How Long an Object Has Been Noncurrent](https://docs.aws.amazon.com/AmazonS3/latest/dev/intro-lifecycle-rules.html#non-current-days-calculations) in the *Amazon S3 User Guide*.").with_provider_name("TransitionInDays")
@@ -611,7 +590,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("status", AttributeType::StringEnum {
                 name: "RuleStatus".to_string(),
                 values: vec!["Enabled".to_string(), "Disabled".to_string()],
-                namespace: Some("awscc.s3.bucket".to_string()),
+                namespace: Some("awscc.s3.Bucket".to_string()),
                 to_dsl: None,
             }).required().with_description("If ``Enabled``, the rule is currently being applied. If ``Disabled``, the rule is not currently being applied.").with_provider_name("Status"),
                     StructField::new("tag_filters", AttributeType::list(tags_type())).with_description("Tags to use to identify a subset of objects to which the lifecycle rule applies.").with_provider_name("TagFilters"),
@@ -621,7 +600,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("storage_class", AttributeType::StringEnum {
                 name: "TransitionStorageClass".to_string(),
                 values: vec!["DEEP_ARCHIVE".to_string(), "GLACIER".to_string(), "GLACIER_IR".to_string(), "INTELLIGENT_TIERING".to_string(), "ONEZONE_IA".to_string(), "STANDARD_IA".to_string()],
-                namespace: Some("awscc.s3.bucket".to_string()),
+                namespace: Some("awscc.s3.Bucket".to_string()),
                 to_dsl: None,
             }).required().with_description("The storage class to which you want the object to transition.").with_provider_name("StorageClass"),
                     StructField::new("transition_date", AttributeType::Custom {
@@ -642,7 +621,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("storage_class", AttributeType::StringEnum {
                 name: "TransitionStorageClass".to_string(),
                 values: vec!["DEEP_ARCHIVE".to_string(), "GLACIER".to_string(), "GLACIER_IR".to_string(), "INTELLIGENT_TIERING".to_string(), "ONEZONE_IA".to_string(), "STANDARD_IA".to_string()],
-                namespace: Some("awscc.s3.bucket".to_string()),
+                namespace: Some("awscc.s3.Bucket".to_string()),
                 to_dsl: None,
             }).required().with_description("The storage class to which you want the object to transition.").with_provider_name("StorageClass"),
                     StructField::new("transition_date", AttributeType::Custom {
@@ -662,7 +641,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("transition_default_minimum_object_size", AttributeType::StringEnum {
                 name: "TransitionDefaultMinimumObjectSize".to_string(),
                 values: vec!["varies_by_storage_class".to_string(), "all_storage_classes_128K".to_string()],
-                namespace: Some("awscc.s3.bucket".to_string()),
+                namespace: Some("awscc.s3.Bucket".to_string()),
                 to_dsl: None,
             }).with_description("Indicates which default minimum object size behavior is applied to the lifecycle configuration. This parameter applies to general purpose buckets only. It isn't supported for directory bucket lifecycle configurations. + ``all_storage_classes_128K`` - Objects smaller than 128 KB will not transition to any storage class by default. + ``varies_by_storage_class`` - Objects smaller than 128 KB will transition to Glacier Flexible Retrieval or Glacier Deep Archive storage classes. By default, all other storage classes will prevent transitions smaller than 128 KB. To customize the minimum object size for any transition you can add a filter that specifies a custom ``ObjectSizeGreaterThan`` or ``ObjectSizeLessThan`` in the body of your transition rule. Custom filters always take precedence over the default transition behavior.").with_provider_name("TransitionDefaultMinimumObjectSize")
                     ],
@@ -686,7 +665,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("partition_date_source", AttributeType::StringEnum {
                 name: "PartitionDateSource".to_string(),
                 values: vec!["EventTime".to_string(), "DeliveryTime".to_string()],
-                namespace: Some("awscc.s3.bucket".to_string()),
+                namespace: Some("awscc.s3.Bucket".to_string()),
                 to_dsl: None,
             }).with_description("Specifies the partition date source for the partitioned prefix. ``PartitionDateSource`` can be ``EventTime`` or ``DeliveryTime``. For ``DeliveryTime``, the time in the log file names corresponds to the delivery time for the log files. For ``EventTime``, The logs delivered are for a specific day only. The year, month, and day correspond to the day on which the event occurred, and the hour, minutes and seconds are set to 00 in the key.").with_provider_name("PartitionDateSource")
                     ],
@@ -713,7 +692,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("table_bucket_type", AttributeType::StringEnum {
                 name: "TableBucketType".to_string(),
                 values: vec!["aws".to_string(), "customer".to_string()],
-                namespace: Some("awscc.s3.bucket".to_string()),
+                namespace: Some("awscc.s3.Bucket".to_string()),
                 to_dsl: None,
             }).required().with_description("The type of the table bucket where the metadata configuration is stored. The ``aws`` value indicates an AWS managed table bucket, and the ``customer`` value indicates a customer-managed table bucket. V2 metadata configurations are stored in AWS managed table buckets, and V1 metadata configurations are stored in customer-managed table buckets.").with_provider_name("TableBucketType"),
                     StructField::new("table_namespace", AttributeType::String).with_description("The namespace in the table bucket where the metadata tables for a metadata configuration are stored.").with_provider_name("TableNamespace")
@@ -725,7 +704,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("configuration_state", AttributeType::StringEnum {
                 name: "ConfigurationState".to_string(),
                 values: vec!["ENABLED".to_string(), "DISABLED".to_string()],
-                namespace: Some("awscc.s3.bucket".to_string()),
+                namespace: Some("awscc.s3.Bucket".to_string()),
                 to_dsl: None,
             }).required().with_description("The configuration state of the inventory table, indicating whether the inventory table is enabled or disabled.").with_provider_name("ConfigurationState"),
                     StructField::new("encryption_configuration", AttributeType::Struct {
@@ -735,7 +714,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("sse_algorithm", AttributeType::StringEnum {
                 name: "MetadataTableEncryptionConfigurationSseAlgorithm".to_string(),
                 values: vec!["aws:kms".to_string(), "AES256".to_string()],
-                namespace: Some("awscc.s3.bucket".to_string()),
+                namespace: Some("awscc.s3.Bucket".to_string()),
                 to_dsl: None,
             }).required().with_description("The encryption type specified for a metadata table. To specify server-side encryption with KMSlong (KMS) keys (SSE-KMS), use the ``aws:kms`` value. To specify server-side encryption with Amazon S3 managed keys (SSE-S3), use the ``AES256`` value.").with_provider_name("SseAlgorithm")
                     ],
@@ -754,7 +733,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("sse_algorithm", AttributeType::StringEnum {
                 name: "MetadataTableEncryptionConfigurationSseAlgorithm".to_string(),
                 values: vec!["aws:kms".to_string(), "AES256".to_string()],
-                namespace: Some("awscc.s3.bucket".to_string()),
+                namespace: Some("awscc.s3.Bucket".to_string()),
                 to_dsl: None,
             }).required().with_description("The encryption type specified for a metadata table. To specify server-side encryption with KMSlong (KMS) keys (SSE-KMS), use the ``aws:kms`` value. To specify server-side encryption with Amazon S3 managed keys (SSE-S3), use the ``AES256`` value.").with_provider_name("SseAlgorithm")
                     ],
@@ -766,7 +745,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("expiration", AttributeType::StringEnum {
                 name: "Expiration".to_string(),
                 values: vec!["ENABLED".to_string(), "DISABLED".to_string()],
-                namespace: Some("awscc.s3.bucket".to_string()),
+                namespace: Some("awscc.s3.Bucket".to_string()),
                 to_dsl: None,
             }).required().with_description("Specifies whether journal table record expiration is enabled or disabled.").with_provider_name("Expiration")
                     ],
@@ -931,7 +910,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("object_lock_enabled", AttributeType::StringEnum {
                 name: "ObjectLockEnabled".to_string(),
                 values: vec!["Enabled".to_string()],
-                namespace: Some("awscc.s3.bucket".to_string()),
+                namespace: Some("awscc.s3.Bucket".to_string()),
                 to_dsl: None,
             }).with_description("Indicates whether this bucket has an Object Lock configuration enabled. Enable ``ObjectLockEnabled`` when you apply ``ObjectLockConfiguration`` to a bucket.").with_provider_name("ObjectLockEnabled"),
                     StructField::new("rule", AttributeType::Struct {
@@ -944,7 +923,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("mode", AttributeType::StringEnum {
                 name: "Mode".to_string(),
                 values: vec!["COMPLIANCE".to_string(), "GOVERNANCE".to_string()],
-                namespace: Some("awscc.s3.bucket".to_string()),
+                namespace: Some("awscc.s3.Bucket".to_string()),
                 to_dsl: None,
             }).with_description("The default Object Lock retention mode you want to apply to new objects placed in the specified bucket. If Object Lock is turned on, you must specify ``Mode`` and specify either ``Days`` or ``Years``.").with_provider_name("Mode"),
                     StructField::new("years", AttributeType::Int).with_description("The number of years that you want to specify for the default retention period. If Object Lock is turned on, you must specify ``Mode`` and specify either ``Days`` or ``Years``.").with_provider_name("Years")
@@ -972,7 +951,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("object_ownership", AttributeType::StringEnum {
                 name: "ObjectOwnership".to_string(),
                 values: vec!["ObjectWriter".to_string(), "BucketOwnerPreferred".to_string(), "BucketOwnerEnforced".to_string()],
-                namespace: Some("awscc.s3.bucket".to_string()),
+                namespace: Some("awscc.s3.Bucket".to_string()),
                 to_dsl: None,
             }).with_description("Specifies an object ownership rule.").with_provider_name("ObjectOwnership")
                     ],
@@ -1016,7 +995,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("status", AttributeType::StringEnum {
                 name: "DeleteMarkerReplicationStatus".to_string(),
                 values: vec!["Disabled".to_string(), "Enabled".to_string()],
-                namespace: Some("awscc.s3.bucket".to_string()),
+                namespace: Some("awscc.s3.Bucket".to_string()),
                 to_dsl: None,
             }).with_description("Indicates whether to replicate delete markers.").with_provider_name("Status")
                     ],
@@ -1030,7 +1009,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("owner", AttributeType::StringEnum {
                 name: "Owner".to_string(),
                 values: vec!["Destination".to_string()],
-                namespace: Some("awscc.s3.bucket".to_string()),
+                namespace: Some("awscc.s3.Bucket".to_string()),
                 to_dsl: None,
             }).required().with_description("Specifies the replica ownership. For default and valid values, see [PUT bucket replication](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTreplication.html) in the *Amazon S3 API Reference*.").with_provider_name("Owner")
                     ],
@@ -1055,7 +1034,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("status", AttributeType::StringEnum {
                 name: "MetricsStatus".to_string(),
                 values: vec!["Disabled".to_string(), "Enabled".to_string()],
-                namespace: Some("awscc.s3.bucket".to_string()),
+                namespace: Some("awscc.s3.Bucket".to_string()),
                 to_dsl: None,
             }).required().with_description("Specifies whether the replication metrics are enabled.").with_provider_name("Status")
                     ],
@@ -1066,7 +1045,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("status", AttributeType::StringEnum {
                 name: "ReplicationTimeStatus".to_string(),
                 values: vec!["Disabled".to_string(), "Enabled".to_string()],
-                namespace: Some("awscc.s3.bucket".to_string()),
+                namespace: Some("awscc.s3.Bucket".to_string()),
                 to_dsl: None,
             }).required().with_description("Specifies whether the replication time is enabled.").with_provider_name("Status"),
                     StructField::new("time", AttributeType::Struct {
@@ -1080,7 +1059,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("storage_class", AttributeType::StringEnum {
                 name: "ReplicationDestinationStorageClass".to_string(),
                 values: vec!["DEEP_ARCHIVE".to_string(), "GLACIER".to_string(), "GLACIER_IR".to_string(), "INTELLIGENT_TIERING".to_string(), "ONEZONE_IA".to_string(), "REDUCED_REDUNDANCY".to_string(), "STANDARD".to_string(), "STANDARD_IA".to_string()],
-                namespace: Some("awscc.s3.bucket".to_string()),
+                namespace: Some("awscc.s3.Bucket".to_string()),
                 to_dsl: None,
             }).with_description("The storage class to use when replicating objects, such as S3 Standard or reduced redundancy. By default, Amazon S3 uses the storage class of the source object to create the object replica. For valid values, see the ``StorageClass`` element of the [PUT Bucket replication](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTreplication.html) action in the *Amazon S3 API Reference*. ``FSX_OPENZFS`` is not an accepted value when replicating objects.").with_provider_name("StorageClass")
                     ],
@@ -1127,7 +1106,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("status", AttributeType::StringEnum {
                 name: "ReplicaModificationsStatus".to_string(),
                 values: vec!["Enabled".to_string(), "Disabled".to_string()],
-                namespace: Some("awscc.s3.bucket".to_string()),
+                namespace: Some("awscc.s3.Bucket".to_string()),
                 to_dsl: None,
             }).required().with_description("Specifies whether Amazon S3 replicates modifications on replicas. *Allowed values*: ``Enabled`` | ``Disabled``").with_provider_name("Status")
                     ],
@@ -1138,7 +1117,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("status", AttributeType::StringEnum {
                 name: "SseKmsEncryptedObjectsStatus".to_string(),
                 values: vec!["Disabled".to_string(), "Enabled".to_string()],
-                namespace: Some("awscc.s3.bucket".to_string()),
+                namespace: Some("awscc.s3.Bucket".to_string()),
                 to_dsl: None,
             }).required().with_description("Specifies whether Amazon S3 replicates objects created with server-side encryption using an AWS KMS key stored in AWS Key Management Service.").with_provider_name("Status")
                     ],
@@ -1148,7 +1127,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("status", AttributeType::StringEnum {
                 name: "ReplicationRuleStatus".to_string(),
                 values: vec!["Disabled".to_string(), "Enabled".to_string()],
-                namespace: Some("awscc.s3.bucket".to_string()),
+                namespace: Some("awscc.s3.Bucket".to_string()),
                 to_dsl: None,
             }).required().with_description("Specifies whether the rule is enabled.").with_provider_name("Status")
                     ],
@@ -1171,7 +1150,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("status", AttributeType::StringEnum {
                 name: "VersioningConfigurationStatus".to_string(),
                 values: vec!["Enabled".to_string(), "Suspended".to_string()],
-                namespace: Some("awscc.s3.bucket".to_string()),
+                namespace: Some("awscc.s3.Bucket".to_string()),
                 to_dsl: None,
             }).required().with_description("The versioning state of the bucket.").with_provider_name("Status")
                     ],
@@ -1192,7 +1171,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("protocol", AttributeType::StringEnum {
                 name: "Protocol".to_string(),
                 values: vec!["http".to_string(), "https".to_string()],
-                namespace: Some("awscc.s3.bucket".to_string()),
+                namespace: Some("awscc.s3.Bucket".to_string()),
                 to_dsl: None,
             }).with_description("Protocol to use when redirecting requests. The default is the protocol that is used in the original request.").with_provider_name("Protocol")
                     ],
@@ -1208,7 +1187,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("protocol", AttributeType::StringEnum {
                 name: "Protocol".to_string(),
                 values: vec!["http".to_string(), "https".to_string()],
-                namespace: Some("awscc.s3.bucket".to_string()),
+                namespace: Some("awscc.s3.Bucket".to_string()),
                 to_dsl: None,
             }).with_description("Protocol to use when redirecting requests. The default is the protocol that is used in the original request.").with_provider_name("Protocol"),
                     StructField::new("replace_key_prefix_with", AttributeType::String).with_description("The object key prefix to use in the redirect request. For example, to redirect requests for all pages with prefix ``docs/`` (objects in the ``docs/`` folder) to ``documents/``, you can set a condition block with ``KeyPrefixEquals`` set to ``docs/`` and in the Redirect set ``ReplaceKeyPrefixWith`` to ``/documents``. Not required if one of the siblings is present. Can be present only if ``ReplaceKeyWith`` is not provided. Replacement must be made for object keys containing special characters (such as carriage returns) when using XML requests. For more information, see [XML related object key constraints](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints).").with_provider_name("ReplaceKeyPrefixWith"),
@@ -1261,7 +1240,7 @@ pub fn enum_valid_values() -> (
     &'static [(&'static str, &'static [&'static str])],
 ) {
     (
-        "s3.bucket",
+        "s3.Bucket",
         &[
             ("abac_status", VALID_ABAC_STATUS),
             (
@@ -1274,7 +1253,6 @@ pub fn enum_valid_values() -> (
                 "encryption_type",
                 VALID_BLOCKED_ENCRYPTION_TYPES_ENCRYPTION_TYPE,
             ),
-            ("bucket_namespace", VALID_BUCKET_NAMESPACE),
             ("allowed_methods", VALID_CORS_RULE_ALLOWED_METHODS),
             (
                 "output_schema_version",
@@ -1353,8 +1331,81 @@ pub fn enum_valid_values() -> (
 /// e.g., ("ip_protocol", "all") -> Some("-1")
 pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
     match (attr_name, value) {
-        ("encryption_type", "SSE_C") => Some("SSE-C"),
-        ("bucket_namespace", "account_regional") => Some("account-regional"),
+        ("abac_status", "enabled") => Some("Enabled"),
+        ("abac_status", "disabled") => Some("Disabled"),
+        ("acceleration_status", "enabled") => Some("Enabled"),
+        ("acceleration_status", "suspended") => Some("Suspended"),
+        ("access_control", "authenticated_read") => Some("AuthenticatedRead"),
+        ("access_control", "aws_exec_read") => Some("AwsExecRead"),
+        ("access_control", "bucket_owner_full_control") => Some("BucketOwnerFullControl"),
+        ("access_control", "bucket_owner_read") => Some("BucketOwnerRead"),
+        ("access_control", "log_delivery_write") => Some("LogDeliveryWrite"),
+        ("access_control", "private") => Some("Private"),
+        ("access_control", "public_read") => Some("PublicRead"),
+        ("access_control", "public_read_write") => Some("PublicReadWrite"),
+        ("owner", "destination") => Some("Destination"),
+        ("encryption_type", "none") => Some("NONE"),
+        ("encryption_type", "sse_c") => Some("SSE-C"),
+        ("allowed_methods", "get") => Some("GET"),
+        ("allowed_methods", "put") => Some("PUT"),
+        ("allowed_methods", "head") => Some("HEAD"),
+        ("allowed_methods", "post") => Some("POST"),
+        ("allowed_methods", "delete") => Some("DELETE"),
+        ("output_schema_version", "v_1") => Some("V_1"),
+        ("mode", "compliance") => Some("COMPLIANCE"),
+        ("mode", "governance") => Some("GOVERNANCE"),
+        ("status", "disabled") => Some("Disabled"),
+        ("status", "enabled") => Some("Enabled"),
+        ("format", "csv") => Some("CSV"),
+        ("format", "orc") => Some("ORC"),
+        ("format", "parquet") => Some("Parquet"),
+        ("included_object_versions", "all") => Some("All"),
+        ("included_object_versions", "current") => Some("Current"),
+        ("optional_fields", "size") => Some("Size"),
+        ("optional_fields", "last_modified_date") => Some("LastModifiedDate"),
+        ("optional_fields", "storage_class") => Some("StorageClass"),
+        ("optional_fields", "e_tag") => Some("ETag"),
+        ("optional_fields", "is_multipart_uploaded") => Some("IsMultipartUploaded"),
+        ("optional_fields", "replication_status") => Some("ReplicationStatus"),
+        ("optional_fields", "encryption_status") => Some("EncryptionStatus"),
+        ("optional_fields", "object_lock_retain_until_date") => Some("ObjectLockRetainUntilDate"),
+        ("optional_fields", "object_lock_mode") => Some("ObjectLockMode"),
+        ("optional_fields", "object_lock_legal_hold_status") => Some("ObjectLockLegalHoldStatus"),
+        ("optional_fields", "intelligent_tiering_access_tier") => {
+            Some("IntelligentTieringAccessTier")
+        }
+        ("optional_fields", "bucket_key_status") => Some("BucketKeyStatus"),
+        ("optional_fields", "checksum_algorithm") => Some("ChecksumAlgorithm"),
+        ("optional_fields", "object_access_control_list") => Some("ObjectAccessControlList"),
+        ("optional_fields", "object_owner") => Some("ObjectOwner"),
+        ("optional_fields", "lifecycle_expiration_date") => Some("LifecycleExpirationDate"),
+        ("schedule_frequency", "daily") => Some("Daily"),
+        ("schedule_frequency", "weekly") => Some("Weekly"),
+        ("configuration_state", "enabled") => Some("ENABLED"),
+        ("configuration_state", "disabled") => Some("DISABLED"),
+        ("transition_default_minimum_object_size", "all_storage_classes_128k") => {
+            Some("all_storage_classes_128K")
+        }
+        ("sse_algorithm", "aes256") => Some("AES256"),
+        ("storage_class", "deep_archive") => Some("DEEP_ARCHIVE"),
+        ("storage_class", "glacier") => Some("GLACIER"),
+        ("storage_class", "glacier_ir") => Some("GLACIER_IR"),
+        ("storage_class", "intelligent_tiering") => Some("INTELLIGENT_TIERING"),
+        ("storage_class", "onezone_ia") => Some("ONEZONE_IA"),
+        ("storage_class", "standard_ia") => Some("STANDARD_IA"),
+        ("object_lock_enabled", "enabled") => Some("Enabled"),
+        ("object_ownership", "object_writer") => Some("ObjectWriter"),
+        ("object_ownership", "bucket_owner_preferred") => Some("BucketOwnerPreferred"),
+        ("object_ownership", "bucket_owner_enforced") => Some("BucketOwnerEnforced"),
+        ("partition_date_source", "event_time") => Some("EventTime"),
+        ("partition_date_source", "delivery_time") => Some("DeliveryTime"),
+        ("expiration", "enabled") => Some("ENABLED"),
+        ("expiration", "disabled") => Some("DISABLED"),
+        ("storage_class", "reduced_redundancy") => Some("REDUCED_REDUNDANCY"),
+        ("storage_class", "standard") => Some("STANDARD"),
+        ("access_tier", "archive_access") => Some("ARCHIVE_ACCESS"),
+        ("access_tier", "deep_archive_access") => Some("DEEP_ARCHIVE_ACCESS"),
+        ("status", "suspended") => Some("Suspended"),
         _ => None,
     }
 }
@@ -1362,7 +1413,120 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
 /// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
 pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
     &[
-        ("encryption_type", "SSE_C", "SSE-C"),
-        ("bucket_namespace", "account_regional", "account-regional"),
+        ("abac_status", "enabled", "Enabled"),
+        ("abac_status", "disabled", "Disabled"),
+        ("acceleration_status", "enabled", "Enabled"),
+        ("acceleration_status", "suspended", "Suspended"),
+        ("access_control", "authenticated_read", "AuthenticatedRead"),
+        ("access_control", "aws_exec_read", "AwsExecRead"),
+        (
+            "access_control",
+            "bucket_owner_full_control",
+            "BucketOwnerFullControl",
+        ),
+        ("access_control", "bucket_owner_read", "BucketOwnerRead"),
+        ("access_control", "log_delivery_write", "LogDeliveryWrite"),
+        ("access_control", "private", "Private"),
+        ("access_control", "public_read", "PublicRead"),
+        ("access_control", "public_read_write", "PublicReadWrite"),
+        ("owner", "destination", "Destination"),
+        ("encryption_type", "none", "NONE"),
+        ("encryption_type", "sse_c", "SSE-C"),
+        ("allowed_methods", "get", "GET"),
+        ("allowed_methods", "put", "PUT"),
+        ("allowed_methods", "head", "HEAD"),
+        ("allowed_methods", "post", "POST"),
+        ("allowed_methods", "delete", "DELETE"),
+        ("output_schema_version", "v_1", "V_1"),
+        ("mode", "compliance", "COMPLIANCE"),
+        ("mode", "governance", "GOVERNANCE"),
+        ("status", "disabled", "Disabled"),
+        ("status", "enabled", "Enabled"),
+        ("format", "csv", "CSV"),
+        ("format", "orc", "ORC"),
+        ("format", "parquet", "Parquet"),
+        ("included_object_versions", "all", "All"),
+        ("included_object_versions", "current", "Current"),
+        ("optional_fields", "size", "Size"),
+        ("optional_fields", "last_modified_date", "LastModifiedDate"),
+        ("optional_fields", "storage_class", "StorageClass"),
+        ("optional_fields", "e_tag", "ETag"),
+        (
+            "optional_fields",
+            "is_multipart_uploaded",
+            "IsMultipartUploaded",
+        ),
+        ("optional_fields", "replication_status", "ReplicationStatus"),
+        ("optional_fields", "encryption_status", "EncryptionStatus"),
+        (
+            "optional_fields",
+            "object_lock_retain_until_date",
+            "ObjectLockRetainUntilDate",
+        ),
+        ("optional_fields", "object_lock_mode", "ObjectLockMode"),
+        (
+            "optional_fields",
+            "object_lock_legal_hold_status",
+            "ObjectLockLegalHoldStatus",
+        ),
+        (
+            "optional_fields",
+            "intelligent_tiering_access_tier",
+            "IntelligentTieringAccessTier",
+        ),
+        ("optional_fields", "bucket_key_status", "BucketKeyStatus"),
+        ("optional_fields", "checksum_algorithm", "ChecksumAlgorithm"),
+        (
+            "optional_fields",
+            "object_access_control_list",
+            "ObjectAccessControlList",
+        ),
+        ("optional_fields", "object_owner", "ObjectOwner"),
+        (
+            "optional_fields",
+            "lifecycle_expiration_date",
+            "LifecycleExpirationDate",
+        ),
+        ("schedule_frequency", "daily", "Daily"),
+        ("schedule_frequency", "weekly", "Weekly"),
+        ("configuration_state", "enabled", "ENABLED"),
+        ("configuration_state", "disabled", "DISABLED"),
+        (
+            "transition_default_minimum_object_size",
+            "all_storage_classes_128k",
+            "all_storage_classes_128K",
+        ),
+        ("sse_algorithm", "aes256", "AES256"),
+        ("storage_class", "deep_archive", "DEEP_ARCHIVE"),
+        ("storage_class", "glacier", "GLACIER"),
+        ("storage_class", "glacier_ir", "GLACIER_IR"),
+        (
+            "storage_class",
+            "intelligent_tiering",
+            "INTELLIGENT_TIERING",
+        ),
+        ("storage_class", "onezone_ia", "ONEZONE_IA"),
+        ("storage_class", "standard_ia", "STANDARD_IA"),
+        ("object_lock_enabled", "enabled", "Enabled"),
+        ("object_ownership", "object_writer", "ObjectWriter"),
+        (
+            "object_ownership",
+            "bucket_owner_preferred",
+            "BucketOwnerPreferred",
+        ),
+        (
+            "object_ownership",
+            "bucket_owner_enforced",
+            "BucketOwnerEnforced",
+        ),
+        ("partition_date_source", "event_time", "EventTime"),
+        ("partition_date_source", "delivery_time", "DeliveryTime"),
+        ("expiration", "enabled", "ENABLED"),
+        ("expiration", "disabled", "DISABLED"),
+        ("storage_class", "reduced_redundancy", "REDUCED_REDUNDANCY"),
+        ("storage_class", "standard", "STANDARD"),
+        ("access_tier", "archive_access", "ARCHIVE_ACCESS"),
+        ("access_tier", "deep_archive_access", "DEEP_ARCHIVE_ACCESS"),
+        ("status", "suspended", "Suspended"),
     ]
 }

--- a/carina-provider-awscc/src/schemas/generated/sso/instance.rs
+++ b/carina-provider-awscc/src/schemas/generated/sso/instance.rs
@@ -89,7 +89,7 @@ fn validate_string_pattern_5a2bd7daee6344f1_len_1_32(value: &Value) -> Result<()
 pub fn sso_instance_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::SSO::Instance",
-        resource_type_name: "sso.instance",
+        resource_type_name: "sso.Instance",
         has_tags: true,
         schema: ResourceSchema::new("awscc.sso.instance")
         .with_description("Resource Type definition for Identity Center (SSO) Instance")
@@ -154,7 +154,7 @@ pub fn enum_valid_values() -> (
     &'static str,
     &'static [(&'static str, &'static [&'static str])],
 ) {
-    ("sso.instance", &[("status", VALID_STATUS)])
+    ("sso.Instance", &[("status", VALID_STATUS)])
 }
 
 /// Maps DSL alias values back to canonical AWS values for this module.

--- a/examples/ec2_egress_only_internet_gateway/main.crn
+++ b/examples/ec2_egress_only_internet_gateway/main.crn
@@ -6,11 +6,11 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-awscc.ec2.egress_only_internet_gateway {
+awscc.ec2.EgressOnlyInternetGateway {
   vpc_id = vpc.vpc_id
 
   tags = {

--- a/examples/ec2_eip/main.crn
+++ b/examples/ec2_eip/main.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.ec2.eip {
+awscc.ec2.Eip {
   domain = 'vpc'
 
   tags = {

--- a/examples/ec2_flow_log/main.crn
+++ b/examples/ec2_flow_log/main.crn
@@ -7,11 +7,11 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-awscc.ec2.flow_log {
+awscc.ec2.FlowLog {
   resource_id          = vpc.vpc_id
   resource_type        = VPC
   traffic_type         = ALL

--- a/examples/ec2_internet_gateway/main.crn
+++ b/examples/ec2_internet_gateway/main.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.ec2.internet_gateway {
+awscc.ec2.InternetGateway {
   tags = {
     Environment = 'example'
   }

--- a/examples/ec2_ipam/main.crn
+++ b/examples/ec2_ipam/main.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.ec2.ipam {
+awscc.ec2.Ipam {
   description = 'Example IPAM'
   tier        = free
 

--- a/examples/ec2_ipam_pool/main.crn
+++ b/examples/ec2_ipam_pool/main.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let ipam = awscc.ec2.ipam {
+let ipam = awscc.ec2.Ipam {
   description = 'Example IPAM'
   tier        = free
 
@@ -15,7 +15,7 @@ let ipam = awscc.ec2.ipam {
   }
 }
 
-awscc.ec2.ipam_pool {
+awscc.ec2.IpamPool {
   ipam_scope_id  = ipam.private_default_scope_id
   address_family = 'IPv4'
   locale         = 'ap-northeast-1'

--- a/examples/ec2_nat_gateway/main.crn
+++ b/examples/ec2_nat_gateway/main.crn
@@ -6,24 +6,24 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
-let public_subnet = awscc.ec2.subnet {
+let public_subnet = awscc.ec2.Subnet {
   vpc_id                  = vpc.vpc_id
   cidr_block              = '10.0.1.0/24'
   availability_zone       = 'ap-northeast-1a'
   map_public_ip_on_launch = true
 }
 
-let eip = awscc.ec2.eip {
+let eip = awscc.ec2.Eip {
   domain = 'vpc'
 }
 
-awscc.ec2.nat_gateway {
+awscc.ec2.NatGateway {
   allocation_id = eip.allocation_id
   subnet_id     = public_subnet.subnet_id
 

--- a/examples/ec2_route/main.crn
+++ b/examples/ec2_route/main.crn
@@ -7,24 +7,24 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
-let igw = awscc.ec2.internet_gateway {}
+let igw = awscc.ec2.InternetGateway {}
 
-let igw_attachment = awscc.ec2.vpc_gateway_attachment {
+let igw_attachment = awscc.ec2.VpcGatewayAttachment {
   vpc_id              = vpc.vpc_id
   internet_gateway_id = igw.internet_gateway_id
 }
 
-let rt = awscc.ec2.route_table {
+let rt = awscc.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 }
 
-awscc.ec2.route {
+awscc.ec2.Route {
   route_table_id         = rt.route_table_id
   destination_cidr_block = '0.0.0.0/0'
   gateway_id             = igw_attachment.internet_gateway_id

--- a/examples/ec2_route_table/main.crn
+++ b/examples/ec2_route_table/main.crn
@@ -6,13 +6,13 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
-awscc.ec2.route_table {
+awscc.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 
   tags = {

--- a/examples/ec2_security_group/main.crn
+++ b/examples/ec2_security_group/main.crn
@@ -6,11 +6,11 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-awscc.ec2.security_group {
+awscc.ec2.SecurityGroup {
   vpc_id            = vpc.vpc_id
   group_description = 'Example security group'
 

--- a/examples/ec2_security_group_egress/main.crn
+++ b/examples/ec2_security_group_egress/main.crn
@@ -7,16 +7,16 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-let sg = awscc.ec2.security_group {
+let sg = awscc.ec2.SecurityGroup {
   vpc_id            = vpc.vpc_id
   group_description = 'Example security group'
 }
 
-awscc.ec2.security_group_egress {
+awscc.ec2.SecurityGroupEgress {
   group_id    = sg.group_id
   description = 'Allow all outbound traffic'
   ip_protocol = all

--- a/examples/ec2_security_group_ingress/main.crn
+++ b/examples/ec2_security_group_ingress/main.crn
@@ -7,16 +7,16 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-let sg = awscc.ec2.security_group {
+let sg = awscc.ec2.SecurityGroup {
   vpc_id            = vpc.vpc_id
   group_description = 'Example security group'
 }
 
-awscc.ec2.security_group_ingress {
+awscc.ec2.SecurityGroupIngress {
   group_id    = sg.group_id
   description = 'Allow HTTPS from VPC'
   ip_protocol = 'tcp'

--- a/examples/ec2_subnet/main.crn
+++ b/examples/ec2_subnet/main.crn
@@ -6,13 +6,13 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
-awscc.ec2.subnet {
+awscc.ec2.Subnet {
   vpc_id                  = vpc.vpc_id
   cidr_block              = '10.0.1.0/24'
   availability_zone       = 'ap-northeast-1a'

--- a/examples/ec2_subnet_route_table_association/main.crn
+++ b/examples/ec2_subnet_route_table_association/main.crn
@@ -7,23 +7,23 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
-let subnet = awscc.ec2.subnet {
+let subnet = awscc.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.1.0/24'
   availability_zone = 'ap-northeast-1a'
 }
 
-let rt = awscc.ec2.route_table {
+let rt = awscc.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 }
 
-awscc.ec2.subnet_route_table_association {
+awscc.ec2.SubnetRouteTableAssociation {
   subnet_id      = subnet.subnet_id
   route_table_id = rt.route_table_id
 }

--- a/examples/ec2_transit_gateway/main.crn
+++ b/examples/ec2_transit_gateway/main.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.ec2.transit_gateway {
+awscc.ec2.TransitGateway {
   description = 'Example Transit Gateway'
 
   tags = {

--- a/examples/ec2_transit_gateway_attachment/main.crn
+++ b/examples/ec2_transit_gateway_attachment/main.crn
@@ -6,21 +6,21 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-let subnet = awscc.ec2.subnet {
+let subnet = awscc.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.1.0/24'
   availability_zone = 'ap-northeast-1a'
 }
 
-let tgw = awscc.ec2.transit_gateway {
+let tgw = awscc.ec2.TransitGateway {
   description = 'Example Transit Gateway'
 }
 
-awscc.ec2.transit_gateway_attachment {
+awscc.ec2.TransitGatewayAttachment {
   transit_gateway_id = tgw.id
   vpc_id             = vpc.vpc_id
   subnet_ids         = [subnet.subnet_id]

--- a/examples/ec2_vpc/main.crn
+++ b/examples/ec2_vpc/main.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.ec2.vpc {
+awscc.ec2.Vpc {
   cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true

--- a/examples/ec2_vpc_endpoint/main.crn
+++ b/examples/ec2_vpc_endpoint/main.crn
@@ -7,24 +7,24 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
-let subnet = awscc.ec2.subnet {
+let subnet = awscc.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.100.0/24'
   availability_zone = 'ap-northeast-1a'
 }
 
-let sg = awscc.ec2.security_group {
+let sg = awscc.ec2.SecurityGroup {
   vpc_id            = vpc.vpc_id
   group_description = 'SG for VPC Endpoint'
 }
 
-awscc.ec2.security_group_ingress {
+awscc.ec2.SecurityGroupIngress {
   group_id    = sg.group_id
   description = 'Allow HTTPS from VPC'
   ip_protocol = 'tcp'
@@ -33,7 +33,7 @@ awscc.ec2.security_group_ingress {
   cidr_ip     = '10.0.0.0/16'
 }
 
-awscc.ec2.vpc_endpoint {
+awscc.ec2.VpcEndpoint {
   vpc_id              = vpc.vpc_id
   service_name        = 'com.amazonaws.ap-northeast-1.ecr.dkr'
   vpc_endpoint_type   = 'Interface'

--- a/examples/ec2_vpc_gateway_attachment/main.crn
+++ b/examples/ec2_vpc_gateway_attachment/main.crn
@@ -6,15 +6,15 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
-let igw = awscc.ec2.internet_gateway {}
+let igw = awscc.ec2.InternetGateway {}
 
-awscc.ec2.vpc_gateway_attachment {
+awscc.ec2.VpcGatewayAttachment {
   vpc_id              = vpc.vpc_id
   internet_gateway_id = igw.internet_gateway_id
 }

--- a/examples/ec2_vpc_peering_connection/main.crn
+++ b/examples/ec2_vpc_peering_connection/main.crn
@@ -6,15 +6,15 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc1 = awscc.ec2.vpc {
+let vpc1 = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-let vpc2 = awscc.ec2.vpc {
+let vpc2 = awscc.ec2.Vpc {
   cidr_block = '10.1.0.0/16'
 }
 
-awscc.ec2.vpc_peering_connection {
+awscc.ec2.VpcPeeringConnection {
   vpc_id      = vpc1.vpc_id
   peer_vpc_id = vpc2.vpc_id
 

--- a/examples/ec2_vpn_gateway/main.crn
+++ b/examples/ec2_vpn_gateway/main.crn
@@ -6,8 +6,8 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.ec2.vpn_gateway {
-  type = awscc.ec2.vpn_gateway.Type.ipsec.1
+awscc.ec2.VpnGateway {
+  type = awscc.ec2.VpnGateway.Type.ipsec.1
 
   tags = {
     Environment = 'example'

--- a/examples/iam_role/main.crn
+++ b/examples/iam_role/main.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.iam.role {
+awscc.iam.Role {
   role_name = 'my-example-role'
 
   assume_role_policy_document = {

--- a/examples/logs_log_group/main.crn
+++ b/examples/logs_log_group/main.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.logs.log_group {
+awscc.logs.LogGroup {
   log_group_name    = '/example/my-app'
   retention_in_days = 30
 

--- a/examples/s3_bucket/main.crn
+++ b/examples/s3_bucket/main.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-awscc.s3.bucket {
+awscc.s3.Bucket {
   bucket_name = 'my-example-bucket'
 
   versioning_configuration = {

--- a/examples/vpc_full/main.crn
+++ b/examples/vpc_full/main.crn
@@ -19,7 +19,7 @@ provider awscc {
 
 # --- VPC and Internet Gateway ---
 
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
@@ -29,20 +29,20 @@ let vpc = awscc.ec2.vpc {
   }
 }
 
-let igw = awscc.ec2.internet_gateway {
+let igw = awscc.ec2.InternetGateway {
   tags = {
     Name = 'main'
   }
 }
 
-let igw_attachment = awscc.ec2.vpc_gateway_attachment {
+let igw_attachment = awscc.ec2.VpcGatewayAttachment {
   vpc_id              = vpc.vpc_id
   internet_gateway_id = igw.internet_gateway_id
 }
 
 # --- Public Subnets ---
 
-let public_subnet_1a = awscc.ec2.subnet {
+let public_subnet_1a = awscc.ec2.Subnet {
   vpc_id                  = vpc.vpc_id
   cidr_block              = '10.0.0.0/24'
   availability_zone       = 'ap-northeast-1a'
@@ -53,7 +53,7 @@ let public_subnet_1a = awscc.ec2.subnet {
   }
 }
 
-let public_subnet_1c = awscc.ec2.subnet {
+let public_subnet_1c = awscc.ec2.Subnet {
   vpc_id                  = vpc.vpc_id
   cidr_block              = '10.0.1.0/24'
   availability_zone       = 'ap-northeast-1c'
@@ -64,7 +64,7 @@ let public_subnet_1c = awscc.ec2.subnet {
   }
 }
 
-let public_subnet_1d = awscc.ec2.subnet {
+let public_subnet_1d = awscc.ec2.Subnet {
   vpc_id                  = vpc.vpc_id
   cidr_block              = '10.0.2.0/24'
   availability_zone       = 'ap-northeast-1d'
@@ -77,7 +77,7 @@ let public_subnet_1d = awscc.ec2.subnet {
 
 # --- Public Route Table ---
 
-let public_rt = awscc.ec2.route_table {
+let public_rt = awscc.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 
   tags = {
@@ -85,30 +85,30 @@ let public_rt = awscc.ec2.route_table {
   }
 }
 
-awscc.ec2.route {
+awscc.ec2.Route {
   route_table_id         = public_rt.route_table_id
   destination_cidr_block = '0.0.0.0/0'
   gateway_id             = igw_attachment.internet_gateway_id
 }
 
-awscc.ec2.subnet_route_table_association {
+awscc.ec2.SubnetRouteTableAssociation {
   subnet_id      = public_subnet_1a.subnet_id
   route_table_id = public_rt.route_table_id
 }
 
-awscc.ec2.subnet_route_table_association {
+awscc.ec2.SubnetRouteTableAssociation {
   subnet_id      = public_subnet_1c.subnet_id
   route_table_id = public_rt.route_table_id
 }
 
-awscc.ec2.subnet_route_table_association {
+awscc.ec2.SubnetRouteTableAssociation {
   subnet_id      = public_subnet_1d.subnet_id
   route_table_id = public_rt.route_table_id
 }
 
 # --- Elastic IPs and NAT Gateways ---
 
-let eip_1a = awscc.ec2.eip {
+let eip_1a = awscc.ec2.Eip {
   domain = 'vpc'
 
   tags = {
@@ -116,7 +116,7 @@ let eip_1a = awscc.ec2.eip {
   }
 }
 
-let eip_1c = awscc.ec2.eip {
+let eip_1c = awscc.ec2.Eip {
   domain = 'vpc'
 
   tags = {
@@ -124,7 +124,7 @@ let eip_1c = awscc.ec2.eip {
   }
 }
 
-let eip_1d = awscc.ec2.eip {
+let eip_1d = awscc.ec2.Eip {
   domain = 'vpc'
 
   tags = {
@@ -132,7 +132,7 @@ let eip_1d = awscc.ec2.eip {
   }
 }
 
-let nat_gw_1a = awscc.ec2.nat_gateway {
+let nat_gw_1a = awscc.ec2.NatGateway {
   allocation_id = eip_1a.allocation_id
   subnet_id     = public_subnet_1a.subnet_id
 
@@ -141,7 +141,7 @@ let nat_gw_1a = awscc.ec2.nat_gateway {
   }
 }
 
-let nat_gw_1c = awscc.ec2.nat_gateway {
+let nat_gw_1c = awscc.ec2.NatGateway {
   allocation_id = eip_1c.allocation_id
   subnet_id     = public_subnet_1c.subnet_id
 
@@ -150,7 +150,7 @@ let nat_gw_1c = awscc.ec2.nat_gateway {
   }
 }
 
-let nat_gw_1d = awscc.ec2.nat_gateway {
+let nat_gw_1d = awscc.ec2.NatGateway {
   allocation_id = eip_1d.allocation_id
   subnet_id     = public_subnet_1d.subnet_id
 
@@ -161,7 +161,7 @@ let nat_gw_1d = awscc.ec2.nat_gateway {
 
 # --- Private Subnets ---
 
-let private_subnet_1a = awscc.ec2.subnet {
+let private_subnet_1a = awscc.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.100.0/24'
   availability_zone = 'ap-northeast-1a'
@@ -171,7 +171,7 @@ let private_subnet_1a = awscc.ec2.subnet {
   }
 }
 
-let private_subnet_1c = awscc.ec2.subnet {
+let private_subnet_1c = awscc.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.101.0/24'
   availability_zone = 'ap-northeast-1c'
@@ -181,7 +181,7 @@ let private_subnet_1c = awscc.ec2.subnet {
   }
 }
 
-let private_subnet_1d = awscc.ec2.subnet {
+let private_subnet_1d = awscc.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.102.0/24'
   availability_zone = 'ap-northeast-1d'
@@ -193,7 +193,7 @@ let private_subnet_1d = awscc.ec2.subnet {
 
 # --- Private Route Tables ---
 
-let private_rt_1a = awscc.ec2.route_table {
+let private_rt_1a = awscc.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 
   tags = {
@@ -201,7 +201,7 @@ let private_rt_1a = awscc.ec2.route_table {
   }
 }
 
-let private_rt_1c = awscc.ec2.route_table {
+let private_rt_1c = awscc.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 
   tags = {
@@ -209,7 +209,7 @@ let private_rt_1c = awscc.ec2.route_table {
   }
 }
 
-let private_rt_1d = awscc.ec2.route_table {
+let private_rt_1d = awscc.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 
   tags = {
@@ -217,42 +217,42 @@ let private_rt_1d = awscc.ec2.route_table {
   }
 }
 
-awscc.ec2.route {
+awscc.ec2.Route {
   route_table_id         = private_rt_1a.route_table_id
   destination_cidr_block = '0.0.0.0/0'
   nat_gateway_id         = nat_gw_1a.nat_gateway_id
 }
 
-awscc.ec2.route {
+awscc.ec2.Route {
   route_table_id         = private_rt_1c.route_table_id
   destination_cidr_block = '0.0.0.0/0'
   nat_gateway_id         = nat_gw_1c.nat_gateway_id
 }
 
-awscc.ec2.route {
+awscc.ec2.Route {
   route_table_id         = private_rt_1d.route_table_id
   destination_cidr_block = '0.0.0.0/0'
   nat_gateway_id         = nat_gw_1d.nat_gateway_id
 }
 
-awscc.ec2.subnet_route_table_association {
+awscc.ec2.SubnetRouteTableAssociation {
   subnet_id      = private_subnet_1a.subnet_id
   route_table_id = private_rt_1a.route_table_id
 }
 
-awscc.ec2.subnet_route_table_association {
+awscc.ec2.SubnetRouteTableAssociation {
   subnet_id      = private_subnet_1c.subnet_id
   route_table_id = private_rt_1c.route_table_id
 }
 
-awscc.ec2.subnet_route_table_association {
+awscc.ec2.SubnetRouteTableAssociation {
   subnet_id      = private_subnet_1d.subnet_id
   route_table_id = private_rt_1d.route_table_id
 }
 
 # --- Database Subnets ---
 
-let database_subnet_1a = awscc.ec2.subnet {
+let database_subnet_1a = awscc.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.200.0/24'
   availability_zone = 'ap-northeast-1a'
@@ -262,7 +262,7 @@ let database_subnet_1a = awscc.ec2.subnet {
   }
 }
 
-let database_subnet_1c = awscc.ec2.subnet {
+let database_subnet_1c = awscc.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.201.0/24'
   availability_zone = 'ap-northeast-1c'
@@ -272,7 +272,7 @@ let database_subnet_1c = awscc.ec2.subnet {
   }
 }
 
-let database_subnet_1d = awscc.ec2.subnet {
+let database_subnet_1d = awscc.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.202.0/24'
   availability_zone = 'ap-northeast-1d'
@@ -284,7 +284,7 @@ let database_subnet_1d = awscc.ec2.subnet {
 
 # --- Database Route Table ---
 
-let database_rt = awscc.ec2.route_table {
+let database_rt = awscc.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 
   tags = {
@@ -292,24 +292,24 @@ let database_rt = awscc.ec2.route_table {
   }
 }
 
-awscc.ec2.subnet_route_table_association {
+awscc.ec2.SubnetRouteTableAssociation {
   subnet_id      = database_subnet_1a.subnet_id
   route_table_id = database_rt.route_table_id
 }
 
-awscc.ec2.subnet_route_table_association {
+awscc.ec2.SubnetRouteTableAssociation {
   subnet_id      = database_subnet_1c.subnet_id
   route_table_id = database_rt.route_table_id
 }
 
-awscc.ec2.subnet_route_table_association {
+awscc.ec2.SubnetRouteTableAssociation {
   subnet_id      = database_subnet_1d.subnet_id
   route_table_id = database_rt.route_table_id
 }
 
 # --- Security Group for VPC Endpoints ---
 
-let endpoint_sg = awscc.ec2.security_group {
+let endpoint_sg = awscc.ec2.SecurityGroup {
   vpc_id            = vpc.vpc_id
   group_description = 'SG for VPC Endpoint'
 
@@ -318,7 +318,7 @@ let endpoint_sg = awscc.ec2.security_group {
   }
 }
 
-awscc.ec2.security_group_ingress {
+awscc.ec2.SecurityGroupIngress {
   group_id    = endpoint_sg.group_id
   description = 'Allow HTTPS from VPC'
   ip_protocol = 'tcp'
@@ -329,7 +329,7 @@ awscc.ec2.security_group_ingress {
 
 # --- VPC Endpoints (Interface type) ---
 
-awscc.ec2.vpc_endpoint {
+awscc.ec2.VpcEndpoint {
   vpc_id              = vpc.vpc_id
   service_name        = 'com.amazonaws.ap-northeast-1.ecr.dkr'
   vpc_endpoint_type   = 'Interface'
@@ -338,7 +338,7 @@ awscc.ec2.vpc_endpoint {
   private_dns_enabled = true
 }
 
-awscc.ec2.vpc_endpoint {
+awscc.ec2.VpcEndpoint {
   vpc_id              = vpc.vpc_id
   service_name        = 'com.amazonaws.ap-northeast-1.ecr.api'
   vpc_endpoint_type   = 'Interface'
@@ -347,7 +347,7 @@ awscc.ec2.vpc_endpoint {
   private_dns_enabled = true
 }
 
-awscc.ec2.vpc_endpoint {
+awscc.ec2.VpcEndpoint {
   vpc_id              = vpc.vpc_id
   service_name        = 'com.amazonaws.ap-northeast-1.logs'
   vpc_endpoint_type   = 'Interface'
@@ -356,7 +356,7 @@ awscc.ec2.vpc_endpoint {
   private_dns_enabled = true
 }
 
-awscc.ec2.vpc_endpoint {
+awscc.ec2.VpcEndpoint {
   vpc_id              = vpc.vpc_id
   service_name        = 'com.amazonaws.ap-northeast-1.ssm'
   vpc_endpoint_type   = 'Interface'
@@ -365,7 +365,7 @@ awscc.ec2.vpc_endpoint {
   private_dns_enabled = true
 }
 
-awscc.ec2.vpc_endpoint {
+awscc.ec2.VpcEndpoint {
   vpc_id              = vpc.vpc_id
   service_name        = 'com.amazonaws.ap-northeast-1.ssmmessages'
   vpc_endpoint_type   = 'Interface'
@@ -376,7 +376,7 @@ awscc.ec2.vpc_endpoint {
 
 # --- VPC Endpoint (Gateway type) ---
 
-awscc.ec2.vpc_endpoint {
+awscc.ec2.VpcEndpoint {
   vpc_id            = vpc.vpc_id
   service_name      = 'com.amazonaws.ap-northeast-1.s3'
   vpc_endpoint_type = 'Gateway'


### PR DESCRIPTION
Closes #148. Refs carina-rs/carina#2143.

Phase A of the naming-conventions migration for \`carina-provider-awscc\`. Resource kinds now emit as \`awscc.<service>.<TypeName>\` (three-segment paths, final segment PascalCase), and every \`StringEnum\` ships an auto-generated snake_case DSL alias so users write \`.enabled\` while the provider round-trips it to \`\"Enabled\"\`.

## Summary

- \`carina-provider-awscc/src/bin/codegen.rs\`
  - \`dsl_resource_name_from_type\` now PascalCases the resource segment, acronym-aware (\`AWS::EC2::VPC\` → \`ec2.Vpc\`, not \`ec2.VPC\`).
  - New \`dsl_enum_value\` helper implements design D7: SHOUTY_SNAKE → lowercase, PascalCase → snake_case, kebab → underscore, dotted/numeric values passthrough.
  - Alias emitter auto-generates a DSL form for every enum value whose form differs from its API form. Replaces the former hyphen-only special case; every \`StringEnum\` now ships a two-way alias table.
  - Codegen test expectations updated for the new resource spelling (\`awscc.test.Resource.ConfigAStatus.Disabled\`).
- \`carina-provider-awscc/src/schemas/generated/**\` regenerated via \`generate-schemas.sh\`. Emitted \`resource_type_name\` and namespaces carry the new PascalCase spelling. Files whose CFN schema cache entry was empty (organizations, iam/oidc_provider, sso/instance) were restored from main with a mechanical literal rewrite.
- \`carina-provider-awscc/src/{provider/,lib,normalizer,conversion,update,operations}.rs\`: dispatch tables and namespaced enum identifiers updated to new spellings.
- \`acceptance-tests/**/*.crn\` (163 files) and \`examples/**/*.crn\` rewritten; primitive type annotations (\`: string\` → \`: String\`, etc.) migrated in the same pass.

## Out of scope

- \`generated-docs/\` regeneration requires live AWS credentials and an active SSO session; run \`aws-vault exec mizzy -- bash scripts/generate-docs.sh\` after merging to refresh. No code depends on this directory.

## Verification

- \`cargo build\` — green on the full workspace
- \`cargo test\` — 389 tests passed, 0 failed
- \`cargo clippy --all-targets -- -D warnings\` — clean
- \`cargo fmt --check\` — clean
- Sample generated output:
  - \`resource_type_name: \"ec2.Vpc\"\` (was \`\"ec2.vpc\"\`)
  - \`resource_type_name: \"ec2.Eip\"\` (was \`\"ec2.EIP\"\`)
  - \`resource_type_name: \"ec2.Ipam\"\` (was \`\"ec2.IPAM\"\`)
- Sample generated alias table entries:
  - \`(\"abac_status\", \"enabled\") => Some(\"Enabled\")\`
  - \`(\"abac_status\", \"disabled\") => Some(\"Disabled\")\`

## Test plan

- [x] \`cargo test\` workspace-wide green
- [x] Acceptance-test \`.crn\` files use the new spellings exclusively
- [x] Auto-generated aliases round-trip (\`enabled\` → \`\"Enabled\"\` → \`enabled\`)
- [x] Dispatch tables in hand-written provider code match the new spellings