### PR TITLE
fix(docs): keep doc filenames snake_case while body retains DSL PascalCase

### DIFF
--- a/generated-docs/awscc/ec2/egress_only_internet_gateway.md
+++ b/generated-docs/awscc/ec2/egress_only_internet_gateway.md
@@ -1,6 +1,6 @@
 ---
-title: "awscc.ec2.egress_only_internet_gateway"
-description: "AWSCC EC2 egress_only_internet_gateway resource reference"
+title: "awscc.ec2.EgressOnlyInternetGateway"
+description: "AWSCC EC2 EgressOnlyInternetGateway resource reference"
 ---
 
 
@@ -11,11 +11,11 @@ Resource Type definition for AWS::EC2::EgressOnlyInternetGateway
 ## Example
 
 ```crn
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-awscc.ec2.egress_only_internet_gateway {
+awscc.ec2.EgressOnlyInternetGateway {
   vpc_id = vpc.vpc_id
 
   tags = {

--- a/generated-docs/awscc/ec2/eip.md
+++ b/generated-docs/awscc/ec2/eip.md
@@ -1,6 +1,6 @@
 ---
-title: "awscc.ec2.eip"
-description: "AWSCC EC2 eip resource reference"
+title: "awscc.ec2.Eip"
+description: "AWSCC EC2 Eip resource reference"
 ---
 
 
@@ -13,7 +13,7 @@ Specifies an Elastic IP (EIP) address and can, optionally, associate it with an 
 ## Example
 
 ```crn
-awscc.ec2.eip {
+awscc.ec2.Eip {
   domain = 'vpc'
 
   tags = {
@@ -93,8 +93,8 @@ The Elastic IP address you are accepting for transfer. You can only accept one t
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `vpc` | `awscc.ec2.eip.Domain.vpc` |
-| `standard` | `awscc.ec2.eip.Domain.standard` |
+| `vpc` | `awscc.ec2.Eip.Domain.vpc` |
+| `standard` | `awscc.ec2.Eip.Domain.standard` |
 
 Shorthand formats: `vpc` or `Domain.vpc`
 

--- a/generated-docs/awscc/ec2/flow_log.md
+++ b/generated-docs/awscc/ec2/flow_log.md
@@ -1,6 +1,6 @@
 ---
-title: "awscc.ec2.flow_log"
-description: "AWSCC EC2 flow_log resource reference"
+title: "awscc.ec2.FlowLog"
+description: "AWSCC EC2 FlowLog resource reference"
 ---
 
 
@@ -11,11 +11,11 @@ Specifies a VPC flow log, which enables you to capture IP traffic for a specific
 ## Example
 
 ```crn
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-awscc.ec2.flow_log {
+awscc.ec2.FlowLog {
   resource_id          = vpc.vpc_id
   resource_type        = VPC
   traffic_type         = ALL
@@ -129,8 +129,8 @@ The type of traffic to log. You can log traffic that the resource accepts or rej
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `plain-text` | `awscc.ec2.flow_log.FileFormat.plain_text` |
-| `parquet` | `awscc.ec2.flow_log.FileFormat.parquet` |
+| `plain-text` | `awscc.ec2.FlowLog.FileFormat.plain_text` |
+| `parquet` | `awscc.ec2.FlowLog.FileFormat.parquet` |
 
 Shorthand formats: `plain_text` or `FileFormat.plain_text`
 
@@ -138,9 +138,9 @@ Shorthand formats: `plain_text` or `FileFormat.plain_text`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `cloud-watch-logs` | `awscc.ec2.flow_log.LogDestinationType.cloud_watch_logs` |
-| `s3` | `awscc.ec2.flow_log.LogDestinationType.s3` |
-| `kinesis-data-firehose` | `awscc.ec2.flow_log.LogDestinationType.kinesis_data_firehose` |
+| `cloud-watch-logs` | `awscc.ec2.FlowLog.LogDestinationType.cloud_watch_logs` |
+| `s3` | `awscc.ec2.FlowLog.LogDestinationType.s3` |
+| `kinesis-data-firehose` | `awscc.ec2.FlowLog.LogDestinationType.kinesis_data_firehose` |
 
 Shorthand formats: `cloud_watch_logs` or `LogDestinationType.cloud_watch_logs`
 
@@ -148,12 +148,12 @@ Shorthand formats: `cloud_watch_logs` or `LogDestinationType.cloud_watch_logs`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `NetworkInterface` | `awscc.ec2.flow_log.ResourceType.NetworkInterface` |
-| `Subnet` | `awscc.ec2.flow_log.ResourceType.Subnet` |
-| `VPC` | `awscc.ec2.flow_log.ResourceType.VPC` |
-| `TransitGateway` | `awscc.ec2.flow_log.ResourceType.TransitGateway` |
-| `TransitGatewayAttachment` | `awscc.ec2.flow_log.ResourceType.TransitGatewayAttachment` |
-| `RegionalNatGateway` | `awscc.ec2.flow_log.ResourceType.RegionalNatGateway` |
+| `NetworkInterface` | `awscc.ec2.FlowLog.ResourceType.NetworkInterface` |
+| `Subnet` | `awscc.ec2.FlowLog.ResourceType.Subnet` |
+| `VPC` | `awscc.ec2.FlowLog.ResourceType.VPC` |
+| `TransitGateway` | `awscc.ec2.FlowLog.ResourceType.TransitGateway` |
+| `TransitGatewayAttachment` | `awscc.ec2.FlowLog.ResourceType.TransitGatewayAttachment` |
+| `RegionalNatGateway` | `awscc.ec2.FlowLog.ResourceType.RegionalNatGateway` |
 
 Shorthand formats: `NetworkInterface` or `ResourceType.NetworkInterface`
 
@@ -161,9 +161,9 @@ Shorthand formats: `NetworkInterface` or `ResourceType.NetworkInterface`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `ACCEPT` | `awscc.ec2.flow_log.TrafficType.ACCEPT` |
-| `ALL` | `awscc.ec2.flow_log.TrafficType.ALL` |
-| `REJECT` | `awscc.ec2.flow_log.TrafficType.REJECT` |
+| `ACCEPT` | `awscc.ec2.FlowLog.TrafficType.ACCEPT` |
+| `ALL` | `awscc.ec2.FlowLog.TrafficType.ALL` |
+| `REJECT` | `awscc.ec2.FlowLog.TrafficType.REJECT` |
 
 Shorthand formats: `ACCEPT` or `TrafficType.ACCEPT`
 

--- a/generated-docs/awscc/ec2/internet_gateway.md
+++ b/generated-docs/awscc/ec2/internet_gateway.md
@@ -1,6 +1,6 @@
 ---
-title: "awscc.ec2.internet_gateway"
-description: "AWSCC EC2 internet_gateway resource reference"
+title: "awscc.ec2.InternetGateway"
+description: "AWSCC EC2 InternetGateway resource reference"
 ---
 
 
@@ -11,7 +11,7 @@ Allocates an internet gateway for use with a VPC. After creating the Internet ga
 ## Example
 
 ```crn
-awscc.ec2.internet_gateway {
+awscc.ec2.InternetGateway {
   tags = {
     Environment = 'example'
   }

--- a/generated-docs/awscc/ec2/ipam.md
+++ b/generated-docs/awscc/ec2/ipam.md
@@ -1,6 +1,6 @@
 ---
-title: "awscc.ec2.ipam"
-description: "AWSCC EC2 ipam resource reference"
+title: "awscc.ec2.Ipam"
+description: "AWSCC EC2 Ipam resource reference"
 ---
 
 
@@ -11,7 +11,7 @@ Resource Schema of AWS::EC2::IPAM Type
 ## Example
 
 ```crn
-awscc.ec2.ipam {
+awscc.ec2.Ipam {
   description = 'Example IPAM'
   tier        = free
 
@@ -80,8 +80,8 @@ The tier of the IPAM.
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `ipam-owner` | `awscc.ec2.ipam.MeteredAccount.ipam_owner` |
-| `resource-owner` | `awscc.ec2.ipam.MeteredAccount.resource_owner` |
+| `ipam-owner` | `awscc.ec2.Ipam.MeteredAccount.ipam_owner` |
+| `resource-owner` | `awscc.ec2.Ipam.MeteredAccount.resource_owner` |
 
 Shorthand formats: `ipam_owner` or `MeteredAccount.ipam_owner`
 
@@ -89,8 +89,8 @@ Shorthand formats: `ipam_owner` or `MeteredAccount.ipam_owner`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `free` | `awscc.ec2.ipam.Tier.free` |
-| `advanced` | `awscc.ec2.ipam.Tier.advanced` |
+| `free` | `awscc.ec2.Ipam.Tier.free` |
+| `advanced` | `awscc.ec2.Ipam.Tier.advanced` |
 
 Shorthand formats: `free` or `Tier.free`
 

--- a/generated-docs/awscc/ec2/ipam_pool.md
+++ b/generated-docs/awscc/ec2/ipam_pool.md
@@ -1,6 +1,6 @@
 ---
-title: "awscc.ec2.ipam_pool"
-description: "AWSCC EC2 ipam_pool resource reference"
+title: "awscc.ec2.IpamPool"
+description: "AWSCC EC2 IpamPool resource reference"
 ---
 
 
@@ -11,7 +11,7 @@ Resource Schema of AWS::EC2::IPAMPool Type
 ## Example
 
 ```crn
-let ipam = awscc.ec2.ipam {
+let ipam = awscc.ec2.Ipam {
   description = 'Example IPAM'
   tier        = free
 
@@ -20,7 +20,7 @@ let ipam = awscc.ec2.ipam {
   }
 }
 
-awscc.ec2.ipam_pool {
+awscc.ec2.IpamPool {
   ipam_scope_id  = ipam.private_default_scope_id
   address_family = 'IPv4'
   locale         = 'ap-northeast-1'
@@ -160,8 +160,8 @@ An array of key-value pairs to apply to this resource.
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `IPv4` | `awscc.ec2.ipam_pool.AddressFamily.IPv4` |
-| `IPv6` | `awscc.ec2.ipam_pool.AddressFamily.IPv6` |
+| `IPv4` | `awscc.ec2.IpamPool.AddressFamily.IPv4` |
+| `IPv6` | `awscc.ec2.IpamPool.AddressFamily.IPv6` |
 
 Shorthand formats: `IPv4` or `AddressFamily.IPv4`
 
@@ -169,8 +169,8 @@ Shorthand formats: `IPv4` or `AddressFamily.IPv4`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `ec2` | `awscc.ec2.ipam_pool.AwsService.ec2` |
-| `global-services` | `awscc.ec2.ipam_pool.AwsService.global_services` |
+| `ec2` | `awscc.ec2.IpamPool.AwsService.ec2` |
+| `global-services` | `awscc.ec2.IpamPool.AwsService.global_services` |
 
 Shorthand formats: `ec2` or `AwsService.ec2`
 
@@ -178,8 +178,8 @@ Shorthand formats: `ec2` or `AwsService.ec2`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `public` | `awscc.ec2.ipam_pool.IpamScopeType.public` |
-| `private` | `awscc.ec2.ipam_pool.IpamScopeType.private` |
+| `public` | `awscc.ec2.IpamPool.IpamScopeType.public` |
+| `private` | `awscc.ec2.IpamPool.IpamScopeType.private` |
 
 Shorthand formats: `public` or `IpamScopeType.public`
 
@@ -187,8 +187,8 @@ Shorthand formats: `public` or `IpamScopeType.public`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `byoip` | `awscc.ec2.ipam_pool.PublicIpSource.byoip` |
-| `amazon` | `awscc.ec2.ipam_pool.PublicIpSource.amazon` |
+| `byoip` | `awscc.ec2.IpamPool.PublicIpSource.byoip` |
+| `amazon` | `awscc.ec2.IpamPool.PublicIpSource.amazon` |
 
 Shorthand formats: `byoip` or `PublicIpSource.byoip`
 
@@ -196,12 +196,12 @@ Shorthand formats: `byoip` or `PublicIpSource.byoip`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `create-in-progress` | `awscc.ec2.ipam_pool.State.create_in_progress` |
-| `create-complete` | `awscc.ec2.ipam_pool.State.create_complete` |
-| `modify-in-progress` | `awscc.ec2.ipam_pool.State.modify_in_progress` |
-| `modify-complete` | `awscc.ec2.ipam_pool.State.modify_complete` |
-| `delete-in-progress` | `awscc.ec2.ipam_pool.State.delete_in_progress` |
-| `delete-complete` | `awscc.ec2.ipam_pool.State.delete_complete` |
+| `create-in-progress` | `awscc.ec2.IpamPool.State.create_in_progress` |
+| `create-complete` | `awscc.ec2.IpamPool.State.create_complete` |
+| `modify-in-progress` | `awscc.ec2.IpamPool.State.modify_in_progress` |
+| `modify-complete` | `awscc.ec2.IpamPool.State.modify_complete` |
+| `delete-in-progress` | `awscc.ec2.IpamPool.State.delete_in_progress` |
+| `delete-complete` | `awscc.ec2.IpamPool.State.delete_complete` |
 
 Shorthand formats: `create_in_progress` or `State.create_in_progress`
 

--- a/generated-docs/awscc/ec2/nat_gateway.md
+++ b/generated-docs/awscc/ec2/nat_gateway.md
@@ -1,6 +1,6 @@
 ---
-title: "awscc.ec2.nat_gateway"
-description: "AWSCC EC2 nat_gateway resource reference"
+title: "awscc.ec2.NatGateway"
+description: "AWSCC EC2 NatGateway resource reference"
 ---
 
 
@@ -14,24 +14,24 @@ Specifies a network address translation (NAT) gateway in the specified subnet. Y
 ## Example
 
 ```crn
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
-let public_subnet = awscc.ec2.subnet {
+let public_subnet = awscc.ec2.Subnet {
   vpc_id                  = vpc.vpc_id
   cidr_block              = '10.0.1.0/24'
   availability_zone       = 'ap-northeast-1a'
   map_public_ip_on_launch = true
 }
 
-let eip = awscc.ec2.eip {
+let eip = awscc.ec2.Eip {
   domain = 'vpc'
 }
 
-awscc.ec2.nat_gateway {
+awscc.ec2.NatGateway {
   allocation_id = eip.allocation_id
   subnet_id     = public_subnet.subnet_id
 
@@ -140,8 +140,8 @@ The ID of the VPC in which the NAT gateway is located.
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `zonal` | `awscc.ec2.nat_gateway.AvailabilityMode.zonal` |
-| `regional` | `awscc.ec2.nat_gateway.AvailabilityMode.regional` |
+| `zonal` | `awscc.ec2.NatGateway.AvailabilityMode.zonal` |
+| `regional` | `awscc.ec2.NatGateway.AvailabilityMode.regional` |
 
 Shorthand formats: `zonal` or `AvailabilityMode.zonal`
 
@@ -149,8 +149,8 @@ Shorthand formats: `zonal` or `AvailabilityMode.zonal`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `public` | `awscc.ec2.nat_gateway.ConnectivityType.public` |
-| `private` | `awscc.ec2.nat_gateway.ConnectivityType.private` |
+| `public` | `awscc.ec2.NatGateway.ConnectivityType.public` |
+| `private` | `awscc.ec2.NatGateway.ConnectivityType.private` |
 
 Shorthand formats: `public` or `ConnectivityType.public`
 

--- a/generated-docs/awscc/ec2/route.md
+++ b/generated-docs/awscc/ec2/route.md
@@ -1,6 +1,6 @@
 ---
-title: "awscc.ec2.route"
-description: "AWSCC EC2 route resource reference"
+title: "awscc.ec2.Route"
+description: "AWSCC EC2 Route resource reference"
 ---
 
 
@@ -13,24 +13,24 @@ Specifies a route in a route table. For more information, see [Routes](https://d
 ## Example
 
 ```crn
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
-let igw = awscc.ec2.internet_gateway {}
+let igw = awscc.ec2.InternetGateway {}
 
-let igw_attachment = awscc.ec2.vpc_gateway_attachment {
+let igw_attachment = awscc.ec2.VpcGatewayAttachment {
   vpc_id              = vpc.vpc_id
   internet_gateway_id = igw.internet_gateway_id
 }
 
-let rt = awscc.ec2.route_table {
+let rt = awscc.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 }
 
-awscc.ec2.route {
+awscc.ec2.Route {
   route_table_id         = rt.route_table_id
   destination_cidr_block = '0.0.0.0/0'
   gateway_id             = igw_attachment.internet_gateway_id

--- a/generated-docs/awscc/ec2/route_table.md
+++ b/generated-docs/awscc/ec2/route_table.md
@@ -1,6 +1,6 @@
 ---
-title: "awscc.ec2.route_table"
-description: "AWSCC EC2 route_table resource reference"
+title: "awscc.ec2.RouteTable"
+description: "AWSCC EC2 RouteTable resource reference"
 ---
 
 
@@ -12,13 +12,13 @@ Specifies a route table for the specified VPC. After you create a route table, y
 ## Example
 
 ```crn
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
-awscc.ec2.route_table {
+awscc.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 
   tags = {

--- a/generated-docs/awscc/ec2/security_group.md
+++ b/generated-docs/awscc/ec2/security_group.md
@@ -1,6 +1,6 @@
 ---
-title: "awscc.ec2.security_group"
-description: "AWSCC EC2 security_group resource reference"
+title: "awscc.ec2.SecurityGroup"
+description: "AWSCC EC2 SecurityGroup resource reference"
 ---
 
 
@@ -11,11 +11,11 @@ Resource Type definition for AWS::EC2::SecurityGroup
 ## Example
 
 ```crn
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-awscc.ec2.security_group {
+awscc.ec2.SecurityGroup {
   vpc_id            = vpc.vpc_id
   group_description = 'Example security group'
 
@@ -92,12 +92,12 @@ The ID of the VPC for the security group.
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `tcp` | `awscc.ec2.security_group.IpProtocol.tcp` |
-| `udp` | `awscc.ec2.security_group.IpProtocol.udp` |
-| `icmp` | `awscc.ec2.security_group.IpProtocol.icmp` |
-| `icmpv6` | `awscc.ec2.security_group.IpProtocol.icmpv6` |
-| `-1` | `awscc.ec2.security_group.IpProtocol.all` |
-| `all` | `awscc.ec2.security_group.IpProtocol.all` |
+| `tcp` | `awscc.ec2.SecurityGroup.IpProtocol.tcp` |
+| `udp` | `awscc.ec2.SecurityGroup.IpProtocol.udp` |
+| `icmp` | `awscc.ec2.SecurityGroup.IpProtocol.icmp` |
+| `icmpv6` | `awscc.ec2.SecurityGroup.IpProtocol.icmpv6` |
+| `-1` | `awscc.ec2.SecurityGroup.IpProtocol.all` |
+| `all` | `awscc.ec2.SecurityGroup.IpProtocol.all` |
 
 Shorthand formats: `tcp` or `IpProtocol.tcp`
 
@@ -135,7 +135,7 @@ Shorthand formats: `tcp` or `IpProtocol.tcp`
 
 ### `group_id`
 
-- **Type:** String
+- **Type:** SecurityGroupId
 
 The group ID of the specified security group.
 

--- a/generated-docs/awscc/ec2/security_group_egress.md
+++ b/generated-docs/awscc/ec2/security_group_egress.md
@@ -1,6 +1,6 @@
 ---
-title: "awscc.ec2.security_group_egress"
-description: "AWSCC EC2 security_group_egress resource reference"
+title: "awscc.ec2.SecurityGroupEgress"
+description: "AWSCC EC2 SecurityGroupEgress resource reference"
 ---
 
 
@@ -15,16 +15,16 @@ Adds the specified outbound (egress) rule to a security group.
 ## Example
 
 ```crn
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-let sg = awscc.ec2.security_group {
+let sg = awscc.ec2.SecurityGroup {
   vpc_id            = vpc.vpc_id
   group_description = 'Example security group'
 }
 
-awscc.ec2.security_group_egress {
+awscc.ec2.SecurityGroupEgress {
   group_id    = sg.group_id
   description = 'Allow all outbound traffic'
   ip_protocol = all
@@ -83,7 +83,7 @@ If the protocol is TCP or UDP, this is the start of the port range. If the proto
 
 ### `group_id`
 
-- **Type:** String
+- **Type:** SecurityGroupId
 - **Required:** Yes
 - **Create-only:** Yes
 
@@ -111,12 +111,12 @@ If the protocol is TCP or UDP, this is the end of the port range. If the protoco
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `tcp` | `awscc.ec2.security_group_egress.IpProtocol.tcp` |
-| `udp` | `awscc.ec2.security_group_egress.IpProtocol.udp` |
-| `icmp` | `awscc.ec2.security_group_egress.IpProtocol.icmp` |
-| `icmpv6` | `awscc.ec2.security_group_egress.IpProtocol.icmpv6` |
-| `-1` | `awscc.ec2.security_group_egress.IpProtocol.all` |
-| `all` | `awscc.ec2.security_group_egress.IpProtocol.all` |
+| `tcp` | `awscc.ec2.SecurityGroupEgress.IpProtocol.tcp` |
+| `udp` | `awscc.ec2.SecurityGroupEgress.IpProtocol.udp` |
+| `icmp` | `awscc.ec2.SecurityGroupEgress.IpProtocol.icmp` |
+| `icmpv6` | `awscc.ec2.SecurityGroupEgress.IpProtocol.icmpv6` |
+| `-1` | `awscc.ec2.SecurityGroupEgress.IpProtocol.all` |
+| `all` | `awscc.ec2.SecurityGroupEgress.IpProtocol.all` |
 
 Shorthand formats: `tcp` or `IpProtocol.tcp`
 

--- a/generated-docs/awscc/ec2/security_group_ingress.md
+++ b/generated-docs/awscc/ec2/security_group_ingress.md
@@ -1,6 +1,6 @@
 ---
-title: "awscc.ec2.security_group_ingress"
-description: "AWSCC EC2 security_group_ingress resource reference"
+title: "awscc.ec2.SecurityGroupIngress"
+description: "AWSCC EC2 SecurityGroupIngress resource reference"
 ---
 
 
@@ -11,16 +11,16 @@ Resource Type definition for AWS::EC2::SecurityGroupIngress
 ## Example
 
 ```crn
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-let sg = awscc.ec2.security_group {
+let sg = awscc.ec2.SecurityGroup {
   vpc_id            = vpc.vpc_id
   group_description = 'Example security group'
 }
 
-awscc.ec2.security_group_ingress {
+awscc.ec2.SecurityGroupIngress {
   group_id    = sg.group_id
   description = 'Allow HTTPS from VPC'
   ip_protocol = 'tcp'
@@ -65,7 +65,7 @@ The start of port range for the TCP and UDP protocols, or an ICMP/ICMPv6 type nu
 
 ### `group_id`
 
-- **Type:** String
+- **Type:** SecurityGroupId
 - **Required:** No
 - **Create-only:** Yes
 
@@ -133,12 +133,12 @@ The end of port range for the TCP and UDP protocols, or an ICMP/ICMPv6 code. A v
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `tcp` | `awscc.ec2.security_group_ingress.IpProtocol.tcp` |
-| `udp` | `awscc.ec2.security_group_ingress.IpProtocol.udp` |
-| `icmp` | `awscc.ec2.security_group_ingress.IpProtocol.icmp` |
-| `icmpv6` | `awscc.ec2.security_group_ingress.IpProtocol.icmpv6` |
-| `-1` | `awscc.ec2.security_group_ingress.IpProtocol.all` |
-| `all` | `awscc.ec2.security_group_ingress.IpProtocol.all` |
+| `tcp` | `awscc.ec2.SecurityGroupIngress.IpProtocol.tcp` |
+| `udp` | `awscc.ec2.SecurityGroupIngress.IpProtocol.udp` |
+| `icmp` | `awscc.ec2.SecurityGroupIngress.IpProtocol.icmp` |
+| `icmpv6` | `awscc.ec2.SecurityGroupIngress.IpProtocol.icmpv6` |
+| `-1` | `awscc.ec2.SecurityGroupIngress.IpProtocol.all` |
+| `all` | `awscc.ec2.SecurityGroupIngress.IpProtocol.all` |
 
 Shorthand formats: `tcp` or `IpProtocol.tcp`
 

--- a/generated-docs/awscc/ec2/subnet.md
+++ b/generated-docs/awscc/ec2/subnet.md
@@ -1,6 +1,6 @@
 ---
-title: "awscc.ec2.subnet"
-description: "AWSCC EC2 subnet resource reference"
+title: "awscc.ec2.Subnet"
+description: "AWSCC EC2 Subnet resource reference"
 ---
 
 
@@ -13,13 +13,13 @@ Specifies a subnet for the specified VPC.
 ## Example
 
 ```crn
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
-awscc.ec2.subnet {
+awscc.ec2.Subnet {
   vpc_id                  = vpc.vpc_id
   cidr_block              = '10.0.1.0/24'
   availability_zone       = 'ap-northeast-1a'
@@ -173,9 +173,9 @@ The ID of the VPC the subnet is in. If you update this property, you must also u
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `off` | `awscc.ec2.subnet.InternetGatewayBlockMode.off` |
-| `block-bidirectional` | `awscc.ec2.subnet.InternetGatewayBlockMode.block_bidirectional` |
-| `block-ingress` | `awscc.ec2.subnet.InternetGatewayBlockMode.block_ingress` |
+| `off` | `awscc.ec2.Subnet.InternetGatewayBlockMode.off` |
+| `block-bidirectional` | `awscc.ec2.Subnet.InternetGatewayBlockMode.block_bidirectional` |
+| `block-ingress` | `awscc.ec2.Subnet.InternetGatewayBlockMode.block_ingress` |
 
 Shorthand formats: `off` or `InternetGatewayBlockMode.off`
 
@@ -183,8 +183,8 @@ Shorthand formats: `off` or `InternetGatewayBlockMode.off`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `ip-name` | `awscc.ec2.subnet.HostnameType.ip_name` |
-| `resource-name` | `awscc.ec2.subnet.HostnameType.resource_name` |
+| `ip-name` | `awscc.ec2.Subnet.HostnameType.ip_name` |
+| `resource-name` | `awscc.ec2.Subnet.HostnameType.resource_name` |
 
 Shorthand formats: `ip_name` or `HostnameType.ip_name`
 

--- a/generated-docs/awscc/ec2/subnet_route_table_association.md
+++ b/generated-docs/awscc/ec2/subnet_route_table_association.md
@@ -1,6 +1,6 @@
 ---
-title: "awscc.ec2.subnet_route_table_association"
-description: "AWSCC EC2 subnet_route_table_association resource reference"
+title: "awscc.ec2.SubnetRouteTableAssociation"
+description: "AWSCC EC2 SubnetRouteTableAssociation resource reference"
 ---
 
 
@@ -11,23 +11,23 @@ Associates a subnet with a route table. The subnet and route table must be in th
 ## Example
 
 ```crn
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
-let subnet = awscc.ec2.subnet {
+let subnet = awscc.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.1.0/24'
   availability_zone = 'ap-northeast-1a'
 }
 
-let rt = awscc.ec2.route_table {
+let rt = awscc.ec2.RouteTable {
   vpc_id = vpc.vpc_id
 }
 
-awscc.ec2.subnet_route_table_association {
+awscc.ec2.SubnetRouteTableAssociation {
   subnet_id      = subnet.subnet_id
   route_table_id = rt.route_table_id
 }

--- a/generated-docs/awscc/ec2/transit_gateway.md
+++ b/generated-docs/awscc/ec2/transit_gateway.md
@@ -1,6 +1,6 @@
 ---
-title: "awscc.ec2.transit_gateway"
-description: "AWSCC EC2 transit_gateway resource reference"
+title: "awscc.ec2.TransitGateway"
+description: "AWSCC EC2 TransitGateway resource reference"
 ---
 
 
@@ -11,7 +11,7 @@ Resource Type definition for AWS::EC2::TransitGateway
 ## Example
 
 ```crn
-awscc.ec2.transit_gateway {
+awscc.ec2.TransitGateway {
   description = 'Example Transit Gateway'
 
   tags = {
@@ -101,8 +101,8 @@ awscc.ec2.transit_gateway {
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `enable` | `awscc.ec2.transit_gateway.AutoAcceptSharedAttachments.enable` |
-| `disable` | `awscc.ec2.transit_gateway.AutoAcceptSharedAttachments.disable` |
+| `enable` | `awscc.ec2.TransitGateway.AutoAcceptSharedAttachments.enable` |
+| `disable` | `awscc.ec2.TransitGateway.AutoAcceptSharedAttachments.disable` |
 
 Shorthand formats: `enable` or `AutoAcceptSharedAttachments.enable`
 
@@ -110,8 +110,8 @@ Shorthand formats: `enable` or `AutoAcceptSharedAttachments.enable`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `enable` | `awscc.ec2.transit_gateway.DefaultRouteTableAssociation.enable` |
-| `disable` | `awscc.ec2.transit_gateway.DefaultRouteTableAssociation.disable` |
+| `enable` | `awscc.ec2.TransitGateway.DefaultRouteTableAssociation.enable` |
+| `disable` | `awscc.ec2.TransitGateway.DefaultRouteTableAssociation.disable` |
 
 Shorthand formats: `enable` or `DefaultRouteTableAssociation.enable`
 
@@ -119,8 +119,8 @@ Shorthand formats: `enable` or `DefaultRouteTableAssociation.enable`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `enable` | `awscc.ec2.transit_gateway.DefaultRouteTablePropagation.enable` |
-| `disable` | `awscc.ec2.transit_gateway.DefaultRouteTablePropagation.disable` |
+| `enable` | `awscc.ec2.TransitGateway.DefaultRouteTablePropagation.enable` |
+| `disable` | `awscc.ec2.TransitGateway.DefaultRouteTablePropagation.disable` |
 
 Shorthand formats: `enable` or `DefaultRouteTablePropagation.enable`
 
@@ -128,8 +128,8 @@ Shorthand formats: `enable` or `DefaultRouteTablePropagation.enable`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `enable` | `awscc.ec2.transit_gateway.DnsSupport.enable` |
-| `disable` | `awscc.ec2.transit_gateway.DnsSupport.disable` |
+| `enable` | `awscc.ec2.TransitGateway.DnsSupport.enable` |
+| `disable` | `awscc.ec2.TransitGateway.DnsSupport.disable` |
 
 Shorthand formats: `enable` or `DnsSupport.enable`
 
@@ -137,8 +137,8 @@ Shorthand formats: `enable` or `DnsSupport.enable`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `disable` | `awscc.ec2.transit_gateway.EncryptionSupport.disable` |
-| `enable` | `awscc.ec2.transit_gateway.EncryptionSupport.enable` |
+| `disable` | `awscc.ec2.TransitGateway.EncryptionSupport.disable` |
+| `enable` | `awscc.ec2.TransitGateway.EncryptionSupport.enable` |
 
 Shorthand formats: `disable` or `EncryptionSupport.disable`
 
@@ -146,8 +146,8 @@ Shorthand formats: `disable` or `EncryptionSupport.disable`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `disable` | `awscc.ec2.transit_gateway.EncryptionSupportState.disable` |
-| `enable` | `awscc.ec2.transit_gateway.EncryptionSupportState.enable` |
+| `disable` | `awscc.ec2.TransitGateway.EncryptionSupportState.disable` |
+| `enable` | `awscc.ec2.TransitGateway.EncryptionSupportState.enable` |
 
 Shorthand formats: `disable` or `EncryptionSupportState.disable`
 
@@ -155,8 +155,8 @@ Shorthand formats: `disable` or `EncryptionSupportState.disable`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `enable` | `awscc.ec2.transit_gateway.MulticastSupport.enable` |
-| `disable` | `awscc.ec2.transit_gateway.MulticastSupport.disable` |
+| `enable` | `awscc.ec2.TransitGateway.MulticastSupport.enable` |
+| `disable` | `awscc.ec2.TransitGateway.MulticastSupport.disable` |
 
 Shorthand formats: `enable` or `MulticastSupport.enable`
 
@@ -164,8 +164,8 @@ Shorthand formats: `enable` or `MulticastSupport.enable`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `enable` | `awscc.ec2.transit_gateway.SecurityGroupReferencingSupport.enable` |
-| `disable` | `awscc.ec2.transit_gateway.SecurityGroupReferencingSupport.disable` |
+| `enable` | `awscc.ec2.TransitGateway.SecurityGroupReferencingSupport.enable` |
+| `disable` | `awscc.ec2.TransitGateway.SecurityGroupReferencingSupport.disable` |
 
 Shorthand formats: `enable` or `SecurityGroupReferencingSupport.enable`
 
@@ -173,8 +173,8 @@ Shorthand formats: `enable` or `SecurityGroupReferencingSupport.enable`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `enable` | `awscc.ec2.transit_gateway.VpnEcmpSupport.enable` |
-| `disable` | `awscc.ec2.transit_gateway.VpnEcmpSupport.disable` |
+| `enable` | `awscc.ec2.TransitGateway.VpnEcmpSupport.enable` |
+| `disable` | `awscc.ec2.TransitGateway.VpnEcmpSupport.disable` |
 
 Shorthand formats: `enable` or `VpnEcmpSupport.enable`
 

--- a/generated-docs/awscc/ec2/transit_gateway_attachment.md
+++ b/generated-docs/awscc/ec2/transit_gateway_attachment.md
@@ -1,6 +1,6 @@
 ---
-title: "awscc.ec2.transit_gateway_attachment"
-description: "AWSCC EC2 transit_gateway_attachment resource reference"
+title: "awscc.ec2.TransitGatewayAttachment"
+description: "AWSCC EC2 TransitGatewayAttachment resource reference"
 ---
 
 
@@ -11,21 +11,21 @@ Resource Type definition for AWS::EC2::TransitGatewayAttachment
 ## Example
 
 ```crn
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-let subnet = awscc.ec2.subnet {
+let subnet = awscc.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.1.0/24'
   availability_zone = 'ap-northeast-1a'
 }
 
-let tgw = awscc.ec2.transit_gateway {
+let tgw = awscc.ec2.TransitGateway {
   description = 'Example Transit Gateway'
 }
 
-awscc.ec2.transit_gateway_attachment {
+awscc.ec2.TransitGatewayAttachment {
   transit_gateway_id = tgw.id
   vpc_id             = vpc.vpc_id
   subnet_ids         = [subnet.subnet_id]
@@ -73,8 +73,8 @@ The options for the transit gateway vpc attachment.
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `enable` | `awscc.ec2.transit_gateway_attachment.ApplianceModeSupport.enable` |
-| `disable` | `awscc.ec2.transit_gateway_attachment.ApplianceModeSupport.disable` |
+| `enable` | `awscc.ec2.TransitGatewayAttachment.ApplianceModeSupport.enable` |
+| `disable` | `awscc.ec2.TransitGatewayAttachment.ApplianceModeSupport.disable` |
 
 Shorthand formats: `enable` or `ApplianceModeSupport.enable`
 
@@ -82,8 +82,8 @@ Shorthand formats: `enable` or `ApplianceModeSupport.enable`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `enable` | `awscc.ec2.transit_gateway_attachment.DnsSupport.enable` |
-| `disable` | `awscc.ec2.transit_gateway_attachment.DnsSupport.disable` |
+| `enable` | `awscc.ec2.TransitGatewayAttachment.DnsSupport.enable` |
+| `disable` | `awscc.ec2.TransitGatewayAttachment.DnsSupport.disable` |
 
 Shorthand formats: `enable` or `DnsSupport.enable`
 
@@ -91,8 +91,8 @@ Shorthand formats: `enable` or `DnsSupport.enable`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `enable` | `awscc.ec2.transit_gateway_attachment.Ipv6Support.enable` |
-| `disable` | `awscc.ec2.transit_gateway_attachment.Ipv6Support.disable` |
+| `enable` | `awscc.ec2.TransitGatewayAttachment.Ipv6Support.enable` |
+| `disable` | `awscc.ec2.TransitGatewayAttachment.Ipv6Support.disable` |
 
 Shorthand formats: `enable` or `Ipv6Support.enable`
 
@@ -100,8 +100,8 @@ Shorthand formats: `enable` or `Ipv6Support.enable`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `enable` | `awscc.ec2.transit_gateway_attachment.SecurityGroupReferencingSupport.enable` |
-| `disable` | `awscc.ec2.transit_gateway_attachment.SecurityGroupReferencingSupport.disable` |
+| `enable` | `awscc.ec2.TransitGatewayAttachment.SecurityGroupReferencingSupport.enable` |
+| `disable` | `awscc.ec2.TransitGatewayAttachment.SecurityGroupReferencingSupport.disable` |
 
 Shorthand formats: `enable` or `SecurityGroupReferencingSupport.enable`
 

--- a/generated-docs/awscc/ec2/vpc.md
+++ b/generated-docs/awscc/ec2/vpc.md
@@ -1,6 +1,6 @@
 ---
-title: "awscc.ec2.vpc"
-description: "AWSCC EC2 vpc resource reference"
+title: "awscc.ec2.Vpc"
+description: "AWSCC EC2 Vpc resource reference"
 ---
 
 
@@ -13,7 +13,7 @@ Specifies a virtual private cloud (VPC).
 ## Example
 
 ```crn
-awscc.ec2.vpc {
+awscc.ec2.Vpc {
   cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
@@ -87,9 +87,9 @@ The tags for the VPC.
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `default` | `awscc.ec2.vpc.InstanceTenancy.default` |
-| `dedicated` | `awscc.ec2.vpc.InstanceTenancy.dedicated` |
-| `host` | `awscc.ec2.vpc.InstanceTenancy.host` |
+| `default` | `awscc.ec2.Vpc.InstanceTenancy.default` |
+| `dedicated` | `awscc.ec2.Vpc.InstanceTenancy.dedicated` |
+| `host` | `awscc.ec2.Vpc.InstanceTenancy.host` |
 
 Shorthand formats: `default` or `InstanceTenancy.default`
 

--- a/generated-docs/awscc/ec2/vpc_endpoint.md
+++ b/generated-docs/awscc/ec2/vpc_endpoint.md
@@ -1,6 +1,6 @@
 ---
-title: "awscc.ec2.vpc_endpoint"
-description: "AWSCC EC2 vpc_endpoint resource reference"
+title: "awscc.ec2.VpcEndpoint"
+description: "AWSCC EC2 VpcEndpoint resource reference"
 ---
 
 
@@ -14,24 +14,24 @@ Specifies a VPC endpoint. A VPC endpoint provides a private connection between y
 ## Example
 
 ```crn
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
-let subnet = awscc.ec2.subnet {
+let subnet = awscc.ec2.Subnet {
   vpc_id            = vpc.vpc_id
   cidr_block        = '10.0.100.0/24'
   availability_zone = 'ap-northeast-1a'
 }
 
-let sg = awscc.ec2.security_group {
+let sg = awscc.ec2.SecurityGroup {
   vpc_id            = vpc.vpc_id
   group_description = 'SG for VPC Endpoint'
 }
 
-awscc.ec2.security_group_ingress {
+awscc.ec2.SecurityGroupIngress {
   group_id    = sg.group_id
   description = 'Allow HTTPS from VPC'
   ip_protocol = 'tcp'
@@ -40,7 +40,7 @@ awscc.ec2.security_group_ingress {
   cidr_ip     = '10.0.0.0/16'
 }
 
-awscc.ec2.vpc_endpoint {
+awscc.ec2.VpcEndpoint {
   vpc_id              = vpc.vpc_id
   service_name        = 'com.amazonaws.ap-northeast-1.ecr.dkr'
   vpc_endpoint_type   = 'Interface'
@@ -162,11 +162,11 @@ The ID of the VPC.
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `ipv4` | `awscc.ec2.vpc_endpoint.DnsRecordIpType.ipv4` |
-| `ipv6` | `awscc.ec2.vpc_endpoint.DnsRecordIpType.ipv6` |
-| `dualstack` | `awscc.ec2.vpc_endpoint.DnsRecordIpType.dualstack` |
-| `service-defined` | `awscc.ec2.vpc_endpoint.DnsRecordIpType.service_defined` |
-| `not-specified` | `awscc.ec2.vpc_endpoint.DnsRecordIpType.not_specified` |
+| `ipv4` | `awscc.ec2.VpcEndpoint.DnsRecordIpType.ipv4` |
+| `ipv6` | `awscc.ec2.VpcEndpoint.DnsRecordIpType.ipv6` |
+| `dualstack` | `awscc.ec2.VpcEndpoint.DnsRecordIpType.dualstack` |
+| `service-defined` | `awscc.ec2.VpcEndpoint.DnsRecordIpType.service_defined` |
+| `not-specified` | `awscc.ec2.VpcEndpoint.DnsRecordIpType.not_specified` |
 
 Shorthand formats: `ipv4` or `DnsRecordIpType.ipv4`
 
@@ -174,9 +174,9 @@ Shorthand formats: `ipv4` or `DnsRecordIpType.ipv4`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `OnlyInboundResolver` | `awscc.ec2.vpc_endpoint.PrivateDnsOnlyForInboundResolverEndpoint.OnlyInboundResolver` |
-| `AllResolvers` | `awscc.ec2.vpc_endpoint.PrivateDnsOnlyForInboundResolverEndpoint.AllResolvers` |
-| `NotSpecified` | `awscc.ec2.vpc_endpoint.PrivateDnsOnlyForInboundResolverEndpoint.NotSpecified` |
+| `OnlyInboundResolver` | `awscc.ec2.VpcEndpoint.PrivateDnsOnlyForInboundResolverEndpoint.OnlyInboundResolver` |
+| `AllResolvers` | `awscc.ec2.VpcEndpoint.PrivateDnsOnlyForInboundResolverEndpoint.AllResolvers` |
+| `NotSpecified` | `awscc.ec2.VpcEndpoint.PrivateDnsOnlyForInboundResolverEndpoint.NotSpecified` |
 
 Shorthand formats: `OnlyInboundResolver` or `PrivateDnsOnlyForInboundResolverEndpoint.OnlyInboundResolver`
 
@@ -184,10 +184,10 @@ Shorthand formats: `OnlyInboundResolver` or `PrivateDnsOnlyForInboundResolverEnd
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `VERIFIED_DOMAINS_ONLY` | `awscc.ec2.vpc_endpoint.PrivateDnsPreference.VERIFIED_DOMAINS_ONLY` |
-| `ALL_DOMAINS` | `awscc.ec2.vpc_endpoint.PrivateDnsPreference.ALL_DOMAINS` |
-| `VERIFIED_DOMAINS_AND_SPECIFIED_DOMAINS` | `awscc.ec2.vpc_endpoint.PrivateDnsPreference.VERIFIED_DOMAINS_AND_SPECIFIED_DOMAINS` |
-| `SPECIFIED_DOMAINS_ONLY` | `awscc.ec2.vpc_endpoint.PrivateDnsPreference.SPECIFIED_DOMAINS_ONLY` |
+| `VERIFIED_DOMAINS_ONLY` | `awscc.ec2.VpcEndpoint.PrivateDnsPreference.VERIFIED_DOMAINS_ONLY` |
+| `ALL_DOMAINS` | `awscc.ec2.VpcEndpoint.PrivateDnsPreference.ALL_DOMAINS` |
+| `VERIFIED_DOMAINS_AND_SPECIFIED_DOMAINS` | `awscc.ec2.VpcEndpoint.PrivateDnsPreference.VERIFIED_DOMAINS_AND_SPECIFIED_DOMAINS` |
+| `SPECIFIED_DOMAINS_ONLY` | `awscc.ec2.VpcEndpoint.PrivateDnsPreference.SPECIFIED_DOMAINS_ONLY` |
 
 Shorthand formats: `VERIFIED_DOMAINS_ONLY` or `PrivateDnsPreference.VERIFIED_DOMAINS_ONLY`
 
@@ -195,10 +195,10 @@ Shorthand formats: `VERIFIED_DOMAINS_ONLY` or `PrivateDnsPreference.VERIFIED_DOM
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `ipv4` | `awscc.ec2.vpc_endpoint.IpAddressType.ipv4` |
-| `ipv6` | `awscc.ec2.vpc_endpoint.IpAddressType.ipv6` |
-| `dualstack` | `awscc.ec2.vpc_endpoint.IpAddressType.dualstack` |
-| `not-specified` | `awscc.ec2.vpc_endpoint.IpAddressType.not_specified` |
+| `ipv4` | `awscc.ec2.VpcEndpoint.IpAddressType.ipv4` |
+| `ipv6` | `awscc.ec2.VpcEndpoint.IpAddressType.ipv6` |
+| `dualstack` | `awscc.ec2.VpcEndpoint.IpAddressType.dualstack` |
+| `not-specified` | `awscc.ec2.VpcEndpoint.IpAddressType.not_specified` |
 
 Shorthand formats: `ipv4` or `IpAddressType.ipv4`
 
@@ -206,11 +206,11 @@ Shorthand formats: `ipv4` or `IpAddressType.ipv4`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `Interface` | `awscc.ec2.vpc_endpoint.VpcEndpointType.Interface` |
-| `Gateway` | `awscc.ec2.vpc_endpoint.VpcEndpointType.Gateway` |
-| `GatewayLoadBalancer` | `awscc.ec2.vpc_endpoint.VpcEndpointType.GatewayLoadBalancer` |
-| `ServiceNetwork` | `awscc.ec2.vpc_endpoint.VpcEndpointType.ServiceNetwork` |
-| `Resource` | `awscc.ec2.vpc_endpoint.VpcEndpointType.Resource` |
+| `Interface` | `awscc.ec2.VpcEndpoint.VpcEndpointType.Interface` |
+| `Gateway` | `awscc.ec2.VpcEndpoint.VpcEndpointType.Gateway` |
+| `GatewayLoadBalancer` | `awscc.ec2.VpcEndpoint.VpcEndpointType.GatewayLoadBalancer` |
+| `ServiceNetwork` | `awscc.ec2.VpcEndpoint.VpcEndpointType.ServiceNetwork` |
+| `Resource` | `awscc.ec2.VpcEndpoint.VpcEndpointType.Resource` |
 
 Shorthand formats: `Interface` or `VpcEndpointType.Interface`
 

--- a/generated-docs/awscc/ec2/vpc_gateway_attachment.md
+++ b/generated-docs/awscc/ec2/vpc_gateway_attachment.md
@@ -1,6 +1,6 @@
 ---
-title: "awscc.ec2.vpc_gateway_attachment"
-description: "AWSCC EC2 vpc_gateway_attachment resource reference"
+title: "awscc.ec2.VpcGatewayAttachment"
+description: "AWSCC EC2 VpcGatewayAttachment resource reference"
 ---
 
 
@@ -11,15 +11,15 @@ Resource Type definition for AWS::EC2::VPCGatewayAttachment
 ## Example
 
 ```crn
-let vpc = awscc.ec2.vpc {
+let vpc = awscc.ec2.Vpc {
   cidr_block           = '10.0.0.0/16'
   enable_dns_support   = true
   enable_dns_hostnames = true
 }
 
-let igw = awscc.ec2.internet_gateway {}
+let igw = awscc.ec2.InternetGateway {}
 
-awscc.ec2.vpc_gateway_attachment {
+awscc.ec2.VpcGatewayAttachment {
   vpc_id              = vpc.vpc_id
   internet_gateway_id = igw.internet_gateway_id
 }

--- a/generated-docs/awscc/ec2/vpc_peering_connection.md
+++ b/generated-docs/awscc/ec2/vpc_peering_connection.md
@@ -1,6 +1,6 @@
 ---
-title: "awscc.ec2.vpc_peering_connection"
-description: "AWSCC EC2 vpc_peering_connection resource reference"
+title: "awscc.ec2.VpcPeeringConnection"
+description: "AWSCC EC2 VpcPeeringConnection resource reference"
 ---
 
 
@@ -11,15 +11,15 @@ Resource Type definition for AWS::EC2::VPCPeeringConnection
 ## Example
 
 ```crn
-let vpc1 = awscc.ec2.vpc {
+let vpc1 = awscc.ec2.Vpc {
   cidr_block = '10.0.0.0/16'
 }
 
-let vpc2 = awscc.ec2.vpc {
+let vpc2 = awscc.ec2.Vpc {
   cidr_block = '10.1.0.0/16'
 }
 
-awscc.ec2.vpc_peering_connection {
+awscc.ec2.VpcPeeringConnection {
   vpc_id      = vpc1.vpc_id
   peer_vpc_id = vpc2.vpc_id
 

--- a/generated-docs/awscc/ec2/vpn_gateway.md
+++ b/generated-docs/awscc/ec2/vpn_gateway.md
@@ -1,6 +1,6 @@
 ---
-title: "awscc.ec2.vpn_gateway"
-description: "AWSCC EC2 vpn_gateway resource reference"
+title: "awscc.ec2.VpnGateway"
+description: "AWSCC EC2 VpnGateway resource reference"
 ---
 
 
@@ -12,8 +12,8 @@ Specifies a virtual private gateway. A virtual private gateway is the endpoint o
 ## Example
 
 ```crn
-awscc.ec2.vpn_gateway {
-  type = awscc.ec2.vpn_gateway.Type.ipsec.1
+awscc.ec2.VpnGateway {
+  type = awscc.ec2.VpnGateway.Type.ipsec.1
 
   tags = {
     Environment = 'example'

--- a/generated-docs/awscc/iam/oidc_provider.md
+++ b/generated-docs/awscc/iam/oidc_provider.md
@@ -1,6 +1,6 @@
 ---
-title: "awscc.iam.oidc_provider"
-description: "AWSCC IAM oidc_provider resource reference"
+title: "awscc.iam.OidcProvider"
+description: "AWSCC IAM OidcProvider resource reference"
 ---
 
 

--- a/generated-docs/awscc/iam/role.md
+++ b/generated-docs/awscc/iam/role.md
@@ -1,6 +1,6 @@
 ---
-title: "awscc.iam.role"
-description: "AWSCC IAM role resource reference"
+title: "awscc.iam.Role"
+description: "AWSCC IAM Role resource reference"
 ---
 
 
@@ -12,7 +12,7 @@ Creates a new role for your AWS-account.
 ## Example
 
 ```crn
-awscc.iam.role {
+awscc.iam.Role {
   role_name = 'my-example-role'
 
   assume_role_policy_document = {

--- a/generated-docs/awscc/identitystore/group.md
+++ b/generated-docs/awscc/identitystore/group.md
@@ -1,6 +1,6 @@
 ---
-title: "awscc.identitystore.group"
-description: "AWSCC IDENTITYSTORE group resource reference"
+title: "awscc.identitystore.Group"
+description: "AWSCC IDENTITYSTORE Group resource reference"
 ---
 
 

--- a/generated-docs/awscc/identitystore/group_membership.md
+++ b/generated-docs/awscc/identitystore/group_membership.md
@@ -1,6 +1,6 @@
 ---
-title: "awscc.identitystore.group_membership"
-description: "AWSCC IDENTITYSTORE group_membership resource reference"
+title: "awscc.identitystore.GroupMembership"
+description: "AWSCC IDENTITYSTORE GroupMembership resource reference"
 ---
 
 

--- a/generated-docs/awscc/logs/log_group.md
+++ b/generated-docs/awscc/logs/log_group.md
@@ -1,6 +1,6 @@
 ---
-title: "awscc.logs.log_group"
-description: "AWSCC LOGS log_group resource reference"
+title: "awscc.logs.LogGroup"
+description: "AWSCC LOGS LogGroup resource reference"
 ---
 
 
@@ -15,7 +15,7 @@ The ``AWS::Logs::LogGroup`` resource specifies a log group. A log group defines 
 ## Example
 
 ```crn
-awscc.logs.log_group {
+awscc.logs.LogGroup {
   log_group_name    = '/example/my-app'
   retention_in_days = 30
 
@@ -33,7 +33,7 @@ awscc.logs.log_group {
 - **Required:** No
 - **Default:** `false`
 
-
+Indicates whether bearer token authentication is enabled for this log group. When enabled, bearer token authentication is allowed on operations until it is explicitly disabled.
 
 ### `data_protection_policy`
 
@@ -107,9 +107,9 @@ An array of key-value pairs to apply to the log group. For more information, see
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `STANDARD` | `awscc.logs.log_group.LogGroupClass.STANDARD` |
-| `INFREQUENT_ACCESS` | `awscc.logs.log_group.LogGroupClass.INFREQUENT_ACCESS` |
-| `DELIVERY` | `awscc.logs.log_group.LogGroupClass.DELIVERY` |
+| `STANDARD` | `awscc.logs.LogGroup.LogGroupClass.STANDARD` |
+| `INFREQUENT_ACCESS` | `awscc.logs.LogGroup.LogGroupClass.INFREQUENT_ACCESS` |
+| `DELIVERY` | `awscc.logs.LogGroup.LogGroupClass.DELIVERY` |
 
 Shorthand formats: `STANDARD` or `LogGroupClass.STANDARD`
 

--- a/generated-docs/awscc/organizations/account.md
+++ b/generated-docs/awscc/organizations/account.md
@@ -1,6 +1,6 @@
 ---
-title: "awscc.organizations.account"
-description: "AWSCC ORGANIZATIONS account resource reference"
+title: "awscc.organizations.Account"
+description: "AWSCC ORGANIZATIONS Account resource reference"
 ---
 
 
@@ -53,8 +53,8 @@ A list of tags that you want to attach to the newly created account. For each ta
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `INVITED` | `awscc.organizations.account.JoinedMethod.INVITED` |
-| `CREATED` | `awscc.organizations.account.JoinedMethod.CREATED` |
+| `INVITED` | `awscc.organizations.Account.JoinedMethod.INVITED` |
+| `CREATED` | `awscc.organizations.Account.JoinedMethod.CREATED` |
 
 Shorthand formats: `INVITED` or `JoinedMethod.INVITED`
 
@@ -62,11 +62,11 @@ Shorthand formats: `INVITED` or `JoinedMethod.INVITED`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `PENDING_ACTIVATION` | `awscc.organizations.account.State.PENDING_ACTIVATION` |
-| `ACTIVE` | `awscc.organizations.account.State.ACTIVE` |
-| `SUSPENDED` | `awscc.organizations.account.State.SUSPENDED` |
-| `PENDING_CLOSURE` | `awscc.organizations.account.State.PENDING_CLOSURE` |
-| `CLOSED` | `awscc.organizations.account.State.CLOSED` |
+| `PENDING_ACTIVATION` | `awscc.organizations.Account.State.PENDING_ACTIVATION` |
+| `ACTIVE` | `awscc.organizations.Account.State.ACTIVE` |
+| `SUSPENDED` | `awscc.organizations.Account.State.SUSPENDED` |
+| `PENDING_CLOSURE` | `awscc.organizations.Account.State.PENDING_CLOSURE` |
+| `CLOSED` | `awscc.organizations.Account.State.CLOSED` |
 
 Shorthand formats: `PENDING_ACTIVATION` or `State.PENDING_ACTIVATION`
 
@@ -74,9 +74,9 @@ Shorthand formats: `PENDING_ACTIVATION` or `State.PENDING_ACTIVATION`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `ACTIVE` | `awscc.organizations.account.Status.ACTIVE` |
-| `SUSPENDED` | `awscc.organizations.account.Status.SUSPENDED` |
-| `PENDING_CLOSURE` | `awscc.organizations.account.Status.PENDING_CLOSURE` |
+| `ACTIVE` | `awscc.organizations.Account.Status.ACTIVE` |
+| `SUSPENDED` | `awscc.organizations.Account.Status.SUSPENDED` |
+| `PENDING_CLOSURE` | `awscc.organizations.Account.Status.PENDING_CLOSURE` |
 
 Shorthand formats: `ACTIVE` or `Status.ACTIVE`
 
@@ -105,6 +105,12 @@ The method by which the account joined the organization.
 - **Type:** String
 
 The date the account became a part of the organization.
+
+### `paths`
+
+- **Type:** `List<String>`
+
+The paths in the organization where the account exists.
 
 ### `state`
 

--- a/generated-docs/awscc/organizations/organization.md
+++ b/generated-docs/awscc/organizations/organization.md
@@ -1,6 +1,6 @@
 ---
-title: "awscc.organizations.organization"
-description: "AWSCC ORGANIZATIONS organization resource reference"
+title: "awscc.organizations.Organization"
+description: "AWSCC ORGANIZATIONS Organization resource reference"
 ---
 
 
@@ -24,8 +24,8 @@ Specifies the feature set supported by the new organization. Each feature set su
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `ALL` | `awscc.organizations.organization.FeatureSet.ALL` |
-| `CONSOLIDATED_BILLING` | `awscc.organizations.organization.FeatureSet.CONSOLIDATED_BILLING` |
+| `ALL` | `awscc.organizations.Organization.FeatureSet.ALL` |
+| `CONSOLIDATED_BILLING` | `awscc.organizations.Organization.FeatureSet.CONSOLIDATED_BILLING` |
 
 Shorthand formats: `ALL` or `FeatureSet.ALL`
 

--- a/generated-docs/awscc/route53/hosted_zone.md
+++ b/generated-docs/awscc/route53/hosted_zone.md
@@ -1,6 +1,6 @@
 ---
-title: "awscc.route53.hosted_zone"
-description: "AWSCC ROUTE53 hosted_zone resource reference"
+title: "awscc.route53.HostedZone"
+description: "AWSCC ROUTE53 HostedZone resource reference"
 ---
 
 

--- a/generated-docs/awscc/s3/bucket.md
+++ b/generated-docs/awscc/s3/bucket.md
@@ -1,6 +1,6 @@
 ---
-title: "awscc.s3.bucket"
-description: "AWSCC S3 bucket resource reference"
+title: "awscc.s3.Bucket"
+description: "AWSCC S3 Bucket resource reference"
 ---
 
 
@@ -13,7 +13,7 @@ The ``AWS::S3::Bucket`` resource creates an Amazon S3 bucket in the same AWS Reg
 ## Example
 
 ```crn
-awscc.s3.bucket {
+awscc.s3.Bucket {
   bucket_name = 'my-example-bucket'
 
   versioning_configuration = {
@@ -215,8 +215,8 @@ Information used to configure the bucket as a static website. For more informati
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `Enabled` | `awscc.s3.bucket.AbacStatus.Enabled` |
-| `Disabled` | `awscc.s3.bucket.AbacStatus.Disabled` |
+| `Enabled` | `awscc.s3.Bucket.AbacStatus.Enabled` |
+| `Disabled` | `awscc.s3.Bucket.AbacStatus.Disabled` |
 
 Shorthand formats: `Enabled` or `AbacStatus.Enabled`
 
@@ -224,8 +224,8 @@ Shorthand formats: `Enabled` or `AbacStatus.Enabled`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `Enabled` | `awscc.s3.bucket.AccelerationStatus.Enabled` |
-| `Suspended` | `awscc.s3.bucket.AccelerationStatus.Suspended` |
+| `Enabled` | `awscc.s3.Bucket.AccelerationStatus.Enabled` |
+| `Suspended` | `awscc.s3.Bucket.AccelerationStatus.Suspended` |
 
 Shorthand formats: `Enabled` or `AccelerationStatus.Enabled`
 
@@ -233,14 +233,14 @@ Shorthand formats: `Enabled` or `AccelerationStatus.Enabled`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `AuthenticatedRead` | `awscc.s3.bucket.AccessControl.AuthenticatedRead` |
-| `AwsExecRead` | `awscc.s3.bucket.AccessControl.AwsExecRead` |
-| `BucketOwnerFullControl` | `awscc.s3.bucket.AccessControl.BucketOwnerFullControl` |
-| `BucketOwnerRead` | `awscc.s3.bucket.AccessControl.BucketOwnerRead` |
-| `LogDeliveryWrite` | `awscc.s3.bucket.AccessControl.LogDeliveryWrite` |
-| `Private` | `awscc.s3.bucket.AccessControl.Private` |
-| `PublicRead` | `awscc.s3.bucket.AccessControl.PublicRead` |
-| `PublicReadWrite` | `awscc.s3.bucket.AccessControl.PublicReadWrite` |
+| `AuthenticatedRead` | `awscc.s3.Bucket.AccessControl.AuthenticatedRead` |
+| `AwsExecRead` | `awscc.s3.Bucket.AccessControl.AwsExecRead` |
+| `BucketOwnerFullControl` | `awscc.s3.Bucket.AccessControl.BucketOwnerFullControl` |
+| `BucketOwnerRead` | `awscc.s3.Bucket.AccessControl.BucketOwnerRead` |
+| `LogDeliveryWrite` | `awscc.s3.Bucket.AccessControl.LogDeliveryWrite` |
+| `Private` | `awscc.s3.Bucket.AccessControl.Private` |
+| `PublicRead` | `awscc.s3.Bucket.AccessControl.PublicRead` |
+| `PublicReadWrite` | `awscc.s3.Bucket.AccessControl.PublicReadWrite` |
 
 Shorthand formats: `AuthenticatedRead` or `AccessControl.AuthenticatedRead`
 
@@ -248,7 +248,7 @@ Shorthand formats: `AuthenticatedRead` or `AccessControl.AuthenticatedRead`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `Destination` | `awscc.s3.bucket.Owner.Destination` |
+| `Destination` | `awscc.s3.Bucket.Owner.Destination` |
 
 Shorthand formats: `Destination` or `Owner.Destination`
 
@@ -256,8 +256,8 @@ Shorthand formats: `Destination` or `Owner.Destination`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `NONE` | `awscc.s3.bucket.EncryptionType.NONE` |
-| `SSE-C` | `awscc.s3.bucket.EncryptionType.SSE_C` |
+| `NONE` | `awscc.s3.Bucket.EncryptionType.NONE` |
+| `SSE-C` | `awscc.s3.Bucket.EncryptionType.SSE_C` |
 
 Shorthand formats: `NONE` or `EncryptionType.NONE`
 
@@ -265,8 +265,8 @@ Shorthand formats: `NONE` or `EncryptionType.NONE`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `global` | `awscc.s3.bucket.BucketNamespace.global` |
-| `account-regional` | `awscc.s3.bucket.BucketNamespace.account_regional` |
+| `global` | `awscc.s3.Bucket.BucketNamespace.global` |
+| `account-regional` | `awscc.s3.Bucket.BucketNamespace.account_regional` |
 
 Shorthand formats: `global` or `BucketNamespace.global`
 
@@ -274,11 +274,11 @@ Shorthand formats: `global` or `BucketNamespace.global`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `GET` | `awscc.s3.bucket.AllowedMethods.GET` |
-| `PUT` | `awscc.s3.bucket.AllowedMethods.PUT` |
-| `HEAD` | `awscc.s3.bucket.AllowedMethods.HEAD` |
-| `POST` | `awscc.s3.bucket.AllowedMethods.POST` |
-| `DELETE` | `awscc.s3.bucket.AllowedMethods.DELETE` |
+| `GET` | `awscc.s3.Bucket.AllowedMethods.GET` |
+| `PUT` | `awscc.s3.Bucket.AllowedMethods.PUT` |
+| `HEAD` | `awscc.s3.Bucket.AllowedMethods.HEAD` |
+| `POST` | `awscc.s3.Bucket.AllowedMethods.POST` |
+| `DELETE` | `awscc.s3.Bucket.AllowedMethods.DELETE` |
 
 Shorthand formats: `GET` or `AllowedMethods.GET`
 
@@ -286,7 +286,7 @@ Shorthand formats: `GET` or `AllowedMethods.GET`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `V_1` | `awscc.s3.bucket.OutputSchemaVersion.V_1` |
+| `V_1` | `awscc.s3.Bucket.OutputSchemaVersion.V_1` |
 
 Shorthand formats: `V_1` or `OutputSchemaVersion.V_1`
 
@@ -294,8 +294,8 @@ Shorthand formats: `V_1` or `OutputSchemaVersion.V_1`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `COMPLIANCE` | `awscc.s3.bucket.Mode.COMPLIANCE` |
-| `GOVERNANCE` | `awscc.s3.bucket.Mode.GOVERNANCE` |
+| `COMPLIANCE` | `awscc.s3.Bucket.Mode.COMPLIANCE` |
+| `GOVERNANCE` | `awscc.s3.Bucket.Mode.GOVERNANCE` |
 
 Shorthand formats: `COMPLIANCE` or `Mode.COMPLIANCE`
 
@@ -303,8 +303,8 @@ Shorthand formats: `COMPLIANCE` or `Mode.COMPLIANCE`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `Disabled` | `awscc.s3.bucket.DeleteMarkerReplicationStatus.Disabled` |
-| `Enabled` | `awscc.s3.bucket.DeleteMarkerReplicationStatus.Enabled` |
+| `Disabled` | `awscc.s3.Bucket.DeleteMarkerReplicationStatus.Disabled` |
+| `Enabled` | `awscc.s3.Bucket.DeleteMarkerReplicationStatus.Enabled` |
 
 Shorthand formats: `Disabled` or `DeleteMarkerReplicationStatus.Disabled`
 
@@ -312,9 +312,9 @@ Shorthand formats: `Disabled` or `DeleteMarkerReplicationStatus.Disabled`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `CSV` | `awscc.s3.bucket.Format.CSV` |
-| `ORC` | `awscc.s3.bucket.Format.ORC` |
-| `Parquet` | `awscc.s3.bucket.Format.Parquet` |
+| `CSV` | `awscc.s3.Bucket.Format.CSV` |
+| `ORC` | `awscc.s3.Bucket.Format.ORC` |
+| `Parquet` | `awscc.s3.Bucket.Format.Parquet` |
 
 Shorthand formats: `CSV` or `Format.CSV`
 
@@ -322,8 +322,8 @@ Shorthand formats: `CSV` or `Format.CSV`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `Disabled` | `awscc.s3.bucket.IntelligentTieringConfigurationStatus.Disabled` |
-| `Enabled` | `awscc.s3.bucket.IntelligentTieringConfigurationStatus.Enabled` |
+| `Disabled` | `awscc.s3.Bucket.IntelligentTieringConfigurationStatus.Disabled` |
+| `Enabled` | `awscc.s3.Bucket.IntelligentTieringConfigurationStatus.Enabled` |
 
 Shorthand formats: `Disabled` or `IntelligentTieringConfigurationStatus.Disabled`
 
@@ -331,8 +331,8 @@ Shorthand formats: `Disabled` or `IntelligentTieringConfigurationStatus.Disabled
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `All` | `awscc.s3.bucket.IncludedObjectVersions.All` |
-| `Current` | `awscc.s3.bucket.IncludedObjectVersions.Current` |
+| `All` | `awscc.s3.Bucket.IncludedObjectVersions.All` |
+| `Current` | `awscc.s3.Bucket.IncludedObjectVersions.Current` |
 
 Shorthand formats: `All` or `IncludedObjectVersions.All`
 
@@ -340,22 +340,22 @@ Shorthand formats: `All` or `IncludedObjectVersions.All`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `Size` | `awscc.s3.bucket.OptionalFields.Size` |
-| `LastModifiedDate` | `awscc.s3.bucket.OptionalFields.LastModifiedDate` |
-| `StorageClass` | `awscc.s3.bucket.OptionalFields.StorageClass` |
-| `ETag` | `awscc.s3.bucket.OptionalFields.ETag` |
-| `IsMultipartUploaded` | `awscc.s3.bucket.OptionalFields.IsMultipartUploaded` |
-| `ReplicationStatus` | `awscc.s3.bucket.OptionalFields.ReplicationStatus` |
-| `EncryptionStatus` | `awscc.s3.bucket.OptionalFields.EncryptionStatus` |
-| `ObjectLockRetainUntilDate` | `awscc.s3.bucket.OptionalFields.ObjectLockRetainUntilDate` |
-| `ObjectLockMode` | `awscc.s3.bucket.OptionalFields.ObjectLockMode` |
-| `ObjectLockLegalHoldStatus` | `awscc.s3.bucket.OptionalFields.ObjectLockLegalHoldStatus` |
-| `IntelligentTieringAccessTier` | `awscc.s3.bucket.OptionalFields.IntelligentTieringAccessTier` |
-| `BucketKeyStatus` | `awscc.s3.bucket.OptionalFields.BucketKeyStatus` |
-| `ChecksumAlgorithm` | `awscc.s3.bucket.OptionalFields.ChecksumAlgorithm` |
-| `ObjectAccessControlList` | `awscc.s3.bucket.OptionalFields.ObjectAccessControlList` |
-| `ObjectOwner` | `awscc.s3.bucket.OptionalFields.ObjectOwner` |
-| `LifecycleExpirationDate` | `awscc.s3.bucket.OptionalFields.LifecycleExpirationDate` |
+| `Size` | `awscc.s3.Bucket.OptionalFields.Size` |
+| `LastModifiedDate` | `awscc.s3.Bucket.OptionalFields.LastModifiedDate` |
+| `StorageClass` | `awscc.s3.Bucket.OptionalFields.StorageClass` |
+| `ETag` | `awscc.s3.Bucket.OptionalFields.ETag` |
+| `IsMultipartUploaded` | `awscc.s3.Bucket.OptionalFields.IsMultipartUploaded` |
+| `ReplicationStatus` | `awscc.s3.Bucket.OptionalFields.ReplicationStatus` |
+| `EncryptionStatus` | `awscc.s3.Bucket.OptionalFields.EncryptionStatus` |
+| `ObjectLockRetainUntilDate` | `awscc.s3.Bucket.OptionalFields.ObjectLockRetainUntilDate` |
+| `ObjectLockMode` | `awscc.s3.Bucket.OptionalFields.ObjectLockMode` |
+| `ObjectLockLegalHoldStatus` | `awscc.s3.Bucket.OptionalFields.ObjectLockLegalHoldStatus` |
+| `IntelligentTieringAccessTier` | `awscc.s3.Bucket.OptionalFields.IntelligentTieringAccessTier` |
+| `BucketKeyStatus` | `awscc.s3.Bucket.OptionalFields.BucketKeyStatus` |
+| `ChecksumAlgorithm` | `awscc.s3.Bucket.OptionalFields.ChecksumAlgorithm` |
+| `ObjectAccessControlList` | `awscc.s3.Bucket.OptionalFields.ObjectAccessControlList` |
+| `ObjectOwner` | `awscc.s3.Bucket.OptionalFields.ObjectOwner` |
+| `LifecycleExpirationDate` | `awscc.s3.Bucket.OptionalFields.LifecycleExpirationDate` |
 
 Shorthand formats: `Size` or `OptionalFields.Size`
 
@@ -363,8 +363,8 @@ Shorthand formats: `Size` or `OptionalFields.Size`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `Daily` | `awscc.s3.bucket.ScheduleFrequency.Daily` |
-| `Weekly` | `awscc.s3.bucket.ScheduleFrequency.Weekly` |
+| `Daily` | `awscc.s3.Bucket.ScheduleFrequency.Daily` |
+| `Weekly` | `awscc.s3.Bucket.ScheduleFrequency.Weekly` |
 
 Shorthand formats: `Daily` or `ScheduleFrequency.Daily`
 
@@ -372,8 +372,8 @@ Shorthand formats: `Daily` or `ScheduleFrequency.Daily`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `ENABLED` | `awscc.s3.bucket.ConfigurationState.ENABLED` |
-| `DISABLED` | `awscc.s3.bucket.ConfigurationState.DISABLED` |
+| `ENABLED` | `awscc.s3.Bucket.ConfigurationState.ENABLED` |
+| `DISABLED` | `awscc.s3.Bucket.ConfigurationState.DISABLED` |
 
 Shorthand formats: `ENABLED` or `ConfigurationState.ENABLED`
 
@@ -381,8 +381,8 @@ Shorthand formats: `ENABLED` or `ConfigurationState.ENABLED`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `varies_by_storage_class` | `awscc.s3.bucket.TransitionDefaultMinimumObjectSize.varies_by_storage_class` |
-| `all_storage_classes_128K` | `awscc.s3.bucket.TransitionDefaultMinimumObjectSize.all_storage_classes_128K` |
+| `varies_by_storage_class` | `awscc.s3.Bucket.TransitionDefaultMinimumObjectSize.varies_by_storage_class` |
+| `all_storage_classes_128K` | `awscc.s3.Bucket.TransitionDefaultMinimumObjectSize.all_storage_classes_128K` |
 
 Shorthand formats: `varies_by_storage_class` or `TransitionDefaultMinimumObjectSize.varies_by_storage_class`
 
@@ -390,8 +390,8 @@ Shorthand formats: `varies_by_storage_class` or `TransitionDefaultMinimumObjectS
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `aws` | `awscc.s3.bucket.TableBucketType.aws` |
-| `customer` | `awscc.s3.bucket.TableBucketType.customer` |
+| `aws` | `awscc.s3.Bucket.TableBucketType.aws` |
+| `customer` | `awscc.s3.Bucket.TableBucketType.customer` |
 
 Shorthand formats: `aws` or `TableBucketType.aws`
 
@@ -399,8 +399,8 @@ Shorthand formats: `aws` or `TableBucketType.aws`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `aws:kms` | `awscc.s3.bucket.MetadataTableEncryptionConfigurationSseAlgorithm.aws:kms` |
-| `AES256` | `awscc.s3.bucket.MetadataTableEncryptionConfigurationSseAlgorithm.AES256` |
+| `aws:kms` | `awscc.s3.Bucket.MetadataTableEncryptionConfigurationSseAlgorithm.aws:kms` |
+| `AES256` | `awscc.s3.Bucket.MetadataTableEncryptionConfigurationSseAlgorithm.AES256` |
 
 Shorthand formats: `aws:kms` or `MetadataTableEncryptionConfigurationSseAlgorithm.aws:kms`
 
@@ -408,8 +408,8 @@ Shorthand formats: `aws:kms` or `MetadataTableEncryptionConfigurationSseAlgorith
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `Disabled` | `awscc.s3.bucket.MetricsStatus.Disabled` |
-| `Enabled` | `awscc.s3.bucket.MetricsStatus.Enabled` |
+| `Disabled` | `awscc.s3.Bucket.MetricsStatus.Disabled` |
+| `Enabled` | `awscc.s3.Bucket.MetricsStatus.Enabled` |
 
 Shorthand formats: `Disabled` or `MetricsStatus.Disabled`
 
@@ -417,12 +417,12 @@ Shorthand formats: `Disabled` or `MetricsStatus.Disabled`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `DEEP_ARCHIVE` | `awscc.s3.bucket.NoncurrentVersionTransitionStorageClass.DEEP_ARCHIVE` |
-| `GLACIER` | `awscc.s3.bucket.NoncurrentVersionTransitionStorageClass.GLACIER` |
-| `GLACIER_IR` | `awscc.s3.bucket.NoncurrentVersionTransitionStorageClass.GLACIER_IR` |
-| `INTELLIGENT_TIERING` | `awscc.s3.bucket.NoncurrentVersionTransitionStorageClass.INTELLIGENT_TIERING` |
-| `ONEZONE_IA` | `awscc.s3.bucket.NoncurrentVersionTransitionStorageClass.ONEZONE_IA` |
-| `STANDARD_IA` | `awscc.s3.bucket.NoncurrentVersionTransitionStorageClass.STANDARD_IA` |
+| `DEEP_ARCHIVE` | `awscc.s3.Bucket.NoncurrentVersionTransitionStorageClass.DEEP_ARCHIVE` |
+| `GLACIER` | `awscc.s3.Bucket.NoncurrentVersionTransitionStorageClass.GLACIER` |
+| `GLACIER_IR` | `awscc.s3.Bucket.NoncurrentVersionTransitionStorageClass.GLACIER_IR` |
+| `INTELLIGENT_TIERING` | `awscc.s3.Bucket.NoncurrentVersionTransitionStorageClass.INTELLIGENT_TIERING` |
+| `ONEZONE_IA` | `awscc.s3.Bucket.NoncurrentVersionTransitionStorageClass.ONEZONE_IA` |
+| `STANDARD_IA` | `awscc.s3.Bucket.NoncurrentVersionTransitionStorageClass.STANDARD_IA` |
 
 Shorthand formats: `DEEP_ARCHIVE` or `NoncurrentVersionTransitionStorageClass.DEEP_ARCHIVE`
 
@@ -430,7 +430,7 @@ Shorthand formats: `DEEP_ARCHIVE` or `NoncurrentVersionTransitionStorageClass.DE
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `Enabled` | `awscc.s3.bucket.ObjectLockEnabled.Enabled` |
+| `Enabled` | `awscc.s3.Bucket.ObjectLockEnabled.Enabled` |
 
 Shorthand formats: `Enabled` or `ObjectLockEnabled.Enabled`
 
@@ -438,9 +438,9 @@ Shorthand formats: `Enabled` or `ObjectLockEnabled.Enabled`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `ObjectWriter` | `awscc.s3.bucket.ObjectOwnership.ObjectWriter` |
-| `BucketOwnerPreferred` | `awscc.s3.bucket.ObjectOwnership.BucketOwnerPreferred` |
-| `BucketOwnerEnforced` | `awscc.s3.bucket.ObjectOwnership.BucketOwnerEnforced` |
+| `ObjectWriter` | `awscc.s3.Bucket.ObjectOwnership.ObjectWriter` |
+| `BucketOwnerPreferred` | `awscc.s3.Bucket.ObjectOwnership.BucketOwnerPreferred` |
+| `BucketOwnerEnforced` | `awscc.s3.Bucket.ObjectOwnership.BucketOwnerEnforced` |
 
 Shorthand formats: `ObjectWriter` or `ObjectOwnership.ObjectWriter`
 
@@ -448,8 +448,8 @@ Shorthand formats: `ObjectWriter` or `ObjectOwnership.ObjectWriter`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `EventTime` | `awscc.s3.bucket.PartitionDateSource.EventTime` |
-| `DeliveryTime` | `awscc.s3.bucket.PartitionDateSource.DeliveryTime` |
+| `EventTime` | `awscc.s3.Bucket.PartitionDateSource.EventTime` |
+| `DeliveryTime` | `awscc.s3.Bucket.PartitionDateSource.DeliveryTime` |
 
 Shorthand formats: `EventTime` or `PartitionDateSource.EventTime`
 
@@ -457,8 +457,8 @@ Shorthand formats: `EventTime` or `PartitionDateSource.EventTime`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `ENABLED` | `awscc.s3.bucket.Expiration.ENABLED` |
-| `DISABLED` | `awscc.s3.bucket.Expiration.DISABLED` |
+| `ENABLED` | `awscc.s3.Bucket.Expiration.ENABLED` |
+| `DISABLED` | `awscc.s3.Bucket.Expiration.DISABLED` |
 
 Shorthand formats: `ENABLED` or `Expiration.ENABLED`
 
@@ -466,8 +466,8 @@ Shorthand formats: `ENABLED` or `Expiration.ENABLED`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `http` | `awscc.s3.bucket.Protocol.http` |
-| `https` | `awscc.s3.bucket.Protocol.https` |
+| `http` | `awscc.s3.Bucket.Protocol.http` |
+| `https` | `awscc.s3.Bucket.Protocol.https` |
 
 Shorthand formats: `http` or `Protocol.http`
 
@@ -475,8 +475,8 @@ Shorthand formats: `http` or `Protocol.http`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `Enabled` | `awscc.s3.bucket.ReplicaModificationsStatus.Enabled` |
-| `Disabled` | `awscc.s3.bucket.ReplicaModificationsStatus.Disabled` |
+| `Enabled` | `awscc.s3.Bucket.ReplicaModificationsStatus.Enabled` |
+| `Disabled` | `awscc.s3.Bucket.ReplicaModificationsStatus.Disabled` |
 
 Shorthand formats: `Enabled` or `ReplicaModificationsStatus.Enabled`
 
@@ -484,14 +484,14 @@ Shorthand formats: `Enabled` or `ReplicaModificationsStatus.Enabled`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `DEEP_ARCHIVE` | `awscc.s3.bucket.ReplicationDestinationStorageClass.DEEP_ARCHIVE` |
-| `GLACIER` | `awscc.s3.bucket.ReplicationDestinationStorageClass.GLACIER` |
-| `GLACIER_IR` | `awscc.s3.bucket.ReplicationDestinationStorageClass.GLACIER_IR` |
-| `INTELLIGENT_TIERING` | `awscc.s3.bucket.ReplicationDestinationStorageClass.INTELLIGENT_TIERING` |
-| `ONEZONE_IA` | `awscc.s3.bucket.ReplicationDestinationStorageClass.ONEZONE_IA` |
-| `REDUCED_REDUNDANCY` | `awscc.s3.bucket.ReplicationDestinationStorageClass.REDUCED_REDUNDANCY` |
-| `STANDARD` | `awscc.s3.bucket.ReplicationDestinationStorageClass.STANDARD` |
-| `STANDARD_IA` | `awscc.s3.bucket.ReplicationDestinationStorageClass.STANDARD_IA` |
+| `DEEP_ARCHIVE` | `awscc.s3.Bucket.ReplicationDestinationStorageClass.DEEP_ARCHIVE` |
+| `GLACIER` | `awscc.s3.Bucket.ReplicationDestinationStorageClass.GLACIER` |
+| `GLACIER_IR` | `awscc.s3.Bucket.ReplicationDestinationStorageClass.GLACIER_IR` |
+| `INTELLIGENT_TIERING` | `awscc.s3.Bucket.ReplicationDestinationStorageClass.INTELLIGENT_TIERING` |
+| `ONEZONE_IA` | `awscc.s3.Bucket.ReplicationDestinationStorageClass.ONEZONE_IA` |
+| `REDUCED_REDUNDANCY` | `awscc.s3.Bucket.ReplicationDestinationStorageClass.REDUCED_REDUNDANCY` |
+| `STANDARD` | `awscc.s3.Bucket.ReplicationDestinationStorageClass.STANDARD` |
+| `STANDARD_IA` | `awscc.s3.Bucket.ReplicationDestinationStorageClass.STANDARD_IA` |
 
 Shorthand formats: `DEEP_ARCHIVE` or `ReplicationDestinationStorageClass.DEEP_ARCHIVE`
 
@@ -499,8 +499,8 @@ Shorthand formats: `DEEP_ARCHIVE` or `ReplicationDestinationStorageClass.DEEP_AR
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `Disabled` | `awscc.s3.bucket.ReplicationRuleStatus.Disabled` |
-| `Enabled` | `awscc.s3.bucket.ReplicationRuleStatus.Enabled` |
+| `Disabled` | `awscc.s3.Bucket.ReplicationRuleStatus.Disabled` |
+| `Enabled` | `awscc.s3.Bucket.ReplicationRuleStatus.Enabled` |
 
 Shorthand formats: `Disabled` or `ReplicationRuleStatus.Disabled`
 
@@ -508,8 +508,8 @@ Shorthand formats: `Disabled` or `ReplicationRuleStatus.Disabled`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `Disabled` | `awscc.s3.bucket.ReplicationTimeStatus.Disabled` |
-| `Enabled` | `awscc.s3.bucket.ReplicationTimeStatus.Enabled` |
+| `Disabled` | `awscc.s3.Bucket.ReplicationTimeStatus.Disabled` |
+| `Enabled` | `awscc.s3.Bucket.ReplicationTimeStatus.Enabled` |
 
 Shorthand formats: `Disabled` or `ReplicationTimeStatus.Disabled`
 
@@ -517,8 +517,8 @@ Shorthand formats: `Disabled` or `ReplicationTimeStatus.Disabled`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `Enabled` | `awscc.s3.bucket.RuleStatus.Enabled` |
-| `Disabled` | `awscc.s3.bucket.RuleStatus.Disabled` |
+| `Enabled` | `awscc.s3.Bucket.RuleStatus.Enabled` |
+| `Disabled` | `awscc.s3.Bucket.RuleStatus.Disabled` |
 
 Shorthand formats: `Enabled` or `RuleStatus.Enabled`
 
@@ -526,9 +526,9 @@ Shorthand formats: `Enabled` or `RuleStatus.Enabled`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `aws:kms` | `awscc.s3.bucket.ServerSideEncryptionByDefaultSseAlgorithm.aws:kms` |
-| `AES256` | `awscc.s3.bucket.ServerSideEncryptionByDefaultSseAlgorithm.AES256` |
-| `aws:kms:dsse` | `awscc.s3.bucket.ServerSideEncryptionByDefaultSseAlgorithm.aws:kms:dsse` |
+| `aws:kms` | `awscc.s3.Bucket.ServerSideEncryptionByDefaultSseAlgorithm.aws:kms` |
+| `AES256` | `awscc.s3.Bucket.ServerSideEncryptionByDefaultSseAlgorithm.AES256` |
+| `aws:kms:dsse` | `awscc.s3.Bucket.ServerSideEncryptionByDefaultSseAlgorithm.aws:kms:dsse` |
 
 Shorthand formats: `aws:kms` or `ServerSideEncryptionByDefaultSseAlgorithm.aws:kms`
 
@@ -536,8 +536,8 @@ Shorthand formats: `aws:kms` or `ServerSideEncryptionByDefaultSseAlgorithm.aws:k
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `Disabled` | `awscc.s3.bucket.SseKmsEncryptedObjectsStatus.Disabled` |
-| `Enabled` | `awscc.s3.bucket.SseKmsEncryptedObjectsStatus.Enabled` |
+| `Disabled` | `awscc.s3.Bucket.SseKmsEncryptedObjectsStatus.Disabled` |
+| `Enabled` | `awscc.s3.Bucket.SseKmsEncryptedObjectsStatus.Enabled` |
 
 Shorthand formats: `Disabled` or `SseKmsEncryptedObjectsStatus.Disabled`
 
@@ -545,8 +545,8 @@ Shorthand formats: `Disabled` or `SseKmsEncryptedObjectsStatus.Disabled`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `ARCHIVE_ACCESS` | `awscc.s3.bucket.AccessTier.ARCHIVE_ACCESS` |
-| `DEEP_ARCHIVE_ACCESS` | `awscc.s3.bucket.AccessTier.DEEP_ARCHIVE_ACCESS` |
+| `ARCHIVE_ACCESS` | `awscc.s3.Bucket.AccessTier.ARCHIVE_ACCESS` |
+| `DEEP_ARCHIVE_ACCESS` | `awscc.s3.Bucket.AccessTier.DEEP_ARCHIVE_ACCESS` |
 
 Shorthand formats: `ARCHIVE_ACCESS` or `AccessTier.ARCHIVE_ACCESS`
 
@@ -554,12 +554,12 @@ Shorthand formats: `ARCHIVE_ACCESS` or `AccessTier.ARCHIVE_ACCESS`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `DEEP_ARCHIVE` | `awscc.s3.bucket.TransitionStorageClass.DEEP_ARCHIVE` |
-| `GLACIER` | `awscc.s3.bucket.TransitionStorageClass.GLACIER` |
-| `GLACIER_IR` | `awscc.s3.bucket.TransitionStorageClass.GLACIER_IR` |
-| `INTELLIGENT_TIERING` | `awscc.s3.bucket.TransitionStorageClass.INTELLIGENT_TIERING` |
-| `ONEZONE_IA` | `awscc.s3.bucket.TransitionStorageClass.ONEZONE_IA` |
-| `STANDARD_IA` | `awscc.s3.bucket.TransitionStorageClass.STANDARD_IA` |
+| `DEEP_ARCHIVE` | `awscc.s3.Bucket.TransitionStorageClass.DEEP_ARCHIVE` |
+| `GLACIER` | `awscc.s3.Bucket.TransitionStorageClass.GLACIER` |
+| `GLACIER_IR` | `awscc.s3.Bucket.TransitionStorageClass.GLACIER_IR` |
+| `INTELLIGENT_TIERING` | `awscc.s3.Bucket.TransitionStorageClass.INTELLIGENT_TIERING` |
+| `ONEZONE_IA` | `awscc.s3.Bucket.TransitionStorageClass.ONEZONE_IA` |
+| `STANDARD_IA` | `awscc.s3.Bucket.TransitionStorageClass.STANDARD_IA` |
 
 Shorthand formats: `DEEP_ARCHIVE` or `TransitionStorageClass.DEEP_ARCHIVE`
 
@@ -567,8 +567,8 @@ Shorthand formats: `DEEP_ARCHIVE` or `TransitionStorageClass.DEEP_ARCHIVE`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `Enabled` | `awscc.s3.bucket.VersioningConfigurationStatus.Enabled` |
-| `Suspended` | `awscc.s3.bucket.VersioningConfigurationStatus.Suspended` |
+| `Enabled` | `awscc.s3.Bucket.VersioningConfigurationStatus.Enabled` |
+| `Suspended` | `awscc.s3.Bucket.VersioningConfigurationStatus.Suspended` |
 
 Shorthand formats: `Enabled` or `VersioningConfigurationStatus.Enabled`
 

--- a/generated-docs/awscc/sso/assignment.md
+++ b/generated-docs/awscc/sso/assignment.md
@@ -1,6 +1,6 @@
 ---
-title: "awscc.sso.assignment"
-description: "AWSCC SSO assignment resource reference"
+title: "awscc.sso.Assignment"
+description: "AWSCC SSO Assignment resource reference"
 ---
 
 
@@ -12,7 +12,7 @@ Resource Type definition for SSO assignmet
 
 ### `instance_arn`
 
-- **Type:** Arn
+- **Type:** String(pattern, len: 10..=1224)
 - **Required:** Yes
 - **Create-only:** Yes
 
@@ -20,7 +20,7 @@ The sso instance that the permission set is owned.
 
 ### `permission_set_arn`
 
-- **Type:** Arn
+- **Type:** String(pattern, len: 10..=1224)
 - **Required:** Yes
 - **Create-only:** Yes
 
@@ -44,7 +44,7 @@ The assignee's type, user/group
 
 ### `target_id`
 
-- **Type:** String
+- **Type:** AwsAccountId
 - **Required:** Yes
 - **Create-only:** Yes
 
@@ -64,8 +64,8 @@ The type of resource to be provisioned to, only aws account now
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `USER` | `awscc.sso.assignment.PrincipalType.USER` |
-| `GROUP` | `awscc.sso.assignment.PrincipalType.GROUP` |
+| `USER` | `awscc.sso.Assignment.PrincipalType.USER` |
+| `GROUP` | `awscc.sso.Assignment.PrincipalType.GROUP` |
 
 Shorthand formats: `USER` or `PrincipalType.USER`
 
@@ -73,7 +73,7 @@ Shorthand formats: `USER` or `PrincipalType.USER`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `AWS_ACCOUNT` | `awscc.sso.assignment.TargetType.AWS_ACCOUNT` |
+| `AWS_ACCOUNT` | `awscc.sso.Assignment.TargetType.AWS_ACCOUNT` |
 
 Shorthand formats: `AWS_ACCOUNT` or `TargetType.AWS_ACCOUNT`
 

--- a/generated-docs/awscc/sso/instance.md
+++ b/generated-docs/awscc/sso/instance.md
@@ -1,6 +1,6 @@
 ---
-title: "awscc.sso.instance"
-description: "AWSCC SSO instance resource reference"
+title: "awscc.sso.Instance"
+description: "AWSCC SSO Instance resource reference"
 ---
 
 
@@ -28,9 +28,9 @@ The name you want to assign to this Identity Center (SSO) Instance
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `CREATE_IN_PROGRESS` | `awscc.sso.instance.Status.CREATE_IN_PROGRESS` |
-| `DELETE_IN_PROGRESS` | `awscc.sso.instance.Status.DELETE_IN_PROGRESS` |
-| `ACTIVE` | `awscc.sso.instance.Status.ACTIVE` |
+| `CREATE_IN_PROGRESS` | `awscc.sso.Instance.Status.CREATE_IN_PROGRESS` |
+| `DELETE_IN_PROGRESS` | `awscc.sso.Instance.Status.DELETE_IN_PROGRESS` |
+| `ACTIVE` | `awscc.sso.Instance.Status.ACTIVE` |
 
 Shorthand formats: `CREATE_IN_PROGRESS` or `Status.CREATE_IN_PROGRESS`
 
@@ -44,7 +44,7 @@ The ID of the identity store associated with the created Identity Center (SSO) I
 
 ### `instance_arn`
 
-- **Type:** Arn
+- **Type:** String(pattern, len: 10..=1224)
 
 The SSO Instance ARN that is returned upon creation of the Identity Center (SSO) Instance
 

--- a/generated-docs/awscc/sso/permission_set.md
+++ b/generated-docs/awscc/sso/permission_set.md
@@ -1,6 +1,6 @@
 ---
-title: "awscc.sso.permission_set"
-description: "AWSCC SSO permission_set resource reference"
+title: "awscc.sso.PermissionSet"
+description: "AWSCC SSO PermissionSet resource reference"
 ---
 
 
@@ -31,7 +31,7 @@ The inline policy to put in permission set.
 
 ### `instance_arn`
 
-- **Type:** Arn
+- **Type:** String(pattern, len: 10..=1224)
 - **Required:** Yes
 - **Create-only:** Yes
 
@@ -94,7 +94,7 @@ The length of time that a user can be signed in to an AWS account.
 
 ### `permission_set_arn`
 
-- **Type:** Arn
+- **Type:** String(pattern, len: 10..=1224)
 
 The permission set that the policy will be attached to
 

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -66,9 +66,16 @@ for TYPE_NAME in "${RESOURCE_TYPES[@]}"; do
     DSL_NAME=$("$CODEGEN_BIN" --type-name "$TYPE_NAME" --print-dsl-resource-name)
     SERVICE=$(echo "$DSL_NAME" | cut -d'.' -f1)
     RESOURCE=$(echo "$DSL_NAME" | cut -d'.' -f2-)
+    # On-disk filenames are snake_case to match the schema files
+    # (carina-provider-awscc/src/schemas/generated/<svc>/<resource>.rs) and the
+    # 1:1 basename invariant enforced by scripts/check-docs-drift.sh.
+    # Strategy Y casing makes the DSL surface PascalCase ("VpcEndpoint"),
+    # so we convert here only for the filename. Title, description, and the
+    # markdown body keep the codegen's PascalCase DSL form.
+    RESOURCE_FILE=$(echo "$RESOURCE" | sed -E 's/([a-z0-9])([A-Z])/\1_\2/g' | tr '[:upper:]' '[:lower:]')
     FULL_RESOURCE=$("$CODEGEN_BIN" --type-name "$TYPE_NAME" --print-full-resource-name)
     mkdir -p "$DOCS_DIR/$SERVICE"
-    OUTPUT_FILE="$DOCS_DIR/$SERVICE/$RESOURCE.md"
+    OUTPUT_FILE="$DOCS_DIR/$SERVICE/$RESOURCE_FILE.md"
 
     echo "Generating: $TYPE_NAME → $OUTPUT_FILE"
 


### PR DESCRIPTION
## Summary

`scripts/generate-docs.sh` derived the on-disk filename from `--print-dsl-resource-name`, which under Strategy Y casing emits the resource part in PascalCase (e.g. `VpcEndpoint`). The committed docs under `generated-docs/awscc/**` are snake_case (`vpc_endpoint.md`) to match the schema files (`carina-provider-awscc/src/schemas/generated/<svc>/<resource>.rs`) and the 1:1 basename invariant enforced by `scripts/check-docs-drift.sh`. Re-running the script therefore tried to rename ~33 files, which is the wrong direction — schemas are not migrating, so docs shouldn't either.

The Markdown body and frontmatter, on the other hand, *do* legitimately need PascalCase: DSL references like `awscc.ec2.VpcEndpoint` are the canonical user-facing form. The pre-existing docs were stale and still showed snake_case because they had not been regenerated since the casing migration.

## Fix

- Introduce a snake_case `RESOURCE_FILE` (derived from `RESOURCE` via `sed` + `tr`) and use it **only** for the output path.
- Keep the original PascalCase `RESOURCE` and `DSL_NAME` for title, description, and let the codegen body retain its PascalCase DSL identifiers.
- Regenerate all 33 docs to apply the casing fix to bodies/frontmatter.

## Notable side-effects

- `organizations/account.md` now includes the `paths` attribute that was added schema-side by commit `f521cbe` — this closes the docs half of #138.
- `s3/bucket.md` is the largest diff because of many enum/struct DSL identifiers; the change is purely casing.

## Test plan

- [x] `./scripts/generate-docs.sh` runs idempotently and produces no rename diffs against `main`
- [x] `./scripts/check-docs-drift.sh` — OK (33 resources)
- [x] `cargo build` — green
- [x] `cargo test --workspace` — green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] No `[A-Z]` characters appear in any `*.md` filename under `generated-docs/awscc/`

Closes #163
Closes #138
