### PR TITLE
Pick up merge-default-tags WIT export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=511c68621adfc0c1e37d73e6c26c3df6b74b4a47#511c68621adfc0c1e37d73e6c26c3df6b74b4a47"
+source = "git+https://github.com/carina-rs/carina?rev=d7d503860b899c2e4727a0b5270b05f75b5d3ac9#d7d503860b899c2e4727a0b5270b05f75b5d3ac9"
 dependencies = [
  "argon2",
  "futures",
@@ -533,7 +533,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=511c68621adfc0c1e37d73e6c26c3df6b74b4a47#511c68621adfc0c1e37d73e6c26c3df6b74b4a47"
+source = "git+https://github.com/carina-rs/carina?rev=d7d503860b899c2e4727a0b5270b05f75b5d3ac9#d7d503860b899c2e4727a0b5270b05f75b5d3ac9"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -578,7 +578,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=511c68621adfc0c1e37d73e6c26c3df6b74b4a47#511c68621adfc0c1e37d73e6c26c3df6b74b4a47"
+source = "git+https://github.com/carina-rs/carina?rev=d7d503860b899c2e4727a0b5270b05f75b5d3ac9#d7d503860b899c2e4727a0b5270b05f75b5d3ac9"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "511c68621adfc0c1e37d73e6c26c3df6b74b4a47" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "d7d503860b899c2e4727a0b5270b05f75b5d3ac9" }

--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -23,10 +23,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "511c68621adfc0c1e37d73e6c26c3df6b74b4a47" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "d7d503860b899c2e4727a0b5270b05f75b5d3ac9" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "511c68621adfc0c1e37d73e6c26c3df6b74b4a47" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "511c68621adfc0c1e37d73e6c26c3df6b74b4a47" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "d7d503860b899c2e4727a0b5270b05f75b5d3ac9" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "d7d503860b899c2e4727a0b5270b05f75b5d3ac9" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-smithy-async = { version = "1", features = ["rt-tokio"] }


### PR DESCRIPTION
## Summary

Stage 3/4 of the chain that closes this issue and the sibling carina-rs/carina-provider-aws#242. Bumps the WIT submodule to `2c34419d` and the carina git-dep `rev=` to `d7d50386` so awscc picks up:

- The `merge-default-tags` WIT export (carina-rs/carina-plugin-wit#11)
- The host-side `WasmProviderNormalizer::merge_default_tags` dispatcher (carina-rs/carina#2622)

The provider's own `merge_default_tags` impl on `AwsccProcessProvider` was already in place (delegating to `merge_default_tags_for_provider` via `AwsccNormalizer`). The bug was never on this side — it was the missing WIT contract / host plumbing. With the rev bump, `carina-plugin-sdk`'s `export_provider!` macro automatically wires the new WIT export to `AwsccProcessProvider::merge_default_tags`, and host-loaded plans of awscc resources finally apply provider-level `default_tags`.

Closes #192.

## Test plan

- [x] `cargo nextest run` (419 tests, all pass)
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt --check`
- [x] `bash scripts/check-docs-drift.sh` (35 resources in sync)
- [x] `cargo build -p carina-provider-awscc --target wasm32-wasip2 --release`
- [ ] End-to-end smoke against the repro from the issue body (real-infra; verifies tags actually appear in plan output) — to do after merge once carina main has all 4 stages.

## Chain status

- Stage 1/4 ✅ carina-rs/carina-plugin-wit#11
- Stage 2/4 ✅ carina-rs/carina#2622
- Stage 3/4 ⬅️ this PR
- Stage 4/4 ⏸ carina-rs/carina-provider-aws — sibling change for the aws provider, lands in parallel with this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
