### PR TITLE
schemas: fix generated mod.rs to use new PascalCase DSL names

### DIFF
--- a/carina-provider-awscc/src/schemas/generated/iam/oidc_provider.rs
+++ b/carina-provider-awscc/src/schemas/generated/iam/oidc_provider.rs
@@ -66,7 +66,7 @@ pub fn iam_oidc_provider_config() -> AwsccSchemaConfig {
         aws_type_name: "AWS::IAM::OIDCProvider",
         resource_type_name: "iam.OidcProvider",
         has_tags: true,
-        schema: ResourceSchema::new("awscc.iam.oidc_provider")
+        schema: ResourceSchema::new("awscc.iam.OidcProvider")
             .with_description("Resource Type definition for AWS::IAM::OIDCProvider")
             .attribute(
                 AttributeSchema::new("arn", super::arn())

--- a/carina-provider-awscc/src/schemas/generated/identitystore/group.rs
+++ b/carina-provider-awscc/src/schemas/generated/identitystore/group.rs
@@ -59,9 +59,9 @@ fn validate_string_pattern_3e29f1c0497511f3_len_1_1024(value: &Value) -> Result<
 pub fn identitystore_group_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::IdentityStore::Group",
-        resource_type_name: "identitystore.group",
+        resource_type_name: "identitystore.Group",
         has_tags: false,
-        schema: ResourceSchema::new("awscc.identitystore.group")
+        schema: ResourceSchema::new("awscc.identitystore.Group")
         .with_description("Resource Type definition for AWS::IdentityStore::Group")
         .attribute(
             AttributeSchema::new("description", AttributeType::Custom {
@@ -111,7 +111,7 @@ pub fn enum_valid_values() -> (
     &'static str,
     &'static [(&'static str, &'static [&'static str])],
 ) {
-    ("identitystore.group", &[])
+    ("identitystore.Group", &[])
 }
 
 /// Maps DSL alias values back to canonical AWS values for this module.

--- a/carina-provider-awscc/src/schemas/generated/identitystore/group_membership.rs
+++ b/carina-provider-awscc/src/schemas/generated/identitystore/group_membership.rs
@@ -35,9 +35,9 @@ fn validate_string_pattern_2a77a2e32f71b5f3_len_1_47(value: &Value) -> Result<()
 pub fn identitystore_group_membership_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::IdentityStore::GroupMembership",
-        resource_type_name: "identitystore.group_membership",
+        resource_type_name: "identitystore.GroupMembership",
         has_tags: false,
-        schema: ResourceSchema::new("awscc.identitystore.group_membership")
+        schema: ResourceSchema::new("awscc.identitystore.GroupMembership")
         .with_description("Resource Type Definition for AWS:IdentityStore::GroupMembership")
         .attribute(
             AttributeSchema::new("group_id", super::sso_principal_id())
@@ -95,7 +95,7 @@ pub fn enum_valid_values() -> (
     &'static str,
     &'static [(&'static str, &'static [&'static str])],
 ) {
-    ("identitystore.group_membership", &[])
+    ("identitystore.GroupMembership", &[])
 }
 
 /// Maps DSL alias values back to canonical AWS values for this module.

--- a/carina-provider-awscc/src/schemas/generated/logs/log_group.rs
+++ b/carina-provider-awscc/src/schemas/generated/logs/log_group.rs
@@ -67,6 +67,12 @@ pub fn logs_log_group_config() -> AwsccSchemaConfig {
                 .with_provider_name("Arn"),
         )
         .attribute(
+            AttributeSchema::new("bearer_token_authentication_enabled", AttributeType::Bool)
+                .with_description("")
+                .with_provider_name("BearerTokenAuthenticationEnabled")
+                .with_default(Value::Bool(false)),
+        )
+        .attribute(
             AttributeSchema::new("data_protection_policy", AttributeType::map(AttributeType::String))
                 .with_description("Creates a data protection policy and assigns it to the log group. A data protection policy can help safeguard sensitive data that's ingested by the log group by auditing and masking the sensitive log data. When a user who does not have permission to view masked data views a log event that includes masked data, the sensitive data is replaced by asterisks.")
                 .with_provider_name("DataProtectionPolicy"),

--- a/carina-provider-awscc/src/schemas/generated/mod.rs
+++ b/carina-provider-awscc/src/schemas/generated/mod.rs
@@ -88,85 +88,79 @@ type EnumAliasReverseFn = fn(&str, &str) -> Option<&'static str>;
 static ENUM_ALIAS_DISPATCH: LazyLock<HashMap<&'static str, EnumAliasReverseFn>> =
     LazyLock::new(|| {
         let entries: Vec<(&str, EnumAliasReverseFn)> = vec![
-            ("ec2.vpc", ec2::vpc::enum_alias_reverse),
-            ("ec2.subnet", ec2::subnet::enum_alias_reverse),
+            ("ec2.Vpc", ec2::vpc::enum_alias_reverse),
+            ("ec2.Subnet", ec2::subnet::enum_alias_reverse),
             (
-                "ec2.internet_gateway",
+                "ec2.InternetGateway",
                 ec2::internet_gateway::enum_alias_reverse,
             ),
-            ("ec2.route_table", ec2::route_table::enum_alias_reverse),
-            ("ec2.route", ec2::route::enum_alias_reverse),
+            ("ec2.RouteTable", ec2::route_table::enum_alias_reverse),
+            ("ec2.Route", ec2::route::enum_alias_reverse),
             (
-                "ec2.subnet_route_table_association",
+                "ec2.SubnetRouteTableAssociation",
                 ec2::subnet_route_table_association::enum_alias_reverse,
             ),
-            ("ec2.eip", ec2::eip::enum_alias_reverse),
-            ("ec2.nat_gateway", ec2::nat_gateway::enum_alias_reverse),
+            ("ec2.Eip", ec2::eip::enum_alias_reverse),
+            ("ec2.NatGateway", ec2::nat_gateway::enum_alias_reverse),
+            ("ec2.SecurityGroup", ec2::security_group::enum_alias_reverse),
             (
-                "ec2.security_group",
-                ec2::security_group::enum_alias_reverse,
-            ),
-            (
-                "ec2.security_group_ingress",
+                "ec2.SecurityGroupIngress",
                 ec2::security_group_ingress::enum_alias_reverse,
             ),
             (
-                "ec2.security_group_egress",
+                "ec2.SecurityGroupEgress",
                 ec2::security_group_egress::enum_alias_reverse,
             ),
-            ("ec2.vpc_endpoint", ec2::vpc_endpoint::enum_alias_reverse),
+            ("ec2.VpcEndpoint", ec2::vpc_endpoint::enum_alias_reverse),
             (
-                "ec2.vpc_gateway_attachment",
+                "ec2.VpcGatewayAttachment",
                 ec2::vpc_gateway_attachment::enum_alias_reverse,
             ),
-            ("ec2.flow_log", ec2::flow_log::enum_alias_reverse),
-            ("ec2.ipam", ec2::ipam::enum_alias_reverse),
-            ("ec2.ipam_pool", ec2::ipam_pool::enum_alias_reverse),
-            ("ec2.vpn_gateway", ec2::vpn_gateway::enum_alias_reverse),
+            ("ec2.FlowLog", ec2::flow_log::enum_alias_reverse),
+            ("ec2.Ipam", ec2::ipam::enum_alias_reverse),
+            ("ec2.IpamPool", ec2::ipam_pool::enum_alias_reverse),
+            ("ec2.VpnGateway", ec2::vpn_gateway::enum_alias_reverse),
             (
-                "ec2.transit_gateway",
+                "ec2.TransitGateway",
                 ec2::transit_gateway::enum_alias_reverse,
             ),
             (
-                "ec2.vpc_peering_connection",
+                "ec2.VpcPeeringConnection",
                 ec2::vpc_peering_connection::enum_alias_reverse,
             ),
             (
-                "ec2.egress_only_internet_gateway",
+                "ec2.EgressOnlyInternetGateway",
                 ec2::egress_only_internet_gateway::enum_alias_reverse,
             ),
             (
-                "ec2.transit_gateway_attachment",
+                "ec2.TransitGatewayAttachment",
                 ec2::transit_gateway_attachment::enum_alias_reverse,
             ),
-            ("s3.bucket", s3::bucket::enum_alias_reverse),
-            ("iam.role", iam::role::enum_alias_reverse),
-            ("iam.oidc_provider", iam::oidc_provider::enum_alias_reverse),
-            ("logs.log_group", logs::log_group::enum_alias_reverse),
+            ("s3.Bucket", s3::bucket::enum_alias_reverse),
+            ("iam.Role", iam::role::enum_alias_reverse),
+            ("iam.OidcProvider", iam::oidc_provider::enum_alias_reverse),
+            ("logs.LogGroup", logs::log_group::enum_alias_reverse),
             (
-                "organizations.organization",
+                "organizations.Organization",
                 organizations::organization::enum_alias_reverse,
             ),
             (
-                "organizations.account",
+                "organizations.Account",
                 organizations::account::enum_alias_reverse,
             ),
-            ("sso.instance", sso::instance::enum_alias_reverse),
+            ("sso.Instance", sso::instance::enum_alias_reverse),
+            ("sso.PermissionSet", sso::permission_set::enum_alias_reverse),
+            ("sso.Assignment", sso::assignment::enum_alias_reverse),
             (
-                "sso.permission_set",
-                sso::permission_set::enum_alias_reverse,
-            ),
-            ("sso.assignment", sso::assignment::enum_alias_reverse),
-            (
-                "identitystore.group",
+                "identitystore.Group",
                 identitystore::group::enum_alias_reverse,
             ),
             (
-                "identitystore.group_membership",
+                "identitystore.GroupMembership",
                 identitystore::group_membership::enum_alias_reverse,
             ),
             (
-                "route53.hosted_zone",
+                "route53.HostedZone",
                 route53::hosted_zone::enum_alias_reverse,
             ),
         ];
@@ -256,231 +250,231 @@ pub fn get_enum_alias_reverse(
 pub fn build_enum_aliases_map() -> HashMap<String, HashMap<String, HashMap<String, String>>> {
     let mut map: HashMap<String, HashMap<String, HashMap<String, String>>> = HashMap::new();
     for (attr, alias, canonical) in ec2::vpc::enum_alias_entries() {
-        map.entry("ec2.vpc".to_string())
+        map.entry("ec2.Vpc".to_string())
             .or_default()
             .entry(attr.to_string())
             .or_default()
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in ec2::subnet::enum_alias_entries() {
-        map.entry("ec2.subnet".to_string())
+        map.entry("ec2.Subnet".to_string())
             .or_default()
             .entry(attr.to_string())
             .or_default()
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in ec2::internet_gateway::enum_alias_entries() {
-        map.entry("ec2.internet_gateway".to_string())
+        map.entry("ec2.InternetGateway".to_string())
             .or_default()
             .entry(attr.to_string())
             .or_default()
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in ec2::route_table::enum_alias_entries() {
-        map.entry("ec2.route_table".to_string())
+        map.entry("ec2.RouteTable".to_string())
             .or_default()
             .entry(attr.to_string())
             .or_default()
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in ec2::route::enum_alias_entries() {
-        map.entry("ec2.route".to_string())
+        map.entry("ec2.Route".to_string())
             .or_default()
             .entry(attr.to_string())
             .or_default()
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in ec2::subnet_route_table_association::enum_alias_entries() {
-        map.entry("ec2.subnet_route_table_association".to_string())
+        map.entry("ec2.SubnetRouteTableAssociation".to_string())
             .or_default()
             .entry(attr.to_string())
             .or_default()
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in ec2::eip::enum_alias_entries() {
-        map.entry("ec2.eip".to_string())
+        map.entry("ec2.Eip".to_string())
             .or_default()
             .entry(attr.to_string())
             .or_default()
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in ec2::nat_gateway::enum_alias_entries() {
-        map.entry("ec2.nat_gateway".to_string())
+        map.entry("ec2.NatGateway".to_string())
             .or_default()
             .entry(attr.to_string())
             .or_default()
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in ec2::security_group::enum_alias_entries() {
-        map.entry("ec2.security_group".to_string())
+        map.entry("ec2.SecurityGroup".to_string())
             .or_default()
             .entry(attr.to_string())
             .or_default()
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in ec2::security_group_ingress::enum_alias_entries() {
-        map.entry("ec2.security_group_ingress".to_string())
+        map.entry("ec2.SecurityGroupIngress".to_string())
             .or_default()
             .entry(attr.to_string())
             .or_default()
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in ec2::security_group_egress::enum_alias_entries() {
-        map.entry("ec2.security_group_egress".to_string())
+        map.entry("ec2.SecurityGroupEgress".to_string())
             .or_default()
             .entry(attr.to_string())
             .or_default()
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in ec2::vpc_endpoint::enum_alias_entries() {
-        map.entry("ec2.vpc_endpoint".to_string())
+        map.entry("ec2.VpcEndpoint".to_string())
             .or_default()
             .entry(attr.to_string())
             .or_default()
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in ec2::vpc_gateway_attachment::enum_alias_entries() {
-        map.entry("ec2.vpc_gateway_attachment".to_string())
+        map.entry("ec2.VpcGatewayAttachment".to_string())
             .or_default()
             .entry(attr.to_string())
             .or_default()
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in ec2::flow_log::enum_alias_entries() {
-        map.entry("ec2.flow_log".to_string())
+        map.entry("ec2.FlowLog".to_string())
             .or_default()
             .entry(attr.to_string())
             .or_default()
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in ec2::ipam::enum_alias_entries() {
-        map.entry("ec2.ipam".to_string())
+        map.entry("ec2.Ipam".to_string())
             .or_default()
             .entry(attr.to_string())
             .or_default()
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in ec2::ipam_pool::enum_alias_entries() {
-        map.entry("ec2.ipam_pool".to_string())
+        map.entry("ec2.IpamPool".to_string())
             .or_default()
             .entry(attr.to_string())
             .or_default()
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in ec2::vpn_gateway::enum_alias_entries() {
-        map.entry("ec2.vpn_gateway".to_string())
+        map.entry("ec2.VpnGateway".to_string())
             .or_default()
             .entry(attr.to_string())
             .or_default()
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in ec2::transit_gateway::enum_alias_entries() {
-        map.entry("ec2.transit_gateway".to_string())
+        map.entry("ec2.TransitGateway".to_string())
             .or_default()
             .entry(attr.to_string())
             .or_default()
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in ec2::vpc_peering_connection::enum_alias_entries() {
-        map.entry("ec2.vpc_peering_connection".to_string())
+        map.entry("ec2.VpcPeeringConnection".to_string())
             .or_default()
             .entry(attr.to_string())
             .or_default()
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in ec2::egress_only_internet_gateway::enum_alias_entries() {
-        map.entry("ec2.egress_only_internet_gateway".to_string())
+        map.entry("ec2.EgressOnlyInternetGateway".to_string())
             .or_default()
             .entry(attr.to_string())
             .or_default()
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in ec2::transit_gateway_attachment::enum_alias_entries() {
-        map.entry("ec2.transit_gateway_attachment".to_string())
+        map.entry("ec2.TransitGatewayAttachment".to_string())
             .or_default()
             .entry(attr.to_string())
             .or_default()
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in s3::bucket::enum_alias_entries() {
-        map.entry("s3.bucket".to_string())
+        map.entry("s3.Bucket".to_string())
             .or_default()
             .entry(attr.to_string())
             .or_default()
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in iam::role::enum_alias_entries() {
-        map.entry("iam.role".to_string())
+        map.entry("iam.Role".to_string())
             .or_default()
             .entry(attr.to_string())
             .or_default()
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in iam::oidc_provider::enum_alias_entries() {
-        map.entry("iam.oidc_provider".to_string())
+        map.entry("iam.OidcProvider".to_string())
             .or_default()
             .entry(attr.to_string())
             .or_default()
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in logs::log_group::enum_alias_entries() {
-        map.entry("logs.log_group".to_string())
+        map.entry("logs.LogGroup".to_string())
             .or_default()
             .entry(attr.to_string())
             .or_default()
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in organizations::organization::enum_alias_entries() {
-        map.entry("organizations.organization".to_string())
+        map.entry("organizations.Organization".to_string())
             .or_default()
             .entry(attr.to_string())
             .or_default()
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in organizations::account::enum_alias_entries() {
-        map.entry("organizations.account".to_string())
+        map.entry("organizations.Account".to_string())
             .or_default()
             .entry(attr.to_string())
             .or_default()
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in sso::instance::enum_alias_entries() {
-        map.entry("sso.instance".to_string())
+        map.entry("sso.Instance".to_string())
             .or_default()
             .entry(attr.to_string())
             .or_default()
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in sso::permission_set::enum_alias_entries() {
-        map.entry("sso.permission_set".to_string())
+        map.entry("sso.PermissionSet".to_string())
             .or_default()
             .entry(attr.to_string())
             .or_default()
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in sso::assignment::enum_alias_entries() {
-        map.entry("sso.assignment".to_string())
+        map.entry("sso.Assignment".to_string())
             .or_default()
             .entry(attr.to_string())
             .or_default()
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in identitystore::group::enum_alias_entries() {
-        map.entry("identitystore.group".to_string())
+        map.entry("identitystore.Group".to_string())
             .or_default()
             .entry(attr.to_string())
             .or_default()
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in identitystore::group_membership::enum_alias_entries() {
-        map.entry("identitystore.group_membership".to_string())
+        map.entry("identitystore.GroupMembership".to_string())
             .or_default()
             .entry(attr.to_string())
             .or_default()
             .insert(alias.to_string(), canonical.to_string());
     }
     for (attr, alias, canonical) in route53::hosted_zone::enum_alias_entries() {
-        map.entry("route53.hosted_zone".to_string())
+        map.entry("route53.HostedZone".to_string())
             .or_default()
             .entry(attr.to_string())
             .or_default()

--- a/carina-provider-awscc/src/schemas/generated/organizations/account.rs
+++ b/carina-provider-awscc/src/schemas/generated/organizations/account.rs
@@ -170,7 +170,7 @@ pub fn organizations_account_config() -> AwsccSchemaConfig {
         aws_type_name: "AWS::Organizations::Account",
         resource_type_name: "organizations.Account",
         has_tags: true,
-        schema: ResourceSchema::new("awscc.organizations.account")
+        schema: ResourceSchema::new("awscc.organizations.Account")
         .with_description("You can use AWS::Organizations::Account to manage accounts in organization.")
         .attribute(
             AttributeSchema::new("account_id", super::aws_account_id())
@@ -216,7 +216,7 @@ pub fn organizations_account_config() -> AwsccSchemaConfig {
             AttributeSchema::new("joined_method", AttributeType::StringEnum {
                 name: "JoinedMethod".to_string(),
                 values: vec!["INVITED".to_string(), "CREATED".to_string()],
-                namespace: Some("awscc.organizations.account".to_string()),
+                namespace: Some("awscc.organizations.Account".to_string()),
                 to_dsl: None,
             })
                 .read_only()
@@ -275,7 +275,7 @@ pub fn organizations_account_config() -> AwsccSchemaConfig {
             AttributeSchema::new("state", AttributeType::StringEnum {
                 name: "State".to_string(),
                 values: vec!["PENDING_ACTIVATION".to_string(), "ACTIVE".to_string(), "SUSPENDED".to_string(), "PENDING_CLOSURE".to_string(), "CLOSED".to_string()],
-                namespace: Some("awscc.organizations.account".to_string()),
+                namespace: Some("awscc.organizations.Account".to_string()),
                 to_dsl: None,
             })
                 .read_only()
@@ -286,7 +286,7 @@ pub fn organizations_account_config() -> AwsccSchemaConfig {
             AttributeSchema::new("status", AttributeType::StringEnum {
                 name: "Status".to_string(),
                 values: vec!["ACTIVE".to_string(), "SUSPENDED".to_string(), "PENDING_CLOSURE".to_string()],
-                namespace: Some("awscc.organizations.account".to_string()),
+                namespace: Some("awscc.organizations.Account".to_string()),
                 to_dsl: None,
             })
                 .read_only()
@@ -326,11 +326,33 @@ pub fn enum_valid_values() -> (
 /// Maps DSL alias values back to canonical AWS values for this module.
 /// e.g., ("ip_protocol", "all") -> Some("-1")
 pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
-    let _ = (attr_name, value);
-    None
+    match (attr_name, value) {
+        ("joined_method", "invited") => Some("INVITED"),
+        ("joined_method", "created") => Some("CREATED"),
+        ("state", "pending_activation") => Some("PENDING_ACTIVATION"),
+        ("state", "active") => Some("ACTIVE"),
+        ("state", "suspended") => Some("SUSPENDED"),
+        ("state", "pending_closure") => Some("PENDING_CLOSURE"),
+        ("state", "closed") => Some("CLOSED"),
+        ("status", "active") => Some("ACTIVE"),
+        ("status", "suspended") => Some("SUSPENDED"),
+        ("status", "pending_closure") => Some("PENDING_CLOSURE"),
+        _ => None,
+    }
 }
 
 /// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
 pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
-    &[]
+    &[
+        ("joined_method", "invited", "INVITED"),
+        ("joined_method", "created", "CREATED"),
+        ("state", "pending_activation", "PENDING_ACTIVATION"),
+        ("state", "active", "ACTIVE"),
+        ("state", "suspended", "SUSPENDED"),
+        ("state", "pending_closure", "PENDING_CLOSURE"),
+        ("state", "closed", "CLOSED"),
+        ("status", "active", "ACTIVE"),
+        ("status", "suspended", "SUSPENDED"),
+        ("status", "pending_closure", "PENDING_CLOSURE"),
+    ]
 }

--- a/carina-provider-awscc/src/schemas/generated/organizations/organization.rs
+++ b/carina-provider-awscc/src/schemas/generated/organizations/organization.rs
@@ -80,7 +80,7 @@ pub fn organizations_organization_config() -> AwsccSchemaConfig {
         aws_type_name: "AWS::Organizations::Organization",
         resource_type_name: "organizations.Organization",
         has_tags: false,
-        schema: ResourceSchema::new("awscc.organizations.organization")
+        schema: ResourceSchema::new("awscc.organizations.Organization")
         .with_description("Resource schema for AWS::Organizations::Organization")
         .attribute(
             AttributeSchema::new("arn", super::arn())
@@ -92,7 +92,7 @@ pub fn organizations_organization_config() -> AwsccSchemaConfig {
             AttributeSchema::new("feature_set", AttributeType::StringEnum {
                 name: "FeatureSet".to_string(),
                 values: vec!["ALL".to_string(), "CONSOLIDATED_BILLING".to_string()],
-                namespace: Some("awscc.organizations.organization".to_string()),
+                namespace: Some("awscc.organizations.Organization".to_string()),
                 to_dsl: None,
             })
                 .with_description("Specifies the feature set supported by the new organization. Each feature set supports different levels of functionality.")
@@ -170,11 +170,21 @@ pub fn enum_valid_values() -> (
 /// Maps DSL alias values back to canonical AWS values for this module.
 /// e.g., ("ip_protocol", "all") -> Some("-1")
 pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
-    let _ = (attr_name, value);
-    None
+    match (attr_name, value) {
+        ("feature_set", "all") => Some("ALL"),
+        ("feature_set", "consolidated_billing") => Some("CONSOLIDATED_BILLING"),
+        _ => None,
+    }
 }
 
 /// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
 pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
-    &[]
+    &[
+        ("feature_set", "all", "ALL"),
+        (
+            "feature_set",
+            "consolidated_billing",
+            "CONSOLIDATED_BILLING",
+        ),
+    ]
 }

--- a/carina-provider-awscc/src/schemas/generated/route53/hosted_zone.rs
+++ b/carina-provider-awscc/src/schemas/generated/route53/hosted_zone.rs
@@ -52,9 +52,9 @@ fn validate_string_length_max_1024(value: &Value) -> Result<(), String> {
 pub fn route53_hosted_zone_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::Route53::HostedZone",
-        resource_type_name: "route53.hosted_zone",
+        resource_type_name: "route53.HostedZone",
         has_tags: true,
-        schema: ResourceSchema::new("awscc.route53.hosted_zone")
+        schema: ResourceSchema::new("awscc.route53.HostedZone")
         .with_description("Creates a new public or private hosted zone. You create records in a public hosted zone to define how you want to route traffic on the internet for a domain, such as example.com, and its subdomains (apex.example.com, acme.example.com). You create records in a private hosted zone to define how you want to route traffic for a domain and its subdomains within one or more Amazon Virtual Private Clouds (Amazon VPCs).    You can't convert a public hosted zone to a private hosted zone or vice versa. Instead, you must create a new hosted zone with the same name and create new resource record sets.   For more information about charges for hosted zones, see [Amazon Route 53 Pricing](https://docs.aws.amazon.com/route53/pricing/).  Note the following:   +  You can't create a hosted zone for a top-level domain (TLD) such as .com.   +  If your domain is registered with a registrar other than Route 53, you must update the name servers with your registrar to make Route 53 the DNS service for the domain. For more information, see [Migrating DNS Service for an Existing Domain to Amazon Route 53](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/MigratingDNS.html) in the *Amazon Route 53 Developer Guide*.      When you submit a ``CreateHostedZone`` request, the initial status of the hosted zone is ``PENDING``. For public hosted zones, this means that the NS and SOA records are not yet available on all Route 53 DNS servers. When the NS and SOA records are available, the status of the zone changes to ``INSYNC``.  The ``CreateHostedZone`` request requires the caller to have an ``ec2:DescribeVpcs`` permission.   When creating private hosted zones, the Amazon VPC must belong to the same partition where the hosted zone is created. A partition is a group of AWS-Regions. Each AWS-account is scoped to one partition.  The following are the supported partitions:   +  ``aws`` - AWS-Regions   +  ``aws-cn`` - China Regions   +  ``aws-us-gov`` - govcloud-us-region     For more information, see [Access Management](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) in the *General Reference*.")
         .attribute(
             AttributeSchema::new("hosted_zone_config", AttributeType::Struct {
@@ -175,7 +175,7 @@ pub fn enum_valid_values() -> (
     &'static str,
     &'static [(&'static str, &'static [&'static str])],
 ) {
-    ("route53.hosted_zone", &[])
+    ("route53.HostedZone", &[])
 }
 
 /// Maps DSL alias values back to canonical AWS values for this module.

--- a/carina-provider-awscc/src/schemas/generated/s3/bucket.rs
+++ b/carina-provider-awscc/src/schemas/generated/s3/bucket.rs
@@ -30,6 +30,8 @@ const VALID_ACCESS_CONTROL_TRANSLATION_OWNER: &[&str] = &["Destination"];
 
 const VALID_BLOCKED_ENCRYPTION_TYPES_ENCRYPTION_TYPE: &[&str] = &["NONE", "SSE-C"];
 
+const VALID_BUCKET_NAMESPACE: &[&str] = &["global", "account-regional"];
+
 const VALID_CORS_RULE_ALLOWED_METHODS: &[&str] = &["GET", "PUT", "HEAD", "POST", "DELETE"];
 
 const VALID_DATA_EXPORT_OUTPUT_SCHEMA_VERSION: &[&str] = &["V_1"];
@@ -362,6 +364,25 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 .create_only()
                 .with_description("A name for the bucket. If you don't specify a name, AWS CloudFormation generates a unique ID and uses that ID for the bucket name. The bucket name must contain only lowercase letters, numbers, periods (.), and dashes (-) and must follow [Amazon S3 bucket restrictions and limitations](https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html). For more information, see [Rules for naming Amazon S3 buckets](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html) in the *Amazon S3 User Guide*. If you specify a name, you can't perform updates that require replacement of this resource. You can perform updates that require no or some interruption. If you need to replace the resource, specify a new name.")
                 .with_provider_name("BucketName"),
+        )
+        .attribute(
+            AttributeSchema::new("bucket_name_prefix", AttributeType::String)
+                .create_only()
+                .write_only()
+                .with_description("")
+                .with_provider_name("BucketNamePrefix"),
+        )
+        .attribute(
+            AttributeSchema::new("bucket_namespace", AttributeType::StringEnum {
+                name: "BucketNamespace".to_string(),
+                values: vec!["global".to_string(), "account-regional".to_string()],
+                namespace: Some("awscc.s3.Bucket".to_string()),
+                to_dsl: Some(|s: &str| s.replace('-', "_")),
+            })
+                .create_only()
+                .write_only()
+                .with_description("")
+                .with_provider_name("BucketNamespace"),
         )
         .attribute(
             AttributeSchema::new("cors_configuration", AttributeType::Struct {
@@ -1253,6 +1274,7 @@ pub fn enum_valid_values() -> (
                 "encryption_type",
                 VALID_BLOCKED_ENCRYPTION_TYPES_ENCRYPTION_TYPE,
             ),
+            ("bucket_namespace", VALID_BUCKET_NAMESPACE),
             ("allowed_methods", VALID_CORS_RULE_ALLOWED_METHODS),
             (
                 "output_schema_version",
@@ -1346,6 +1368,7 @@ pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> 
         ("owner", "destination") => Some("Destination"),
         ("encryption_type", "none") => Some("NONE"),
         ("encryption_type", "sse_c") => Some("SSE-C"),
+        ("bucket_namespace", "account_regional") => Some("account-regional"),
         ("allowed_methods", "get") => Some("GET"),
         ("allowed_methods", "put") => Some("PUT"),
         ("allowed_methods", "head") => Some("HEAD"),
@@ -1432,6 +1455,7 @@ pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static s
         ("owner", "destination", "Destination"),
         ("encryption_type", "none", "NONE"),
         ("encryption_type", "sse_c", "SSE-C"),
+        ("bucket_namespace", "account_regional", "account-regional"),
         ("allowed_methods", "get", "GET"),
         ("allowed_methods", "put", "PUT"),
         ("allowed_methods", "head", "HEAD"),

--- a/carina-provider-awscc/src/schemas/generated/sso/assignment.rs
+++ b/carina-provider-awscc/src/schemas/generated/sso/assignment.rs
@@ -15,9 +15,9 @@ const VALID_TARGET_TYPE: &[&str] = &["AWS_ACCOUNT"];
 pub fn sso_assignment_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::SSO::Assignment",
-        resource_type_name: "sso.assignment",
+        resource_type_name: "sso.Assignment",
         has_tags: false,
-        schema: ResourceSchema::new("awscc.sso.assignment")
+        schema: ResourceSchema::new("awscc.sso.Assignment")
             .with_description("Resource Type definition for SSO assignmet")
             .attribute(
                 AttributeSchema::new("instance_arn", super::sso_instance_arn())
@@ -46,7 +46,7 @@ pub fn sso_assignment_config() -> AwsccSchemaConfig {
                     AttributeType::StringEnum {
                         name: "PrincipalType".to_string(),
                         values: vec!["USER".to_string(), "GROUP".to_string()],
-                        namespace: Some("awscc.sso.assignment".to_string()),
+                        namespace: Some("awscc.sso.Assignment".to_string()),
                         to_dsl: None,
                     },
                 )
@@ -68,7 +68,7 @@ pub fn sso_assignment_config() -> AwsccSchemaConfig {
                     AttributeType::StringEnum {
                         name: "TargetType".to_string(),
                         values: vec!["AWS_ACCOUNT".to_string()],
-                        namespace: Some("awscc.sso.assignment".to_string()),
+                        namespace: Some("awscc.sso.Assignment".to_string()),
                         to_dsl: None,
                     },
                 )
@@ -86,7 +86,7 @@ pub fn enum_valid_values() -> (
     &'static [(&'static str, &'static [&'static str])],
 ) {
     (
-        "sso.assignment",
+        "sso.Assignment",
         &[
             ("principal_type", VALID_PRINCIPAL_TYPE),
             ("target_type", VALID_TARGET_TYPE),
@@ -97,11 +97,19 @@ pub fn enum_valid_values() -> (
 /// Maps DSL alias values back to canonical AWS values for this module.
 /// e.g., ("ip_protocol", "all") -> Some("-1")
 pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
-    let _ = (attr_name, value);
-    None
+    match (attr_name, value) {
+        ("principal_type", "user") => Some("USER"),
+        ("principal_type", "group") => Some("GROUP"),
+        ("target_type", "aws_account") => Some("AWS_ACCOUNT"),
+        _ => None,
+    }
 }
 
 /// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
 pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
-    &[]
+    &[
+        ("principal_type", "user", "USER"),
+        ("principal_type", "group", "GROUP"),
+        ("target_type", "aws_account", "AWS_ACCOUNT"),
+    ]
 }

--- a/carina-provider-awscc/src/schemas/generated/sso/instance.rs
+++ b/carina-provider-awscc/src/schemas/generated/sso/instance.rs
@@ -91,7 +91,7 @@ pub fn sso_instance_config() -> AwsccSchemaConfig {
         aws_type_name: "AWS::SSO::Instance",
         resource_type_name: "sso.Instance",
         has_tags: true,
-        schema: ResourceSchema::new("awscc.sso.instance")
+        schema: ResourceSchema::new("awscc.sso.Instance")
         .with_description("Resource Type definition for Identity Center (SSO) Instance")
         .attribute(
             AttributeSchema::new("identity_store_id", super::identity_store_id())
@@ -128,7 +128,7 @@ pub fn sso_instance_config() -> AwsccSchemaConfig {
             AttributeSchema::new("status", AttributeType::StringEnum {
                 name: "Status".to_string(),
                 values: vec!["CREATE_IN_PROGRESS".to_string(), "DELETE_IN_PROGRESS".to_string(), "ACTIVE".to_string()],
-                namespace: Some("awscc.sso.instance".to_string()),
+                namespace: Some("awscc.sso.Instance".to_string()),
                 to_dsl: None,
             })
                 .read_only()
@@ -160,11 +160,19 @@ pub fn enum_valid_values() -> (
 /// Maps DSL alias values back to canonical AWS values for this module.
 /// e.g., ("ip_protocol", "all") -> Some("-1")
 pub fn enum_alias_reverse(attr_name: &str, value: &str) -> Option<&'static str> {
-    let _ = (attr_name, value);
-    None
+    match (attr_name, value) {
+        ("status", "create_in_progress") => Some("CREATE_IN_PROGRESS"),
+        ("status", "delete_in_progress") => Some("DELETE_IN_PROGRESS"),
+        ("status", "active") => Some("ACTIVE"),
+        _ => None,
+    }
 }
 
 /// Returns all enum alias entries as (attr_name, alias, canonical) tuples.
 pub fn enum_alias_entries() -> &'static [(&'static str, &'static str, &'static str)] {
-    &[]
+    &[
+        ("status", "create_in_progress", "CREATE_IN_PROGRESS"),
+        ("status", "delete_in_progress", "DELETE_IN_PROGRESS"),
+        ("status", "active", "ACTIVE"),
+    ]
 }

--- a/carina-provider-awscc/src/schemas/generated/sso/permission_set.rs
+++ b/carina-provider-awscc/src/schemas/generated/sso/permission_set.rs
@@ -183,9 +183,9 @@ fn validate_string_pattern_1e58d8243b46a2f1_len_1_100(value: &Value) -> Result<(
 pub fn sso_permission_set_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
         aws_type_name: "AWS::SSO::PermissionSet",
-        resource_type_name: "sso.permission_set",
+        resource_type_name: "sso.PermissionSet",
         has_tags: true,
-        schema: ResourceSchema::new("awscc.sso.permission_set")
+        schema: ResourceSchema::new("awscc.sso.PermissionSet")
         .with_description("Resource Type definition for SSO PermissionSet")
         .attribute(
             AttributeSchema::new("customer_managed_policy_references", AttributeType::Custom {
@@ -357,7 +357,7 @@ pub fn enum_valid_values() -> (
     &'static str,
     &'static [(&'static str, &'static [&'static str])],
 ) {
-    ("sso.permission_set", &[])
+    ("sso.PermissionSet", &[])
 }
 
 /// Maps DSL alias values back to canonical AWS values for this module.


### PR DESCRIPTION
Follow-up to #150. Refs carina-rs/carina#2143.

## Problem

PR #150 regenerated per-resource schema files with the new PascalCase spellings, but the aggregated \`mod.rs\` was only partially regenerated because the CloudFormation schema cache was missing entries for \`OIDCProvider\` / \`organizations\` / \`sso::instance\`. The result was a split-brain state: individual \`_config()\` helpers returned \`\"sso.Instance\"\`, but the \`ENUM_ALIAS_DISPATCH\` and \`build_enum_aliases_map()\` tables keyed on the old \`\"sso.instance\"\` spelling, so the provider responded with \`Unknown resource type: awscc.sso.Instance\` at validation time.

## Fix

Refresh the schema cache end-to-end and regenerate everything:

\`\`\`
aws-vault exec <profile> -- bash carina-provider-awscc/scripts/generate-schemas.sh --refresh-cache
\`\`\`

All aggregated tables now carry the new PascalCase spellings:

\`\`\`
(\"iam.OidcProvider\",  iam::oidc_provider::enum_alias_reverse),
(\"organizations.Organization\", organizations::organization::...),
(\"sso.Instance\",      sso::instance::enum_alias_reverse),
\`\`\`

## Verification

- \`cargo build\` / \`cargo test\` green
- \`cargo clippy --all-targets -- -D warnings\` clean
- \`cargo fmt --check\` clean
- \`carina validate\` on the infra repo's directories, built against this branch, returns green (no \`Unknown resource type\` errors).