### PR TITLE
provider: track WIT rename lifecycle-config to directives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=d7d503860b899c2e4727a0b5270b05f75b5d3ac9#d7d503860b899c2e4727a0b5270b05f75b5d3ac9"
+source = "git+https://github.com/carina-rs/carina?rev=3ea08a67a4fb5a347f4939ca90bfa9b82b2e21c6#3ea08a67a4fb5a347f4939ca90bfa9b82b2e21c6"
 dependencies = [
  "argon2",
  "futures",
@@ -533,7 +533,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=d7d503860b899c2e4727a0b5270b05f75b5d3ac9#d7d503860b899c2e4727a0b5270b05f75b5d3ac9"
+source = "git+https://github.com/carina-rs/carina?rev=3ea08a67a4fb5a347f4939ca90bfa9b82b2e21c6#3ea08a67a4fb5a347f4939ca90bfa9b82b2e21c6"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -578,7 +578,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=d7d503860b899c2e4727a0b5270b05f75b5d3ac9#d7d503860b899c2e4727a0b5270b05f75b5d3ac9"
+source = "git+https://github.com/carina-rs/carina?rev=3ea08a67a4fb5a347f4939ca90bfa9b82b2e21c6#3ea08a67a4fb5a347f4939ca90bfa9b82b2e21c6"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "d7d503860b899c2e4727a0b5270b05f75b5d3ac9" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "3ea08a67a4fb5a347f4939ca90bfa9b82b2e21c6" }

--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -23,10 +23,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "d7d503860b899c2e4727a0b5270b05f75b5d3ac9" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "3ea08a67a4fb5a347f4939ca90bfa9b82b2e21c6" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "d7d503860b899c2e4727a0b5270b05f75b5d3ac9" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "d7d503860b899c2e4727a0b5270b05f75b5d3ac9" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "3ea08a67a4fb5a347f4939ca90bfa9b82b2e21c6" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "3ea08a67a4fb5a347f4939ca90bfa9b82b2e21c6" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-smithy-async = { version = "1", features = ["rt-tokio"] }

--- a/carina-provider-awscc/src/convert.rs
+++ b/carina-provider-awscc/src/convert.rs
@@ -11,7 +11,7 @@ use carina_core::provider::{
     UpdatePatch as CoreUpdatePatch,
 };
 use carina_core::resource::{
-    LifecycleConfig as CoreLifecycle, Resource as CoreResource, ResourceId as CoreResourceId,
+    Directives as CoreDirectives, Resource as CoreResource, ResourceId as CoreResourceId,
     State as CoreState, Value as CoreValue,
 };
 use carina_core::schema::{
@@ -20,7 +20,7 @@ use carina_core::schema::{
 };
 use carina_provider_protocol::types::{
     AttributeSchema as ProtoAttributeSchema, AttributeType as ProtoAttributeType,
-    LifecycleConfig as ProtoLifecycle, PatchOp as ProtoPatchOp, PatchOpKind as ProtoPatchOpKind,
+    Directives as ProtoDirectives, PatchOp as ProtoPatchOp, PatchOpKind as ProtoPatchOpKind,
     ProviderError as ProtoProviderError, ProviderErrorKind as ProtoProviderErrorKind,
     Resource as ProtoResource, ResourceId as ProtoResourceId,
     ResourceSchema as ProtoResourceSchema, State as ProtoState, StructField as ProtoStructField,
@@ -118,14 +118,14 @@ pub fn core_to_proto_resource(r: &CoreResource) -> ProtoResource {
     ProtoResource {
         id: core_to_proto_resource_id(&r.id),
         attributes: core_to_proto_value_map(&r.resolved_attributes()),
-        lifecycle: core_to_proto_lifecycle(&r.lifecycle),
+        directives: core_to_proto_directives(&r.directives),
     }
 }
 
-// -- LifecycleConfig --
+// -- Directives --
 
-pub fn core_to_proto_lifecycle(l: &CoreLifecycle) -> ProtoLifecycle {
-    ProtoLifecycle {
+pub fn core_to_proto_directives(l: &CoreDirectives) -> ProtoDirectives {
+    ProtoDirectives {
         force_delete: l.force_delete,
         create_before_destroy: l.create_before_destroy,
         prevent_destroy: l.prevent_destroy,
@@ -141,10 +141,10 @@ pub fn proto_to_core_resource(r: &ProtoResource) -> CoreResource {
         .iter()
         .map(|(k, v)| (k.clone(), proto_to_core_value(v)))
         .collect();
-    resource.lifecycle = CoreLifecycle {
-        force_delete: r.lifecycle.force_delete,
-        create_before_destroy: r.lifecycle.create_before_destroy,
-        prevent_destroy: r.lifecycle.prevent_destroy,
+    resource.directives = CoreDirectives {
+        force_delete: r.directives.force_delete,
+        create_before_destroy: r.directives.create_before_destroy,
+        prevent_destroy: r.directives.prevent_destroy,
     };
     resource
 }

--- a/carina-provider-awscc/src/lib.rs
+++ b/carina-provider-awscc/src/lib.rs
@@ -317,7 +317,7 @@ impl Provider for AwsccProvider {
         let id = id.clone();
         let identifier = identifier.to_string();
         Box::pin(async move {
-            self.delete_resource(&id, &identifier, &request.lifecycle)
+            self.delete_resource(&id, &identifier, &request.directives)
                 .await
         })
     }

--- a/carina-provider-awscc/src/main.rs
+++ b/carina-provider-awscc/src/main.rs
@@ -250,16 +250,16 @@ impl CarinaProvider for AwsccProcessProvider {
         request: proto::DeleteRequest,
     ) -> Result<(), proto::ProviderError> {
         let core_id = convert::proto_to_core_resource_id(id);
-        let core_lifecycle = carina_core::resource::LifecycleConfig {
-            force_delete: request.lifecycle.force_delete,
-            create_before_destroy: request.lifecycle.create_before_destroy,
-            prevent_destroy: request.lifecycle.prevent_destroy,
+        let core_directives = carina_core::resource::Directives {
+            force_delete: request.directives.force_delete,
+            create_before_destroy: request.directives.create_before_destroy,
+            prevent_destroy: request.directives.prevent_destroy,
         };
         let result = self.runtime.block_on(self.provider().delete(
             &core_id,
             identifier,
             CoreDeleteRequest {
-                lifecycle: core_lifecycle,
+                directives: core_directives,
             },
         ));
         match result {

--- a/carina-provider-awscc/src/provider/operations.rs
+++ b/carina-provider-awscc/src/provider/operations.rs
@@ -7,7 +7,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult, UpdatePatch};
-use carina_core::resource::{LifecycleConfig, Resource, ResourceId, State, Value};
+use carina_core::resource::{Directives, Resource, ResourceId, State, Value};
 use carina_core::schema::{AttributeSchema, AttributeType};
 use indexmap::IndexMap;
 use serde_json::json;
@@ -209,7 +209,7 @@ impl AwsccProvider {
         &self,
         id: &ResourceId,
         identifier: &str,
-        lifecycle: &LifecycleConfig,
+        directives: &Directives,
     ) -> ProviderResult<()> {
         let config = get_schema_config(&id.resource_type).ok_or_else(|| {
             ProviderError::internal(format!("Unknown resource type: {}", id.resource_type))
@@ -220,7 +220,7 @@ impl AwsccProvider {
         self.pre_delete_operations(id, config, identifier).await?;
 
         // Handle force_delete for S3 buckets: empty the bucket before deletion
-        if lifecycle.force_delete && id.resource_type == "s3.Bucket" {
+        if directives.force_delete && id.resource_type == "s3.Bucket" {
             self.empty_s3_bucket(identifier).await.map_err(|e| {
                 ProviderError::api_error("Failed to empty S3 bucket before deletion")
                     .with_cause(e)


### PR DESCRIPTION
## Summary

Track the WIT contract rename `lifecycle-config` → `directives` from carina-rs/carina-plugin-wit#13. This PR bumps the `carina-plugin-wit` submodule and the `carina-*` crate `rev` to point at the merged carina-rs/carina#2827, then renames the local Rust type aliases and the `Provider::delete` bridge.

## Scope

- Submodule `carina-plugin-wit` bumped to `eb29474` (wit#13).
- `carina-core` crate `rev` bumped to `3ea08a6` (carina#2827).
- Type alias rename: `LifecycleConfig as CoreLifecycle` / `as ProtoLifecycle` → `Directives as CoreDirectives` / `as ProtoDirectives`.
- Helper rename: `core_to_proto_lifecycle` → `core_to_proto_directives`.
- `Provider::delete` bridge: `request.lifecycle` → `request.directives`, `DeleteRequest { lifecycle: ... }` → `DeleteRequest { directives: ... }`.
- `delete_resource` parameter and `force_delete` field access renamed accordingly.
- The Cloud Control resource attribute name `LifecycleConfiguration` (e.g. `s3.BucketLifecycleConfiguration`) is unrelated to the Carina meta-block and is deliberately preserved.

## BREAKING CHANGE

This provider build is incompatible with carina hosts on the old WIT contract. Coordinated with carina#2827 (already merged).

## Test plan

- [x] `cargo nextest run --workspace` — 423 tests pass
- [x] `cargo test --workspace --doc` — doctests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] CI on PR

Refs carina-rs/carina#2826
Closes #202
