### PR TITLE
acceptance-tests: mark ec2_route/nat_gateway as .slow

### DIFF
--- a/acceptance-tests/ec2_route/nat_gateway.slow
+++ b/acceptance-tests/ec2_route/nat_gateway.slow
@@ -1,0 +1,6 @@
+NAT Gateway + VPC Gateway Attachment destroy operations each take ~8–9 minutes
+via CloudControl, so the full cycle exceeds the 15-minute aws-vault SSO token
+lifetime and fails in destroy with ExpiredTokenException (see issue #157).
+
+Run explicitly with --include-slow (or a matching filter) when a fresh token
+or a longer session is available; otherwise this test is skipped.


### PR DESCRIPTION
## Summary

Mark `acceptance-tests/ec2_route/nat_gateway.crn` as `.slow` so the default `full` cadence stops trying to destroy it under the 15-minute aws-vault SSO token. Explicit runs (`--include-slow`, or a matching filter) still exercise it.

## Why

From #157: the destroy phase for NAT Gateway + VpcGatewayAttachment takes ~9 minutes each via CloudControl. Under the default aws-vault SSO session, that regularly exceeds the 15-minute token lifetime, so the destroy step fails with `ExpiredTokenException` and the fixture leaks a VPC + subnet + IGW + main route table.

The repo already has the `.slow` convention for exactly this shape — the existing `ec2_nat_gateway/{private,public}.crn` tests both carry `.slow` markers. This extends the same pattern to the `ec2_route/nat_gateway` fixture so the default cadence stays green.

## Scope

- **Mitigation, not a fix.** The underlying fix lives upstream of this PR (provider-level credential refresh, parallelized destroy, or a longer-lived acceptance credential). Issue #157 stays open for those improvements; this PR just keeps the default cadence green in the meantime.
- Uses `Refs #157`, not `Closes #157`, for that reason.

## Test plan

- [x] `./acceptance-tests/run-tests.sh validate` now lists `ec2_route/nat_gateway.crn` under "Skipping 3 slow test(s)" alongside the existing two NAT-gateway fixtures.
- [ ] Next full `run-acceptance-tests` cadence will confirm no more token-expiry failures on this test.

Refs #157
