### PR TITLE
refactor: switch ProviderFactory trait impls to &IndexMap (#2255 lockstep)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,15 +510,17 @@ name = "carina-aws-types"
 version = "0.4.0"
 dependencies = [
  "carina-core",
+ "indexmap",
 ]
 
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina#aaa17511613befcec5f014b7d3ccc85e8a9b8298"
+source = "git+https://github.com/carina-rs/carina#f5bde953f57ef10f663803f7e382202237f16d76"
 dependencies = [
  "argon2",
  "futures",
+ "indexmap",
  "pest",
  "pest_derive",
  "semver",
@@ -531,7 +533,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina#aaa17511613befcec5f014b7d3ccc85e8a9b8298"
+source = "git+https://github.com/carina-rs/carina#f5bde953f57ef10f663803f7e382202237f16d76"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -561,6 +563,7 @@ dependencies = [
  "clap",
  "heck",
  "http 1.4.0",
+ "indexmap",
  "log",
  "regex",
  "serde",
@@ -574,7 +577,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#aaa17511613befcec5f014b7d3ccc85e8a9b8298"
+source = "git+https://github.com/carina-rs/carina#f5bde953f57ef10f663803f7e382202237f16d76"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -10,5 +10,8 @@ description = "AWS type definitions for Carina infrastructure management tool"
 [lib]
 doctest = false
 
+[dev-dependencies]
+indexmap = "2"
+
 [dependencies]
 carina-core = { git = "https://github.com/carina-rs/carina" }

--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -2599,7 +2599,7 @@ mod tests {
                         Value::Map(
                             vec![(
                                 "StringEquals".to_string(),
-                                Value::Map(std::collections::HashMap::new()),
+                                Value::Map(indexmap::IndexMap::new()),
                             )]
                             .into_iter()
                             .collect(),
@@ -2628,12 +2628,9 @@ mod tests {
                     vec![(
                         "condition".to_string(),
                         Value::Map(
-                            vec![(
-                                "foo_bar".to_string(),
-                                Value::Map(std::collections::HashMap::new()),
-                            )]
-                            .into_iter()
-                            .collect(),
+                            vec![("foo_bar".to_string(), Value::Map(indexmap::IndexMap::new()))]
+                                .into_iter()
+                                .collect(),
                         ),
                     )]
                     .into_iter()
@@ -2657,7 +2654,7 @@ mod tests {
                         Value::Map(
                             vec![(
                                 "string_equals_if_exists".to_string(),
-                                Value::Map(std::collections::HashMap::new()),
+                                Value::Map(indexmap::IndexMap::new()),
                             )]
                             .into_iter()
                             .collect(),

--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -27,6 +27,7 @@ carina-core = { git = "https://github.com/carina-rs/carina" }
 carina-aws-types = { path = "../carina-aws-types" }
 carina-plugin-sdk = { git = "https://github.com/carina-rs/carina" }
 carina-provider-protocol = { git = "https://github.com/carina-rs/carina" }
+indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-smithy-async = { version = "1", features = ["rt-tokio"] }
 aws-sdk-cloudcontrol = { version = "1", default-features = false, features = ["behavior-version-latest"] }

--- a/carina-provider-awscc/src/convert.rs
+++ b/carina-provider-awscc/src/convert.rs
@@ -27,7 +27,7 @@ pub fn core_to_proto_resource_id(id: &CoreResourceId) -> ProtoResourceId {
     ProtoResourceId {
         provider: id.provider.clone(),
         resource_type: id.resource_type.clone(),
-        name: id.name.clone(),
+        name: id.name.to_string(),
     }
 }
 

--- a/carina-provider-awscc/src/lib.rs
+++ b/carina-provider-awscc/src/lib.rs
@@ -17,6 +17,8 @@ pub use provider::AwsccProvider;
 
 use std::collections::HashMap;
 
+use indexmap::IndexMap;
+
 use carina_core::provider::{
     BoxFuture, Provider, ProviderFactory, ProviderNormalizer, ProviderResult, SavedAttrs,
     merge_default_tags_for_provider,
@@ -50,7 +52,7 @@ impl ProviderNormalizer for AwsccNormalizer {
     fn merge_default_tags(
         &self,
         resources: &mut [Resource],
-        default_tags: &HashMap<String, Value>,
+        default_tags: &IndexMap<String, Value>,
         schemas: &HashMap<String, ResourceSchema>,
     ) {
         merge_default_tags_for_provider("awscc", resources, default_tags, schemas);
@@ -88,7 +90,7 @@ impl ProviderFactory for AwsccProviderFactory {
         types
     }
 
-    fn validate_config(&self, _attributes: &HashMap<String, Value>) -> Result<(), String> {
+    fn validate_config(&self, _attributes: &IndexMap<String, Value>) -> Result<(), String> {
         // Region format/value validation is handled by the host via
         // `provider_config_attribute_types`. No provider-specific semantic
         // checks are needed beyond that for now.
@@ -107,7 +109,7 @@ impl ProviderFactory for AwsccProviderFactory {
         }
     }
 
-    fn extract_region(&self, attributes: &HashMap<String, Value>) -> String {
+    fn extract_region(&self, attributes: &IndexMap<String, Value>) -> String {
         if let Some(Value::String(region)) = attributes.get("region") {
             return carina_core::utils::convert_region_value(region);
         }
@@ -116,7 +118,7 @@ impl ProviderFactory for AwsccProviderFactory {
 
     fn create_provider(
         &self,
-        attributes: &HashMap<String, Value>,
+        attributes: &IndexMap<String, Value>,
     ) -> BoxFuture<'_, Box<dyn Provider>> {
         let region = self.extract_region(attributes);
         Box::pin(async move { Box::new(AwsccProvider::new(&region).await) as Box<dyn Provider> })
@@ -124,7 +126,7 @@ impl ProviderFactory for AwsccProviderFactory {
 
     fn create_normalizer(
         &self,
-        _attributes: &HashMap<String, Value>,
+        _attributes: &IndexMap<String, Value>,
     ) -> BoxFuture<'_, Box<dyn ProviderNormalizer>> {
         Box::pin(async { Box::new(AwsccNormalizer) as Box<dyn ProviderNormalizer> })
     }
@@ -174,7 +176,7 @@ impl Provider for AwsccProvider {
         let id = id.clone();
         let identifier = identifier.map(|s| s.to_string());
         Box::pin(async move {
-            self.read_resource(&id.resource_type, &id.name, identifier.as_deref())
+            self.read_resource(&id.resource_type, id.name_str(), identifier.as_deref())
                 .await
         })
     }
@@ -238,7 +240,7 @@ mod tests {
             "cidr_block".to_string(),
             Value::String("10.0.0.0/16".to_string()),
         );
-        let mut resource_tags = HashMap::new();
+        let mut resource_tags: IndexMap<String, Value> = IndexMap::new();
         resource_tags.insert("Name".to_string(), Value::String("my-vpc".to_string()));
         resource_tags.insert(
             "Environment".to_string(),
@@ -246,7 +248,7 @@ mod tests {
         );
         resource.set_attr("tags".to_string(), Value::Map(resource_tags));
 
-        let mut default_tags = HashMap::new();
+        let mut default_tags: IndexMap<String, Value> = IndexMap::new();
         default_tags.insert(
             "Environment".to_string(),
             Value::String("production".to_string()),
@@ -295,7 +297,7 @@ mod tests {
             Value::String("10.0.0.0/16".to_string()),
         );
 
-        let mut default_tags = HashMap::new();
+        let mut default_tags: IndexMap<String, Value> = IndexMap::new();
         default_tags.insert(
             "Environment".to_string(),
             Value::String("production".to_string()),
@@ -338,7 +340,7 @@ mod tests {
             Value::String("rtb-123".to_string()),
         );
 
-        let mut default_tags = HashMap::new();
+        let mut default_tags: IndexMap<String, Value> = IndexMap::new();
         default_tags.insert(
             "Environment".to_string(),
             Value::String("production".to_string()),
@@ -361,11 +363,11 @@ mod tests {
             "cidr_block".to_string(),
             Value::String("10.0.0.0/16".to_string()),
         );
-        let mut resource_tags = HashMap::new();
+        let mut resource_tags: IndexMap<String, Value> = IndexMap::new();
         resource_tags.insert("Name".to_string(), Value::String("my-vpc".to_string()));
         resource.set_attr("tags".to_string(), Value::Map(resource_tags));
 
-        let default_tags = HashMap::new();
+        let default_tags: IndexMap<String, Value> = IndexMap::new();
 
         let mut resources = vec![resource];
         normalizer.merge_default_tags(&mut resources, &default_tags, &schemas);

--- a/carina-provider-awscc/src/main.rs
+++ b/carina-provider-awscc/src/main.rs
@@ -302,7 +302,10 @@ impl CarinaProvider for AwsccProcessProvider {
             .iter()
             .map(convert::proto_to_core_resource)
             .collect();
-        let core_tags = convert::proto_to_core_value_map(default_tags);
+        let core_tags: indexmap::IndexMap<String, _> = default_tags
+            .iter()
+            .map(|(k, v)| (k.clone(), convert::proto_to_core_value(v)))
+            .collect();
         let core_schemas: HashMap<String, _> = proto_schemas
             .iter()
             .map(|s| (s.resource_type.clone(), convert::proto_to_core_schema(s)))

--- a/carina-provider-awscc/src/provider/conversion.rs
+++ b/carina-provider-awscc/src/provider/conversion.rs
@@ -4,7 +4,7 @@
 //! and AWS CloudControl API JSON representations. It includes type-aware conversion
 //! for enums, structs, lists, maps, and unions.
 
-use std::collections::HashMap;
+use indexmap::IndexMap;
 
 use carina_core::resource::Value;
 use carina_core::schema::AttributeType;
@@ -77,7 +77,7 @@ pub(crate) fn aws_value_to_dsl(
     if let AttributeType::Struct { fields, .. } = attr_type
         && let Some(obj) = value.as_object()
     {
-        let map: HashMap<String, Value> = fields
+        let map: IndexMap<String, Value> = fields
             .iter()
             .filter_map(|field| {
                 let provider_key = field.provider_name.as_deref().unwrap_or(&field.name);
@@ -98,7 +98,7 @@ pub(crate) fn aws_value_to_dsl(
         && let Some(obj) = value.as_object()
     {
         let is_condition = dsl_name == "condition";
-        let map: HashMap<String, Value> = obj
+        let map: IndexMap<String, Value> = obj
             .iter()
             .filter_map(|(k, v)| {
                 let result = aws_value_to_dsl(dsl_name, v, inner, resource_type);
@@ -166,7 +166,7 @@ pub(crate) fn json_to_value(value: &serde_json::Value) -> Option<Value> {
             Some(Value::List(items))
         }
         serde_json::Value::Object(obj) => {
-            let map: HashMap<String, Value> = obj
+            let map: IndexMap<String, Value> = obj
                 .iter()
                 .filter_map(|(k, v)| {
                     let result = json_to_value(v);
@@ -417,7 +417,7 @@ mod tests {
         };
 
         // Parser produces Value::Map(...) for map assignment syntax (= { ... })
-        let mut map = HashMap::new();
+        let mut map = IndexMap::new();
         map.insert("status".to_string(), Value::String("Enabled".to_string()));
         let dsl_value = Value::Map(map);
 
@@ -449,7 +449,7 @@ mod tests {
         };
 
         // Parser produces Value::List(vec![Value::Map(...)]) for block syntax (name { ... })
-        let mut map = HashMap::new();
+        let mut map = IndexMap::new();
         map.insert("status".to_string(), Value::String("Enabled".to_string()));
         let dsl_value = Value::List(vec![Value::Map(map)]);
 
@@ -491,7 +491,7 @@ mod tests {
         .expect("read should succeed");
 
         // Simulate parser output (what the user wrote in .crn with map assignment syntax)
-        let mut parser_map = HashMap::new();
+        let mut parser_map = IndexMap::new();
         parser_map.insert("status".to_string(), Value::String("Enabled".to_string()));
         let parser_value = Value::Map(parser_map);
 
@@ -672,7 +672,7 @@ mod tests {
     fn test_dsl_value_to_aws_map_preserves_user_keys() {
         let attr_type = AttributeType::map(AttributeType::String);
 
-        let mut map = HashMap::new();
+        let mut map = IndexMap::new();
         map.insert(
             "my_custom_key".to_string(),
             Value::String("value1".to_string()),
@@ -706,7 +706,7 @@ mod tests {
         };
         let attr_type = AttributeType::map(inner_type);
 
-        let mut map = HashMap::new();
+        let mut map = IndexMap::new();
         map.insert(
             "item_one".to_string(),
             Value::String("awscc.test.resource.Status.Active".to_string()),
@@ -943,7 +943,7 @@ mod tests {
         let json_val = json!([{"RegionName": "ap-northeast-1"}]);
 
         let result = aws_value_to_dsl("operating_regions", &json_val, &attr_type, "ec2.Ipam");
-        let expected = Value::List(vec![Value::Map(HashMap::from([(
+        let expected = Value::List(vec![Value::Map(IndexMap::from([(
             "region_name".to_string(),
             Value::String("awscc.Region.ap_northeast_1".to_string()),
         )]))]);

--- a/carina-provider-awscc/src/provider/normalizer.rs
+++ b/carina-provider-awscc/src/provider/normalizer.rs
@@ -3,6 +3,7 @@
 //! This module contains standalone functions used by `ProviderNormalizer` to resolve
 //! enum identifiers in resources and restore unreturned attributes from saved state.
 
+use indexmap::IndexMap;
 use std::collections::HashMap;
 
 use carina_core::resource::{Resource, ResourceId, State, Value};
@@ -83,7 +84,7 @@ fn resolve_struct_enum_values(value: &Value, fields: &[StructField]) -> Value {
             Value::List(resolved_items)
         }
         Value::Map(map) => {
-            let mut resolved_map = HashMap::new();
+            let mut resolved_map = IndexMap::new();
             for (field_key, field_value) in map {
                 if let Some(field) = fields.iter().find(|f| f.name == *field_key) {
                     // Direct enum field (String value)
@@ -501,7 +502,7 @@ mod tests {
     #[test]
     fn test_resolve_struct_enum_values_bare_ident() {
         let fields = test_ip_protocol_fields();
-        let mut map = HashMap::new();
+        let mut map = IndexMap::new();
         map.insert("ip_protocol".to_string(), Value::String("all".to_string()));
         map.insert("from_port".to_string(), Value::Int(443));
         let value = Value::List(vec![Value::Map(map)]);
@@ -527,7 +528,7 @@ mod tests {
     #[test]
     fn test_resolve_struct_enum_values_typename_dot_value() {
         let fields = test_ip_protocol_fields();
-        let mut map = HashMap::new();
+        let mut map = IndexMap::new();
         map.insert(
             "ip_protocol".to_string(),
             Value::String("IpProtocol.tcp".to_string()),
@@ -554,7 +555,7 @@ mod tests {
     #[test]
     fn test_resolve_struct_enum_values_string_passthrough() {
         let fields = test_ip_protocol_fields();
-        let mut map = HashMap::new();
+        let mut map = IndexMap::new();
         map.insert(
             "ip_protocol".to_string(),
             Value::String("awscc.ec2.SecurityGroup.IpProtocol.tcp".to_string()),
@@ -585,7 +586,7 @@ mod tests {
             "group_description".to_string(),
             Value::String("test".to_string()),
         );
-        let mut egress_map = HashMap::new();
+        let mut egress_map = IndexMap::new();
         egress_map.insert("ip_protocol".to_string(), Value::String("all".to_string()));
         egress_map.insert(
             "cidr_ip".to_string(),
@@ -777,18 +778,18 @@ mod tests {
             ),
         ];
 
-        let mut inner_map = HashMap::new();
+        let mut inner_map = IndexMap::new();
         inner_map.insert(
             "encryption_type".to_string(),
             Value::List(vec![Value::String("SSE-C".to_string())]),
         );
-        let mut map = HashMap::new();
+        let mut map = IndexMap::new();
         map.insert(
             "blocked_encryption_types".to_string(),
             Value::Map(inner_map),
         );
         map.insert("bucket_key_enabled".to_string(), Value::Bool(false));
-        let mut sse_map = HashMap::new();
+        let mut sse_map = IndexMap::new();
         sse_map.insert(
             "sse_algorithm".to_string(),
             Value::String("AES256".to_string()),

--- a/carina-provider-awscc/src/provider/operations.rs
+++ b/carina-provider-awscc/src/provider/operations.rs
@@ -136,7 +136,7 @@ impl AwsccProvider {
         let mut state = self
             .read_resource(
                 &resource.id.resource_type,
-                &resource.id.name,
+                resource.id.name_str(),
                 Some(&identifier),
             )
             .await?;
@@ -185,7 +185,7 @@ impl AwsccProvider {
             .map_err(|e| e.for_resource(id.clone()))?;
 
         let mut state = self
-            .read_resource(&id.resource_type, &id.name, Some(identifier))
+            .read_resource(&id.resource_type, id.name_str(), Some(identifier))
             .await?;
 
         // Preserve desired attributes not returned by CloudControl API.

--- a/carina-provider-awscc/src/provider/tags.rs
+++ b/carina-provider-awscc/src/provider/tags.rs
@@ -4,7 +4,7 @@
 //! while the DSL uses `{ k = "v", ... }` map format. This module handles
 //! bidirectional conversion between these formats.
 
-use std::collections::HashMap;
+use indexmap::IndexMap;
 
 use carina_core::resource::Value;
 use serde_json::json;
@@ -26,8 +26,8 @@ impl AwsccProvider {
     }
 
     /// Parse tags from CloudFormation format to map
-    pub(crate) fn parse_tags(&self, tags_array: &[serde_json::Value]) -> HashMap<String, Value> {
-        let mut tags_map = HashMap::new();
+    pub(crate) fn parse_tags(&self, tags_array: &[serde_json::Value]) -> IndexMap<String, Value> {
+        let mut tags_map = IndexMap::new();
         for tag in tags_array {
             if let (Some(key), Some(value)) = (
                 tag.get("Key").and_then(|v| v.as_str()),

--- a/carina-provider-awscc/src/provider/update.rs
+++ b/carina-provider-awscc/src/provider/update.rs
@@ -121,6 +121,8 @@ pub(crate) fn build_update_patches(
 mod tests {
     use std::collections::HashMap;
 
+    use indexmap::IndexMap;
+
     use super::*;
     use carina_core::resource::ResourceId;
 
@@ -206,7 +208,7 @@ mod tests {
             "cidr_block".to_string(),
             Value::String("10.0.0.0/16".to_string()),
         );
-        let mut tags = HashMap::new();
+        let mut tags = IndexMap::new();
         tags.insert("Name".to_string(), Value::String("my-vpc".to_string()));
         from_attrs.insert("tags".to_string(), Value::Map(tags));
         let from = State::existing(id.clone(), from_attrs);
@@ -381,7 +383,7 @@ mod tests {
             "cidr_block".to_string(),
             Value::String("10.0.0.0/16".to_string()),
         );
-        let mut tags = HashMap::new();
+        let mut tags = IndexMap::new();
         tags.insert("Name".to_string(), Value::String("my-vpc".to_string()));
         from_attrs.insert("tags".to_string(), Value::Map(tags.clone()));
         let from = State::existing(id.clone(), from_attrs);
@@ -565,7 +567,7 @@ mod tests {
             Value::String("{\"Version\":\"2012-10-17\"}".to_string()),
         );
         // DnsOptions is returned by CloudControl API but has create-only sub-properties
-        let mut dns_options = HashMap::new();
+        let mut dns_options = IndexMap::new();
         dns_options.insert(
             "dns_record_ip_type".to_string(),
             Value::String("awscc.ec2.VpcEndpoint.DnsRecordIpType.ipv4".to_string()),


### PR DESCRIPTION
## Summary

Companion to carina-rs/carina#2257 (Stage 2 of #2222).

carina-core's host-side ``ProviderFactory`` trait now takes ``&IndexMap<String, Value>`` instead of ``&HashMap<String, Value>`` for ``validate_config``, ``extract_region``, ``create_provider``, ``create_normalizer``, and ``merge_default_tags`` (on ``ProviderNormalizer``).

This PR lifts every consumer of ``Value::Map`` payloads in the AWSCC provider to ``IndexMap`` so it builds against the new carina-core. The behavioural change is "user-authored attribute order survives parse → provider", same story as the core PR.

Side effects already on ``main`` since this branch was last bumped:

- ``ResourceId::name`` is now ``ResourceName`` (enum), so call sites that passed ``&id.name`` to ``read_resource(name: &str, ...)`` now use ``id.name_str()``.

``parse_tags()`` was changed to return ``IndexMap`` so its callers can flow it straight into ``Value::Map(...)`` without a HashMap → IndexMap laundering.

## Test plan

- [x] ``cargo build`` (lib + bin)
- [x] ``cargo test --lib``
- [x] ``cargo clippy --all-targets -- -D warnings``
- [x] ``cargo fmt --check``

Refs carina-rs/carina#2255

🤖 Generated with [Claude Code](https://claude.com/claude-code)