### PR TITLE
Adopt Option<&str> identifier in Provider::read

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=f6d7aa6297a9ac66fe3359e4e694b831c37d37b1#f6d7aa6297a9ac66fe3359e4e694b831c37d37b1"
+source = "git+https://github.com/carina-rs/carina?rev=511c68621adfc0c1e37d73e6c26c3df6b74b4a47#511c68621adfc0c1e37d73e6c26c3df6b74b4a47"
 dependencies = [
  "argon2",
  "futures",
@@ -533,7 +533,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=f6d7aa6297a9ac66fe3359e4e694b831c37d37b1#f6d7aa6297a9ac66fe3359e4e694b831c37d37b1"
+source = "git+https://github.com/carina-rs/carina?rev=511c68621adfc0c1e37d73e6c26c3df6b74b4a47#511c68621adfc0c1e37d73e6c26c3df6b74b4a47"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -578,7 +578,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=f6d7aa6297a9ac66fe3359e4e694b831c37d37b1#f6d7aa6297a9ac66fe3359e4e694b831c37d37b1"
+source = "git+https://github.com/carina-rs/carina?rev=511c68621adfc0c1e37d73e6c26c3df6b74b4a47#511c68621adfc0c1e37d73e6c26c3df6b74b4a47"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "f6d7aa6297a9ac66fe3359e4e694b831c37d37b1" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "511c68621adfc0c1e37d73e6c26c3df6b74b4a47" }

--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -23,10 +23,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "f6d7aa6297a9ac66fe3359e4e694b831c37d37b1" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "511c68621adfc0c1e37d73e6c26c3df6b74b4a47" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "f6d7aa6297a9ac66fe3359e4e694b831c37d37b1" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "f6d7aa6297a9ac66fe3359e4e694b831c37d37b1" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "511c68621adfc0c1e37d73e6c26c3df6b74b4a47" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "511c68621adfc0c1e37d73e6c26c3df6b74b4a47" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-smithy-async = { version = "1", features = ["rt-tokio"] }

--- a/carina-provider-awscc/src/lib.rs
+++ b/carina-provider-awscc/src/lib.rs
@@ -221,7 +221,7 @@ impl Provider for AwsccProvider {
     fn read(
         &self,
         id: &ResourceId,
-        identifier: &str,
+        identifier: Option<&str>,
         _request: ReadRequest,
     ) -> BoxFuture<'_, ProviderResult<State>> {
         if let Some(err) = self.init_error() {
@@ -234,9 +234,9 @@ impl Provider for AwsccProvider {
             });
         }
         let id = id.clone();
-        let identifier = identifier.to_string();
+        let identifier = identifier.map(|s| s.to_string());
         Box::pin(async move {
-            self.read_resource(&id.resource_type, id.name_str(), Some(&identifier))
+            self.read_resource(&id.resource_type, id.name_str(), identifier.as_deref())
                 .await
         })
     }

--- a/carina-provider-awscc/src/main.rs
+++ b/carina-provider-awscc/src/main.rs
@@ -174,7 +174,7 @@ impl CarinaProvider for AwsccProcessProvider {
     fn read(
         &self,
         id: &proto::ResourceId,
-        identifier: &str,
+        identifier: Option<&str>,
         _request: proto::ReadRequest,
     ) -> Result<proto::State, proto::ProviderError> {
         let core_id = convert::proto_to_core_resource_id(id);


### PR DESCRIPTION
Closes #189.
Refs carina-rs/carina#2596.

Adopts the WIT + core trait migration that turned `Provider::read`'s `identifier` from `&str` to `Option<&str>`. The awscc side already had an internal `read_resource(_, _, Option<&str>)` whose `None` arm returns `State::not_found`; that arm finally gets exercised end-to-end now that the trait boundary stops re-wrapping `&""` into `Some(&"")`.

## Changes

- Bump `carina-core` / `carina-plugin-sdk` / `carina-provider-protocol` git pins to the post-migration commit, and the local `carina-aws-types` pin in lockstep.
- Bump the `carina-plugin-wit` submodule to the merged `option<string>` contract.
- `impl Provider for AwsccProvider` (`lib.rs::read`) takes `Option<&str>` and threads it through to `read_resource`. The previous `Some(&identifier.to_string())` re-wrap is removed.
- WIT host glue (`main.rs::read`) accepts `Option<&str>` and forwards it unchanged.

## Test plan

- [x] `cargo nextest run --workspace`: 411 passed.
- [x] `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- [x] `cargo build -p carina-provider-awscc --target wasm32-wasip2 --release`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)