### PR TITLE
acceptance-tests: init work_dir and run carina from it in create_before_destroy

### DIFF
--- a/acceptance-tests/create_before_destroy/run.sh
+++ b/acceptance-tests/create_before_destroy/run.sh
@@ -24,18 +24,14 @@ TOTAL_FAILED=0
 
 # Track active work dir for signal cleanup
 ACTIVE_WORK_DIR=""
-ACTIVE_STEP1=""
-ACTIVE_STEP2=""
 
 signal_cleanup() {
     if [ -n "$ACTIVE_WORK_DIR" ] && [ -d "$ACTIVE_WORK_DIR" ]; then
         set +e
         echo ""
         echo "Interrupted. Cleaning up resources..."
-        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP2" 2>&1
-        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP1" 2>&1
-        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP2" 2>&1
-        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP1" 2>&1
+        (cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve . 2>&1)
+        (cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve . 2>&1)
         rm -rf "$ACTIVE_WORK_DIR"
         ACTIVE_WORK_DIR=""
     fi
@@ -48,13 +44,12 @@ run_step() {
     local work_dir="$1"
     local description="$2"
     local command="$3"
-    local crn_file="$4"
-    local extra_args="${5:-}"
+    local extra_args="${4:-}"
 
     printf "  %-55s " "$description"
 
     local output
-    if output=$(cd "$work_dir" && "$CARINA_BIN" $command $extra_args "$crn_file" 2>&1); then
+    if output=$(cd "$work_dir" && "$CARINA_BIN" $command $extra_args . 2>&1); then
         echo "OK"
         TOTAL_PASSED=$((TOTAL_PASSED + 1))
         return 0
@@ -129,13 +124,12 @@ assert_identifiers() {
 run_plan_verify() {
     local work_dir="$1"
     local description="$2"
-    local crn_file="$3"
 
     printf "  %-55s " "$description"
 
     local output
     local rc
-    output=$(cd "$work_dir" && "$CARINA_BIN" plan --detailed-exitcode "$crn_file" 2>&1) || rc=$?
+    output=$(cd "$work_dir" && "$CARINA_BIN" plan --detailed-exitcode . 2>&1) || rc=$?
     rc=${rc:-0}
 
     if [ $rc -eq 2 ]; then
@@ -156,28 +150,20 @@ run_plan_verify() {
     return 0
 }
 
-# Cleanup helper: try to destroy with both step configs, then retry
+# Cleanup helper: destroy resources in work_dir, retrying to handle dependencies
 # Returns 0 if at least one destroy succeeded, 1 if ALL failed
 cleanup() {
     local work_dir="$1"
-    local step2="$2"
-    local step1="$3"
     local any_success=false
 
     # Disable set -e to ensure all destroy attempts run
     set +e
     echo "  Cleanup: destroying resources..."
-    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1; then
-        any_success=true
-    fi
-    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1; then
+    if (cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve . 2>&1); then
         any_success=true
     fi
     # Retry: resources may have dependencies that prevent deletion on first pass
-    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1; then
-        any_success=true
-    fi
-    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1; then
+    if (cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve . 2>&1); then
         any_success=true
     fi
     set -e
@@ -186,6 +172,17 @@ cleanup() {
         return 1
     fi
     return 0
+}
+
+# Swap the active .crn into work_dir/main.crn (with provider source injected).
+# Args: source_crn target_work_dir
+swap_crn() {
+    local src="$1"
+    local target="$2"
+    local injected_dir
+    injected_dir=$(inject_provider_source "$src")
+    cp "$injected_dir/main.crn" "$target/main.crn"
+    rm -rf "$injected_dir"
 }
 
 # Run a single multi-step test
@@ -204,32 +201,34 @@ run_test() {
     local work_dir
     work_dir=$(mktemp -d)
 
-    # Inject provider source into .crn files
-    step1=$(inject_provider_source "$step1")
-    step2=$(inject_provider_source "$step2")
-
     # Register for signal cleanup
     ACTIVE_WORK_DIR="$work_dir"
-    ACTIVE_STEP1="$step1"
-    ACTIVE_STEP2="$step2"
 
     echo "$desc"
     echo ""
 
-    # Step 1: Apply initial config
-    if ! run_step "$work_dir" "step1: apply initial" "apply" "$step1" "--auto-approve"; then
-        cleanup "$work_dir" "$step2" "$step1"
+    # Load step1 and initialize (creates backend lock + installs providers)
+    swap_crn "$step1" "$work_dir"
+    if ! (cd "$work_dir" && "$CARINA_BIN" init . >/dev/null 2>&1); then
+        echo "  step1: init                                             FAIL"
+        TOTAL_FAILED=$((TOTAL_FAILED + 1))
         rm -rf "$work_dir"
-        rm -rf "$step1" "$step2"
+        ACTIVE_WORK_DIR=""
+        return 1
+    fi
+
+    # Step 1: Apply initial config
+    if ! run_step "$work_dir" "step1: apply initial" "apply" "--auto-approve"; then
+        cleanup "$work_dir"
+        rm -rf "$work_dir"
         ACTIVE_WORK_DIR=""
         return 1
     fi
 
     # Step 1b: Plan-verify initial state
-    if ! run_plan_verify "$work_dir" "step1: plan-verify initial" "$step1"; then
-        cleanup "$work_dir" "$step2" "$step1"
+    if ! run_plan_verify "$work_dir" "step1: plan-verify initial"; then
+        cleanup "$work_dir"
         rm -rf "$work_dir"
-        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -238,11 +237,13 @@ run_test() {
     local ids_after_step1
     ids_after_step1=$(get_identifiers "$work_dir")
 
+    # Swap in step2 config (providers are the same, lock already present)
+    swap_crn "$step2" "$work_dir"
+
     # Step 2: Apply modified config (triggers create_before_destroy replacement)
-    if ! run_step "$work_dir" "step2: apply replace (create_before_destroy)" "apply" "$step2" "--auto-approve"; then
-        cleanup "$work_dir" "$step2" "$step1"
+    if ! run_step "$work_dir" "step2: apply replace (create_before_destroy)" "apply" "--auto-approve"; then
+        cleanup "$work_dir"
         rm -rf "$work_dir"
-        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -253,35 +254,31 @@ run_test() {
 
     # Assert identifiers changed (create_before_destroy should replace at least one resource)
     if ! assert_identifiers "assert: identifiers changed after replace" "$ids_after_step1" "$ids_after_step2" "different"; then
-        cleanup "$work_dir" "$step2" "$step1"
+        cleanup "$work_dir"
         rm -rf "$work_dir"
-        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
 
     # Step 3: Plan-verify after replacement
-    if ! run_plan_verify "$work_dir" "step3: plan-verify after replace" "$step2"; then
-        cleanup "$work_dir" "$step2" "$step1"
+    if ! run_plan_verify "$work_dir" "step3: plan-verify after replace"; then
+        cleanup "$work_dir"
         rm -rf "$work_dir"
-        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
 
-    # Step 4: Destroy (use cleanup to try both configs and retry)
-    if ! cleanup "$work_dir" "$step2" "$step1"; then
+    # Step 4: Destroy
+    if ! cleanup "$work_dir"; then
         echo "  WARNING: All destroy attempts failed. Preserving work dir for debugging:"
         echo "    $work_dir"
         TOTAL_FAILED=$((TOTAL_FAILED + 1))
-        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         echo ""
         return 1
     fi
 
     rm -rf "$work_dir"
-    rm -rf "$step1" "$step2"
     ACTIVE_WORK_DIR=""
     echo ""
 }


### PR DESCRIPTION
## Summary

Every `create_before_destroy` scenario was failing on step 1 with `Provider 'awscc' not installed. Run `carina init`` / `Backend lock file not found`, followed by `[PATH] but none was supplied` during cleanup. Same class of breakage that #153 fixed for `run-tests.sh`.

## Why

Upstream carina commit [`1004ecf1`](https://github.com/carina-rs/carina/commit/1004ecf1) moved backend-lock creation and provider installation into `carina init`. `create_before_destroy/run.sh` called `carina apply /path/to/step1.crn` from a `work_dir` without ever initializing either the work_dir (where state lives) or the step dirs (where providers were resolved from).

## Fix

- Treat `work_dir` as the single persistent project directory. Run `carina init`, `apply`, `plan`, `destroy` with `cd "$work_dir" && "$CARINA_BIN" ... .`. State and lock files live alongside `main.crn`.
- Swap step1 / step2 `.crn` into `work_dir/main.crn` between steps so state is preserved across the replacement.
- Drop the old `step1`/`step2` directory arguments and the secondary empty-path calls that produced `[PATH] but none was supplied`.

## Test plan

- [x] `aws-vault exec carina-test-000 -- ./acceptance-tests/create_before_destroy/run.sh ec2_vpc` → `5 passed, 0 failed`
- [ ] Full suite will run via the usual `run-acceptance-tests` cadence

Closes #154
