### PR TITLE
acceptance-tests: stop EXIT trap from running carina destroy in cwd

### DIFF
--- a/acceptance-tests/create_before_destroy/run.sh
+++ b/acceptance-tests/create_before_destroy/run.sh
@@ -180,9 +180,12 @@ run_plan_verify() {
     return 0
 }
 
-# Cleanup helper: destroy resources in work_dir, retrying to handle dependencies
+# destroy_work_dir: destroy resources in work_dir, retrying to handle dependencies
 # Returns 0 if at least one destroy succeeded, 1 if ALL failed
-cleanup() {
+# (Named distinctly from `cleanup` so the EXIT trap in _helpers.sh keeps using
+# its own cleanup() — overriding it would call this with no args at exit and
+# emit "No .crn files found in .".)
+destroy_work_dir() {
     local work_dir="$1"
     local any_success=false
 
@@ -249,7 +252,7 @@ run_test() {
 
     # Step 1: Apply initial config
     if ! run_step "$work_dir" "step1: apply initial" "apply" "--auto-approve"; then
-        cleanup "$work_dir"
+        destroy_work_dir "$work_dir"
         rm -rf "$work_dir"
         ACTIVE_WORK_DIR=""
         return 1
@@ -257,7 +260,7 @@ run_test() {
 
     # Step 1b: Plan-verify initial state
     if ! run_plan_verify "$work_dir" "step1: plan-verify initial"; then
-        cleanup "$work_dir"
+        destroy_work_dir "$work_dir"
         rm -rf "$work_dir"
         ACTIVE_WORK_DIR=""
         return 1
@@ -272,7 +275,7 @@ run_test() {
 
     # Step 2: Apply modified config (triggers create_before_destroy replacement)
     if ! run_step "$work_dir" "step2: apply replace (create_before_destroy)" "apply" "--auto-approve"; then
-        cleanup "$work_dir"
+        destroy_work_dir "$work_dir"
         rm -rf "$work_dir"
         ACTIVE_WORK_DIR=""
         return 1
@@ -284,7 +287,7 @@ run_test() {
 
     # Assert identifiers changed (create_before_destroy should replace at least one resource)
     if ! assert_identifiers "assert: identifiers changed after replace" "$ids_after_step1" "$ids_after_step2" "different"; then
-        cleanup "$work_dir"
+        destroy_work_dir "$work_dir"
         rm -rf "$work_dir"
         ACTIVE_WORK_DIR=""
         return 1
@@ -292,7 +295,7 @@ run_test() {
 
     # Step 3: Plan-verify after replacement
     if ! run_plan_verify "$work_dir" "step3: plan-verify after replace"; then
-        cleanup "$work_dir"
+        destroy_work_dir "$work_dir"
         rm -rf "$work_dir"
         ACTIVE_WORK_DIR=""
         return 1

--- a/acceptance-tests/shared/_helpers.sh
+++ b/acceptance-tests/shared/_helpers.sh
@@ -86,7 +86,8 @@ prepare_work_dir() {
 
 ACTIVE_WORK_DIR=""
 cleanup() {
-    if [ -n "$ACTIVE_WORK_DIR" ] && [ -d "$ACTIVE_WORK_DIR" ]; then
+    if [ -n "$ACTIVE_WORK_DIR" ] && [ -d "$ACTIVE_WORK_DIR" ] && \
+       compgen -G "$ACTIVE_WORK_DIR/*.crn" > /dev/null; then
         echo "  Cleanup: destroying resources..."
         cd "$ACTIVE_WORK_DIR"
         "$CARINA_BIN" destroy --auto-approve . 2>/dev/null || true


### PR DESCRIPTION
## Summary

- Guard `_helpers.sh:cleanup()` on `compgen -G` so the EXIT trap is a no-op when the work dir holds no `.crn` files.
- Rename `create_before_destroy/run.sh`'s `cleanup()` to `destroy_work_dir()` to stop overriding the trap-bound function. 5 call sites updated.

Closes #172.

## Test plan

- [x] `bash -n` syntax check on both files
- [x] Synthetic trap test: cleanup is no-op when work dir lacks `.crn`, runs when present
- [ ] Re-run `acceptance-tests/create_before_destroy/run.sh` against a real account; verify exit code 0 and no "No .crn files found" tail