### PR TITLE
Add IamOidcProviderArn semantic ARN type

### DIFF
--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -1129,6 +1129,27 @@ pub fn iam_policy_arn() -> AttributeType {
     }
 }
 
+/// IAM OIDC Provider ARN type (e.g., `arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com`)
+#[allow(dead_code)]
+pub fn iam_oidc_provider_arn() -> AttributeType {
+    AttributeType::Custom {
+        semantic_name: Some("IamOidcProviderArn".to_string()),
+        pattern: None,
+        length: None,
+        base: Box::new(arn()),
+        validate: legacy_validator(|value| {
+            if let Value::String(s) = value {
+                validate_iam_arn(s, "oidc-provider/")
+                    .map_err(|reason| format!("Invalid IAM OIDC Provider ARN '{}': {}", s, reason))
+            } else {
+                Err("Expected string".to_string())
+            }
+        }),
+        namespace: None,
+        to_dsl: None,
+    }
+}
+
 /// KMS Key ARN type (e.g., "arn:aws:kms:us-east-1:123456789012:key/...")
 #[allow(dead_code)]
 pub fn kms_key_arn() -> AttributeType {
@@ -2155,6 +2176,77 @@ mod tests {
             err.contains("IAM Role ARN"),
             "Error should say 'IAM Role ARN': {err}"
         );
+    }
+
+    // --- IAM OIDC Provider ARN tests ---
+
+    #[test]
+    fn iam_oidc_provider_arn_semantic_name() {
+        let AttributeType::Custom { semantic_name, .. } = iam_oidc_provider_arn() else {
+            panic!("iam_oidc_provider_arn() should be a Custom type");
+        };
+        assert_eq!(semantic_name.as_deref(), Some("IamOidcProviderArn"));
+    }
+
+    #[test]
+    fn iam_oidc_provider_arn_accepts_valid() {
+        let AttributeType::Custom { validate, .. } = iam_oidc_provider_arn() else {
+            panic!("iam_oidc_provider_arn() should be a Custom type");
+        };
+        let v = Value::String(
+            "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"
+                .to_string(),
+        );
+        assert!(validate(&v).is_ok());
+    }
+
+    #[test]
+    fn iam_oidc_provider_arn_rejects_wrong_resource() {
+        let AttributeType::Custom { validate, .. } = iam_oidc_provider_arn() else {
+            panic!("iam_oidc_provider_arn() should be a Custom type");
+        };
+        let v = Value::String("arn:aws:iam::123456789012:role/MyRole".to_string());
+        assert!(validate(&v).is_err());
+    }
+
+    #[test]
+    fn iam_oidc_provider_arn_rejects_non_iam_service() {
+        let AttributeType::Custom { validate, .. } = iam_oidc_provider_arn() else {
+            panic!("iam_oidc_provider_arn() should be a Custom type");
+        };
+        let v = Value::String("arn:aws:s3:::my-bucket".to_string());
+        assert!(validate(&v).is_err());
+    }
+
+    #[test]
+    fn iam_oidc_provider_arn_rejects_empty_provider_name() {
+        let AttributeType::Custom { validate, .. } = iam_oidc_provider_arn() else {
+            panic!("iam_oidc_provider_arn() should be a Custom type");
+        };
+        let v = Value::String("arn:aws:iam::123456789012:oidc-provider/".to_string());
+        assert!(validate(&v).is_err());
+    }
+
+    #[test]
+    fn iam_oidc_provider_arn_accepts_eks_multi_segment() {
+        let AttributeType::Custom { validate, .. } = iam_oidc_provider_arn() else {
+            panic!("iam_oidc_provider_arn() should be a Custom type");
+        };
+        let v = Value::String(
+            "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-east-1.amazonaws.com/id/AAAAAAAA000000"
+                .to_string(),
+        );
+        assert!(validate(&v).is_ok());
+    }
+
+    #[test]
+    fn iam_oidc_provider_arn_accepts_china_partition() {
+        let AttributeType::Custom { validate, .. } = iam_oidc_provider_arn() else {
+            panic!("iam_oidc_provider_arn() should be a Custom type");
+        };
+        let v =
+            Value::String("arn:aws-cn:iam::123456789012:oidc-provider/foo.example.com".to_string());
+        assert!(validate(&v).is_ok());
     }
 
     // UUID tests

--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -510,6 +510,7 @@ fn override_type_to_display_name(override_type: &str) -> &str {
         "super::aws_resource_id()" => "AwsResourceId",
         "super::iam_role_arn()" => "IamRoleArn",
         "super::iam_policy_arn()" => "IamPolicyArn",
+        "super::iam_oidc_provider_arn()" => "IamOidcProviderArn",
         "super::kms_key_arn()" => "KmsKeyArn",
         "super::kms_key_id()" => "KmsKeyId",
         "super::gateway_id()" => "GatewayId",
@@ -3052,6 +3053,11 @@ fn resource_type_overrides() -> &'static HashMap<(&'static str, &'static str), T
             m.insert(
                 ("AWS::IAM::Role", "Arn"),
                 TypeOverride::StringType("super::iam_role_arn()"),
+            );
+            // IAM OIDCProvider's Arn is always an IAM OIDC Provider ARN
+            m.insert(
+                ("AWS::IAM::OIDCProvider", "Arn"),
+                TypeOverride::StringType("super::iam_oidc_provider_arn()"),
             );
             // IAM Role's RoleId uses AROA prefix pattern
             m.insert(
@@ -6685,6 +6691,19 @@ mod tests {
         assert_eq!(
             infer_string_type("GatewayId", "AWS::EC2::VPNGatewayRoutePropagation"),
             Some("super::aws_resource_id()".to_string())
+        );
+    }
+
+    #[test]
+    fn test_iam_oidc_provider_arn_override() {
+        // IAM OIDCProvider's Arn should use iam_oidc_provider_arn(), not generic arn
+        assert_eq!(
+            infer_string_type("Arn", "AWS::IAM::OIDCProvider"),
+            Some("super::iam_oidc_provider_arn()".to_string())
+        );
+        assert_eq!(
+            infer_string_type_display("Arn", "AWS::IAM::OIDCProvider"),
+            "IamOidcProviderArn"
         );
     }
 

--- a/carina-provider-awscc/src/schemas/awscc_types.rs
+++ b/carina-provider-awscc/src/schemas/awscc_types.rs
@@ -94,6 +94,7 @@ pub fn awscc_validators() -> HashMap<String, ValidatorFn> {
         service_arn {
             iam_role_arn => |s: &str| validate_iam_arn(s, "role/"),
             iam_policy_arn => |s: &str| validate_iam_arn(s, "policy/"),
+            iam_oidc_provider_arn => |s: &str| validate_iam_arn(s, "oidc-provider/"),
             kms_key_arn => |s: &str| validate_kms_key_id(s),
         }
     }
@@ -322,7 +323,12 @@ mod tests {
         ];
 
         // Service ARNs
-        let expected_arn = ["iam_role_arn", "iam_policy_arn", "kms_key_arn"];
+        let expected_arn = [
+            "iam_role_arn",
+            "iam_policy_arn",
+            "iam_oidc_provider_arn",
+            "kms_key_arn",
+        ];
 
         let mut all_expected: Vec<&str> = Vec::new();
         all_expected.extend_from_slice(&expected_single);
@@ -367,6 +373,16 @@ mod tests {
         // Test a service ARN validator
         let iam_role_arn_validator = validators.get("iam_role_arn").unwrap();
         assert!(iam_role_arn_validator("arn:aws:iam::123456789012:role/my-role").is_ok());
+
+        // Test the OIDC provider ARN validator
+        let oidc_validator = validators.get("iam_oidc_provider_arn").unwrap();
+        assert!(
+            oidc_validator(
+                "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"
+            )
+            .is_ok()
+        );
+        assert!(oidc_validator("arn:aws:iam::123456789012:role/my-role").is_err());
     }
 
     #[test]

--- a/carina-provider-awscc/src/schemas/generated/iam/oidc_provider.rs
+++ b/carina-provider-awscc/src/schemas/generated/iam/oidc_provider.rs
@@ -69,7 +69,7 @@ pub fn iam_oidc_provider_config() -> AwsccSchemaConfig {
         schema: ResourceSchema::new("iam.OidcProvider")
             .with_description("Resource Type definition for AWS::IAM::OIDCProvider")
             .attribute(
-                AttributeSchema::new("arn", super::arn())
+                AttributeSchema::new("arn", super::iam_oidc_provider_arn())
                     .read_only()
                     .with_description("Amazon Resource Name (ARN) of the OIDC provider (read-only)")
                     .with_provider_name("Arn"),

--- a/generated-docs/awscc/iam/oidc_provider.md
+++ b/generated-docs/awscc/iam/oidc_provider.md
@@ -35,7 +35,7 @@ Resource Type definition for AWS::IAM::OIDCProvider
 
 ### `arn`
 
-- **Type:** Arn
+- **Type:** IamOidcProviderArn
 
 Amazon Resource Name (ARN) of the OIDC provider
 


### PR DESCRIPTION
## Summary

- Add a new semantic ARN type `IamOidcProviderArn` alongside the existing `IamRoleArn` / `IamPolicyArn` / `KmsKeyArn`, so authors can annotate `arguments` (or any value position) with `IamOidcProviderArn` instead of falling back to the generic `Arn`.
- Wire `awscc.iam.OidcProvider`'s `arn` attribute to the new type via codegen's `resource_type_overrides`, so consumers get the precise type for free.
- Validator reuses the existing `validate_iam_arn(s, "oidc-provider/")` helper, mirroring the role / policy implementations.

Closes carina-rs/carina#2612.

## Coverage

The validator accepts every real-world OIDC provider ARN shape:

- GitHub Actions: `arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com`
- EKS (multi-segment): `arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-east-1.amazonaws.com/id/AAAA...`
- All partitions: `aws`, `aws-cn`, `aws-us-gov`

And rejects: wrong service, wrong resource prefix (`role/`, `policy/`), empty provider name, malformed account.

## Test plan

- [x] `cargo nextest run` (419 tests, all pass)
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `bash scripts/check-docs-drift.sh` (`OK: schemas and docs are in sync`)
- [x] `cargo build -p carina-provider-awscc --target wasm32-wasip2 --release`
- [x] 7 new unit tests covering: semantic name, GitHub Actions form, EKS multi-segment form, `aws-cn` partition, wrong resource, wrong service, empty provider name
- [x] Updated `awscc_validators_all_registered` and `awscc_validators_produce_correct_results` to cover the new validator
- [x] Added `test_iam_oidc_provider_arn_override` covering both `infer_string_type` and `infer_string_type_display`

🤖 Generated with [Claude Code](https://claude.com/claude-code)