### PR TITLE
acceptance-tests: unmark ec2_route/nat_gateway as .slow

### DIFF
--- a/acceptance-tests/ec2_route/nat_gateway.slow
+++ b/acceptance-tests/ec2_route/nat_gateway.slow
@@ -1,6 +1,0 @@
-NAT Gateway + VPC Gateway Attachment destroy operations each take ~8–9 minutes
-via CloudControl, so the full cycle exceeds the 15-minute aws-vault SSO token
-lifetime and fails in destroy with ExpiredTokenException (see issue #157).
-
-Run explicitly with --include-slow (or a matching filter) when a fresh token
-or a longer session is available; otherwise this test is skipped.


### PR DESCRIPTION
## Summary

Drop the `.slow` marker from `ec2_route/nat_gateway.crn`. With the sso-session auth flow (#159) giving every carina invocation a fresh ~1h STS session, the NAT Gateway destroy (which was the specific timeout we were avoiding) now completes within one credential lifetime.

## Verification

```
./acceptance-tests/run-tests.sh --include-slow full ec2_route/nat_gateway
→ Total: 1 passed, 0 failed (of 1)
```

Apply + plan-verify + destroy all succeeded end-to-end under the new auth flow. No `ExpiredTokenException` during the long-running CloudControl calls.

## Scope

This is the follow-up flagged in #158's PR description: remove the mitigation once the root fix is in place. Doing it as a separate PR so #159's history stays focused on the infrastructure change and this one narrowly closes #157.

Closes #157
