### PR TITLE
Adopt Level 3 Provider trait; route UpdatePatch to CloudControl JSON Patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina#4f81d57f9900376dcdbb785f2c5697b692ed7e1d"
+source = "git+https://github.com/carina-rs/carina?rev=f6d7aa6297a9ac66fe3359e4e694b831c37d37b1#f6d7aa6297a9ac66fe3359e4e694b831c37d37b1"
 dependencies = [
  "argon2",
  "futures",
@@ -533,7 +533,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina#4f81d57f9900376dcdbb785f2c5697b692ed7e1d"
+source = "git+https://github.com/carina-rs/carina?rev=f6d7aa6297a9ac66fe3359e4e694b831c37d37b1#f6d7aa6297a9ac66fe3359e4e694b831c37d37b1"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -578,7 +578,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina#4f81d57f9900376dcdbb785f2c5697b692ed7e1d"
+source = "git+https://github.com/carina-rs/carina?rev=f6d7aa6297a9ac66fe3359e4e694b831c37d37b1#f6d7aa6297a9ac66fe3359e4e694b831c37d37b1"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "f6d7aa6297a9ac66fe3359e4e694b831c37d37b1" }

--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -23,10 +23,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "f6d7aa6297a9ac66fe3359e4e694b831c37d37b1" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "f6d7aa6297a9ac66fe3359e4e694b831c37d37b1" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "f6d7aa6297a9ac66fe3359e4e694b831c37d37b1" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-smithy-async = { version = "1", features = ["rt-tokio"] }

--- a/carina-provider-awscc/src/convert.rs
+++ b/carina-provider-awscc/src/convert.rs
@@ -6,6 +6,10 @@
 
 use std::collections::HashMap;
 
+use carina_core::provider::{
+    PatchOp as CorePatchOp, PatchOpKind as CorePatchOpKind, ProviderError as CoreProviderError,
+    UpdatePatch as CoreUpdatePatch,
+};
 use carina_core::resource::{
     LifecycleConfig as CoreLifecycle, Resource as CoreResource, ResourceId as CoreResourceId,
     State as CoreState, Value as CoreValue,
@@ -16,9 +20,11 @@ use carina_core::schema::{
 };
 use carina_provider_protocol::types::{
     AttributeSchema as ProtoAttributeSchema, AttributeType as ProtoAttributeType,
-    LifecycleConfig as ProtoLifecycle, Resource as ProtoResource, ResourceId as ProtoResourceId,
+    LifecycleConfig as ProtoLifecycle, PatchOp as ProtoPatchOp, PatchOpKind as ProtoPatchOpKind,
+    ProviderError as ProtoProviderError, ProviderErrorKind as ProtoProviderErrorKind,
+    Resource as ProtoResource, ResourceId as ProtoResourceId,
     ResourceSchema as ProtoResourceSchema, State as ProtoState, StructField as ProtoStructField,
-    Value as ProtoValue,
+    UpdatePatch as ProtoUpdatePatch, Value as ProtoValue,
 };
 
 // -- ResourceId --
@@ -356,6 +362,58 @@ pub fn core_to_proto_schema(s: &CoreResourceSchema) -> ProtoResourceSchema {
         }),
         validators: vec![],
         exclusive_required: s.exclusive_required.clone(),
+    }
+}
+
+// -- UpdatePatch --
+
+fn proto_to_core_patch_op_kind(k: ProtoPatchOpKind) -> CorePatchOpKind {
+    match k {
+        ProtoPatchOpKind::Add => CorePatchOpKind::Add,
+        ProtoPatchOpKind::Replace => CorePatchOpKind::Replace,
+        ProtoPatchOpKind::Remove => CorePatchOpKind::Remove,
+    }
+}
+
+fn proto_to_core_patch_op(op: &ProtoPatchOp) -> CorePatchOp {
+    CorePatchOp {
+        kind: proto_to_core_patch_op_kind(op.kind),
+        key: op.key.clone(),
+        value: op.value.as_ref().map(proto_to_core_value),
+    }
+}
+
+pub fn proto_to_core_update_patch(p: &ProtoUpdatePatch) -> CoreUpdatePatch {
+    CoreUpdatePatch {
+        ops: p.ops.iter().map(proto_to_core_patch_op).collect(),
+    }
+}
+
+// -- ProviderError --
+
+fn core_to_proto_provider_error_kind(e: &CoreProviderError) -> ProtoProviderErrorKind {
+    match e {
+        CoreProviderError::InvalidInput(_) => ProtoProviderErrorKind::InvalidInput,
+        CoreProviderError::ApiError(_) => ProtoProviderErrorKind::ApiError,
+        CoreProviderError::NotFound(_) => ProtoProviderErrorKind::NotFound,
+        CoreProviderError::Timeout(_) => ProtoProviderErrorKind::Timeout,
+        CoreProviderError::Internal(_) => ProtoProviderErrorKind::Internal,
+    }
+}
+
+pub fn core_to_proto_provider_error(e: CoreProviderError) -> ProtoProviderError {
+    let kind = core_to_proto_provider_error_kind(&e);
+    let detail = e.detail();
+    let resource_id = detail.resource_id.as_deref().map(core_to_proto_resource_id);
+    let cause = detail.cause.as_ref().map(|c| c.to_string());
+    let provider_name = detail.provider_name.clone();
+    let message = detail.message.clone();
+    ProtoProviderError {
+        kind,
+        message,
+        resource_id,
+        cause,
+        provider_name,
     }
 }
 

--- a/carina-provider-awscc/src/lib.rs
+++ b/carina-provider-awscc/src/lib.rs
@@ -20,10 +20,11 @@ use std::collections::HashMap;
 use indexmap::IndexMap;
 
 use carina_core::provider::{
-    BoxFuture, Provider, ProviderError, ProviderFactory, ProviderNormalizer, ProviderResult,
-    SavedAttrs, merge_default_tags_for_provider,
+    BoxFuture, CreateRequest, DeleteRequest, Provider, ProviderError, ProviderFactory,
+    ProviderNormalizer, ProviderResult, ReadRequest, SavedAttrs, UpdateRequest,
+    merge_default_tags_for_provider,
 };
-use carina_core::resource::{LifecycleConfig, Resource, ResourceId, State, Value};
+use carina_core::resource::{Resource, ResourceId, State, Value};
 use carina_core::schema::SchemaRegistry;
 
 use crate::provider::AwsccProviderConfig;
@@ -220,32 +221,58 @@ impl Provider for AwsccProvider {
     fn read(
         &self,
         id: &ResourceId,
-        identifier: Option<&str>,
+        identifier: &str,
+        _request: ReadRequest,
     ) -> BoxFuture<'_, ProviderResult<State>> {
         if let Some(err) = self.init_error() {
             let err = err.to_string();
             let id = id.clone();
-            return Box::pin(async move { Err(ProviderError::new(err).for_resource(id)) });
+            return Box::pin(async move {
+                Err(ProviderError::invalid_input(err)
+                    .for_provider("awscc")
+                    .for_resource(id))
+            });
         }
         let id = id.clone();
-        let identifier = identifier.map(|s| s.to_string());
+        let identifier = identifier.to_string();
         Box::pin(async move {
-            self.read_resource(&id.resource_type, id.name_str(), identifier.as_deref())
+            self.read_resource(&id.resource_type, id.name_str(), Some(&identifier))
                 .await
         })
     }
 
     fn read_data_source(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
-        self.read(&resource.id, None)
-    }
-
-    fn create(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
         if let Some(err) = self.init_error() {
             let err = err.to_string();
             let id = resource.id.clone();
-            return Box::pin(async move { Err(ProviderError::new(err).for_resource(id)) });
+            return Box::pin(async move {
+                Err(ProviderError::invalid_input(err)
+                    .for_provider("awscc")
+                    .for_resource(id))
+            });
         }
-        let resource = resource.clone();
+        let id = resource.id.clone();
+        Box::pin(async move {
+            self.read_resource(&id.resource_type, id.name_str(), None)
+                .await
+        })
+    }
+
+    fn create(
+        &self,
+        _id: &ResourceId,
+        request: CreateRequest,
+    ) -> BoxFuture<'_, ProviderResult<State>> {
+        if let Some(err) = self.init_error() {
+            let err = err.to_string();
+            let id = request.resource.id.clone();
+            return Box::pin(async move {
+                Err(ProviderError::invalid_input(err)
+                    .for_provider("awscc")
+                    .for_resource(id))
+            });
+        }
+        let resource = request.resource;
         Box::pin(async move { self.create_resource(resource).await })
     }
 
@@ -253,36 +280,46 @@ impl Provider for AwsccProvider {
         &self,
         id: &ResourceId,
         identifier: &str,
-        from: &State,
-        to: &Resource,
+        request: UpdateRequest,
     ) -> BoxFuture<'_, ProviderResult<State>> {
         if let Some(err) = self.init_error() {
             let err = err.to_string();
             let id = id.clone();
-            return Box::pin(async move { Err(ProviderError::new(err).for_resource(id)) });
+            return Box::pin(async move {
+                Err(ProviderError::invalid_input(err)
+                    .for_provider("awscc")
+                    .for_resource(id))
+            });
         }
         let id = id.clone();
         let identifier = identifier.to_string();
-        let from = from.clone();
-        let to = to.clone();
-        Box::pin(async move { self.update_resource(id, &identifier, &from, to).await })
+        Box::pin(async move {
+            self.update_resource(id, &identifier, &request.from, &request.patch)
+                .await
+        })
     }
 
     fn delete(
         &self,
         id: &ResourceId,
         identifier: &str,
-        lifecycle: &LifecycleConfig,
+        request: DeleteRequest,
     ) -> BoxFuture<'_, ProviderResult<()>> {
         if let Some(err) = self.init_error() {
             let err = err.to_string();
             let id = id.clone();
-            return Box::pin(async move { Err(ProviderError::new(err).for_resource(id)) });
+            return Box::pin(async move {
+                Err(ProviderError::invalid_input(err)
+                    .for_provider("awscc")
+                    .for_resource(id))
+            });
         }
         let id = id.clone();
         let identifier = identifier.to_string();
-        let lifecycle = lifecycle.clone();
-        Box::pin(async move { self.delete_resource(&id, &identifier, &lifecycle).await })
+        Box::pin(async move {
+            self.delete_resource(&id, &identifier, &request.lifecycle)
+                .await
+        })
     }
 }
 

--- a/carina-provider-awscc/src/main.rs
+++ b/carina-provider-awscc/src/main.rs
@@ -5,7 +5,9 @@ use carina_plugin_sdk::CarinaProvider;
 use carina_provider_protocol::types as proto;
 
 use carina_core::provider::{
-    Provider, ProviderError as CoreProviderError, ProviderNormalizer, SavedAttrs,
+    CreateRequest as CoreCreateRequest, DeleteRequest as CoreDeleteRequest, Provider,
+    ProviderError as CoreProviderError, ProviderNormalizer, ReadRequest as CoreReadRequest,
+    SavedAttrs, UpdateRequest as CoreUpdateRequest,
 };
 use carina_core::resource::{ResourceId as CoreResourceId, State as CoreState, Value as CoreValue};
 
@@ -42,14 +44,7 @@ impl AwsccProcessProvider {
     }
 
     fn convert_error(e: CoreProviderError) -> proto::ProviderError {
-        proto::ProviderError {
-            message: e.to_string(),
-            resource_id: e
-                .resource_id
-                .as_deref()
-                .map(convert::core_to_proto_resource_id),
-            is_timeout: e.is_timeout,
-        }
+        convert::core_to_proto_provider_error(e)
     }
 
     fn provider(&self) -> &AwsccProvider {
@@ -179,12 +174,13 @@ impl CarinaProvider for AwsccProcessProvider {
     fn read(
         &self,
         id: &proto::ResourceId,
-        identifier: Option<&str>,
+        identifier: &str,
+        _request: proto::ReadRequest,
     ) -> Result<proto::State, proto::ProviderError> {
         let core_id = convert::proto_to_core_resource_id(id);
-        let result = self
-            .runtime
-            .block_on(self.provider().read(&core_id, identifier));
+        let result =
+            self.runtime
+                .block_on(self.provider().read(&core_id, identifier, CoreReadRequest));
         match result {
             Ok(state) => Ok(convert::core_to_proto_state(&state)),
             Err(e) => Err(Self::convert_error(e)),
@@ -195,14 +191,29 @@ impl CarinaProvider for AwsccProcessProvider {
         &self,
         resource: &proto::Resource,
     ) -> Result<proto::State, proto::ProviderError> {
-        self.read(&resource.id, None)
-    }
-
-    fn create(&self, resource: &proto::Resource) -> Result<proto::State, proto::ProviderError> {
         let core_resource = convert::proto_to_core_resource(resource);
         let result = self
             .runtime
-            .block_on(self.provider().create(&core_resource));
+            .block_on(self.provider().read_data_source(&core_resource));
+        match result {
+            Ok(state) => Ok(convert::core_to_proto_state(&state)),
+            Err(e) => Err(Self::convert_error(e)),
+        }
+    }
+
+    fn create(
+        &self,
+        id: &proto::ResourceId,
+        request: proto::CreateRequest,
+    ) -> Result<proto::State, proto::ProviderError> {
+        let core_id = convert::proto_to_core_resource_id(id);
+        let core_resource = convert::proto_to_core_resource(&request.resource);
+        let result = self.runtime.block_on(self.provider().create(
+            &core_id,
+            CoreCreateRequest {
+                resource: core_resource,
+            },
+        ));
         match result {
             Ok(state) => Ok(convert::core_to_proto_state(&state)),
             Err(e) => Err(Self::convert_error(e)),
@@ -213,16 +224,19 @@ impl CarinaProvider for AwsccProcessProvider {
         &self,
         id: &proto::ResourceId,
         identifier: &str,
-        from: &proto::State,
-        to: &proto::Resource,
+        request: proto::UpdateRequest,
     ) -> Result<proto::State, proto::ProviderError> {
         let core_id = convert::proto_to_core_resource_id(id);
-        let core_from = convert::proto_to_core_state(from);
-        let core_to = convert::proto_to_core_resource(to);
-        let result = self.runtime.block_on(
-            self.provider()
-                .update(&core_id, identifier, &core_from, &core_to),
-        );
+        let core_from = convert::proto_to_core_state(&request.from);
+        let core_patch = convert::proto_to_core_update_patch(&request.patch);
+        let result = self.runtime.block_on(self.provider().update(
+            &core_id,
+            identifier,
+            CoreUpdateRequest {
+                from: core_from,
+                patch: core_patch,
+            },
+        ));
         match result {
             Ok(state) => Ok(convert::core_to_proto_state(&state)),
             Err(e) => Err(Self::convert_error(e)),
@@ -233,18 +247,20 @@ impl CarinaProvider for AwsccProcessProvider {
         &self,
         id: &proto::ResourceId,
         identifier: &str,
-        lifecycle: &proto::LifecycleConfig,
+        request: proto::DeleteRequest,
     ) -> Result<(), proto::ProviderError> {
         let core_id = convert::proto_to_core_resource_id(id);
         let core_lifecycle = carina_core::resource::LifecycleConfig {
-            force_delete: lifecycle.force_delete,
-            create_before_destroy: lifecycle.create_before_destroy,
-            prevent_destroy: lifecycle.prevent_destroy,
+            force_delete: request.lifecycle.force_delete,
+            create_before_destroy: request.lifecycle.create_before_destroy,
+            prevent_destroy: request.lifecycle.prevent_destroy,
         };
         let result = self.runtime.block_on(self.provider().delete(
             &core_id,
             identifier,
-            &core_lifecycle,
+            CoreDeleteRequest {
+                lifecycle: core_lifecycle,
+            },
         ));
         match result {
             Ok(()) => Ok(()),

--- a/carina-provider-awscc/src/provider/cloudcontrol.rs
+++ b/carina-provider-awscc/src/provider/cloudcontrol.rs
@@ -48,7 +48,7 @@ impl AwsccProvider {
                     Ok(None)
                 } else {
                     let detail = Self::format_sdk_error(&e);
-                    Err(ProviderError::new(format!(
+                    Err(ProviderError::api_error(format!(
                         "Failed to get resource: {}",
                         detail
                     )))
@@ -93,7 +93,7 @@ impl AwsccProvider {
                         response
                             .progress_event()
                             .and_then(|p| p.request_token())
-                            .ok_or_else(|| ProviderError::new("No request token returned"))?;
+                            .ok_or_else(|| ProviderError::internal("No request token returned"))?;
 
                     match self
                         .wait_for_operation_with_attempts(request_token, max_polling_attempts)
@@ -101,7 +101,7 @@ impl AwsccProvider {
                     {
                         Ok(identifier) => return Ok(identifier),
                         Err(e)
-                            if Self::is_retryable_status_message(&e.message)
+                            if Self::is_retryable_status_message(e.message())
                                 && attempt < max_retry_attempts =>
                         {
                             log::warn!(
@@ -109,7 +109,7 @@ impl AwsccProvider {
                                 type_name,
                                 attempt + 1,
                                 max_retry_attempts,
-                                e.message,
+                                e.message(),
                                 delay_secs,
                             );
                             tokio::time::sleep(Duration::from_secs(delay_secs)).await;
@@ -134,7 +134,7 @@ impl AwsccProvider {
                         continue;
                     }
                     let detail = Self::format_sdk_error(&e);
-                    return Err(ProviderError::new(format!(
+                    return Err(ProviderError::api_error(format!(
                         "Failed to create resource: {}",
                         detail
                     )));
@@ -142,7 +142,7 @@ impl AwsccProvider {
             }
         }
 
-        Err(ProviderError::new(format!(
+        Err(ProviderError::api_error(format!(
             "Failed to create resource {} after {} retry attempts",
             type_name, max_retry_attempts
         )))
@@ -160,7 +160,7 @@ impl AwsccProvider {
         }
 
         let patch_document = serde_json::to_string(&patch_ops)
-            .map_err(|e| ProviderError::new("Failed to build patch").with_cause(e))?;
+            .map_err(|e| ProviderError::internal("Failed to build patch").with_cause(e))?;
 
         let result = self
             .cloudcontrol_client
@@ -172,7 +172,7 @@ impl AwsccProvider {
             .await
             .map_err(|e| {
                 let detail = Self::format_sdk_error(&e);
-                ProviderError::new(format!("Failed to update resource: {}", detail))
+                ProviderError::api_error(format!("Failed to update resource: {}", detail))
             })?;
 
         if let Some(request_token) = result.progress_event().and_then(|p| p.request_token()) {
@@ -223,7 +223,7 @@ impl AwsccProvider {
                         {
                             Ok(_) => return Ok(()),
                             Err(e)
-                                if Self::is_retryable_status_message(&e.message)
+                                if Self::is_retryable_status_message(e.message())
                                     && attempt < max_retry_attempts =>
                             {
                                 log::warn!(
@@ -231,7 +231,7 @@ impl AwsccProvider {
                                     type_name,
                                     attempt + 1,
                                     max_retry_attempts,
-                                    e.message,
+                                    e.message(),
                                     delay_secs,
                                 );
                                 tokio::time::sleep(Duration::from_secs(delay_secs)).await;
@@ -258,7 +258,7 @@ impl AwsccProvider {
                         continue;
                     }
                     let detail = Self::format_sdk_error(&e);
-                    return Err(ProviderError::new(format!(
+                    return Err(ProviderError::api_error(format!(
                         "Failed to delete resource: {}",
                         detail
                     )));
@@ -266,7 +266,7 @@ impl AwsccProvider {
             }
         }
 
-        Err(ProviderError::new(format!(
+        Err(ProviderError::api_error(format!(
             "Failed to delete resource {} after {} retry attempts",
             type_name, max_retry_attempts
         )))
@@ -465,7 +465,9 @@ impl AwsccProvider {
                 .request_token(request_token)
                 .send()
                 .await
-                .map_err(|e| ProviderError::new("Failed to get operation status").with_cause(e))?;
+                .map_err(|e| {
+                    ProviderError::api_error("Failed to get operation status").with_cause(e)
+                })?;
 
             if let Some(progress) = status.progress_event() {
                 match progress.operation_status() {
@@ -474,10 +476,13 @@ impl AwsccProvider {
                     }
                     Some(OperationStatus::Failed) => {
                         let msg = progress.status_message().unwrap_or("Unknown error");
-                        return Err(ProviderError::new(format!("Operation failed: {}", msg)));
+                        return Err(ProviderError::api_error(format!(
+                            "Operation failed: {}",
+                            msg
+                        )));
                     }
                     Some(OperationStatus::CancelComplete) => {
-                        return Err(ProviderError::new("Operation was cancelled"));
+                        return Err(ProviderError::api_error("Operation was cancelled"));
                     }
                     _ => {
                         tokio::time::sleep(delay).await;
@@ -486,7 +491,7 @@ impl AwsccProvider {
             }
         }
 
-        Err(ProviderError::new("Operation timed out").timeout())
+        Err(ProviderError::timeout("Operation timed out"))
     }
 }
 

--- a/carina-provider-awscc/src/provider/operations.rs
+++ b/carina-provider-awscc/src/provider/operations.rs
@@ -6,7 +6,7 @@
 
 use std::collections::HashMap;
 
-use carina_core::provider::{ProviderError, ProviderResult};
+use carina_core::provider::{ProviderError, ProviderResult, UpdatePatch};
 use carina_core::resource::{LifecycleConfig, Resource, ResourceId, State, Value};
 use serde_json::json;
 
@@ -25,7 +25,7 @@ impl AwsccProvider {
         let id = ResourceId::with_provider("awscc", resource_type, name);
 
         let config = get_schema_config(resource_type).ok_or_else(|| {
-            ProviderError::new(format!("Unknown resource type: {}", resource_type))
+            ProviderError::internal(format!("Unknown resource type: {}", resource_type))
                 .for_resource(id.clone())
         })?;
 
@@ -80,7 +80,7 @@ impl AwsccProvider {
     /// Create a resource using its configuration
     pub async fn create_resource(&self, resource: Resource) -> ProviderResult<State> {
         let config = get_schema_config(&resource.id.resource_type).ok_or_else(|| {
-            ProviderError::new(format!(
+            ProviderError::internal(format!(
                 "Unknown resource type: {}",
                 resource.id.resource_type
             ))
@@ -156,29 +156,42 @@ impl AwsccProvider {
         Ok(state)
     }
 
-    /// Update a resource
+    /// Update a resource by applying an [`UpdatePatch`] to its
+    /// CloudControl-side state.
+    ///
+    /// The patch is the sole source of truth for the update payload —
+    /// fields the user has never specified are not in `patch.ops` and
+    /// therefore generate no JSON Patch op, leaving CloudControl's
+    /// other state alone (this is the actual fix for
+    /// `carina-rs/carina#2559`).
+    ///
+    /// `from` is the current provider-side state; it is used only to
+    /// reconstruct the post-update desired-state view that's carried
+    /// forward into the returned `State` for attributes the API does
+    /// not return in its read response. It MUST NOT be used to derive
+    /// additional fields to write back.
     pub async fn update_resource(
         &self,
         id: ResourceId,
         identifier: &str,
         from: &State,
-        to: Resource,
+        patch: &UpdatePatch,
     ) -> ProviderResult<State> {
         let config = get_schema_config(&id.resource_type).ok_or_else(|| {
-            ProviderError::new(format!("Unknown resource type: {}", id.resource_type))
+            ProviderError::internal(format!("Unknown resource type: {}", id.resource_type))
                 .for_resource(id.clone())
         })?;
 
         // Reject updates for resource types marked as force_replace in the schema
         if config.schema.force_replace {
-            return Err(ProviderError::new(format!(
+            return Err(ProviderError::invalid_input(format!(
                 "Update not supported for {}, delete and recreate",
                 id.resource_type
             ))
             .for_resource(id));
         }
 
-        let patch_ops = build_update_patches(config, from, &to);
+        let patch_ops = build_update_patches(config, &id.resource_type, patch);
 
         self.cc_update_resource(config.aws_type_name, identifier, patch_ops)
             .await
@@ -188,14 +201,17 @@ impl AwsccProvider {
             .read_resource(&id.resource_type, id.name_str(), Some(identifier))
             .await?;
 
-        // Preserve desired attributes not returned by CloudControl API.
-        // Same logic as create_resource: carry forward attributes that were accepted
-        // by the API but aren't included in the read response.
+        // Reconstruct the post-update desired view (current state + the
+        // patch we just applied). This is the source of values to carry
+        // forward for attributes CloudControl's read does not return —
+        // same logic as `create_resource` but built without a `to:
+        // Resource` (which Level 3 deliberately does not pass through).
+        let desired = post_update_attributes(from, patch);
         for dsl_name in config.schema.attributes.keys() {
             if !state.attributes.contains_key(dsl_name)
-                && let Some(value) = to.get_attr(dsl_name.as_str())
+                && let Some(value) = desired.get(dsl_name)
             {
-                state.attributes.insert(dsl_name.to_string(), value.clone());
+                state.attributes.insert(dsl_name.clone(), value.clone());
             }
         }
 
@@ -210,7 +226,7 @@ impl AwsccProvider {
         lifecycle: &LifecycleConfig,
     ) -> ProviderResult<()> {
         let config = get_schema_config(&id.resource_type).ok_or_else(|| {
-            ProviderError::new(format!("Unknown resource type: {}", id.resource_type))
+            ProviderError::internal(format!("Unknown resource type: {}", id.resource_type))
                 .for_resource(id.clone())
         })?;
 
@@ -220,7 +236,7 @@ impl AwsccProvider {
         // Handle force_delete for S3 buckets: empty the bucket before deletion
         if lifecycle.force_delete && id.resource_type == "s3.Bucket" {
             self.empty_s3_bucket(identifier).await.map_err(|e| {
-                ProviderError::new("Failed to empty S3 bucket before deletion")
+                ProviderError::api_error("Failed to empty S3 bucket before deletion")
                     .with_cause(e)
                     .for_resource(id.clone())
             })?;
@@ -234,4 +250,35 @@ impl AwsccProvider {
         .await
         .map_err(|e| e.for_resource(id.clone()))
     }
+}
+
+/// Reconstruct the post-update desired-state attribute map: take the
+/// current provider-side `from` state and apply each patch op on top.
+///
+/// Used by `update_resource` to know which attributes to carry forward
+/// when CloudControl's read response omits them. The map is the same
+/// logical shape as the old `to: Resource.attributes`, but built
+/// without exposing a full `Resource` to the update path.
+fn post_update_attributes(
+    from: &State,
+    patch: &UpdatePatch,
+) -> std::collections::HashMap<String, Value> {
+    use carina_core::provider::PatchOpKind;
+
+    let mut attributes = from.attributes.clone();
+    for op in &patch.ops {
+        match op.kind {
+            PatchOpKind::Add | PatchOpKind::Replace => {
+                if let Some(value) = &op.value {
+                    attributes.insert(op.key.clone(), value.clone());
+                } else {
+                    attributes.remove(&op.key);
+                }
+            }
+            PatchOpKind::Remove => {
+                attributes.remove(&op.key);
+            }
+        }
+    }
+    attributes
 }

--- a/carina-provider-awscc/src/provider/s3.rs
+++ b/carina-provider-awscc/src/provider/s3.rs
@@ -40,7 +40,7 @@ impl AwsccProvider {
                     if is_no_such_bucket(&e) {
                         return Ok(());
                     }
-                    return Err(ProviderError::new(format!(
+                    return Err(ProviderError::api_error(format!(
                         "Failed to list object versions: {}",
                         format_s3_error(&e)
                     )));
@@ -57,7 +57,7 @@ impl AwsccProvider {
                         id = id.version_id(vid);
                     }
                     objects_to_delete.push(id.build().map_err(|e| {
-                        ProviderError::new("Failed to build ObjectIdentifier").with_cause(e)
+                        ProviderError::internal("Failed to build ObjectIdentifier").with_cause(e)
                     })?);
                 }
             }
@@ -70,7 +70,7 @@ impl AwsccProvider {
                         id = id.version_id(vid);
                     }
                     objects_to_delete.push(id.build().map_err(|e| {
-                        ProviderError::new("Failed to build ObjectIdentifier").with_cause(e)
+                        ProviderError::internal("Failed to build ObjectIdentifier").with_cause(e)
                     })?);
                 }
             }
@@ -82,7 +82,7 @@ impl AwsccProvider {
                     .quiet(true)
                     .build()
                     .map_err(|e| {
-                        ProviderError::new("Failed to build Delete request").with_cause(e)
+                        ProviderError::internal("Failed to build Delete request").with_cause(e)
                     })?;
 
                 s3.delete_objects()
@@ -91,7 +91,7 @@ impl AwsccProvider {
                     .send()
                     .await
                     .map_err(|e| {
-                        ProviderError::new(format!(
+                        ProviderError::api_error(format!(
                             "Failed to delete objects: {}",
                             format_s3_error(&e)
                         ))

--- a/carina-provider-awscc/src/provider/special_cases.rs
+++ b/carina-provider-awscc/src/provider/special_cases.rs
@@ -85,7 +85,7 @@ impl AwsccProvider {
                 self.cc_update_resource(config.aws_type_name, identifier, patch_ops)
                     .await
                     .map_err(|e| {
-                        ProviderError::new(
+                        ProviderError::api_error(
                             "Failed to detach Internet Gateway from VPC before deletion",
                         )
                         .with_cause(e)

--- a/carina-provider-awscc/src/provider/update.rs
+++ b/carina-provider-awscc/src/provider/update.rs
@@ -1,10 +1,15 @@
 //! Update patch building and resource property parsing.
 //!
-//! This module builds JSON Patch operations for CloudControl API update requests
-//! by comparing current state with desired state.
+//! This module maps `carina_core::provider::UpdatePatch` ops directly to
+//! CloudControl JSON Patch operations. The patch carries only the
+//! attributes the user explicitly specified or removed — fields the user
+//! has never specified do not appear in the patch and therefore generate
+//! no JSON Patch op, leaving CloudControl-managed defaults and
+//! sibling-resource state alone (the actual fix for
+//! `carina-rs/carina#2559`).
 
-use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{Resource, State, Value};
+use carina_core::provider::{PatchOp, PatchOpKind, ProviderError, ProviderResult, UpdatePatch};
+use carina_core::resource::Value;
 use serde_json::json;
 
 use super::conversion::dsl_value_to_aws;
@@ -15,116 +20,123 @@ use crate::schemas::generated::AwsccSchemaConfig;
 /// Returns an error instead of silently returning an empty object when the JSON is malformed.
 pub(crate) fn parse_resource_properties(props_str: &str) -> ProviderResult<serde_json::Value> {
     serde_json::from_str(props_str)
-        .map_err(|e| ProviderError::new("Failed to parse resource properties").with_cause(e))
+        .map_err(|e| ProviderError::internal("Failed to parse resource properties").with_cause(e))
 }
 
-/// Build JSON Patch operations for updating a resource.
+/// Build CloudControl JSON Patch operations from an [`UpdatePatch`].
 ///
-/// Compares `from` (current state) and `to` (desired state) to generate:
-/// - `"add"` operations for attributes present in `to`
-/// - `"remove"` operations for attributes present in `from` but absent in `to`
-///   (only for non-required, non-create-only attributes with a provider_name)
+/// Each [`PatchOp`] in `patch.ops` corresponds to a key the user
+/// explicitly added, replaced, or removed in the desired state.
+/// Attributes the user has never specified do not appear in `patch.ops`
+/// and therefore generate no JSON Patch op — CloudControl leaves them
+/// untouched.
+///
+/// Mapping rules:
+/// - [`PatchOpKind::Add`] / [`PatchOpKind::Replace`] with a value →
+///   `{"op": "add", "path": "/<aws_name>", "value": <serialized>}`
+///   (`add` is used for both because CloudControl's JSON Patch
+///   `replace` fails when the property does not exist in the resource
+///   model, while `add` works for both create-and-set and replace-existing
+///   cases — matches the Terraform AWSCC provider's behavior).
+/// - [`PatchOpKind::Remove`] (or Add/Replace with `value: None`) →
+///   `{"op": "remove", "path": "/<aws_name>"}`.
+///
+/// Read-only and create-only attributes are filtered out: CloudControl
+/// rejects patches that touch them, so even if the user changed the
+/// value in their `.crn` (typically because the schema was wrong) the
+/// op is dropped before the API call.
+///
+/// `tags` is special-cased to project the per-key DSL `Map<String,
+/// String>` into CloudControl's `[{"Key": ..., "Value": ...}]` shape.
 pub(crate) fn build_update_patches(
     config: &AwsccSchemaConfig,
-    from: &State,
-    to: &Resource,
+    resource_type: &str,
+    patch: &UpdatePatch,
 ) -> Vec<serde_json::Value> {
     let mut patch_ops = Vec::new();
-    let resource_type = &to.id.resource_type;
 
-    // Build add operations for attributes that changed between `from` and `to`
-    for (dsl_name, attr_schema) in &config.schema.attributes {
-        // Skip tags - handled separately below
-        if dsl_name == "tags" {
+    for op in &patch.ops {
+        // tags handled below
+        if op.key == "tags" {
+            push_tags_op(&mut patch_ops, op);
             continue;
         }
-        // Skip read-only attributes - they are set by the provider and cannot be updated
-        if attr_schema.read_only {
-            continue;
-        }
-        // Skip create-only attributes - they cannot be modified after creation
-        if attr_schema.create_only {
-            continue;
-        }
-        if let Some(aws_name) = &attr_schema.provider_name
-            && let Some(value) = to.get_attr(dsl_name.as_str())
-            && let Some(aws_value) =
-                dsl_value_to_aws(value, &attr_schema.attr_type, resource_type, dsl_name)
-        {
-            // Skip if the value is unchanged from the current state
-            if let Some(from_value) = from.attributes.get(dsl_name)
-                && from_value == value
-            {
-                continue;
-            }
-            patch_ops.push(json!({
-                "op": "add",
-                "path": format!("/{}", aws_name),
-                "value": aws_value
-            }));
-        }
-    }
 
-    // Build remove operations for attributes present in `from` but absent in `to`
-    for (dsl_name, attr_schema) in &config.schema.attributes {
-        if dsl_name == "tags" {
-            continue;
-        }
-        // Skip read-only attributes - they are set by the provider and cannot be updated
-        if attr_schema.read_only {
-            continue;
-        }
-        // Only generate remove for attributes that:
-        // 1. Have a provider_name (so we know the AWS path)
-        // 2. Are not required (required attributes cannot be removed)
-        // 3. Are not create-only (create-only attributes cannot be changed after creation)
-        // 4. Exist in from but not in to
-        if let Some(aws_name) = &attr_schema.provider_name
-            && !attr_schema.required
-            && !attr_schema.create_only
-            && from.attributes.contains_key(dsl_name)
-            && !to.attributes.contains_key(dsl_name)
-        {
-            patch_ops.push(json!({
-                "op": "remove",
-                "path": format!("/{}", aws_name)
-            }));
-        }
-    }
+        let attr_schema = match config.schema.attributes.get(&op.key) {
+            Some(s) => s,
+            // Unknown keys (not in the schema) are silently dropped:
+            // CloudControl will reject anything we don't have an AWS
+            // path for, and surfacing this as an error here would mask
+            // schema bugs as user errors.
+            None => continue,
+        };
 
-    // Handle tags
-    if config.has_tags {
-        if let Some(Value::Map(user_tags)) = to.get_attr("tags") {
-            // Skip if tags are unchanged from the current state
-            let tags_unchanged = matches!(from.attributes.get("tags"), Some(Value::Map(from_tags)) if from_tags == user_tags);
-            if !tags_unchanged {
-                let mut tags = Vec::new();
-                for (key, value) in user_tags {
-                    if let Value::String(v) = value {
-                        tags.push(json!({"Key": key, "Value": v}));
-                    }
-                }
-                if !tags.is_empty() {
-                    patch_ops.push(json!({"op": "add", "path": "/Tags", "value": tags}));
+        // CloudControl rejects patches that touch read-only or create-only
+        // properties. Drop them even if they appear in the patch.
+        if attr_schema.read_only || attr_schema.create_only {
+            continue;
+        }
+
+        let aws_name = match &attr_schema.provider_name {
+            Some(name) => name,
+            None => continue,
+        };
+
+        match (op.kind, &op.value) {
+            (PatchOpKind::Add | PatchOpKind::Replace, Some(value)) => {
+                if let Some(aws_value) =
+                    dsl_value_to_aws(value, &attr_schema.attr_type, resource_type, &op.key)
+                {
+                    patch_ops.push(json!({
+                        "op": "add",
+                        "path": format!("/{}", aws_name),
+                        "value": aws_value,
+                    }));
                 }
             }
-        } else if from.attributes.contains_key("tags") {
-            // Tags existed in from but removed in to: generate remove operation
-            patch_ops.push(json!({"op": "remove", "path": "/Tags"}));
+            (PatchOpKind::Remove, _) | (PatchOpKind::Add | PatchOpKind::Replace, None) => {
+                patch_ops.push(json!({
+                    "op": "remove",
+                    "path": format!("/{}", aws_name),
+                }));
+            }
         }
     }
 
     patch_ops
 }
 
+/// Project a `tags` patch op (DSL `Map<String, String>`) into the
+/// CloudControl `[{"Key": ..., "Value": ...}]` shape.
+fn push_tags_op(patch_ops: &mut Vec<serde_json::Value>, op: &PatchOp) {
+    match (op.kind, &op.value) {
+        (PatchOpKind::Add | PatchOpKind::Replace, Some(Value::Map(user_tags))) => {
+            let mut tags = Vec::new();
+            for (key, value) in user_tags {
+                if let Value::String(v) = value {
+                    tags.push(json!({"Key": key, "Value": v}));
+                }
+            }
+            if tags.is_empty() {
+                // Empty map after projection: treat as remove so we
+                // don't push an empty Tags array (CloudControl rejects
+                // some resource types' empty Tags).
+                patch_ops.push(json!({"op": "remove", "path": "/Tags"}));
+            } else {
+                patch_ops.push(json!({"op": "add", "path": "/Tags", "value": tags}));
+            }
+        }
+        (PatchOpKind::Remove, _) | (PatchOpKind::Add | PatchOpKind::Replace, _) => {
+            patch_ops.push(json!({"op": "remove", "path": "/Tags"}));
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-
     use indexmap::IndexMap;
 
     use super::*;
-    use carina_core::resource::ResourceId;
 
     fn get_schema_config(resource_type: &str) -> Option<&'static AwsccSchemaConfig> {
         super::super::get_schema_config(resource_type)
@@ -132,6 +144,30 @@ mod tests {
 
     fn get_vpc_config() -> &'static AwsccSchemaConfig {
         get_schema_config("ec2.Vpc").expect("ec2.vpc schema should exist")
+    }
+
+    fn replace(key: &str, value: Value) -> PatchOp {
+        PatchOp {
+            kind: PatchOpKind::Replace,
+            key: key.to_string(),
+            value: Some(value),
+        }
+    }
+
+    fn add(key: &str, value: Value) -> PatchOp {
+        PatchOp {
+            kind: PatchOpKind::Add,
+            key: key.to_string(),
+            value: Some(value),
+        }
+    }
+
+    fn remove(key: &str) -> PatchOp {
+        PatchOp {
+            kind: PatchOpKind::Remove,
+            key: key.to_string(),
+            value: None,
+        }
     }
 
     #[test]
@@ -151,9 +187,14 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(
-            err.message.contains("Failed to parse resource properties"),
+            err.message()
+                .contains("Failed to parse resource properties"),
             "Expected error message about parsing, got: {}",
-            err.message
+            err.message()
+        );
+        assert!(
+            matches!(err, ProviderError::Internal(_)),
+            "Expected Internal variant, got: {err:?}"
         );
     }
 
@@ -163,450 +204,187 @@ mod tests {
         assert!(result.is_err());
     }
 
+    /// Regression test for `carina-rs/carina#2559`: a user `.crn` that
+    /// changes only `tags` on `awscc.iam.Role` must produce exactly one
+    /// JSON Patch op (`add /Tags`). It must NOT also emit a
+    /// `remove /Policies` (or any other `remove`) for fields the user
+    /// never specified, because that clobbers sibling
+    /// `awscc.iam.RolePolicy` resources.
     #[test]
-    fn test_build_update_patches_remove_attribute_absent_in_to() {
-        let config = get_vpc_config();
-        let id = ResourceId::with_provider("awscc", "ec2.Vpc", "test");
+    fn issue_2559_tags_only_patch_does_not_touch_other_fields() {
+        let config = get_schema_config("iam.Role").expect("iam.role schema should exist");
 
-        let mut from_attrs = HashMap::new();
-        from_attrs.insert(
-            "cidr_block".to_string(),
-            Value::String("10.0.0.0/16".to_string()),
-        );
-        from_attrs.insert(
-            "instance_tenancy".to_string(),
-            Value::String("awscc.ec2.Vpc.InstanceTenancy.default".to_string()),
-        );
-        let from = State::existing(id.clone(), from_attrs);
-
-        let mut to = Resource::new("ec2.Vpc", "test");
-        to.set_attr(
-            "cidr_block".to_string(),
-            Value::String("10.0.0.0/16".to_string()),
-        );
-
-        let patches = build_update_patches(config, &from, &to);
-
-        let has_remove_instance_tenancy = patches.iter().any(|p| {
-            p.get("op").and_then(|v| v.as_str()) == Some("remove")
-                && p.get("path").and_then(|v| v.as_str()) == Some("/InstanceTenancy")
-        });
-        assert!(
-            has_remove_instance_tenancy,
-            "Expected remove patch for /InstanceTenancy, got: {:?}",
-            patches
-        );
-    }
-
-    #[test]
-    fn test_build_update_patches_remove_tags_absent_in_to() {
-        let config = get_vpc_config();
-        let id = ResourceId::with_provider("awscc", "ec2.Vpc", "test");
-
-        let mut from_attrs = HashMap::new();
-        from_attrs.insert(
-            "cidr_block".to_string(),
-            Value::String("10.0.0.0/16".to_string()),
-        );
         let mut tags = IndexMap::new();
-        tags.insert("Name".to_string(), Value::String("my-vpc".to_string()));
-        from_attrs.insert("tags".to_string(), Value::Map(tags));
-        let from = State::existing(id.clone(), from_attrs);
+        tags.insert("Env".to_string(), Value::String("staging".to_string()));
+        let patch = UpdatePatch {
+            ops: vec![replace("tags", Value::Map(tags))],
+        };
 
-        let mut to = Resource::new("ec2.Vpc", "test");
-        to.set_attr(
-            "cidr_block".to_string(),
-            Value::String("10.0.0.0/16".to_string()),
-        );
-
-        let patches = build_update_patches(config, &from, &to);
-
-        let has_remove_tags = patches.iter().any(|p| {
-            p.get("op").and_then(|v| v.as_str()) == Some("remove")
-                && p.get("path").and_then(|v| v.as_str()) == Some("/Tags")
-        });
-        assert!(
-            has_remove_tags,
-            "Expected remove patch for /Tags, got: {:?}",
-            patches
-        );
-    }
-
-    #[test]
-    fn test_build_update_patches_no_remove_for_required_attribute() {
-        let config = get_vpc_config();
-        let id = ResourceId::with_provider("awscc", "ec2.Vpc", "test");
-
-        let mut from_attrs = HashMap::new();
-        from_attrs.insert(
-            "cidr_block".to_string(),
-            Value::String("10.0.0.0/16".to_string()),
-        );
-        let from = State::existing(id.clone(), from_attrs);
-
-        let to = Resource::new("ec2.Vpc", "test");
-
-        let patches = build_update_patches(config, &from, &to);
-
-        let has_remove_cidr = patches.iter().any(|p| {
-            p.get("op").and_then(|v| v.as_str()) == Some("remove")
-                && p.get("path").and_then(|v| v.as_str()) == Some("/CidrBlock")
-        });
-        assert!(
-            !has_remove_cidr,
-            "Should not remove required attribute CidrBlock, got: {:?}",
-            patches
-        );
-    }
-
-    #[test]
-    fn test_build_update_patches_no_remove_when_both_present() {
-        let config = get_vpc_config();
-        let id = ResourceId::with_provider("awscc", "ec2.Vpc", "test");
-
-        let mut from_attrs = HashMap::new();
-        from_attrs.insert(
-            "cidr_block".to_string(),
-            Value::String("10.0.0.0/16".to_string()),
-        );
-        from_attrs.insert(
-            "instance_tenancy".to_string(),
-            Value::String("awscc.ec2.Vpc.InstanceTenancy.default".to_string()),
-        );
-        let from = State::existing(id.clone(), from_attrs);
-
-        let mut to = Resource::new("ec2.Vpc", "test");
-        to.set_attr(
-            "cidr_block".to_string(),
-            Value::String("10.0.0.0/16".to_string()),
-        );
-        to.set_attr(
-            "instance_tenancy".to_string(),
-            Value::String("awscc.ec2.Vpc.InstanceTenancy.dedicated".to_string()),
-        );
-
-        let patches = build_update_patches(config, &from, &to);
-
-        let has_remove = patches
-            .iter()
-            .any(|p| p.get("op").and_then(|v| v.as_str()) == Some("remove"));
-        assert!(
-            !has_remove,
-            "Should not have remove operations when attribute is present in both from and to, got: {:?}",
-            patches
-        );
-    }
-
-    #[test]
-    fn test_build_update_patches_skip_unchanged_attributes() {
-        let config = get_vpc_config();
-        let id = ResourceId::with_provider("awscc", "ec2.Vpc", "test");
-
-        let mut from_attrs = HashMap::new();
-        from_attrs.insert(
-            "cidr_block".to_string(),
-            Value::String("10.0.0.0/16".to_string()),
-        );
-        from_attrs.insert(
-            "instance_tenancy".to_string(),
-            Value::String("awscc.ec2.Vpc.InstanceTenancy.default".to_string()),
-        );
-        let from = State::existing(id.clone(), from_attrs);
-
-        let mut to = Resource::new("ec2.Vpc", "test");
-        to.set_attr(
-            "cidr_block".to_string(),
-            Value::String("10.0.0.0/16".to_string()),
-        );
-        to.set_attr(
-            "instance_tenancy".to_string(),
-            Value::String("awscc.ec2.Vpc.InstanceTenancy.dedicated".to_string()),
-        );
-
-        let patches = build_update_patches(config, &from, &to);
-
-        let has_cidr_replace = patches.iter().any(|p| {
-            p.get("op").and_then(|v| v.as_str()) == Some("add")
-                && p.get("path").and_then(|v| v.as_str()) == Some("/CidrBlock")
-        });
-        assert!(
-            !has_cidr_replace,
-            "Should not generate add patch for unchanged attribute /CidrBlock, got: {:?}",
-            patches
-        );
-
-        let has_tenancy_replace = patches.iter().any(|p| {
-            p.get("op").and_then(|v| v.as_str()) == Some("add")
-                && p.get("path").and_then(|v| v.as_str()) == Some("/InstanceTenancy")
-        });
-        assert!(
-            has_tenancy_replace,
-            "Should generate add patch for changed attribute /InstanceTenancy, got: {:?}",
-            patches
-        );
-    }
-
-    #[test]
-    fn test_build_update_patches_no_patches_when_identical() {
-        let config = get_vpc_config();
-        let id = ResourceId::with_provider("awscc", "ec2.Vpc", "test");
-
-        let mut from_attrs = HashMap::new();
-        from_attrs.insert(
-            "cidr_block".to_string(),
-            Value::String("10.0.0.0/16".to_string()),
-        );
-        let from = State::existing(id.clone(), from_attrs);
-
-        let mut to = Resource::new("ec2.Vpc", "test");
-        to.set_attr(
-            "cidr_block".to_string(),
-            Value::String("10.0.0.0/16".to_string()),
-        );
-
-        let patches = build_update_patches(config, &from, &to);
-
-        assert!(
-            patches.is_empty(),
-            "Should generate no patches when from and to are identical, got: {:?}",
-            patches
-        );
-    }
-
-    #[test]
-    fn test_build_update_patches_skip_unchanged_tags() {
-        let config = get_vpc_config();
-        let id = ResourceId::with_provider("awscc", "ec2.Vpc", "test");
-
-        let mut from_attrs = HashMap::new();
-        from_attrs.insert(
-            "cidr_block".to_string(),
-            Value::String("10.0.0.0/16".to_string()),
-        );
-        let mut tags = IndexMap::new();
-        tags.insert("Name".to_string(), Value::String("my-vpc".to_string()));
-        from_attrs.insert("tags".to_string(), Value::Map(tags.clone()));
-        let from = State::existing(id.clone(), from_attrs);
-
-        let mut to = Resource::new("ec2.Vpc", "test");
-        to.set_attr(
-            "cidr_block".to_string(),
-            Value::String("10.0.0.0/16".to_string()),
-        );
-        to.set_attr("tags".to_string(), Value::Map(tags));
-
-        let patches = build_update_patches(config, &from, &to);
-
-        assert!(
-            patches.is_empty(),
-            "Should generate no patches when tags are unchanged, got: {:?}",
-            patches
-        );
-    }
-
-    #[test]
-    fn test_build_update_patches_uses_add_op_not_replace() {
-        // CloudControl API JSON Patch: "add" works whether the property exists or not,
-        // while "replace" fails if the property doesn't exist in the model.
-        // Using "add" is more robust and matches the AWS AWSCC Terraform provider behavior.
-        let config = get_vpc_config();
-        let id = ResourceId::with_provider("awscc", "ec2.Vpc", "test");
-
-        let mut from_attrs = HashMap::new();
-        from_attrs.insert(
-            "cidr_block".to_string(),
-            Value::String("10.0.0.0/16".to_string()),
-        );
-        from_attrs.insert(
-            "instance_tenancy".to_string(),
-            Value::String("awscc.ec2.Vpc.InstanceTenancy.default".to_string()),
-        );
-        let from = State::existing(id.clone(), from_attrs);
-
-        let mut to = Resource::new("ec2.Vpc", "test");
-        to.set_attr(
-            "cidr_block".to_string(),
-            Value::String("10.0.0.0/16".to_string()),
-        );
-        to.set_attr(
-            "instance_tenancy".to_string(),
-            Value::String("awscc.ec2.Vpc.InstanceTenancy.dedicated".to_string()),
-        );
-
-        let patches = build_update_patches(config, &from, &to);
-
-        // All value-setting operations should use "add", not "replace"
-        for patch in &patches {
-            let op = patch.get("op").and_then(|v| v.as_str()).unwrap_or("");
-            if op != "remove" {
-                assert_eq!(
-                    op, "add",
-                    "Expected 'add' op for value-setting patch, got '{}': {:?}",
-                    op, patch
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn test_build_update_patches_log_group_retention_uses_add() {
-        // Regression test for issue #791: logs_log_group in-place update fails
-        // because "replace" op fails when the property path doesn't exist in
-        // the CloudControl model.
-        let config =
-            get_schema_config("logs.LogGroup").expect("logs.log_group schema should exist");
-        let id = ResourceId::with_provider("awscc", "logs.LogGroup", "test");
-
-        let mut from_attrs = HashMap::new();
-        from_attrs.insert("retention_in_days".to_string(), Value::Int(7));
-        from_attrs.insert(
-            "log_group_name".to_string(),
-            Value::String("/carina/test-group".to_string()),
-        );
-        let from = State::existing(id.clone(), from_attrs);
-
-        let mut to = Resource::new("logs.LogGroup", "test");
-        to.set_attr("retention_in_days".to_string(), Value::Int(14));
-        to.set_attr(
-            "log_group_name".to_string(),
-            Value::String("/carina/test-group".to_string()),
-        );
-
-        let patches = build_update_patches(config, &from, &to);
+        let patches = build_update_patches(config, "iam.Role", &patch);
 
         assert_eq!(
             patches.len(),
             1,
-            "Should have exactly one patch: {:?}",
-            patches
+            "Tags-only patch should produce exactly one JSON Patch op, got: {patches:?}"
         );
-        let patch = &patches[0];
-        assert_eq!(
-            patch.get("op").and_then(|v| v.as_str()),
-            Some("add"),
-            "Should use 'add' op for RetentionInDays update"
+        let op = &patches[0];
+        assert_eq!(op.get("op").and_then(|v| v.as_str()), Some("add"));
+        assert_eq!(op.get("path").and_then(|v| v.as_str()), Some("/Tags"));
+
+        // Defensive: no `remove` op should be present.
+        assert!(
+            !patches
+                .iter()
+                .any(|p| p.get("op").and_then(|v| v.as_str()) == Some("remove")),
+            "Tags-only patch must not emit any /remove op (caused #2559 by clobbering /Policies); got: {patches:?}"
         );
-        assert_eq!(
-            patch.get("path").and_then(|v| v.as_str()),
-            Some("/RetentionInDays"),
-        );
-        assert_eq!(patch.get("value"), Some(&serde_json::json!(14)),);
     }
 
     #[test]
-    fn test_build_update_patches_excludes_read_only_properties() {
-        // Regression test for issue #806: update patch includes readOnly property Arn
-        // CloudFormation rejects patches that include read-only properties like Arn.
+    fn test_empty_patch_produces_no_ops() {
+        let config = get_vpc_config();
+        let patch = UpdatePatch::default();
+        let patches = build_update_patches(config, "ec2.Vpc", &patch);
+        assert!(
+            patches.is_empty(),
+            "Empty patch must produce no JSON Patch ops, got: {patches:?}"
+        );
+    }
+
+    #[test]
+    fn test_replace_op_emits_add_json_patch() {
+        // CloudControl JSON Patch: "add" works whether the property exists or not,
+        // while "replace" fails if the property doesn't exist in the model.
+        // We always emit "add" for set operations, matching Terraform AWSCC.
+        let config = get_vpc_config();
+        let patch = UpdatePatch {
+            ops: vec![replace(
+                "instance_tenancy",
+                Value::String("awscc.ec2.Vpc.InstanceTenancy.dedicated".to_string()),
+            )],
+        };
+        let patches = build_update_patches(config, "ec2.Vpc", &patch);
+
+        assert_eq!(patches.len(), 1, "got: {patches:?}");
+        let op = &patches[0];
+        assert_eq!(op.get("op").and_then(|v| v.as_str()), Some("add"));
+        assert_eq!(
+            op.get("path").and_then(|v| v.as_str()),
+            Some("/InstanceTenancy")
+        );
+    }
+
+    #[test]
+    fn test_add_op_emits_add_json_patch() {
         let config =
             get_schema_config("logs.LogGroup").expect("logs.log_group schema should exist");
-        let id = ResourceId::with_provider("awscc", "logs.LogGroup", "test");
+        let patch = UpdatePatch {
+            ops: vec![add("retention_in_days", Value::Int(14))],
+        };
+        let patches = build_update_patches(config, "logs.LogGroup", &patch);
 
-        let mut from_attrs = HashMap::new();
-        from_attrs.insert("retention_in_days".to_string(), Value::Int(7));
-        from_attrs.insert(
-            "log_group_name".to_string(),
-            Value::String("/carina/test-group".to_string()),
+        assert_eq!(patches.len(), 1, "got: {patches:?}");
+        let op = &patches[0];
+        assert_eq!(op.get("op").and_then(|v| v.as_str()), Some("add"));
+        assert_eq!(
+            op.get("path").and_then(|v| v.as_str()),
+            Some("/RetentionInDays")
         );
-        // Arn is a read-only property returned by the API in current state
-        from_attrs.insert(
-            "arn".to_string(),
-            Value::String(
-                "arn:aws:logs:ap-northeast-1:123456789012:log-group:/carina/test-group:*"
-                    .to_string(),
-            ),
+        assert_eq!(op.get("value"), Some(&serde_json::json!(14)));
+    }
+
+    #[test]
+    fn test_remove_op_emits_remove_json_patch() {
+        let config = get_vpc_config();
+        let patch = UpdatePatch {
+            ops: vec![remove("instance_tenancy")],
+        };
+        let patches = build_update_patches(config, "ec2.Vpc", &patch);
+
+        assert_eq!(patches.len(), 1, "got: {patches:?}");
+        let op = &patches[0];
+        assert_eq!(op.get("op").and_then(|v| v.as_str()), Some("remove"));
+        assert_eq!(
+            op.get("path").and_then(|v| v.as_str()),
+            Some("/InstanceTenancy")
         );
-        let from = State::existing(id.clone(), from_attrs);
+        assert!(op.get("value").is_none());
+    }
 
-        let mut to = Resource::new("logs.LogGroup", "test");
-        to.set_attr("retention_in_days".to_string(), Value::Int(14));
-        to.set_attr(
-            "log_group_name".to_string(),
-            Value::String("/carina/test-group".to_string()),
-        );
-
-        let patches = build_update_patches(config, &from, &to);
-
-        // Should only have the retention_in_days patch, not Arn
-        let has_arn_patch = patches
-            .iter()
-            .any(|p| p.get("path").and_then(|v| v.as_str()) == Some("/Arn"));
+    #[test]
+    fn test_read_only_attribute_is_dropped() {
+        // Regression for issue #806: update patch must never include
+        // read-only properties (e.g. Arn). CloudControl rejects patches
+        // that touch them. The new mapper drops them silently rather
+        // than erroring out, on the theory that the diff layer
+        // shouldn't have generated the op in the first place — this is
+        // a defensive filter, not a primary check.
+        let config =
+            get_schema_config("logs.LogGroup").expect("logs.log_group schema should exist");
+        let patch = UpdatePatch {
+            ops: vec![replace(
+                "arn",
+                Value::String("arn:aws:logs:::*".to_string()),
+            )],
+        };
+        let patches = build_update_patches(config, "logs.LogGroup", &patch);
         assert!(
-            !has_arn_patch,
-            "Should not include read-only property Arn in update patches, got: {:?}",
-            patches
-        );
-
-        // Should still have the retention_in_days patch
-        let has_retention_patch = patches
-            .iter()
-            .any(|p| p.get("path").and_then(|v| v.as_str()) == Some("/RetentionInDays"));
-        assert!(
-            has_retention_patch,
-            "Should include RetentionInDays in update patches, got: {:?}",
-            patches
+            patches.is_empty(),
+            "read-only attribute must be dropped, got: {patches:?}"
         );
     }
 
     #[test]
-    fn test_build_update_patches_excludes_create_only_properties() {
-        // Regression test for issue #809: update patch includes create-only property DnsOptions
-        // When DnsOptions has nested create-only sub-properties (PrivateDnsPreference,
-        // PrivateDnsSpecifiedDomains), the whole DnsOptions should be excluded from patches.
-        let config =
-            get_schema_config("ec2.VpcEndpoint").expect("ec2.vpc_endpoint schema should exist");
-        let id = ResourceId::with_provider("awscc", "ec2.VpcEndpoint", "test");
+    fn test_remove_tags_emits_tags_remove() {
+        let config = get_vpc_config();
+        let patch = UpdatePatch {
+            ops: vec![remove("tags")],
+        };
+        let patches = build_update_patches(config, "ec2.Vpc", &patch);
 
-        let mut from_attrs = HashMap::new();
-        from_attrs.insert("vpc_id".to_string(), Value::String("vpc-123".to_string()));
-        from_attrs.insert(
-            "service_name".to_string(),
-            Value::String("com.amazonaws.ap-northeast-1.s3".to_string()),
-        );
-        from_attrs.insert(
-            "policy_document".to_string(),
-            Value::String("{\"Version\":\"2012-10-17\"}".to_string()),
-        );
-        // DnsOptions is returned by CloudControl API but has create-only sub-properties
-        let mut dns_options = IndexMap::new();
-        dns_options.insert(
-            "dns_record_ip_type".to_string(),
-            Value::String("awscc.ec2.VpcEndpoint.DnsRecordIpType.ipv4".to_string()),
-        );
-        from_attrs.insert("dns_options".to_string(), Value::Map(dns_options));
-        let from = State::existing(id.clone(), from_attrs);
+        assert_eq!(patches.len(), 1);
+        let op = &patches[0];
+        assert_eq!(op.get("op").and_then(|v| v.as_str()), Some("remove"));
+        assert_eq!(op.get("path").and_then(|v| v.as_str()), Some("/Tags"));
+    }
 
-        // User only specifies policy_document change, no dns_options
-        let mut to = Resource::new("ec2.VpcEndpoint", "test");
-        to.set_attr("vpc_id".to_string(), Value::String("vpc-123".to_string()));
-        to.set_attr(
-            "service_name".to_string(),
-            Value::String("com.amazonaws.ap-northeast-1.s3".to_string()),
-        );
-        to.set_attr(
-            "policy_document".to_string(),
-            Value::String("{\"Version\":\"2012-10-17\",\"Statement\":[]}".to_string()),
-        );
+    #[test]
+    fn test_replace_tags_projects_to_aws_shape() {
+        let config = get_vpc_config();
+        let mut tags = IndexMap::new();
+        tags.insert("Name".to_string(), Value::String("my-vpc".to_string()));
+        tags.insert("Env".to_string(), Value::String("prod".to_string()));
+        let patch = UpdatePatch {
+            ops: vec![replace("tags", Value::Map(tags))],
+        };
+        let patches = build_update_patches(config, "ec2.Vpc", &patch);
 
-        let patches = build_update_patches(config, &from, &to);
-
-        // Should not include DnsOptions in patches (it has create-only sub-properties)
-        let has_dns_options_patch = patches
-            .iter()
-            .any(|p| p.get("path").and_then(|v| v.as_str()) == Some("/DnsOptions"));
+        assert_eq!(patches.len(), 1);
+        let op = &patches[0];
+        assert_eq!(op.get("op").and_then(|v| v.as_str()), Some("add"));
+        assert_eq!(op.get("path").and_then(|v| v.as_str()), Some("/Tags"));
+        let arr = op
+            .get("value")
+            .and_then(|v| v.as_array())
+            .expect("Tags should be array");
+        assert_eq!(arr.len(), 2);
         assert!(
-            !has_dns_options_patch,
-            "Should not include create-only property DnsOptions in update patches, got: {:?}",
-            patches
+            arr.iter()
+                .any(|t| t.get("Key").and_then(|v| v.as_str()) == Some("Name")
+                    && t.get("Value").and_then(|v| v.as_str()) == Some("my-vpc"))
         );
+    }
 
-        // Should still have the policy_document patch
-        let has_policy_patch = patches
-            .iter()
-            .any(|p| p.get("path").and_then(|v| v.as_str()) == Some("/PolicyDocument"));
+    #[test]
+    fn test_unknown_attribute_is_dropped() {
+        let config = get_vpc_config();
+        let patch = UpdatePatch {
+            ops: vec![replace("not_a_real_attr", Value::String("x".to_string()))],
+        };
+        let patches = build_update_patches(config, "ec2.Vpc", &patch);
         assert!(
-            has_policy_patch,
-            "Should include PolicyDocument in update patches, got: {:?}",
-            patches
+            patches.is_empty(),
+            "unknown attributes must be dropped, got: {patches:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

Step 3b of meta tracker `carina-rs/carina#2564`. Bumps the carina
dependency pin to the post-`#2569` commit (`f6d7aa6`) and the
`carina-plugin-wit` submodule to the Level 3 commit (`1f8c4b9`),
then propagates the new shape through the provider end-to-end.

The actual fix for `carina-rs/carina#2559` lives in
`carina-provider-awscc/src/provider/update.rs`. `build_update_patches`
no longer compares `from: &State` against `to: &Resource` (which
silently emitted a `remove` op for every key in `from` that was
missing from `to`, including AWS-populated defaults like
`Policies = []`). It now maps `request.patch.ops` directly to
CloudControl JSON Patch ops:

- `PatchOpKind::Add` / `Replace` with a value -> `add /<aws_name>`
- `PatchOpKind::Remove` (or value-less Add/Replace) -> `remove /<aws_name>`

Fields the user has never specified are not in `request.patch.ops`
and therefore generate no JSON Patch op -- CloudControl leaves
them alone, which is the user-visible fix for #2559's
`awscc.iam.Role` update clearing sibling `awscc.iam.RolePolicy`
attachments.

## Trait shape

```rust
fn create(&self, id: &ResourceId, request: CreateRequest)
    -> BoxFuture<'_, ProviderResult<State>>;
fn read(&self, id: &ResourceId, identifier: &str, request: ReadRequest)
    -> BoxFuture<'_, ProviderResult<State>>;
fn update(&self, id: &ResourceId, identifier: &str, request: UpdateRequest)
    -> BoxFuture<'_, ProviderResult<State>>;
fn delete(&self, id: &ResourceId, identifier: &str, request: DeleteRequest)
    -> BoxFuture<'_, ProviderResult<()>>;
```

`UpdateRequest { from: State, patch: UpdatePatch }` is the source
of truth for an update; `to: Resource` is gone. The post-update
"carry forward attributes the read response omits" logic now
reconstructs the desired view via a small `post_update_attributes`
helper that applies `patch` on top of `from`, so we never expose
a full desired `Resource` to the update path.

## ProviderError migration (30 sites)

| Variant | Count | Where |
| ------- | ----- | ----- |
| `api_error` | 13 | CloudControl HTTP failures, S3 list/delete, IGW detach pre-delete, operation-failed/cancelled, retry-exhausted. |
| `internal` | 10 | Schema lookup misses, JSON parse failures, builder failures (`ObjectIdentifier`, `Delete`, JSON-Patch document), "No request token returned" unexpected-state shim. |
| `invalid_input` | 6 | `init_error` re-raises (account-guard violations) on every CRUD entry point + the `force_replace` "delete and recreate" rejection. |
| `timeout` | 1 | `wait_for_operation_with_attempts` exhaust. |
| `not_found` | 0 | Read paths convert "not found" responses to `State::not_found(id)` rather than raising; the variant is used by core but no awscc call site needed it in this PR. |

## Tests

- `issue_2559_tags_only_patch_does_not_touch_other_fields`:
  a single `Replace tags` op against `iam.Role` produces exactly
  one JSON Patch op (`add /Tags`) and no spurious `remove` ops.
  This is the regression test for the user-visible #2559 symptom.
- One test per `PatchOpKind` variant.
- Empty-patch test (no ops -> no JSON Patch ops, CloudControl
  no-op short-circuits in `cc_update_resource`).
- `read_only` / `create_only` / unknown-attribute filter tests.
- All 405 existing tests still pass.

## Verify

- [x] `cargo test --all-targets` -- 405 passed
- [x] `cargo test --workspace --doc` -- clean (no doctests in this
  workspace)
- [x] `cargo clippy --all-targets -- -D warnings` -- clean
- [x] `cargo fmt --check` -- clean
- [x] `cargo build -p carina-provider-awscc --target wasm32-wasip2 --release` -- builds
- [x] `bash scripts/check-docs-drift.sh` -- "OK: schemas and docs are in sync (35 resources)"

## Real-infra smoke test (deferred)

The user-visible acceptance condition for `carina-rs/carina#2559`
is "the standalone `awscc.iam.RolePolicy` survives an
`awscc.iam.Role` attribute update". Confirming this requires
running `carina apply` against
`infra/.worktrees/issue-24-registry-dev-bootstrap/registry/dev/bootstrap/`
under `aws-vault exec mizzy --` and then verifying with
`aws iam list-role-policies --role-name carina-bootstrap` that
the inline policy is still attached.

That step was deferred from this PR because the aws-vault SSO
flow would prompt for browser interaction outside the agent run.
The unit-test coverage above closes the loop on the JSON Patch
shape (a tags-only patch produces zero `remove` ops); the live
acceptance check is the next step before declaring `#2559`
closed.

## Dependencies

This PR requires `carina-rs/carina#2569` to be merged. `Cargo.toml`
pins the carina dependency at commit `f6d7aa6` (post-#2569 main),
and the `carina-plugin-wit` submodule is bumped to `1f8c4b9`
(Level 3).

## Related

- Closes carina-rs/carina-provider-awscc#186
- Refs carina-rs/carina#2559 (user-visible bug this PR fixes)
- Refs carina-rs/carina#2564 (meta tracker)
- Refs carina-rs/carina-provider-awscc#185 (prior Level-1 attempt
  that was reverted before Level 3 landed)