### PR TITLE
Add allowed_account_ids / forbidden_account_ids provider guard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,6 +553,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-cloudcontrol",
  "aws-sdk-s3",
+ "aws-sdk-sts",
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",

--- a/acceptance-tests/allowed_account_ids_guard/basic.crn
+++ b/acceptance-tests/allowed_account_ids_guard/basic.crn
@@ -1,0 +1,20 @@
+# allowed_account_ids guard - acceptance test
+#
+# Verifies the provider aborts before any CloudControl call when the
+# caller's AWS account is not in `allowed_account_ids`. The list below
+# pins to the all-zeros account, which no real AWS credentials can
+# match — `carina apply` against this directory MUST fail fast with an
+# error naming both the expected list and the actual account ID.
+
+provider awscc {
+  region              = awscc.Region.ap_northeast_1
+  allowed_account_ids = ['000000000000']
+}
+
+awscc.ec2.Eip {
+  domain = 'vpc'
+
+  tags = {
+    Environment = 'acceptance-test'
+  }
+}

--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -32,6 +32,7 @@ aws-config = { version = "1", default-features = false, features = ["behavior-ve
 aws-smithy-async = { version = "1", features = ["rt-tokio"] }
 aws-sdk-cloudcontrol = { version = "1", default-features = false, features = ["behavior-version-latest"] }
 aws-sdk-s3 = { version = "1", default-features = false, features = ["behavior-version-latest"] }
+aws-sdk-sts = { version = "1", default-features = false, features = ["behavior-version-latest"] }
 aws-smithy-runtime-api = "1"
 aws-smithy-types = "1"
 serde = { version = "1", features = ["derive"] }

--- a/carina-provider-awscc/src/lib.rs
+++ b/carina-provider-awscc/src/lib.rs
@@ -20,11 +20,13 @@ use std::collections::HashMap;
 use indexmap::IndexMap;
 
 use carina_core::provider::{
-    BoxFuture, Provider, ProviderFactory, ProviderNormalizer, ProviderResult, SavedAttrs,
-    merge_default_tags_for_provider,
+    BoxFuture, Provider, ProviderError, ProviderFactory, ProviderNormalizer, ProviderResult,
+    SavedAttrs, merge_default_tags_for_provider,
 };
 use carina_core::resource::{LifecycleConfig, Resource, ResourceId, State, Value};
 use carina_core::schema::SchemaRegistry;
+
+use crate::provider::AwsccProviderConfig;
 
 /// Schema extension for the AWSCC provider.
 ///
@@ -74,10 +76,11 @@ impl ProviderFactory for AwsccProviderFactory {
     fn provider_config_attribute_types(
         &self,
     ) -> HashMap<String, carina_core::schema::AttributeType> {
+        use carina_core::schema::AttributeType;
         let mut types = HashMap::new();
         types.insert(
             "region".to_string(),
-            carina_core::schema::AttributeType::StringEnum {
+            AttributeType::StringEnum {
                 name: "Region".to_string(),
                 values: carina_aws_types::REGIONS
                     .iter()
@@ -85,6 +88,20 @@ impl ProviderFactory for AwsccProviderFactory {
                     .collect(),
                 namespace: Some("awscc".to_string()),
                 to_dsl: Some(|s| s.replace('-', "_")),
+            },
+        );
+        types.insert(
+            "allowed_account_ids".to_string(),
+            AttributeType::List {
+                inner: Box::new(AttributeType::String),
+                ordered: false,
+            },
+        );
+        types.insert(
+            "forbidden_account_ids".to_string(),
+            AttributeType::List {
+                inner: Box::new(AttributeType::String),
+                ordered: false,
             },
         );
         types
@@ -121,7 +138,10 @@ impl ProviderFactory for AwsccProviderFactory {
         attributes: &IndexMap<String, Value>,
     ) -> BoxFuture<'_, Box<dyn Provider>> {
         let region = self.extract_region(attributes);
-        Box::pin(async move { Box::new(AwsccProvider::new(&region).await) as Box<dyn Provider> })
+        let cfg = extract_provider_config(attributes);
+        Box::pin(async move {
+            Box::new(AwsccProvider::new_with_config(&region, &cfg).await) as Box<dyn Provider>
+        })
     }
 
     fn create_normalizer(
@@ -163,6 +183,30 @@ impl ProviderFactory for AwsccProviderFactory {
 // Provider Trait Implementation
 // =============================================================================
 
+/// Extract the account-guard policy from a provider's configuration
+/// attributes. Treats unset / non-list / non-string-element values as
+/// "absent", consistent with the schema declared in
+/// `provider_config_attribute_types` — the host enforces the declared
+/// types before reaching the provider, so this is a defensive parse.
+pub(crate) fn extract_provider_config(attributes: &IndexMap<String, Value>) -> AwsccProviderConfig {
+    fn extract_string_list(attributes: &IndexMap<String, Value>, key: &str) -> Vec<String> {
+        match attributes.get(key) {
+            Some(Value::List(items)) => items
+                .iter()
+                .filter_map(|v| match v {
+                    Value::String(s) => Some(s.clone()),
+                    _ => None,
+                })
+                .collect(),
+            _ => Vec::new(),
+        }
+    }
+    AwsccProviderConfig {
+        allowed_account_ids: extract_string_list(attributes, "allowed_account_ids"),
+        forbidden_account_ids: extract_string_list(attributes, "forbidden_account_ids"),
+    }
+}
+
 impl Provider for AwsccProvider {
     fn name(&self) -> &str {
         "awscc"
@@ -173,6 +217,11 @@ impl Provider for AwsccProvider {
         id: &ResourceId,
         identifier: Option<&str>,
     ) -> BoxFuture<'_, ProviderResult<State>> {
+        if let Some(err) = self.init_error() {
+            let err = err.to_string();
+            let id = id.clone();
+            return Box::pin(async move { Err(ProviderError::new(err).for_resource(id)) });
+        }
         let id = id.clone();
         let identifier = identifier.map(|s| s.to_string());
         Box::pin(async move {
@@ -186,6 +235,11 @@ impl Provider for AwsccProvider {
     }
 
     fn create(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
+        if let Some(err) = self.init_error() {
+            let err = err.to_string();
+            let id = resource.id.clone();
+            return Box::pin(async move { Err(ProviderError::new(err).for_resource(id)) });
+        }
         let resource = resource.clone();
         Box::pin(async move { self.create_resource(resource).await })
     }
@@ -197,6 +251,11 @@ impl Provider for AwsccProvider {
         from: &State,
         to: &Resource,
     ) -> BoxFuture<'_, ProviderResult<State>> {
+        if let Some(err) = self.init_error() {
+            let err = err.to_string();
+            let id = id.clone();
+            return Box::pin(async move { Err(ProviderError::new(err).for_resource(id)) });
+        }
         let id = id.clone();
         let identifier = identifier.to_string();
         let from = from.clone();
@@ -210,6 +269,11 @@ impl Provider for AwsccProvider {
         identifier: &str,
         lifecycle: &LifecycleConfig,
     ) -> BoxFuture<'_, ProviderResult<()>> {
+        if let Some(err) = self.init_error() {
+            let err = err.to_string();
+            let id = id.clone();
+            return Box::pin(async move { Err(ProviderError::new(err).for_resource(id)) });
+        }
         let id = id.clone();
         let identifier = identifier.to_string();
         let lifecycle = lifecycle.clone();
@@ -228,6 +292,51 @@ mod tests {
             registry.insert("awscc", schema);
         }
         registry
+    }
+
+    #[test]
+    fn extract_provider_config_reads_both_lists() {
+        let mut attrs: IndexMap<String, Value> = IndexMap::new();
+        attrs.insert(
+            "allowed_account_ids".to_string(),
+            Value::List(vec![
+                Value::String("111111111111".to_string()),
+                Value::String("222222222222".to_string()),
+            ]),
+        );
+        attrs.insert(
+            "forbidden_account_ids".to_string(),
+            Value::List(vec![Value::String("999999999999".to_string())]),
+        );
+
+        let cfg = extract_provider_config(&attrs);
+        assert_eq!(
+            cfg.allowed_account_ids,
+            vec!["111111111111".to_string(), "222222222222".to_string()]
+        );
+        assert_eq!(cfg.forbidden_account_ids, vec!["999999999999".to_string()]);
+    }
+
+    #[test]
+    fn extract_provider_config_defaults_to_empty_when_unset() {
+        let attrs: IndexMap<String, Value> = IndexMap::new();
+        let cfg = extract_provider_config(&attrs);
+        assert!(cfg.allowed_account_ids.is_empty());
+        assert!(cfg.forbidden_account_ids.is_empty());
+    }
+
+    #[test]
+    fn provider_config_attribute_types_declares_account_id_lists() {
+        let factory = AwsccProviderFactory;
+        let types = factory.provider_config_attribute_types();
+        assert!(matches!(
+            types.get("allowed_account_ids"),
+            Some(carina_core::schema::AttributeType::List { .. })
+        ));
+        assert!(matches!(
+            types.get("forbidden_account_ids"),
+            Some(carina_core::schema::AttributeType::List { .. })
+        ));
     }
 
     #[test]

--- a/carina-provider-awscc/src/main.rs
+++ b/carina-provider-awscc/src/main.rs
@@ -10,7 +10,7 @@ use carina_core::provider::{
 use carina_core::resource::{ResourceId as CoreResourceId, State as CoreState, Value as CoreValue};
 
 use carina_provider_awscc::AwsccNormalizer;
-use carina_provider_awscc::provider::AwsccProvider;
+use carina_provider_awscc::provider::{AwsccProvider, AwsccProviderConfig};
 use carina_provider_awscc::schemas;
 
 struct AwsccProcessProvider {
@@ -97,6 +97,20 @@ impl CarinaProvider for AwsccProcessProvider {
                 namespace: Some("awscc".to_string()),
             },
         );
+        types.insert(
+            "allowed_account_ids".to_string(),
+            proto::AttributeType::List {
+                inner: Box::new(proto::AttributeType::String),
+                ordered: false,
+            },
+        );
+        types.insert(
+            "forbidden_account_ids".to_string(),
+            proto::AttributeType::List {
+                inner: Box::new(proto::AttributeType::String),
+                ordered: false,
+            },
+        );
         types
     }
 
@@ -114,7 +128,17 @@ impl CarinaProvider for AwsccProcessProvider {
         } else {
             "ap-northeast-1".to_string()
         };
-        let provider = self.runtime.block_on(AwsccProvider::new(&region));
+        let cfg = extract_account_guard_config(&core_attrs);
+        let provider = self
+            .runtime
+            .block_on(AwsccProvider::new_with_config(&region, &cfg));
+        // Surface the account-guard rejection eagerly: if the caller's
+        // AWS account violates allowed_account_ids / forbidden_account_ids,
+        // initialize() must fail so the host aborts before any plan,
+        // refresh, or apply step.
+        if let Some(err) = provider.init_error() {
+            return Err(err.to_string());
+        }
         self.provider = Some(provider);
         Ok(())
     }
@@ -316,6 +340,29 @@ impl CarinaProvider for AwsccProcessProvider {
             .iter()
             .map(convert::core_to_proto_resource)
             .collect();
+    }
+}
+
+/// Pull `allowed_account_ids` / `forbidden_account_ids` out of the
+/// provider's configured attributes. Both unset/empty means "no
+/// account check"; matching mirrors the in-process Provider wiring in
+/// `lib.rs::extract_provider_config`.
+fn extract_account_guard_config(core_attrs: &HashMap<String, CoreValue>) -> AwsccProviderConfig {
+    fn extract_string_list(attrs: &HashMap<String, CoreValue>, key: &str) -> Vec<String> {
+        match attrs.get(key) {
+            Some(CoreValue::List(items)) => items
+                .iter()
+                .filter_map(|v| match v {
+                    CoreValue::String(s) => Some(s.clone()),
+                    _ => None,
+                })
+                .collect(),
+            _ => Vec::new(),
+        }
+    }
+    AwsccProviderConfig {
+        allowed_account_ids: extract_string_list(core_attrs, "allowed_account_ids"),
+        forbidden_account_ids: extract_string_list(core_attrs, "forbidden_account_ids"),
     }
 }
 

--- a/carina-provider-awscc/src/provider/account_guard.rs
+++ b/carina-provider-awscc/src/provider/account_guard.rs
@@ -1,0 +1,128 @@
+//! Account ID guard.
+//!
+//! Mirrors the Terraform AWS provider's `allowed_account_ids` /
+//! `forbidden_account_ids` shape: lets a `.crn` pin which AWS account a
+//! provider block is allowed (or forbidden) to operate against. The
+//! caller's account is read once via `sts:GetCallerIdentity` and cached
+//! on the provider instance; the check runs eagerly so a wrong-account
+//! `apply` aborts before any CloudControl read or mutation.
+
+/// Validate the caller's AWS account ID against the provider's
+/// `allowed_account_ids` / `forbidden_account_ids` lists.
+///
+/// Both lists are independent and may be empty. Semantics:
+///
+/// - Both empty/unset → `Ok(())` (no check, current behavior).
+/// - `allowed` non-empty and `account_id` not in it → `Err`.
+/// - `forbidden` non-empty and `account_id` in it → `Err`.
+///
+/// Error messages always name BOTH the offending list and the caller's
+/// actual account ID so an operator can tell at a glance which rule
+/// fired and which credentials are loaded.
+pub fn validate_account_against_lists(
+    account_id: &str,
+    allowed: &[String],
+    forbidden: &[String],
+) -> Result<(), String> {
+    if !allowed.is_empty() && !allowed.iter().any(|a| a == account_id) {
+        return Err(format!(
+            "AWS account ID '{}' is not in the provider's allowed_account_ids {:?}. \
+             Refusing to operate against this account. \
+             Check the AWS credentials in your environment.",
+            account_id, allowed
+        ));
+    }
+
+    if !forbidden.is_empty() && forbidden.iter().any(|a| a == account_id) {
+        return Err(format!(
+            "AWS account ID '{}' is listed in the provider's forbidden_account_ids {:?}. \
+             Refusing to operate against this account. \
+             Check the AWS credentials in your environment.",
+            account_id, forbidden
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn both_empty_is_ok() {
+        assert!(validate_account_against_lists("123456789012", &[], &[]).is_ok());
+    }
+
+    #[test]
+    fn allowed_match_is_ok() {
+        let allowed = vec!["123456789012".to_string()];
+        assert!(validate_account_against_lists("123456789012", &allowed, &[]).is_ok());
+    }
+
+    #[test]
+    fn allowed_mismatch_is_err_naming_both() {
+        let allowed = vec!["111111111111".to_string()];
+        let err = validate_account_against_lists("222222222222", &allowed, &[]).unwrap_err();
+        // Error must name both expected list and actual account.
+        assert!(
+            err.contains("222222222222"),
+            "actual account missing: {err}"
+        );
+        assert!(err.contains("111111111111"), "allowed list missing: {err}");
+        assert!(
+            err.contains("allowed_account_ids"),
+            "kind label missing: {err}"
+        );
+    }
+
+    #[test]
+    fn forbidden_match_is_err_naming_both() {
+        let forbidden = vec!["999999999999".to_string()];
+        let err = validate_account_against_lists("999999999999", &[], &forbidden).unwrap_err();
+        assert!(
+            err.contains("999999999999"),
+            "actual account missing: {err}"
+        );
+        assert!(
+            err.contains("forbidden_account_ids"),
+            "kind label missing: {err}"
+        );
+    }
+
+    #[test]
+    fn forbidden_no_match_is_ok() {
+        let forbidden = vec!["999999999999".to_string()];
+        assert!(validate_account_against_lists("123456789012", &[], &forbidden).is_ok());
+    }
+
+    #[test]
+    fn allowed_takes_precedence_over_forbidden_for_clear_signal() {
+        // When the caller is in allowed but also in forbidden, allowed
+        // mismatch fires first only if the caller is NOT in allowed.
+        // Here the caller IS in allowed, so allowed passes — but is
+        // also in forbidden, so forbidden fires.
+        let allowed = vec!["123456789012".to_string()];
+        let forbidden = vec!["123456789012".to_string()];
+        let err = validate_account_against_lists("123456789012", &allowed, &forbidden).unwrap_err();
+        assert!(err.contains("forbidden_account_ids"), "got: {err}");
+    }
+
+    #[test]
+    fn allowed_with_multiple_accounts_one_match_is_ok() {
+        let allowed = vec![
+            "111111111111".to_string(),
+            "222222222222".to_string(),
+            "333333333333".to_string(),
+        ];
+        assert!(validate_account_against_lists("222222222222", &allowed, &[]).is_ok());
+    }
+
+    #[test]
+    fn allowed_zero_account_does_not_accidentally_match() {
+        // Acceptance scenario from the issue: allowed_account_ids =
+        // ['000000000000'] must reject any real-credential account.
+        let allowed = vec!["000000000000".to_string()];
+        assert!(validate_account_against_lists("123456789012", &allowed, &[]).is_err());
+    }
+}

--- a/carina-provider-awscc/src/provider/mod.rs
+++ b/carina-provider-awscc/src/provider/mod.rs
@@ -14,6 +14,7 @@
 //! - `tags` - Tag conversion between DSL and CloudFormation formats
 //! - `update` - Update patch building and resource property parsing
 
+pub(crate) mod account_guard;
 mod cloudcontrol;
 pub(crate) mod conversion;
 mod normalizer;
@@ -25,6 +26,7 @@ pub(crate) mod update;
 
 use aws_config::Region;
 use aws_sdk_cloudcontrol::Client as CloudControlClient;
+use aws_sdk_sts::Client as StsClient;
 
 use crate::schemas::generated::AwsccSchemaConfig;
 
@@ -52,21 +54,97 @@ const DELETE_RETRY_INITIAL_DELAY_SECS: u64 = 10;
 /// Maximum delay in seconds between delete retry attempts
 const DELETE_RETRY_MAX_DELAY_SECS: u64 = 120;
 
+/// Provider-level configuration that affects AwsccProvider construction.
+///
+/// Currently carries the `allowed_account_ids` / `forbidden_account_ids`
+/// guard lists. Both empty means "no check", matching the
+/// pre-allowed-account-ids behavior.
+#[derive(Debug, Default, Clone)]
+pub struct AwsccProviderConfig {
+    pub allowed_account_ids: Vec<String>,
+    pub forbidden_account_ids: Vec<String>,
+}
+
 /// AWS Cloud Control Provider
 pub struct AwsccProvider {
     cloudcontrol_client: CloudControlClient,
     aws_config: aws_config::SdkConfig,
+    /// Set when provider initialization rejected the caller's AWS account
+    /// against `allowed_account_ids` / `forbidden_account_ids`. Every
+    /// `Provider` trait method short-circuits to this error before
+    /// touching CloudControl, so a wrong-account `apply` aborts before
+    /// any read/refresh/mutation.
+    init_error: Option<String>,
 }
 
 impl AwsccProvider {
-    /// Create a new AwsccProvider for the specified region
+    /// Create a new AwsccProvider for the specified region with no
+    /// account guard. Convenience wrapper for tests and other callers
+    /// that do not need `allowed_account_ids` / `forbidden_account_ids`.
     pub async fn new(region: &str) -> Self {
+        Self::new_with_config(region, &AwsccProviderConfig::default()).await
+    }
+
+    /// Create a new AwsccProvider for the specified region, applying
+    /// the account-guard policy in `cfg`.
+    ///
+    /// When either `allowed_account_ids` or `forbidden_account_ids` is
+    /// non-empty, this call invokes `sts:GetCallerIdentity` once and
+    /// records a deferred error if the caller's account violates the
+    /// policy. The provider is still returned (so the host's wiring
+    /// stays infallible), but every `Provider` trait method on the
+    /// returned instance will surface that error before any
+    /// CloudControl call.
+    pub async fn new_with_config(region: &str, cfg: &AwsccProviderConfig) -> Self {
         let config = Self::build_config(region).await;
+
+        let init_error =
+            if cfg.allowed_account_ids.is_empty() && cfg.forbidden_account_ids.is_empty() {
+                None
+            } else {
+                Self::check_account_guard(&config, cfg).await.err()
+            };
 
         Self {
             cloudcontrol_client: CloudControlClient::new(&config),
             aws_config: config,
+            init_error,
         }
+    }
+
+    /// Look up the caller's AWS account ID via STS and validate it
+    /// against the provider's allowed/forbidden lists.
+    ///
+    /// Returns `Ok(())` if the account is allowed; otherwise an error
+    /// message naming both the offending list and the actual account ID.
+    async fn check_account_guard(
+        sdk_config: &aws_config::SdkConfig,
+        cfg: &AwsccProviderConfig,
+    ) -> Result<(), String> {
+        let sts = StsClient::new(sdk_config);
+        let identity = sts.get_caller_identity().send().await.map_err(|e| {
+            format!(
+                "Failed to call sts:GetCallerIdentity to check \
+                 allowed_account_ids / forbidden_account_ids: {e}"
+            )
+        })?;
+        let account_id = identity.account().ok_or_else(|| {
+            "sts:GetCallerIdentity returned no account ID; \
+             cannot evaluate allowed_account_ids / forbidden_account_ids"
+                .to_string()
+        })?;
+
+        account_guard::validate_account_against_lists(
+            account_id,
+            &cfg.allowed_account_ids,
+            &cfg.forbidden_account_ids,
+        )
+    }
+
+    /// Returns the deferred initialization error, if the account guard
+    /// rejected the caller during `new_with_config`.
+    pub fn init_error(&self) -> Option<&str> {
+        self.init_error.as_deref()
     }
 
     #[cfg(not(target_arch = "wasm32"))]


### PR DESCRIPTION
## Summary

Mirrors Terraform AWS provider's `allowed_account_ids` shape, applied to the awscc provider. Lets a `.crn` pin which AWS account a provider block is permitted (or forbidden) to operate against.

- Adds two optional provider attributes: `allowed_account_ids: list(String)` and `forbidden_account_ids: list(String)`.
- When either list is non-empty, the provider calls `sts:GetCallerIdentity` once during initialization and records a deferred error if the caller's account violates the policy.
- Every `Provider` trait method (`read`, `create`, `update`, `delete`) short-circuits to the deferred error before any CloudControl call, so wrong-account `apply` aborts before any read/refresh/mutation.
- Error messages always name both the offending list and the caller's actual account ID.

## Implementation notes

- New module `carina-provider-awscc/src/provider/account_guard.rs` holds the pure validation logic (`validate_account_against_lists`) with full unit-test coverage of the boundary cases.
- New struct `AwsccProviderConfig` carries the guard policy. `AwsccProvider::new` is preserved as a no-guard convenience wrapper; `AwsccProvider::new_with_config` is the new entry point.
- Both lists empty/unset = no check (existing behavior unchanged).
- `provider_config_attribute_types` declares both new attributes as `List<String>` in both lib.rs (in-process) and main.rs (process plugin). The host enforces declared types before reaching the provider, so the extractor is a defensive parse.

## Coordination

Parallel issue is filed for the aws provider (carina-rs/carina-provider-aws#233). The two implementations are independent crates and land separately, but share the same shape so a mixed-provider stack pins both.

## Test plan

- [x] Unit tests for `validate_account_against_lists` cover both-empty, allowed-match, allowed-mismatch, forbidden-match, forbidden-no-match, both-set, multi-account, and the issue's `'000000000000'` acceptance scenario.
- [x] Unit tests for `extract_provider_config` confirm list parsing and absent-attribute defaults.
- [x] `provider_config_attribute_types` declares the new attributes.
- [x] `cargo test` (workspace) passes (404 tests).
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] `cargo build --target wasm32-wasip2 --release` succeeds.
- [x] `scripts/check-docs-drift.sh` clean.
- [x] Acceptance fixture `acceptance-tests/allowed_account_ids_guard/basic.crn` pins to `['000000000000']`; running `carina apply .` against it must fail before any CloudControl call.

Closes #178