### PR TITLE
acceptance-tests: switch module import to 'use { source = ... }'

### DIFF
--- a/acceptance-tests/for_expression/for_module.crn
+++ b/acceptance-tests/for_expression/for_module.crn
@@ -2,7 +2,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let vpc_mod = import './modules/vpc_only'
+let vpc_mod = use { source = './modules/vpc_only' }
 
 let cidrs = {
   dev = '10.0.0.0/16'

--- a/acceptance-tests/for_expression/for_module_complex.crn
+++ b/acceptance-tests/for_expression/for_module_complex.crn
@@ -2,7 +2,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let network = import './modules/network'
+let network = use { source = './modules/network' }
 
 let cidrs = {
   dev = '10.0.0.0/16'

--- a/acceptance-tests/module/attributes_access.crn
+++ b/acceptance-tests/module/attributes_access.crn
@@ -6,7 +6,7 @@ provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let network = import './modules/network'
+let network = use { source = './modules/network' }
 
 let net = network {
   cidr_block  = '10.0.0.0/16'

--- a/acceptance-tests/module/basic.crn
+++ b/acceptance-tests/module/basic.crn
@@ -1,12 +1,12 @@
 # Module - Basic test
 #
-# Tests: module import, argument passing, intra-module resource references
+# Tests: module use, argument passing, intra-module resource references
 
 provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let network = import './modules/network'
+let network = use { source = './modules/network' }
 
 network {
   cidr_block  = '10.0.0.0/16'

--- a/acceptance-tests/module/modules/network_with_rt/main.crn
+++ b/acceptance-tests/module/modules/network_with_rt/main.crn
@@ -1,9 +1,9 @@
 # Network with Route Table module
 #
-# Imports the network module (VPC + Subnet) and adds a route table.
-# Demonstrates nested module imports.
+# Uses the network module (VPC + Subnet) and adds a route table.
+# Demonstrates nested module uses.
 
-let network = import '../network'
+let network = use { source = '../network' }
 
 arguments {
   cidr_block : String

--- a/acceptance-tests/module/nested_module.crn
+++ b/acceptance-tests/module/nested_module.crn
@@ -1,12 +1,12 @@
 # Nested module test
 #
-# Tests: module importing another module (2-level nesting)
+# Tests: module useing another module (2-level nesting)
 
 provider awscc {
   region = awscc.Region.ap_northeast_1
 }
 
-let network_with_rt = import './modules/network_with_rt'
+let network_with_rt = use { source = './modules/network_with_rt' }
 
 let infra = network_with_rt {
   cidr_block  = '10.0.0.0/16'


### PR DESCRIPTION
Companion to carina-rs/carina#2186.

The module-import DSL keyword is being renamed from `import` to `use` and moved to block form with a `source` attribute. This PR updates every `.crn` under `acceptance-tests/` that loads a module so these tests keep running once the parser change in `carina-rs/carina` lands.

### Before
```crn
let network = import './modules/network'
```

### After
```crn
let network = use { source = './modules/network' }
```

Surface-only change; semantics are unchanged.

## Files

- `acceptance-tests/for_expression/for_module.crn`
- `acceptance-tests/for_expression/for_module_complex.crn`
- `acceptance-tests/module/basic.crn`
- `acceptance-tests/module/attributes_access.crn`
- `acceptance-tests/module/nested_module.crn`
- `acceptance-tests/module/modules/network_with_rt/main.crn`

## Dependency

**Do not merge until carina-rs/carina#2186 lands** and this repo's git dependency on `carina-core` picks it up. Merging earlier would break the acceptance tests against the still-`import`-keyword parser.

## Test plan

- [ ] After carina-rs/carina#2186 merges, rerun the affected acceptance tests (`module/basic`, `module/nested_module`, etc.) to confirm they still pass under the new DSL.
