### PR TITLE
provider: normalize absent optional list/map attributes in read state

### DIFF
--- a/carina-provider-awscc/src/lib.rs
+++ b/carina-provider-awscc/src/lib.rs
@@ -46,6 +46,14 @@ impl ProviderNormalizer for AwsccNormalizer {
         // scalar normalization no longer leaks past the provider
         // boundary. See carina-rs/carina#2481, sub-issue 5.
         crate::provider::canonicalize_string_or_list_states_impl(current_states);
+        // Backfill optional list/map attributes that CloudControl
+        // omitted from the read response with empty containers, so
+        // the differ doesn't see `(none) → []` for resources that
+        // were applied with an empty list (e.g.
+        // `awscc.iam.Role.managed_policy_arns`). See
+        // carina-rs/carina-provider-awscc#182 (parent
+        // carina-rs/carina#2544).
+        crate::provider::normalize_absent_optional_lists_and_maps_impl(current_states);
     }
 
     fn hydrate_read_state(

--- a/carina-provider-awscc/src/provider/mod.rs
+++ b/carina-provider-awscc/src/provider/mod.rs
@@ -32,8 +32,8 @@ use crate::schemas::generated::AwsccSchemaConfig;
 
 // Re-export public API
 pub use normalizer::{
-    canonicalize_string_or_list_states_impl, normalize_state_enums_impl,
-    resolve_enum_identifiers_impl, restore_unreturned_attrs_impl,
+    canonicalize_string_or_list_states_impl, normalize_absent_optional_lists_and_maps_impl,
+    normalize_state_enums_impl, resolve_enum_identifiers_impl, restore_unreturned_attrs_impl,
 };
 pub(crate) use update::parse_resource_properties;
 

--- a/carina-provider-awscc/src/provider/normalizer.rs
+++ b/carina-provider-awscc/src/provider/normalizer.rs
@@ -232,6 +232,74 @@ pub fn canonicalize_string_or_list_states_impl(current_states: &mut HashMap<Reso
     }
 }
 
+/// Normalize "absent" optional `list(...)` / `map(...)` attributes in
+/// awscc states to empty containers.
+///
+/// AWS CloudControl `GetResource` responses omit optional list / map
+/// properties when the resource has no values for them (e.g.
+/// `awscc.iam.Role.managed_policy_arns` for a role with no attached
+/// managed policies). The differ then sees `desired = []` vs
+/// `current = (none)` and emits a permanent `(none) → []` diff that
+/// survives apply.
+///
+/// This pass establishes a canonical form at the provider boundary —
+/// same philosophy as `canonicalize_string_or_list_states_impl` for
+/// `Union[String, list(String)]` (carina-rs/carina#2511) — so the
+/// differ doesn't need to learn schema-dependent special-cases for
+/// "absent equals empty list".
+///
+/// Skipped:
+/// - `write_only` attributes — never present in read responses by
+///   design; their values come from saved state via
+///   `restore_unreturned_attrs_impl`. Inserting an empty container
+///   here would shadow the saved value.
+/// - `required` attributes — these are not optional, so absence is
+///   either a real bug or a CloudControl response shape we shouldn't
+///   paper over.
+///
+/// Note: this pass must run *after* `restore_unreturned_attrs_impl`
+/// (which fires from `hydrate_read_state`) so that values carried
+/// forward from saved state still take precedence over the empty
+/// fallback. The current call order in
+/// `AwsccNormalizer::normalize_state` runs after `hydrate_read_state`
+/// (the host invokes `hydrate_read_state` at read time and
+/// `normalize_state` later in `PlanPreprocessor::prepare`).
+pub fn normalize_absent_optional_lists_and_maps_impl(
+    current_states: &mut HashMap<ResourceId, State>,
+) {
+    for (resource_id, state) in current_states.iter_mut() {
+        if !state.exists || resource_id.provider != "awscc" {
+            continue;
+        }
+        let config = match crate::schemas::generated::get_config_by_type(&resource_id.resource_type)
+        {
+            Some(c) => c,
+            None => continue,
+        };
+        for (dsl_name, attr_schema) in &config.schema.attributes {
+            if attr_schema.required || attr_schema.write_only {
+                continue;
+            }
+            if state.attributes.contains_key(dsl_name) {
+                continue;
+            }
+            match &attr_schema.attr_type {
+                AttributeType::List { .. } => {
+                    state
+                        .attributes
+                        .insert(dsl_name.clone(), Value::List(Vec::new()));
+                }
+                AttributeType::Map { .. } => {
+                    state
+                        .attributes
+                        .insert(dsl_name.clone(), Value::Map(IndexMap::new()));
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
 /// Restore unreturned attributes from saved state into current read states.
 ///
 /// CloudControl API doesn't always return all properties in GetResource responses
@@ -1008,6 +1076,204 @@ mod tests {
             state.attributes.get("attr"),
             Some(&Value::String("x".to_string())),
             "unknown resource types pass through unchanged"
+        );
+    }
+
+    // ---- normalize_absent_optional_lists_and_maps_impl tests ----
+    // (carina-rs/carina-provider-awscc#182, parent carina-rs/carina#2544)
+
+    #[test]
+    fn normalize_absent_optional_list_inserts_empty_list() {
+        // Repro for #182: CloudControl returned no `ManagedPolicyArns`
+        // for an iam.Role with no attached managed policies. The state
+        // should normalize the absent attribute to `Value::List(vec![])`
+        // so the differ sees `[] == []` instead of `(none) → []`.
+        let (id, state) = make_state(
+            "awscc",
+            "iam.Role",
+            "test-role",
+            vec![
+                ("role_name", Value::String("test-role".to_string())),
+                (
+                    "arn",
+                    Value::String("arn:aws:iam::123:role/test".to_string()),
+                ),
+            ],
+        );
+        let mut current_states: HashMap<ResourceId, State> = HashMap::new();
+        current_states.insert(id.clone(), state);
+
+        normalize_absent_optional_lists_and_maps_impl(&mut current_states);
+
+        let state = &current_states[&id];
+        assert_eq!(
+            state.attributes.get("managed_policy_arns"),
+            Some(&Value::List(Vec::new())),
+            "absent optional list should be normalized to Value::List(vec![])"
+        );
+    }
+
+    #[test]
+    fn normalize_absent_optional_list_preserves_existing_list() {
+        // If CloudControl actually returned a list, leave it alone.
+        let existing = Value::List(vec![Value::String("arn:aws:iam::aws:policy/X".to_string())]);
+        let (id, state) = make_state(
+            "awscc",
+            "iam.Role",
+            "test-role",
+            vec![
+                ("role_name", Value::String("test-role".to_string())),
+                ("managed_policy_arns", existing.clone()),
+            ],
+        );
+        let mut current_states: HashMap<ResourceId, State> = HashMap::new();
+        current_states.insert(id.clone(), state);
+
+        normalize_absent_optional_lists_and_maps_impl(&mut current_states);
+
+        let state = &current_states[&id];
+        assert_eq!(
+            state.attributes.get("managed_policy_arns"),
+            Some(&existing),
+            "non-empty list should be preserved"
+        );
+    }
+
+    #[test]
+    fn normalize_absent_optional_list_skips_non_awscc() {
+        let (id, state) = make_state(
+            "aws",
+            "iam.Role",
+            "test-role",
+            vec![("role_name", Value::String("test-role".to_string()))],
+        );
+        let mut current_states: HashMap<ResourceId, State> = HashMap::new();
+        current_states.insert(id.clone(), state);
+
+        normalize_absent_optional_lists_and_maps_impl(&mut current_states);
+
+        let state = &current_states[&id];
+        assert!(
+            !state.attributes.contains_key("managed_policy_arns"),
+            "non-awscc states should be untouched"
+        );
+    }
+
+    #[test]
+    fn normalize_absent_optional_list_skips_unknown_resource_type() {
+        let (id, state) = make_state(
+            "awscc",
+            "unknown.UnknownType",
+            "test",
+            vec![("attr", Value::String("x".to_string()))],
+        );
+        let mut current_states: HashMap<ResourceId, State> = HashMap::new();
+        current_states.insert(id.clone(), state);
+
+        normalize_absent_optional_lists_and_maps_impl(&mut current_states);
+
+        let state = &current_states[&id];
+        assert_eq!(
+            state.attributes.len(),
+            1,
+            "unknown resource types should be untouched"
+        );
+    }
+
+    #[test]
+    fn normalize_absent_optional_list_skips_nonexistent_state() {
+        let mut state = make_state("awscc", "iam.Role", "ghost", vec![]).1;
+        state.exists = false;
+        let id = state.id.clone();
+        let mut current_states: HashMap<ResourceId, State> = HashMap::new();
+        current_states.insert(id.clone(), state);
+
+        normalize_absent_optional_lists_and_maps_impl(&mut current_states);
+
+        let state = &current_states[&id];
+        assert!(
+            state.attributes.is_empty(),
+            "non-existing states should be untouched"
+        );
+    }
+
+    #[test]
+    fn normalize_absent_optional_map_inserts_empty_map() {
+        // Use a resource type whose schema declares an optional Map
+        // attribute. AWS::IAM::Role's `tags` is technically a list of
+        // CloudFormation Tag structs, but `policy_options` on
+        // `iam.UserPolicy` is not present either. Instead, exercise
+        // the Map branch by using a resource we know has an optional
+        // Map. `awscc.cloudfront.Distribution.tags` is a map in the
+        // DSL after tag conversion in some shapes; safer to just use
+        // a synthetic Schema-driven test on a real resource.
+        //
+        // Find any awscc resource type with an optional Map attribute
+        // by scanning the registry.
+        use crate::schemas::generated;
+        let mut found: Option<(String, String)> = None;
+        for cfg in generated::configs().iter() {
+            for (attr_name, attr_schema) in &cfg.schema.attributes {
+                if attr_schema.required || attr_schema.write_only {
+                    continue;
+                }
+                if matches!(attr_schema.attr_type, AttributeType::Map { .. }) {
+                    found = Some((cfg.schema.resource_type.clone(), attr_name.clone()));
+                    break;
+                }
+            }
+            if found.is_some() {
+                break;
+            }
+        }
+        let Some((resource_type, attr_name)) = found else {
+            // No optional Map attribute exists in the current schema
+            // registry — the Map branch is still exercised at the
+            // type-system level and the implementation handles it
+            // symmetrically with List. Skip the runtime assertion in
+            // this case.
+            return;
+        };
+
+        let (id, state) = make_state(
+            "awscc",
+            &resource_type,
+            "test-resource",
+            vec![("name", Value::String("test".to_string()))],
+        );
+        let mut current_states: HashMap<ResourceId, State> = HashMap::new();
+        current_states.insert(id.clone(), state);
+
+        normalize_absent_optional_lists_and_maps_impl(&mut current_states);
+
+        let state = &current_states[&id];
+        assert_eq!(
+            state.attributes.get(&attr_name),
+            Some(&Value::Map(IndexMap::new())),
+            "absent optional map ({attr_name} on {resource_type}) should be \
+             normalized to Value::Map(IndexMap::new())"
+        );
+    }
+
+    #[test]
+    fn normalize_absent_required_attribute_is_not_filled() {
+        // assume_role_policy_document is required on iam.Role; even if
+        // somehow absent, the normalizer must not silently fill it in.
+        let (id, state) = make_state(
+            "awscc",
+            "iam.Role",
+            "test-role",
+            vec![("role_name", Value::String("test-role".to_string()))],
+        );
+        let mut current_states: HashMap<ResourceId, State> = HashMap::new();
+        current_states.insert(id.clone(), state);
+
+        normalize_absent_optional_lists_and_maps_impl(&mut current_states);
+
+        let state = &current_states[&id];
+        assert!(
+            !state.attributes.contains_key("assume_role_policy_document"),
+            "required attributes must not be auto-filled by absent normalization"
         );
     }
 }


### PR DESCRIPTION
## Summary

- AWS CloudControl `GetResource` omits optional `list(...)` / `map(...)` properties when a resource has no values for them. The differ then saw `desired = []` vs `current = (none)` and emitted a permanent `(none) -> []` diff that survived apply (e.g. `awscc.iam.Role.managed_policy_arns` for a role with no attached managed policies).
- Add `normalize_absent_optional_lists_and_maps_impl` to walk each awscc state's schema and backfill absent optional `list(...)` / `map(...)` attributes with `Value::List(vec![])` / `Value::Map(IndexMap::new())`. Wired into `AwsccNormalizer::normalize_state` after the existing enum and `Union[String, list(String)]` canonicalizers.
- Skips `required` (not optional) and `write_only` (never present in read responses by design — values come from saved state via `restore_unreturned_attrs_impl`, and overwriting them with empty would shadow the saved value). Order is safe: `normalize_state` runs after `hydrate_read_state` in `PlanPreprocessor::prepare`, so saved-state values take precedence over the empty fallback.
- Same philosophy as `canonicalize_string_or_list_states_impl` (carina-rs/carina#2511): keep the differ a pure structural comparator and absorb shape mismatches at the provider boundary, rather than teach `find_changed_attributes` schema-dependent "absent equals empty" rules.

## Test plan

- [x] Unit: `normalize_absent_optional_list_inserts_empty_list` — issue reproduction with `iam.Role` missing `managed_policy_arns` is normalized to `Value::List(vec![])`.
- [x] Unit: preserves an existing non-empty list, skips non-awscc, skips unknown resource types, skips non-existing states, skips `required` attributes (`assume_role_policy_document`).
- [x] Unit: optional `Map` branch — schema-driven scan over generated configs, asserting `Value::Map(IndexMap::new())` on the first matching resource.
- [x] `cargo nextest run -p carina-provider-awscc` (329 tests pass).
- [x] `cargo test --workspace --doc`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check`, `scripts/check-docs-drift.sh`, `cargo build -p carina-provider-awscc --target wasm32-wasip2 --release`.
- Real-infra acceptance (post-apply `carina plan` reports no change for `managed_policy_arns` instead of `(none) -> []`) deferred to apply-cycle verification on `carina-rs/infra` `registry/dev/bootstrap/`.

## Related

- Closes carina-rs/carina-provider-awscc#182
- Refs carina-rs/carina#2544 (parent — design choice to fix at provider boundary, not differ)
- Sibling: carina-rs/carina-provider-aws#236