### PR TITLE
codegen: emit types::email() for email properties

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina#f5bde953f57ef10f663803f7e382202237f16d76"
+source = "git+https://github.com/carina-rs/carina#8d09acb30a8957b01dfd79efffb2a4d7887ce076"
 dependencies = [
  "argon2",
  "futures",
@@ -533,7 +533,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina#f5bde953f57ef10f663803f7e382202237f16d76"
+source = "git+https://github.com/carina-rs/carina#8d09acb30a8957b01dfd79efffb2a4d7887ce076"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -577,7 +577,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#f5bde953f57ef10f663803f7e382202237f16d76"
+source = "git+https://github.com/carina-rs/carina#8d09acb30a8957b01dfd79efffb2a4d7887ce076"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -537,6 +537,7 @@ fn override_type_to_display_name(override_type: &str) -> &str {
         "super::vpc_cidr_block_association_id()" => "VpcCidrBlockAssociationId",
         "super::tgw_route_table_id()" => "TgwRouteTableId",
         "types::cidr()" => "Cidr",
+        "types::email()" => "Email",
         "AttributeType::String" => "String",
         _ => "String",
     }
@@ -3372,7 +3373,23 @@ fn infer_string_type(prop_name: &str, resource_type: &str) -> Option<String> {
         return Some("super::aws_account_id()".to_string());
     }
 
+    // Email addresses. Conservative match: property name is exactly "Email"
+    // or ends with "EmailAddress". Avoids false positives on names like
+    // "EmailEnabled" or "PrimaryEmailType" that are flags/categories rather
+    // than email addresses.
+    if is_email_property(prop_name) {
+        return Some("types::email()".to_string());
+    }
+
     None
+}
+
+/// Check if a property name represents an email address.
+/// Conservative: matches `Email` exactly or any name ending in `EmailAddress`
+/// (case-insensitive). Used to map CFN string properties to `types::email()`.
+fn is_email_property(prop_name: &str) -> bool {
+    let lower = prop_name.to_lowercase();
+    lower == "email" || lower.ends_with("emailaddress")
 }
 
 /// Check if a property name represents an AWS resource ID with the standard
@@ -8619,6 +8636,93 @@ mod tests {
         assert!(
             generated.contains("..=256"),
             "Should display open-ended range for max-only: {generated}"
+        );
+    }
+
+    #[test]
+    fn test_is_email_property_matches_expected_names() {
+        // Exact match (case-insensitive)
+        assert!(is_email_property("Email"));
+        assert!(is_email_property("email"));
+        // EmailAddress suffix
+        assert!(is_email_property("EmailAddress"));
+        assert!(is_email_property("PrimaryEmailAddress"));
+        assert!(is_email_property("ContactEmailAddress"));
+        // Should NOT match — these are flags / categories, not addresses
+        assert!(!is_email_property("EmailEnabled"));
+        assert!(!is_email_property("EmailType"));
+        assert!(!is_email_property("EmailVerified"));
+        assert!(!is_email_property("Name"));
+    }
+
+    #[test]
+    fn test_infer_string_type_email() {
+        assert_eq!(
+            infer_string_type("Email", ""),
+            Some("types::email()".to_string())
+        );
+        assert_eq!(
+            infer_string_type("EmailAddress", ""),
+            Some("types::email()".to_string())
+        );
+        assert_eq!(
+            infer_string_type("ContactEmailAddress", ""),
+            Some("types::email()".to_string())
+        );
+        // Negative cases
+        assert_eq!(infer_string_type("EmailEnabled", ""), None);
+    }
+
+    #[test]
+    fn test_generate_schema_code_email_uses_types_email() {
+        // Mirrors the AWS::Organizations::Account "Email" property: a CFN
+        // string with a pattern + length range. The generated code must use
+        // `types::email()` instead of an ad-hoc Custom validator.
+        let mut properties = BTreeMap::new();
+        properties.insert(
+            "Email".to_string(),
+            CfnProperty {
+                prop_type: Some(TypeValue::Single("string".to_string())),
+                description: Some(
+                    "The email address of the owner to assign to the new member account."
+                        .to_string(),
+                ),
+                pattern: Some("[^\\s@]+@[^\\s@]+\\.[^\\s@]+".to_string()),
+                min_length: Some(6),
+                max_length: Some(64),
+                ..Default::default()
+            },
+        );
+
+        let schema = CfnSchema {
+            type_name: "AWS::Organizations::Account".to_string(),
+            description: None,
+            properties,
+            required: vec!["Email".to_string()],
+            read_only_properties: vec![],
+            create_only_properties: vec![],
+            write_only_properties: vec![],
+            primary_identifier: None,
+            definitions: None,
+            tagging: None,
+            one_of: vec![],
+            any_of: vec![],
+            handlers: BTreeMap::new(),
+        };
+
+        let generated = generate_schema_code(&schema, "AWS::Organizations::Account").unwrap();
+
+        assert!(
+            generated.contains("types::email()"),
+            "Expected types::email() in generated code: {generated}"
+        );
+        assert!(
+            !generated.contains("validate_string_pattern_ec4d9bee0dcd262b_len_6_64"),
+            "Should not emit ad-hoc pattern validator for email: {generated}"
+        );
+        assert!(
+            !generated.contains("[^\\s@]+@[^\\s@]+"),
+            "Should not embed the email regex pattern in generated code: {generated}"
         );
     }
 

--- a/carina-provider-awscc/src/schemas/generated/organizations/account.rs
+++ b/carina-provider-awscc/src/schemas/generated/organizations/account.rs
@@ -8,7 +8,7 @@ use super::AwsccSchemaConfig;
 use super::tags_type;
 use super::validate_tags_map;
 use carina_core::resource::Value;
-use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, types};
 use regex::Regex;
 
 const VALID_JOINED_METHOD: &[&str] = &["INVITED", "CREATED"];
@@ -142,28 +142,6 @@ fn validate_string_pattern_253e7eb79a4beec5_len_1_64(value: &Value) -> Result<()
     }
 }
 
-#[allow(dead_code)]
-fn validate_string_pattern_ec4d9bee0dcd262b_len_6_64(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
-        static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-            Regex::new("[^\\s@]+@[^\\s@]+\\.[^\\s@]+").expect("invalid pattern regex")
-        });
-        if !RE.is_match(s) {
-            return Err(format!(
-                "Value '{}' does not match pattern [^\\s@]+@[^\\s@]+\\.[^\\s@]+",
-                s
-            ));
-        }
-        let len = s.chars().count();
-        if !(6..=64).contains(&len) {
-            return Err(format!("String length {} is out of range 6..=64", len));
-        }
-        Ok(())
-    } else {
-        Err("Expected string".to_string())
-    }
-}
-
 /// Returns the schema config for organizations_account (AWS::Organizations::Account)
 pub fn organizations_account_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
@@ -199,15 +177,7 @@ pub fn organizations_account_config() -> AwsccSchemaConfig {
                 .with_provider_name("Arn"),
         )
         .attribute(
-            AttributeSchema::new("email", AttributeType::Custom {
-                semantic_name: None,
-                pattern: Some("[^\\s@]+@[^\\s@]+\\.[^\\s@]+".to_string()),
-                length: Some((Some(6), Some(64))),
-                base: Box::new(AttributeType::String),
-                validate: validate_string_pattern_ec4d9bee0dcd262b_len_6_64,
-                namespace: None,
-                to_dsl: None,
-            })
+            AttributeSchema::new("email", types::email())
                 .required()
                 .with_description("The email address of the owner to assign to the new member account.")
                 .with_provider_name("Email"),


### PR DESCRIPTION
## Summary

- Teach the awscc codegen mapper to detect email-typed CFN properties (name is exactly `Email`, case-insensitive, or ends with `EmailAddress`) and emit `carina_core::schema::types::email()` — the semantic email type added in carina-rs/carina#2282 — instead of an ad-hoc `AttributeType::Custom { pattern: "[^\s@]+@[^\s@]+\.[^\s@]+", len: 6..=64, validate: validate_string_pattern_…_len_6_64, … }`.
- Bumps the `carina-core` / `carina-plugin-sdk` / `carina-provider-protocol` git revisions from `f5bde953` to `8d09acb3` so `types::email()` is in scope.
- Regenerates schemas. The only meaningful schema delta is `organizations/account.rs::email`, which now reads `AttributeSchema::new("email", types::email())`. The previously-emitted `validate_string_pattern_ec4d9bee0dcd262b_len_6_64` helper is dropped cleanly (no other call sites).

## Detection rules

The match is intentionally conservative to avoid false positives like `EmailEnabled` / `EmailType`:

- exact match `email` (case-insensitive), OR
- `*EmailAddress` suffix (case-insensitive)

Implemented in a small `is_email_property()` helper alongside the other `infer_string_type` heuristics in `carina-provider-awscc/src/bin/codegen.rs`.

## Tests

Three unit tests in `codegen.rs::tests`:

- `test_is_email_property_matches_expected_names` — covers positive (`Email`, `EmailAddress`, `PrimaryEmailAddress`, `ContactEmailAddress`) and negative (`EmailEnabled`, `EmailType`, `EmailVerified`, `Name`).
- `test_infer_string_type_email` — confirms `infer_string_type` returns `Some("types::email()")` for matching names and `None` for negative ones.
- `test_generate_schema_code_email_uses_types_email` — feeds the actual `AWS::Organizations::Account::Email` shape (string + email regex + `minLength: 6` + `maxLength: 64`) through `generate_schema_code` and asserts the output contains `types::email()` and does NOT contain the ad-hoc `validate_string_pattern_…_len_6_64` helper or the inline regex pattern.

## Docs

Per project policy `docs/awscc/*.md` regeneration is intentionally out of scope here — running `generate-docs.sh` triggers an unrelated 33-file PascalCase rename (tracked separately as carina-rs/carina-provider-awscc#163). The schema-side change in this PR is the meaningful work for #102; docs can refresh once #163 lands.

## Test plan

- [x] `cargo build` passes
- [x] `cargo test --workspace` passes (4 test binaries, all green; the 3 new tests pass)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `./scripts/check-docs-drift.sh` clean (33 resources, schemas/docs in sync)
- [x] Regenerated schemas show only the expected `organizations/account.rs::email` swap (unrelated drift in `logs/log_group.rs` / `s3/bucket.rs` from public-vs-cached schema content was reverted to keep this PR scoped)

Closes #102
Refs #163
