### PR TITLE
docs: fix Map(String) Rust syntax leak and naive service uppercasing

### DIFF
--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -576,10 +576,10 @@ fn type_display_string(
             enum_link
         }
     } else if prop_name == "Tags" {
-        "Map(String)".to_string()
+        "`Map<String, String>`".to_string()
     } else if let Some(ref_path) = &prop.ref_path {
         if ref_path.contains("/Tag") {
-            "Map(String)".to_string()
+            "`Map<String, String>`".to_string()
         } else if let Some(def_name) = ref_def_name(ref_path)
             && resolve_ref(schema, ref_path)
                 .and_then(|d| d.properties.as_ref())
@@ -737,7 +737,7 @@ fn type_display_string(
                                 "`List<String>`".to_string()
                             }
                         } else {
-                            "`List<Map(String)>`".to_string()
+                            "`List<Map<String, String>>`".to_string()
                         }
                     } else {
                         list_element_type_display(items, prop_name, &schema.type_name)
@@ -761,7 +761,7 @@ fn type_display_string(
                 } else if prop_name.ends_with("PolicyDocument") {
                     "IamPolicyDocument".to_string()
                 } else {
-                    "Map(String)".to_string()
+                    "`Map<String, String>`".to_string()
                 }
             }
             _ => "String".to_string(),
@@ -5196,7 +5196,7 @@ mod tests {
         let enums = BTreeMap::new();
         assert_eq!(
             type_display_string("ResourceTags", &prop, &schema, &enums),
-            "`List<Map(String)>`"
+            "`List<Map<String, String>>`"
         );
     }
 
@@ -8034,10 +8034,10 @@ mod tests {
             handlers: BTreeMap::new(),
         };
         let enums = BTreeMap::new();
-        // Tags property should display Map(String)
+        // Tags property should display Map<String, String>
         assert_eq!(
             type_display_string("Tags", &prop, &schema, &enums),
-            "Map(String)"
+            "`Map<String, String>`"
         );
     }
 
@@ -8063,10 +8063,10 @@ mod tests {
             handlers: BTreeMap::new(),
         };
         let enums = BTreeMap::new();
-        // Generic object should display Map(String)
+        // Generic object should display Map<String, String>
         assert_eq!(
             type_display_string("DataProtectionPolicy", &prop, &schema, &enums),
-            "Map(String)"
+            "`Map<String, String>`"
         );
     }
 

--- a/generated-docs/awscc/ec2/egress_only_internet_gateway.md
+++ b/generated-docs/awscc/ec2/egress_only_internet_gateway.md
@@ -28,7 +28,7 @@ awscc.ec2.EgressOnlyInternetGateway {
 
 ### `tags`
 
-- **Type:** Map(String)
+- **Type:** `Map<String, String>`
 - **Required:** No
 
 Any tags assigned to the egress only internet gateway.

--- a/generated-docs/awscc/ec2/eip.md
+++ b/generated-docs/awscc/ec2/eip.md
@@ -73,7 +73,7 @@ The ID of an address pool that you own. Use this parameter to let Amazon EC2 sel
 
 ### `tags`
 
-- **Type:** Map(String)
+- **Type:** `Map<String, String>`
 - **Required:** No
 
 Any tags assigned to the Elastic IP address. Updates to the ``Tags`` property may require *some interruptions*. Updates on an EIP reassociates the address on its associated resource.

--- a/generated-docs/awscc/ec2/flow_log.md
+++ b/generated-docs/awscc/ec2/flow_log.md
@@ -110,7 +110,7 @@ The type of resource for which to create the flow log. For example, if you speci
 
 ### `tags`
 
-- **Type:** Map(String)
+- **Type:** `Map<String, String>`
 - **Required:** No
 
 The tags to apply to the flow logs.

--- a/generated-docs/awscc/ec2/internet_gateway.md
+++ b/generated-docs/awscc/ec2/internet_gateway.md
@@ -22,7 +22,7 @@ awscc.ec2.InternetGateway {
 
 ### `tags`
 
-- **Type:** Map(String)
+- **Type:** `Map<String, String>`
 - **Required:** No
 
 Any tags to assign to the internet gateway.

--- a/generated-docs/awscc/ec2/ipam.md
+++ b/generated-docs/awscc/ec2/ipam.md
@@ -62,7 +62,7 @@ The regions IPAM is enabled for. Allows pools to be created in these regions, as
 
 ### `tags`
 
-- **Type:** Map(String)
+- **Type:** `Map<String, String>`
 - **Required:** No
 
 An array of key-value pairs to apply to this resource.

--- a/generated-docs/awscc/ec2/ipam_pool.md
+++ b/generated-docs/awscc/ec2/ipam_pool.md
@@ -69,7 +69,7 @@ The minimum allowed netmask length for allocations made from this pool.
 
 ### `allocation_resource_tags`
 
-- **Type:** `List<Map(String)>`
+- **Type:** `List<Map<String, String>>`
 - **Required:** No
 
 When specified, an allocation will not be allowed unless a resource has a matching set of tags.
@@ -149,7 +149,7 @@ The Id of this pool's source. If set, all space provisioned in this pool must be
 
 ### `tags`
 
-- **Type:** Map(String)
+- **Type:** `Map<String, String>`
 - **Required:** No
 
 An array of key-value pairs to apply to this resource.

--- a/generated-docs/awscc/ec2/nat_gateway.md
+++ b/generated-docs/awscc/ec2/nat_gateway.md
@@ -121,7 +121,7 @@ The ID of the subnet in which the NAT gateway is located.
 
 ### `tags`
 
-- **Type:** Map(String)
+- **Type:** `Map<String, String>`
 - **Required:** No
 
 The tags for the NAT gateway.

--- a/generated-docs/awscc/ec2/route_table.md
+++ b/generated-docs/awscc/ec2/route_table.md
@@ -31,7 +31,7 @@ awscc.ec2.RouteTable {
 
 ### `tags`
 
-- **Type:** Map(String)
+- **Type:** `Map<String, String>`
 - **Required:** No
 
 Any tags assigned to the route table.

--- a/generated-docs/awscc/ec2/security_group.md
+++ b/generated-docs/awscc/ec2/security_group.md
@@ -73,7 +73,7 @@ The inbound rules associated with the security group. There is a short interrupt
 
 ### `tags`
 
-- **Type:** Map(String)
+- **Type:** `Map<String, String>`
 - **Required:** No
 
 Any tags assigned to the security group.

--- a/generated-docs/awscc/ec2/subnet.md
+++ b/generated-docs/awscc/ec2/subnet.md
@@ -154,7 +154,7 @@ The hostname type for EC2 instances launched into this subnet and how DNS A and 
 
 ### `tags`
 
-- **Type:** Map(String)
+- **Type:** `Map<String, String>`
 - **Required:** No
 
 Any tags assigned to the subnet.

--- a/generated-docs/awscc/ec2/transit_gateway.md
+++ b/generated-docs/awscc/ec2/transit_gateway.md
@@ -82,7 +82,7 @@ awscc.ec2.TransitGateway {
 
 ### `tags`
 
-- **Type:** Map(String)
+- **Type:** `Map<String, String>`
 - **Required:** No
 
 ### `transit_gateway_cidr_blocks`

--- a/generated-docs/awscc/ec2/transit_gateway_attachment.md
+++ b/generated-docs/awscc/ec2/transit_gateway_attachment.md
@@ -52,7 +52,7 @@ The options for the transit gateway vpc attachment.
 
 ### `tags`
 
-- **Type:** Map(String)
+- **Type:** `Map<String, String>`
 - **Required:** No
 
 ### `transit_gateway_id`

--- a/generated-docs/awscc/ec2/vpc.md
+++ b/generated-docs/awscc/ec2/vpc.md
@@ -76,7 +76,7 @@ The netmask length of the IPv4 CIDR you want to allocate to this VPC from an Ama
 
 ### `tags`
 
-- **Type:** Map(String)
+- **Type:** `Map<String, String>`
 - **Required:** No
 
 The tags for the VPC.

--- a/generated-docs/awscc/ec2/vpc_endpoint.md
+++ b/generated-docs/awscc/ec2/vpc_endpoint.md
@@ -135,7 +135,7 @@ The IDs of the subnets in which to create endpoint network interfaces. You must 
 
 ### `tags`
 
-- **Type:** Map(String)
+- **Type:** `Map<String, String>`
 - **Required:** No
 
 The tags to associate with the endpoint.

--- a/generated-docs/awscc/ec2/vpc_peering_connection.md
+++ b/generated-docs/awscc/ec2/vpc_peering_connection.md
@@ -75,7 +75,7 @@ The ID of the VPC with which you are creating the VPC peering connection. You mu
 
 ### `tags`
 
-- **Type:** Map(String)
+- **Type:** `Map<String, String>`
 - **Required:** No
 
 ### `vpc_id`

--- a/generated-docs/awscc/ec2/vpn_gateway.md
+++ b/generated-docs/awscc/ec2/vpn_gateway.md
@@ -33,7 +33,7 @@ The private Autonomous System Number (ASN) for the Amazon side of a BGP session.
 
 ### `tags`
 
-- **Type:** Map(String)
+- **Type:** `Map<String, String>`
 - **Required:** No
 
 Any tags assigned to the virtual private gateway.

--- a/generated-docs/awscc/iam/oidc_provider.md
+++ b/generated-docs/awscc/iam/oidc_provider.md
@@ -17,7 +17,7 @@ Resource Type definition for AWS::IAM::OIDCProvider
 
 ### `tags`
 
-- **Type:** Map(String)
+- **Type:** `Map<String, String>`
 - **Required:** No
 
 ### `thumbprint_list`

--- a/generated-docs/awscc/iam/role.md
+++ b/generated-docs/awscc/iam/role.md
@@ -97,7 +97,7 @@ A name for the IAM role, up to 64 characters in length. For valid values, see th
 
 ### `tags`
 
-- **Type:** Map(String)
+- **Type:** `Map<String, String>`
 - **Required:** No
 
 A list of tags that are attached to the role. For more information about tagging, see [Tagging IAM resources](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html) in the *IAM User Guide*.

--- a/generated-docs/awscc/identitystore/group.md
+++ b/generated-docs/awscc/identitystore/group.md
@@ -1,6 +1,6 @@
 ---
 title: "awscc.identitystore.Group"
-description: "AWSCC IDENTITYSTORE Group resource reference"
+description: "AWSCC Identity Store Group resource reference"
 ---
 
 

--- a/generated-docs/awscc/identitystore/group_membership.md
+++ b/generated-docs/awscc/identitystore/group_membership.md
@@ -1,6 +1,6 @@
 ---
 title: "awscc.identitystore.GroupMembership"
-description: "AWSCC IDENTITYSTORE GroupMembership resource reference"
+description: "AWSCC Identity Store GroupMembership resource reference"
 ---
 
 

--- a/generated-docs/awscc/logs/log_group.md
+++ b/generated-docs/awscc/logs/log_group.md
@@ -1,6 +1,6 @@
 ---
 title: "awscc.logs.LogGroup"
-description: "AWSCC LOGS LogGroup resource reference"
+description: "AWSCC CloudWatch Logs LogGroup resource reference"
 ---
 
 
@@ -27,17 +27,9 @@ awscc.logs.LogGroup {
 
 ## Argument Reference
 
-### `bearer_token_authentication_enabled`
-
-- **Type:** Bool
-- **Required:** No
-- **Default:** `false`
-
-Indicates whether bearer token authentication is enabled for this log group. When enabled, bearer token authentication is allowed on operations until it is explicitly disabled.
-
 ### `data_protection_policy`
 
-- **Type:** Map(String)
+- **Type:** `Map<String, String>`
 - **Required:** No
 
 Creates a data protection policy and assigns it to the log group. A data protection policy can help safeguard sensitive data that's ingested by the log group by auditing and masking the sensitive log data. When a user who does not have permission to view masked data views a log event that includes masked data, the sensitive data is replaced by asterisks.
@@ -96,7 +88,7 @@ The number of days to retain the log events in the specified log group. Possible
 
 ### `tags`
 
-- **Type:** Map(String)
+- **Type:** `Map<String, String>`
 - **Required:** No
 
 An array of key-value pairs to apply to the log group. For more information, see [Tag](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html).

--- a/generated-docs/awscc/organizations/account.md
+++ b/generated-docs/awscc/organizations/account.md
@@ -1,6 +1,6 @@
 ---
 title: "awscc.organizations.Account"
-description: "AWSCC ORGANIZATIONS Account resource reference"
+description: "AWSCC Organizations Account resource reference"
 ---
 
 
@@ -42,7 +42,7 @@ The name of an IAM role that AWS Organizations automatically preconfigures in th
 
 ### `tags`
 
-- **Type:** Map(String)
+- **Type:** `Map<String, String>`
 - **Required:** No
 
 A list of tags that you want to attach to the newly created account. For each tag in the list, you must specify both a tag key and a value.

--- a/generated-docs/awscc/organizations/organization.md
+++ b/generated-docs/awscc/organizations/organization.md
@@ -1,6 +1,6 @@
 ---
 title: "awscc.organizations.Organization"
-description: "AWSCC ORGANIZATIONS Organization resource reference"
+description: "AWSCC Organizations Organization resource reference"
 ---
 
 

--- a/generated-docs/awscc/route53/hosted_zone.md
+++ b/generated-docs/awscc/route53/hosted_zone.md
@@ -1,6 +1,6 @@
 ---
 title: "awscc.route53.HostedZone"
-description: "AWSCC ROUTE53 HostedZone resource reference"
+description: "AWSCC Route 53 HostedZone resource reference"
 ---
 
 

--- a/generated-docs/awscc/s3/bucket.md
+++ b/generated-docs/awscc/s3/bucket.md
@@ -72,24 +72,6 @@ Specifies default encryption for a bucket using server-side encryption with Amaz
 
 A name for the bucket. If you don't specify a name, AWS CloudFormation generates a unique ID and uses that ID for the bucket name. The bucket name must contain only lowercase letters, numbers, periods (.), and dashes (-) and must follow [Amazon S3 bucket restrictions and limitations](https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html). For more information, see [Rules for naming Amazon S3 buckets](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html) in the *Amazon S3 User Guide*. If you specify a name, you can't perform updates that require replacement of this resource. You can perform updates that require no or some interruption. If you need to replace the resource, specify a new name.
 
-### `bucket_name_prefix`
-
-- **Type:** String
-- **Required:** No
-- **Create-only:** Yes
-- **Write-only:** Yes
-
-
-
-### `bucket_namespace`
-
-- **Type:** [Enum (BucketNamespace)](#bucket_namespace-bucketnamespace)
-- **Required:** No
-- **Create-only:** Yes
-- **Write-only:** Yes
-
-
-
 ### `cors_configuration`
 
 - **Type:** [Struct(CorsConfiguration)](#corsconfiguration)
@@ -190,7 +172,7 @@ Configuration for replicating objects in an S3 bucket. To enable replication, yo
 
 ### `tags`
 
-- **Type:** Map(String)
+- **Type:** `Map<String, String>`
 - **Required:** No
 
 An arbitrary set of tags (key-value pairs) for this S3 bucket.
@@ -260,15 +242,6 @@ Shorthand formats: `Destination` or `Owner.Destination`
 | `SSE-C` | `awscc.s3.Bucket.EncryptionType.SSE_C` |
 
 Shorthand formats: `NONE` or `EncryptionType.NONE`
-
-### bucket_namespace (BucketNamespace)
-
-| Value | DSL Identifier |
-|-------|----------------|
-| `global` | `awscc.s3.Bucket.BucketNamespace.global` |
-| `account-regional` | `awscc.s3.Bucket.BucketNamespace.account_regional` |
-
-Shorthand formats: `global` or `BucketNamespace.global`
 
 ### allowed_methods (AllowedMethods)
 
@@ -599,7 +572,7 @@ Shorthand formats: `Enabled` or `VersioningConfigurationStatus.Enabled`
 | `id` | String | Yes | The ID that identifies the analytics configuration. |
 | `prefix` | String | No | The prefix that an object must have to be included in the analytics results. |
 | `storage_class_analysis` | [Struct(StorageClassAnalysis)](#storageclassanalysis) | Yes | Contains data related to access patterns to be collected and made available to analyze the tradeoffs between different storage classes. |
-| `tag_filters` | `List<Map(String)>` | No | The tags to use when evaluating an analytics filter. The analytics only includes objects that meet the filter's criteria. If no filter is specified, all of the contents of the bucket are included in the analysis. |
+| `tag_filters` | `List<Map<String, String>>` | No | The tags to use when evaluating an analytics filter. The analytics only includes objects that meet the filter's criteria. If no filter is specified, all of the contents of the bucket are included in the analysis. |
 
 ### BlockedEncryptionTypes
 
@@ -686,7 +659,7 @@ Shorthand formats: `Enabled` or `VersioningConfigurationStatus.Enabled`
 | `id` | String | Yes | The ID used to identify the S3 Intelligent-Tiering configuration. |
 | `prefix` | String | No | An object key name prefix that identifies the subset of objects to which the rule applies. |
 | `status` | [Enum (IntelligentTieringConfigurationStatus)](#status-intelligenttieringconfigurationstatus) | Yes | Specifies the status of the configuration. |
-| `tag_filters` | `List<Map(String)>` | No | A container for a key-value pair. |
+| `tag_filters` | `List<Map<String, String>>` | No | A container for a key-value pair. |
 | `tierings` | [List\<Tiering\>](#tiering) | Yes | Specifies a list of S3 Intelligent-Tiering storage class tiers in the configuration. At least one tier must be defined in the list. At most, you can specify two tiers in the list, one for each available AccessTier: ``ARCHIVE_ACCESS`` and ``DEEP_ARCHIVE_ACCESS``. You only need Intelligent Tiering Configuration enabled on a bucket if you want to automatically move objects stored in the Intelligent-Tiering storage class to Archive Access or Deep Archive Access tiers. |
 
 ### InventoryConfiguration
@@ -785,7 +758,7 @@ Shorthand formats: `Enabled` or `VersioningConfigurationStatus.Enabled`
 | `access_point_arn` | Arn | No | The access point that was used while performing operations on the object. The metrics configuration only includes objects that meet the filter's criteria. |
 | `id` | String | Yes | The ID used to identify the metrics configuration. This can be any value you choose that helps you identify your metrics configuration. |
 | `prefix` | String | No | The prefix that an object must have to be included in the metrics results. |
-| `tag_filters` | `List<Map(String)>` | No | Specifies a list of tag filters to use as a metrics configuration filter. The metrics configuration includes only objects that meet the filter's criteria. |
+| `tag_filters` | `List<Map<String, String>>` | No | Specifies a list of tag filters to use as a metrics configuration filter. The metrics configuration includes only objects that meet the filter's criteria. |
 
 ### NoncurrentVersionExpiration
 
@@ -932,7 +905,7 @@ Shorthand formats: `Enabled` or `VersioningConfigurationStatus.Enabled`
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `prefix` | String | No | An object key name prefix that identifies the subset of objects to which the rule applies. |
-| `tag_filters` | `List<Map(String)>` | No | An array of tags containing key and value pairs. |
+| `tag_filters` | `List<Map<String, String>>` | No | An array of tags containing key and value pairs. |
 
 ### ReplicationRuleFilter
 
@@ -940,7 +913,7 @@ Shorthand formats: `Enabled` or `VersioningConfigurationStatus.Enabled`
 |-------|------|----------|-------------|
 | `and` | [Struct(ReplicationRuleAndOperator)](#replicationruleandoperator) | No | A container for specifying rule filters. The filters determine the subset of objects to which the rule applies. This element is required only if you specify more than one filter. For example: + If you specify both a ``Prefix`` and a ``TagFilter``, wrap these filters in an ``And`` tag. + If you specify a filter based on multiple tags, wrap the ``TagFilter`` elements in an ``And`` tag. |
 | `prefix` | String | No | An object key name prefix that identifies the subset of objects to which the rule applies. Replacement must be made for object keys containing special characters (such as carriage returns) when using XML requests. For more information, see [XML related object key constraints](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints). |
-| `tag_filter` | Map(String) | No | A container for specifying a tag key and value. The rule applies only to objects that have the tag in their tag set. |
+| `tag_filter` | `Map<String, String>` | No | A container for specifying a tag key and value. The rule applies only to objects that have the tag in their tag set. |
 
 ### ReplicationTime
 
@@ -986,7 +959,7 @@ Shorthand formats: `Enabled` or `VersioningConfigurationStatus.Enabled`
 | `object_size_less_than` | NumericString(len: ..=20) | No | Specifies the maximum object size in bytes for this rule to apply to. Objects must be smaller than this value in bytes. For more information about sized based rules, see [Lifecycle configuration using size-based rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/lifecycle-configuration-examples.html#lc-size-rules) in the *Amazon S3 User Guide*. |
 | `prefix` | String | No | Object key prefix that identifies one or more objects to which this rule applies. Replacement must be made for object keys containing special characters (such as carriage returns) when using XML requests. For more information, see [XML related object key constraints](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints). |
 | `status` | [Enum (RuleStatus)](#status-rulestatus) | Yes | If ``Enabled``, the rule is currently being applied. If ``Disabled``, the rule is not currently being applied. |
-| `tag_filters` | `List<Map(String)>` | No | Tags to use to identify a subset of objects to which the lifecycle rule applies. |
+| `tag_filters` | `List<Map<String, String>>` | No | Tags to use to identify a subset of objects to which the lifecycle rule applies. |
 | `transition` | [Struct(Transition)](#transition) | No | (Deprecated.) Specifies when an object transitions to a specified storage class. If you specify an expiration and transition time, you must use the same time unit for both properties (either in days or by date). The expiration time must also be later than the transition time. If you specify this property, don't specify the ``Transitions`` property. |
 | `transitions` | [List\<Transition\>](#transition) | No | One or more transition rules that specify when an object transitions to a specified storage class. If you specify an expiration and transition time, you must use the same time unit for both properties (either in days or by date). The expiration time must also be later than the transition time. If you specify this property, don't specify the ``Transition`` property. |
 
@@ -1044,7 +1017,7 @@ Shorthand formats: `Enabled` or `VersioningConfigurationStatus.Enabled`
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `partitioned_prefix` | [Struct(PartitionedPrefix)](#partitionedprefix) | No |  |
-| `simple_prefix` | Map(String) | No | This format defaults the prefix to the given log file prefix for delivering server access log file. |
+| `simple_prefix` | `Map<String, String>` | No | This format defaults the prefix to the given log file prefix for delivering server access log file. |
 
 ### Tiering
 

--- a/generated-docs/awscc/sso/assignment.md
+++ b/generated-docs/awscc/sso/assignment.md
@@ -1,6 +1,6 @@
 ---
 title: "awscc.sso.Assignment"
-description: "AWSCC SSO Assignment resource reference"
+description: "AWSCC IAM Identity Center Assignment resource reference"
 ---
 
 

--- a/generated-docs/awscc/sso/instance.md
+++ b/generated-docs/awscc/sso/instance.md
@@ -1,6 +1,6 @@
 ---
 title: "awscc.sso.Instance"
-description: "AWSCC SSO Instance resource reference"
+description: "AWSCC IAM Identity Center Instance resource reference"
 ---
 
 
@@ -19,7 +19,7 @@ The name you want to assign to this Identity Center (SSO) Instance
 
 ### `tags`
 
-- **Type:** Map(String)
+- **Type:** `Map<String, String>`
 - **Required:** No
 
 ## Enum Values

--- a/generated-docs/awscc/sso/permission_set.md
+++ b/generated-docs/awscc/sso/permission_set.md
@@ -1,6 +1,6 @@
 ---
 title: "awscc.sso.PermissionSet"
-description: "AWSCC SSO PermissionSet resource reference"
+description: "AWSCC IAM Identity Center PermissionSet resource reference"
 ---
 
 
@@ -24,7 +24,7 @@ The permission set description.
 
 ### `inline_policy`
 
-- **Type:** Map(String)
+- **Type:** `Map<String, String>`
 - **Required:** No
 
 The inline policy to put in permission set.
@@ -71,7 +71,7 @@ The length of time that a user can be signed in to an AWS account.
 
 ### `tags`
 
-- **Type:** Map(String)
+- **Type:** `Map<String, String>`
 - **Required:** No
 
 ## Struct Definitions

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -33,6 +33,25 @@ mkdir -p "$DOCS_DIR"
 
 cd "$PROJECT_ROOT"
 
+# Map a lowercase service code to its canonical AWS display name.
+# Naive uppercasing produces unreadable strings like "AWSCC LOGS LogGroup ..."
+# in the frontmatter description. Keep this list aligned with the services
+# present in carina-provider-awscc/src/schemas/generated/.
+service_display_name() {
+    case "$1" in
+        s3)            echo "S3" ;;
+        ec2)           echo "EC2" ;;
+        iam)           echo "IAM" ;;
+        sts)           echo "STS" ;;
+        sso)           echo "IAM Identity Center" ;;
+        logs)          echo "CloudWatch Logs" ;;
+        route53)       echo "Route 53" ;;
+        identitystore) echo "Identity Store" ;;
+        organizations) echo "Organizations" ;;
+        *)             echo "$1" | tr '[:lower:]' '[:upper:]' ;;
+    esac
+}
+
 # Derive resource types from generated schema files (single source of truth).
 # Each .rs file (excluding mod.rs) has a header comment:
 #   Auto-generated from CloudFormation schema: AWS::EC2::VPC
@@ -118,7 +137,7 @@ for TYPE_NAME in "${RESOURCE_TYPES[@]}"; do
     # Add Starlight frontmatter
     if [ -f "$OUTPUT_FILE" ]; then
         DSL_NAME_FULL="awscc.$DSL_NAME"
-        SERVICE_DISPLAY=$(echo "$SERVICE" | tr '[:lower:]' '[:upper:]')
+        SERVICE_DISPLAY=$(service_display_name "$SERVICE")
         FRONTMATTER_TMPFILE=$(mktemp)
         {
             echo "---"


### PR DESCRIPTION
## Summary

Fixes the two docs-quality issues filed earlier today against this repo:

- #169 — service segment in `description:` was naively uppercased (`LOGS`, `ROUTE53`, `IDENTITYSTORE`, `ORGANIZATIONS`, `SSO`)
- #170 — `Map(String)` Rust constructor syntax leaked into the rendered `Type:` field of every Tags / tag_filter / empty-object attribute

### Changes

**Codegen (`carina-provider-awscc/src/bin/codegen.rs`)**
- `type_display_string`: replace the four `"Map(String)"` sites (Tags property, Tag `$ref`, list-of-Tag `$ref`, generic empty `object`) with `` "`Map<String, String>`" ``, matching the existing `` `List<X>` `` / `` `List<String>` `` style for non-linked container types. Three test assertions updated accordingly.

**Script (`scripts/generate-docs.sh`)**
- New `service_display_name()` mapping service codes to canonical AWS display names (`S3`, `EC2`, `IAM`, `STS`, `CloudWatch Logs`, `Route 53`, `IAM Identity Center`, `Identity Store`, `Organizations`) instead of naive uppercasing.
- The `description:` frontmatter line now reads e.g. `AWSCC Route 53 HostedZone resource reference` (was `AWSCC ROUTE53 HostedZone resource reference`).

**Regenerated artifacts**
- All 33 `generated-docs/awscc/*/*.md` picked up the description fix.
- The dozen-ish docs that contain Tags, tag_filter, or empty-object properties (s3.Bucket, organizations.Account, iam.OidcProvider, most ec2 resources) picked up the `Map<String, String>` rendering.

### Sample diff

`s3/bucket.md`:
```diff
-description: "AWSCC S3 Bucket resource reference"
+description: "AWSCC S3 Bucket resource reference"
...
-| `tag_filters` | `List<Map(String)>` | No | The tags to use ... |
+| `tag_filters` | `List<Map<String, String>>` | No | The tags to use ... |
```

`route53/hosted_zone.md`:
```diff
-description: "AWSCC ROUTE53 HostedZone resource reference"
+description: "AWSCC Route 53 HostedZone resource reference"
```

## Test plan

- [x] `cargo nextest run --workspace` (393 tests, all green; the three `Map(String)` tests now assert the new form)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --doc` clean
- [x] `aws-vault exec mizzy -- bash scripts/generate-docs.sh` runs end-to-end and produces 33 docs
- [x] `grep -rn "Map(String)" generated-docs/` returns nothing
- [x] All `description:` lines render with canonical service display names

## Notes

- Per project policy this is a non-draft PR with no backwards-compatibility shims.
- A parallel fix is in flight on `carina-provider-aws` for the same naive-uppercasing bug (#199 there) — same `service_display_name()` shape, since both scripts share the pattern.
