### PR TITLE
provider: canonicalize Union[String, list(String)] in normalize_state (#180)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina#45ac4edb70e89227e3f004574c38cf42b7eebe18"
+source = "git+https://github.com/carina-rs/carina#4f81d57f9900376dcdbb785f2c5697b692ed7e1d"
 dependencies = [
  "argon2",
  "futures",
@@ -533,7 +533,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina#45ac4edb70e89227e3f004574c38cf42b7eebe18"
+source = "git+https://github.com/carina-rs/carina#4f81d57f9900376dcdbb785f2c5697b692ed7e1d"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -578,7 +578,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#45ac4edb70e89227e3f004574c38cf42b7eebe18"
+source = "git+https://github.com/carina-rs/carina#4f81d57f9900376dcdbb785f2c5697b692ed7e1d"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-provider-awscc/src/lib.rs
+++ b/carina-provider-awscc/src/lib.rs
@@ -41,6 +41,11 @@ impl ProviderNormalizer for AwsccNormalizer {
 
     fn normalize_state(&self, current_states: &mut HashMap<ResourceId, State>) {
         crate::provider::normalize_state_enums_impl(current_states);
+        // Canonicalize `Union[String, list(String)]` typed values
+        // (IAM-style `string_or_list_of_strings`) so AWS's silent
+        // scalar normalization no longer leaks past the provider
+        // boundary. See carina-rs/carina#2481, sub-issue 5.
+        crate::provider::canonicalize_string_or_list_states_impl(current_states);
     }
 
     fn hydrate_read_state(
@@ -136,11 +141,11 @@ impl ProviderFactory for AwsccProviderFactory {
     fn create_provider(
         &self,
         attributes: &IndexMap<String, Value>,
-    ) -> BoxFuture<'_, Box<dyn Provider>> {
+    ) -> BoxFuture<'_, Result<Box<dyn Provider>, carina_core::provider::ProviderError>> {
         let region = self.extract_region(attributes);
         let cfg = extract_provider_config(attributes);
         Box::pin(async move {
-            Box::new(AwsccProvider::new_with_config(&region, &cfg).await) as Box<dyn Provider>
+            Ok(Box::new(AwsccProvider::new_with_config(&region, &cfg).await) as Box<dyn Provider>)
         })
     }
 

--- a/carina-provider-awscc/src/main.rs
+++ b/carina-provider-awscc/src/main.rs
@@ -46,7 +46,7 @@ impl AwsccProcessProvider {
             message: e.to_string(),
             resource_id: e
                 .resource_id
-                .as_ref()
+                .as_deref()
                 .map(convert::core_to_proto_resource_id),
             is_timeout: e.is_timeout,
         }

--- a/carina-provider-awscc/src/provider/mod.rs
+++ b/carina-provider-awscc/src/provider/mod.rs
@@ -32,7 +32,8 @@ use crate::schemas::generated::AwsccSchemaConfig;
 
 // Re-export public API
 pub use normalizer::{
-    normalize_state_enums_impl, resolve_enum_identifiers_impl, restore_unreturned_attrs_impl,
+    canonicalize_string_or_list_states_impl, normalize_state_enums_impl,
+    resolve_enum_identifiers_impl, restore_unreturned_attrs_impl,
 };
 pub(crate) use update::parse_resource_properties;
 

--- a/carina-provider-awscc/src/provider/normalizer.rs
+++ b/carina-provider-awscc/src/provider/normalizer.rs
@@ -198,6 +198,40 @@ pub fn normalize_state_enums_impl(current_states: &mut HashMap<ResourceId, State
     }
 }
 
+/// Canonicalize attributes of every awscc state whose declared schema
+/// type is `Union[String, list(String)]` (the IAM-style
+/// `string_or_list_of_strings` shape) into `Value::StringList`.
+///
+/// AWS server-side normalizes single-element list condition values back
+/// to scalars on read (e.g. `["x"]` is stored and returned as `"x"`).
+/// Pre-canonicalizing the actual-side at the provider boundary lets
+/// every downstream consumer (state writeback, plan display, the
+/// differ) see the same shape as the canonicalized desired side.
+/// See carina-rs/carina#2481, sub-issue 5.
+pub fn canonicalize_string_or_list_states_impl(current_states: &mut HashMap<ResourceId, State>) {
+    for (resource_id, state) in current_states.iter_mut() {
+        if !state.exists || resource_id.provider != "awscc" {
+            continue;
+        }
+        let config = match crate::schemas::generated::get_config_by_type(&resource_id.resource_type)
+        {
+            Some(c) => c,
+            None => continue,
+        };
+        let mut new_attrs = HashMap::with_capacity(state.attributes.len());
+        for (key, value) in std::mem::take(&mut state.attributes) {
+            let canon = match config.schema.attributes.get(key.as_str()) {
+                Some(attr_schema) => {
+                    carina_core::value::canonicalize_with_type(value, &attr_schema.attr_type)
+                }
+                None => value,
+            };
+            new_attrs.insert(key, canon);
+        }
+        state.attributes = new_attrs;
+    }
+}
+
 /// Restore unreturned attributes from saved state into current read states.
 ///
 /// CloudControl API doesn't always return all properties in GetResource responses
@@ -835,5 +869,145 @@ mod tests {
         } else {
             panic!("Expected List");
         }
+    }
+
+    // ---- canonicalize_string_or_list_states_impl tests ----
+    // (carina-rs/carina#2481, sub-issue 5)
+
+    fn make_state(
+        provider: &str,
+        resource_type: &str,
+        name: &str,
+        attrs: Vec<(&str, Value)>,
+    ) -> (ResourceId, State) {
+        use carina_core::resource::ResourceName;
+        use std::collections::BTreeSet;
+        let id = ResourceId {
+            provider: provider.to_string(),
+            resource_type: resource_type.to_string(),
+            name: ResourceName::Bound(name.to_string()),
+        };
+        let mut attributes = HashMap::new();
+        for (k, v) in attrs {
+            attributes.insert(k.to_string(), v);
+        }
+        let state = State {
+            id: id.clone(),
+            identifier: Some(name.to_string()),
+            attributes,
+            exists: true,
+            dependency_bindings: BTreeSet::new(),
+        };
+        (id, state)
+    }
+
+    #[test]
+    fn canonicalize_string_or_list_recurses_into_iam_policy_document() {
+        // AWS::IAM::RolePolicy has `policy_document` typed as
+        // `iam_policy_document()`, a Struct that nests
+        // Union[String, list(String)] fields like Statement[].Action.
+        // The provider canonicalize pass walks via the Struct schema
+        // and folds nested scalars to StringList.
+        let mut policy_map = IndexMap::new();
+        policy_map.insert(
+            "Statement".to_string(),
+            Value::List(vec![Value::Map({
+                let mut stmt = IndexMap::new();
+                stmt.insert("Effect".to_string(), Value::String("Allow".to_string()));
+                stmt.insert(
+                    "Action".to_string(),
+                    Value::String("s3:GetObject".to_string()),
+                );
+                stmt.insert(
+                    "Resource".to_string(),
+                    Value::String("arn:aws:s3:::my-bucket/*".to_string()),
+                );
+                stmt
+            })]),
+        );
+
+        let (id, state) = make_state(
+            "awscc",
+            "iam.RolePolicy",
+            "test-policy",
+            vec![
+                ("policy_name", Value::String("test-policy".to_string())),
+                ("policy_document", Value::Map(policy_map)),
+            ],
+        );
+        let mut current_states: HashMap<ResourceId, State> = HashMap::new();
+        current_states.insert(id.clone(), state);
+
+        canonicalize_string_or_list_states_impl(&mut current_states);
+
+        // Statement[0].Action: scalar → StringList(["s3:GetObject"])
+        let state = &current_states[&id];
+        let policy_document = state
+            .attributes
+            .get("policy_document")
+            .expect("policy_document present");
+        let Value::Map(pd) = policy_document else {
+            panic!("expected Map for policy_document");
+        };
+        let Value::List(stmts) = pd.get("Statement").expect("Statement present") else {
+            panic!("expected List for Statement");
+        };
+        let Value::Map(stmt) = &stmts[0] else {
+            panic!("expected Map for Statement[0]");
+        };
+        assert_eq!(
+            stmt.get("Action"),
+            Some(&Value::StringList(vec!["s3:GetObject".to_string()])),
+            "Action should be canonicalized to StringList"
+        );
+        assert_eq!(
+            stmt.get("Resource"),
+            Some(&Value::StringList(vec![
+                "arn:aws:s3:::my-bucket/*".to_string()
+            ])),
+            "Resource should be canonicalized to StringList"
+        );
+    }
+
+    #[test]
+    fn canonicalize_string_or_list_skips_non_awscc() {
+        let (id, state) = make_state(
+            "aws",
+            "iam.RolePolicy",
+            "test",
+            vec![("policy_name", Value::String("test".to_string()))],
+        );
+        let mut current_states: HashMap<ResourceId, State> = HashMap::new();
+        current_states.insert(id.clone(), state);
+
+        canonicalize_string_or_list_states_impl(&mut current_states);
+
+        let state = &current_states[&id];
+        assert_eq!(
+            state.attributes.get("policy_name"),
+            Some(&Value::String("test".to_string())),
+            "non-awscc state untouched"
+        );
+    }
+
+    #[test]
+    fn canonicalize_string_or_list_skips_unknown_resource_type() {
+        let (id, state) = make_state(
+            "awscc",
+            "unknown.UnknownType",
+            "test",
+            vec![("attr", Value::String("x".to_string()))],
+        );
+        let mut current_states: HashMap<ResourceId, State> = HashMap::new();
+        current_states.insert(id.clone(), state);
+
+        canonicalize_string_or_list_states_impl(&mut current_states);
+
+        let state = &current_states[&id];
+        assert_eq!(
+            state.attributes.get("attr"),
+            Some(&Value::String("x".to_string())),
+            "unknown resource types pass through unchanged"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Sub-issue 5 of carina-rs/carina#2481. AWS server-side normalizes single-element list condition values back to scalars on read (e.g. `["x"]` is stored and returned as `"x"`), so a desired side that canonicalizes to `Value::StringList(["x"])` would diff against the provider's `Value::String("x")` actual side forever. The new canonicalize pass at the provider boundary folds the actual-side shape to the canonical `Value::StringList` form before the rest of the apply / display machinery sees it.

## Changes

- **New `canonicalize_string_or_list_states_impl`** in `provider/normalizer.rs` walks every awscc state and applies `carina_core::value::canonicalize_with_type` to each top-level attribute. Recursion into `Struct` / `List` / `Map` containers (already handled by `canonicalize_with_type`) reaches nested `Union[String, list(String)]` fields like `policy_document.Statement[].Action`.
- **Wired into `AwsccNormalizer::normalize_state`** as a second pass after enum normalization.
- **Re-uses the canonicalizer from carina-core** (carina-rs/carina#2510) instead of duplicating the logic.
- **Cargo.lock updated** to pin a carina-core revision that exports `canonicalize_with_type` and the `Value::StringList` variant.
- **`create_provider` signature update** to the new `Result<Box<dyn Provider>, ProviderError>` shape introduced by the carina-core update; `convert_error` handles `ProviderError`'s new `Box<ResourceId>` field via `as_deref`.
- **3 new unit tests** in `provider::normalizer::tests::canonicalize_string_or_list_*` covering: nested IAM `policy_document` fold to StringList, non-awscc skip, unknown resource type skip.

## Test plan

- [x] `cargo nextest run --workspace` (407 tests passed)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `bash scripts/check-*.sh`
- [ ] CI green

Closes #180.
