### PR TITLE
Sync to carina-core RFC #2972 Phase 5a: Value Concrete/Deferred split

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=1d5f1a24233aff498fb523f3316148031be56348#1d5f1a24233aff498fb523f3316148031be56348"
+source = "git+https://github.com/carina-rs/carina?rev=e73e8bee#e73e8bee97531037bdbe2bd3b1cfab42d1a9794c"
 dependencies = [
  "argon2",
  "futures",
@@ -527,13 +527,14 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "tokio",
  "uuid",
 ]
 
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=1d5f1a24233aff498fb523f3316148031be56348#1d5f1a24233aff498fb523f3316148031be56348"
+source = "git+https://github.com/carina-rs/carina?rev=e73e8bee#e73e8bee97531037bdbe2bd3b1cfab42d1a9794c"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -578,7 +579,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=1d5f1a24233aff498fb523f3316148031be56348#1d5f1a24233aff498fb523f3316148031be56348"
+source = "git+https://github.com/carina-rs/carina?rev=e73e8bee#e73e8bee97531037bdbe2bd3b1cfab42d1a9794c"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "1d5f1a24233aff498fb523f3316148031be56348" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "e73e8bee" }

--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -4,7 +4,7 @@
 //! and `carina-provider-awscc`. Provider-specific types (region with namespace,
 //! schema config structs) remain in their respective crates.
 
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, Value};
 use carina_core::schema::{AttributeType, CompletionValue, StructField, legacy_validator};
 
 // ========== Enum helpers ==========
@@ -160,7 +160,7 @@ pub fn tags_type() -> AttributeType {
 pub fn validate_tags_map(
     attributes: &std::collections::HashMap<String, Value>,
 ) -> Result<(), Vec<carina_core::schema::TypeError>> {
-    if let Some(Value::Map(map)) = attributes.get("tags") {
+    if let Some(Value::Concrete(ConcreteValue::Map(map))) = attributes.get("tags") {
         let has_key = map.keys().any(|k| k.eq_ignore_ascii_case("key"));
         let has_value = map.keys().any(|k| k.eq_ignore_ascii_case("value"));
         if has_key && has_value {
@@ -227,7 +227,7 @@ pub fn aws_resource_id() -> AttributeType {
         length: None,
         base: Box::new(AttributeType::String),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_aws_resource_id(s)
                     .map_err(|reason| format!("Invalid resource ID '{}': {}", s, reason))
             } else {
@@ -247,7 +247,7 @@ pub fn vpc_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "vpc")
                     .map_err(|reason| format!("Invalid VPC ID '{}': {}", s, reason))
             } else {
@@ -267,7 +267,7 @@ pub fn subnet_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "subnet")
                     .map_err(|reason| format!("Invalid Subnet ID '{}': {}", s, reason))
             } else {
@@ -287,7 +287,7 @@ pub fn security_group_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "sg")
                     .map_err(|reason| format!("Invalid Security Group ID '{}': {}", s, reason))
             } else {
@@ -307,7 +307,7 @@ pub fn internet_gateway_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "igw")
                     .map_err(|reason| format!("Invalid Internet Gateway ID '{}': {}", s, reason))
             } else {
@@ -327,7 +327,7 @@ pub fn route_table_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "rtb")
                     .map_err(|reason| format!("Invalid Route Table ID '{}': {}", s, reason))
             } else {
@@ -347,7 +347,7 @@ pub fn nat_gateway_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "nat")
                     .map_err(|reason| format!("Invalid NAT Gateway ID '{}': {}", s, reason))
             } else {
@@ -367,7 +367,7 @@ pub fn vpc_peering_connection_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "pcx").map_err(|reason| {
                     format!("Invalid VPC Peering Connection ID '{}': {}", s, reason)
                 })
@@ -388,7 +388,7 @@ pub fn transit_gateway_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "tgw")
                     .map_err(|reason| format!("Invalid Transit Gateway ID '{}': {}", s, reason))
             } else {
@@ -408,7 +408,7 @@ pub fn vpc_cidr_block_association_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "vpc-cidr-assoc").map_err(|reason| {
                     format!("Invalid VPC CIDR Block Association ID '{}': {}", s, reason)
                 })
@@ -429,7 +429,7 @@ pub fn tgw_route_table_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "tgw-rtb")
                     .map_err(|reason| format!("Invalid TGW Route Table ID '{}': {}", s, reason))
             } else {
@@ -449,7 +449,7 @@ pub fn vpn_gateway_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "vgw")
                     .map_err(|reason| format!("Invalid VPN Gateway ID '{}': {}", s, reason))
             } else {
@@ -474,7 +474,7 @@ pub fn egress_only_internet_gateway_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "eigw").map_err(|reason| {
                     format!(
                         "Invalid Egress Only Internet Gateway ID '{}': {}",
@@ -498,7 +498,7 @@ pub fn vpc_endpoint_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "vpce")
                     .map_err(|reason| format!("Invalid VPC Endpoint ID '{}': {}", s, reason))
             } else {
@@ -518,7 +518,7 @@ pub fn instance_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "i")
                     .map_err(|reason| format!("Invalid Instance ID '{}': {}", s, reason))
             } else {
@@ -538,7 +538,7 @@ pub fn network_interface_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "eni")
                     .map_err(|reason| format!("Invalid Network Interface ID '{}': {}", s, reason))
             } else {
@@ -559,7 +559,7 @@ pub fn allocation_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "eipalloc")
                     .map_err(|reason| format!("Invalid Allocation ID '{}': {}", s, reason))
             } else {
@@ -579,7 +579,7 @@ pub fn prefix_list_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "pl")
                     .map_err(|reason| format!("Invalid Prefix List ID '{}': {}", s, reason))
             } else {
@@ -599,7 +599,7 @@ pub fn carrier_gateway_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "cagw")
                     .map_err(|reason| format!("Invalid Carrier Gateway ID '{}': {}", s, reason))
             } else {
@@ -619,7 +619,7 @@ pub fn local_gateway_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "lgw")
                     .map_err(|reason| format!("Invalid Local Gateway ID '{}': {}", s, reason))
             } else {
@@ -640,7 +640,7 @@ pub fn network_acl_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "acl")
                     .map_err(|reason| format!("Invalid Network ACL ID '{}': {}", s, reason))
             } else {
@@ -660,7 +660,7 @@ pub fn transit_gateway_attachment_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "tgw-attach").map_err(|reason| {
                     format!("Invalid Transit Gateway Attachment ID '{}': {}", s, reason)
                 })
@@ -681,7 +681,7 @@ pub fn flow_log_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "fl")
                     .map_err(|reason| format!("Invalid Flow Log ID '{}': {}", s, reason))
             } else {
@@ -701,7 +701,7 @@ pub fn ipam_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "ipam")
                     .map_err(|reason| format!("Invalid IPAM ID '{}': {}", s, reason))
             } else {
@@ -721,7 +721,7 @@ pub fn subnet_route_table_association_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "rtbassoc").map_err(|reason| {
                     format!(
                         "Invalid Subnet Route Table Association ID '{}': {}",
@@ -745,7 +745,7 @@ pub fn security_group_rule_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_prefixed_resource_id(s, "sgr")
                     .map_err(|reason| format!("Invalid Security Group Rule ID '{}': {}", s, reason))
             } else {
@@ -779,7 +779,7 @@ pub fn iam_role_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_iam_role_id(s)
                     .map_err(|reason| format!("Invalid IAM Role ID '{}': {}", s, reason))
             } else {
@@ -815,7 +815,7 @@ pub fn aws_account_id() -> AttributeType {
         length: None,
         base: Box::new(AttributeType::String),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_aws_account_id(s)
                     .map_err(|reason| format!("Invalid AWS Account ID '{}': {}", s, reason))
             } else {
@@ -850,7 +850,7 @@ pub fn sso_principal_id() -> AttributeType {
         length: None,
         base: Box::new(AttributeType::String),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_sso_principal_id(s)
                     .map_err(|reason| format!("Invalid SSO principal ID '{}': {}", s, reason))
             } else {
@@ -886,7 +886,7 @@ pub fn sso_instance_arn() -> AttributeType {
         length: None,
         base: Box::new(arn()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_sso_instance_arn(s)
                     .map_err(|reason| format!("Invalid SSO instance ARN '{}': {}", s, reason))
             } else {
@@ -923,7 +923,7 @@ pub fn identity_store_id() -> AttributeType {
         length: None,
         base: Box::new(AttributeType::String),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_identity_store_id(s)
                     .map_err(|reason| format!("Invalid IdentityStore id '{}': {}", s, reason))
             } else {
@@ -956,7 +956,7 @@ pub fn sso_permission_set_arn() -> AttributeType {
         length: None,
         base: Box::new(arn()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_sso_permission_set_arn(s)
                     .map_err(|reason| format!("Invalid SSO permission set ARN '{}': {}", s, reason))
             } else {
@@ -1095,7 +1095,7 @@ pub fn arn() -> AttributeType {
         length: None,
         base: Box::new(AttributeType::String),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_arn(s).map_err(|reason| format!("Invalid ARN '{}': {}", s, reason))
             } else {
                 Err("Expected string".to_string())
@@ -1115,7 +1115,7 @@ pub fn iam_role_arn() -> AttributeType {
         length: None,
         base: Box::new(arn()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_iam_arn(s, "role/")
                     .map_err(|reason| format!("Invalid IAM Role ARN '{}': {}", s, reason))
             } else {
@@ -1136,7 +1136,7 @@ pub fn iam_policy_arn() -> AttributeType {
         length: None,
         base: Box::new(arn()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_iam_arn(s, "policy/")
                     .map_err(|reason| format!("Invalid IAM Policy ARN '{}': {}", s, reason))
             } else {
@@ -1157,7 +1157,7 @@ pub fn iam_oidc_provider_arn() -> AttributeType {
         length: None,
         base: Box::new(arn()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_iam_arn(s, "oidc-provider/")
                     .map_err(|reason| format!("Invalid IAM OIDC Provider ARN '{}': {}", s, reason))
             } else {
@@ -1178,7 +1178,7 @@ pub fn kms_key_arn() -> AttributeType {
         length: None,
         base: Box::new(arn()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_service_arn(s, "kms", Some("key/"))
                     .map_err(|reason| format!("Invalid KMS Key ARN '{}': {}", s, reason))
             } else {
@@ -1248,7 +1248,7 @@ pub fn kms_key_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_kms_key_id(s)
                     .map_err(|reason| format!("Invalid KMS key identifier '{}': {}", s, reason))
             } else {
@@ -1284,7 +1284,7 @@ pub fn ipam_pool_id() -> AttributeType {
         length: None,
         base: Box::new(aws_resource_id()),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_ipam_pool_id(s)
                     .map_err(|reason| format!("Invalid IPAM Pool ID '{}': {}", s, reason))
             } else {
@@ -1393,7 +1393,7 @@ pub fn availability_zone_id() -> AttributeType {
         length: None,
         base: Box::new(AttributeType::String),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_availability_zone_id(s)
                     .map_err(|reason| format!("Invalid availability zone ID '{}': {}", s, reason))
             } else {
@@ -1446,7 +1446,7 @@ fn iam_policy_effect() -> AttributeType {
         length: None,
         base: Box::new(AttributeType::String),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 match s.as_str() {
                     "Allow" | "Deny" => Ok(()),
                     _ => Err(format!(
@@ -1472,7 +1472,7 @@ fn iam_policy_version() -> AttributeType {
         length: None,
         base: Box::new(AttributeType::String),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 match s.as_str() {
                     "2012-10-17" | "2008-10-17" => Ok(()),
                     _ => Err(format!(
@@ -1679,18 +1679,18 @@ pub fn is_valid_condition_operator(key: &str) -> bool {
 /// Walks the document looking for `condition` maps and validates that
 /// all operator keys are valid snake_case condition operators.
 pub fn validate_condition_operators(value: &Value) -> Result<(), String> {
-    let Value::Map(doc) = value else {
+    let Value::Concrete(ConcreteValue::Map(doc)) = value else {
         return Ok(());
     };
     // Look for "statement" list
-    let Some(Value::List(statements)) = doc.get("statement") else {
+    let Some(Value::Concrete(ConcreteValue::List(statements))) = doc.get("statement") else {
         return Ok(());
     };
     for (i, stmt) in statements.iter().enumerate() {
-        let Value::Map(stmt_map) = stmt else {
+        let Value::Concrete(ConcreteValue::Map(stmt_map)) = stmt else {
             continue;
         };
-        let Some(Value::Map(condition)) = stmt_map.get("condition") else {
+        let Some(Value::Concrete(ConcreteValue::Map(condition))) = stmt_map.get("condition") else {
             continue;
         };
         for key in condition.keys() {
@@ -1759,14 +1759,21 @@ mod tests {
     fn validate_arn_type_with_value() {
         let t = arn();
         assert!(
-            t.validate(&Value::String("arn:aws:s3:::my-bucket".to_string()))
-                .is_ok()
+            t.validate(&Value::Concrete(ConcreteValue::String(
+                "arn:aws:s3:::my-bucket".to_string()
+            )))
+            .is_ok()
         );
         assert!(
-            t.validate(&Value::String("not-an-arn".to_string()))
+            t.validate(&Value::Concrete(ConcreteValue::String(
+                "not-an-arn".to_string()
+            )))
+            .is_err()
+        );
+        assert!(
+            t.validate(&Value::Concrete(ConcreteValue::Int(42)))
                 .is_err()
         );
-        assert!(t.validate(&Value::Int(42)).is_err());
         assert!(
             t.validate(&Value::resource_ref(
                 "role".to_string(),
@@ -1802,11 +1809,19 @@ mod tests {
     fn validate_aws_resource_id_type_with_value() {
         let t = aws_resource_id();
         assert!(
-            t.validate(&Value::String("vpc-1a2b3c4d".to_string()))
-                .is_ok()
+            t.validate(&Value::Concrete(ConcreteValue::String(
+                "vpc-1a2b3c4d".to_string()
+            )))
+            .is_ok()
         );
-        assert!(t.validate(&Value::String("vpc".to_string())).is_err());
-        assert!(t.validate(&Value::Int(42)).is_err());
+        assert!(
+            t.validate(&Value::Concrete(ConcreteValue::String("vpc".to_string())))
+                .is_err()
+        );
+        assert!(
+            t.validate(&Value::Concrete(ConcreteValue::Int(42)))
+                .is_err()
+        );
         assert!(
             t.validate(&Value::resource_ref(
                 "my_vpc".to_string(),
@@ -1821,13 +1836,15 @@ mod tests {
     fn validate_vpc_cidr_block_association_id_valid() {
         let t = vpc_cidr_block_association_id();
         assert!(
-            t.validate(&Value::String("vpc-cidr-assoc-12345678".to_string()))
-                .is_ok()
+            t.validate(&Value::Concrete(ConcreteValue::String(
+                "vpc-cidr-assoc-12345678".to_string()
+            )))
+            .is_ok()
         );
         assert!(
-            t.validate(&Value::String(
+            t.validate(&Value::Concrete(ConcreteValue::String(
                 "vpc-cidr-assoc-0123456789abcdef0".to_string()
-            ))
+            )))
             .is_ok()
         );
     }
@@ -1836,22 +1853,33 @@ mod tests {
     fn validate_vpc_cidr_block_association_id_invalid() {
         let t = vpc_cidr_block_association_id();
         assert!(
-            t.validate(&Value::String("vpc-12345678".to_string()))
-                .is_err()
+            t.validate(&Value::Concrete(ConcreteValue::String(
+                "vpc-12345678".to_string()
+            )))
+            .is_err()
         );
-        assert!(t.validate(&Value::String("invalid".to_string())).is_err());
+        assert!(
+            t.validate(&Value::Concrete(ConcreteValue::String(
+                "invalid".to_string()
+            )))
+            .is_err()
+        );
     }
 
     #[test]
     fn validate_tgw_route_table_id_valid() {
         let t = tgw_route_table_id();
         assert!(
-            t.validate(&Value::String("tgw-rtb-12345678".to_string()))
-                .is_ok()
+            t.validate(&Value::Concrete(ConcreteValue::String(
+                "tgw-rtb-12345678".to_string()
+            )))
+            .is_ok()
         );
         assert!(
-            t.validate(&Value::String("tgw-rtb-0123456789abcdef0".to_string()))
-                .is_ok()
+            t.validate(&Value::Concrete(ConcreteValue::String(
+                "tgw-rtb-0123456789abcdef0".to_string()
+            )))
+            .is_ok()
         );
     }
 
@@ -1860,15 +1888,24 @@ mod tests {
         let t = tgw_route_table_id();
         // Regular route table ID should fail
         assert!(
-            t.validate(&Value::String("rtb-12345678".to_string()))
-                .is_err()
+            t.validate(&Value::Concrete(ConcreteValue::String(
+                "rtb-12345678".to_string()
+            )))
+            .is_err()
         );
         // Transit gateway ID should fail
         assert!(
-            t.validate(&Value::String("tgw-12345678".to_string()))
-                .is_err()
+            t.validate(&Value::Concrete(ConcreteValue::String(
+                "tgw-12345678".to_string()
+            )))
+            .is_err()
         );
-        assert!(t.validate(&Value::String("invalid".to_string())).is_err());
+        assert!(
+            t.validate(&Value::Concrete(ConcreteValue::String(
+                "invalid".to_string()
+            )))
+            .is_err()
+        );
     }
 
     // Availability zone tests
@@ -1936,12 +1973,22 @@ mod tests {
     #[test]
     fn validate_availability_zone_id_type_with_value() {
         let t = availability_zone_id();
-        assert!(t.validate(&Value::String("use1-az1".to_string())).is_ok());
         assert!(
-            t.validate(&Value::String("us-east-1a".to_string()))
+            t.validate(&Value::Concrete(ConcreteValue::String(
+                "use1-az1".to_string()
+            )))
+            .is_ok()
+        );
+        assert!(
+            t.validate(&Value::Concrete(ConcreteValue::String(
+                "us-east-1a".to_string()
+            )))
+            .is_err()
+        );
+        assert!(
+            t.validate(&Value::Concrete(ConcreteValue::Int(42)))
                 .is_err()
         );
-        assert!(t.validate(&Value::Int(42)).is_err());
         assert!(
             t.validate(&Value::resource_ref(
                 "subnet".to_string(),
@@ -2212,10 +2259,10 @@ mod tests {
         let AttributeType::Custom { validate, .. } = iam_oidc_provider_arn() else {
             panic!("iam_oidc_provider_arn() should be a Custom type");
         };
-        let v = Value::String(
+        let v = Value::Concrete(ConcreteValue::String(
             "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"
                 .to_string(),
-        );
+        ));
         assert!(validate(&v).is_ok());
     }
 
@@ -2224,7 +2271,9 @@ mod tests {
         let AttributeType::Custom { validate, .. } = iam_oidc_provider_arn() else {
             panic!("iam_oidc_provider_arn() should be a Custom type");
         };
-        let v = Value::String("arn:aws:iam::123456789012:role/MyRole".to_string());
+        let v = Value::Concrete(ConcreteValue::String(
+            "arn:aws:iam::123456789012:role/MyRole".to_string(),
+        ));
         assert!(validate(&v).is_err());
     }
 
@@ -2233,7 +2282,7 @@ mod tests {
         let AttributeType::Custom { validate, .. } = iam_oidc_provider_arn() else {
             panic!("iam_oidc_provider_arn() should be a Custom type");
         };
-        let v = Value::String("arn:aws:s3:::my-bucket".to_string());
+        let v = Value::Concrete(ConcreteValue::String("arn:aws:s3:::my-bucket".to_string()));
         assert!(validate(&v).is_err());
     }
 
@@ -2242,7 +2291,9 @@ mod tests {
         let AttributeType::Custom { validate, .. } = iam_oidc_provider_arn() else {
             panic!("iam_oidc_provider_arn() should be a Custom type");
         };
-        let v = Value::String("arn:aws:iam::123456789012:oidc-provider/".to_string());
+        let v = Value::Concrete(ConcreteValue::String(
+            "arn:aws:iam::123456789012:oidc-provider/".to_string(),
+        ));
         assert!(validate(&v).is_err());
     }
 
@@ -2251,10 +2302,10 @@ mod tests {
         let AttributeType::Custom { validate, .. } = iam_oidc_provider_arn() else {
             panic!("iam_oidc_provider_arn() should be a Custom type");
         };
-        let v = Value::String(
+        let v = Value::Concrete(ConcreteValue::String(
             "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-east-1.amazonaws.com/id/AAAAAAAA000000"
                 .to_string(),
-        );
+        ));
         assert!(validate(&v).is_ok());
     }
 
@@ -2263,8 +2314,9 @@ mod tests {
         let AttributeType::Custom { validate, .. } = iam_oidc_provider_arn() else {
             panic!("iam_oidc_provider_arn() should be a Custom type");
         };
-        let v =
-            Value::String("arn:aws-cn:iam::123456789012:oidc-provider/foo.example.com".to_string());
+        let v = Value::Concrete(ConcreteValue::String(
+            "arn:aws-cn:iam::123456789012:oidc-provider/foo.example.com".to_string(),
+        ));
         assert!(validate(&v).is_ok());
     }
 
@@ -2286,7 +2338,7 @@ mod tests {
 
     #[test]
     fn validate_iam_policy_document_basic() {
-        let doc = Value::Map(
+        let doc = Value::Concrete(ConcreteValue::Map(
             vec![
                 (
                     "version".to_string(),
@@ -2310,26 +2362,26 @@ mod tests {
             ]
             .into_iter()
             .collect(),
-        );
+        ));
         assert!(validate_iam_policy_document(&doc).is_ok());
     }
 
     #[test]
     fn validate_iam_policy_document_invalid_version() {
-        let doc = Value::Map(
+        let doc = Value::Concrete(ConcreteValue::Map(
             vec![(
                 "version".to_string(),
                 Value::String("2020-01-01".to_string()),
             )]
             .into_iter()
             .collect(),
-        );
+        ));
         assert!(validate_iam_policy_document(&doc).is_err());
     }
 
     #[test]
     fn validate_iam_policy_document_invalid_effect() {
-        let doc = Value::Map(
+        let doc = Value::Concrete(ConcreteValue::Map(
             vec![(
                 "statement".to_string(),
                 Value::List(vec![Value::Map(
@@ -2340,14 +2392,14 @@ mod tests {
             )]
             .into_iter()
             .collect(),
-        );
+        ));
         assert!(validate_iam_policy_document(&doc).is_err());
     }
 
     #[test]
     fn iam_policy_document_type_validates() {
         let t = iam_policy_document();
-        let valid_doc = Value::Map(
+        let valid_doc = Value::Concrete(ConcreteValue::Map(
             vec![
                 (
                     "version".to_string(),
@@ -2368,7 +2420,7 @@ mod tests {
             ]
             .into_iter()
             .collect(),
-        );
+        ));
         assert!(t.validate(&valid_doc).is_ok());
     }
 
@@ -2376,7 +2428,7 @@ mod tests {
     fn iam_policy_document_principal_map_validates() {
         let t = iam_policy_document();
         // principal as a map: { service = "ec2.amazonaws.com" }
-        let doc_with_principal_map = Value::Map(
+        let doc_with_principal_map = Value::Concrete(ConcreteValue::Map(
             vec![
                 (
                     "version".to_string(),
@@ -2410,7 +2462,7 @@ mod tests {
             ]
             .into_iter()
             .collect(),
-        );
+        ));
         assert!(
             t.validate(&doc_with_principal_map).is_ok(),
             "principal as map (struct) should be valid: {:?}",
@@ -2422,7 +2474,7 @@ mod tests {
     fn iam_policy_document_principal_string_validates() {
         let t = iam_policy_document();
         // principal as a string: "*"
-        let doc_with_principal_string = Value::Map(
+        let doc_with_principal_string = Value::Concrete(ConcreteValue::Map(
             vec![
                 (
                     "version".to_string(),
@@ -2446,7 +2498,7 @@ mod tests {
             ]
             .into_iter()
             .collect(),
-        );
+        ));
         assert!(
             t.validate(&doc_with_principal_string).is_ok(),
             "principal as string should be valid: {:?}",
@@ -2546,14 +2598,14 @@ mod tests {
         let mut attrs = std::collections::HashMap::new();
         attrs.insert(
             "tags".to_string(),
-            Value::Map(
+            Value::Concrete(ConcreteValue::Map(
                 [
                     ("key".to_string(), Value::String("Project".to_string())),
                     ("value".to_string(), Value::String("carina".to_string())),
                 ]
                 .into_iter()
                 .collect(),
-            ),
+            )),
         );
         assert!(validate_tags_map(&attrs).is_err());
     }
@@ -2563,14 +2615,14 @@ mod tests {
         let mut attrs = std::collections::HashMap::new();
         attrs.insert(
             "tags".to_string(),
-            Value::Map(
+            Value::Concrete(ConcreteValue::Map(
                 [
                     ("Key".to_string(), Value::String("Project".to_string())),
                     ("Value".to_string(), Value::String("carina".to_string())),
                 ]
                 .into_iter()
                 .collect(),
-            ),
+            )),
         );
         assert!(validate_tags_map(&attrs).is_err());
     }
@@ -2580,14 +2632,14 @@ mod tests {
         let mut attrs = std::collections::HashMap::new();
         attrs.insert(
             "tags".to_string(),
-            Value::Map(
+            Value::Concrete(ConcreteValue::Map(
                 [
                     ("Project".to_string(), Value::String("carina".to_string())),
                     ("ManagedBy".to_string(), Value::String("carina".to_string())),
                 ]
                 .into_iter()
                 .collect(),
-            ),
+            )),
         );
         assert!(validate_tags_map(&attrs).is_ok());
     }
@@ -2667,7 +2719,7 @@ mod tests {
 
     #[test]
     fn validate_condition_operators_accepts_valid() {
-        let doc = Value::Map(
+        let doc = Value::Concrete(ConcreteValue::Map(
             vec![(
                 "statement".to_string(),
                 Value::List(vec![Value::Map(
@@ -2695,13 +2747,13 @@ mod tests {
             )]
             .into_iter()
             .collect(),
-        );
+        ));
         assert!(validate_condition_operators(&doc).is_ok());
     }
 
     #[test]
     fn validate_condition_operators_rejects_pascal_case() {
-        let doc = Value::Map(
+        let doc = Value::Concrete(ConcreteValue::Map(
             vec![(
                 "statement".to_string(),
                 Value::List(vec![Value::Map(
@@ -2722,7 +2774,7 @@ mod tests {
             )]
             .into_iter()
             .collect(),
-        );
+        ));
         let err = validate_condition_operators(&doc).unwrap_err();
         assert!(
             err.contains("StringEquals"),
@@ -2732,7 +2784,7 @@ mod tests {
 
     #[test]
     fn validate_condition_operators_rejects_unknown() {
-        let doc = Value::Map(
+        let doc = Value::Concrete(ConcreteValue::Map(
             vec![(
                 "statement".to_string(),
                 Value::List(vec![Value::Map(
@@ -2750,13 +2802,13 @@ mod tests {
             )]
             .into_iter()
             .collect(),
-        );
+        ));
         assert!(validate_condition_operators(&doc).is_err());
     }
 
     #[test]
     fn validate_condition_operators_accepts_if_exists() {
-        let doc = Value::Map(
+        let doc = Value::Concrete(ConcreteValue::Map(
             vec![(
                 "statement".to_string(),
                 Value::List(vec![Value::Map(
@@ -2777,7 +2829,7 @@ mod tests {
             )]
             .into_iter()
             .collect(),
-        );
+        ));
         assert!(validate_condition_operators(&doc).is_ok());
     }
 }

--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -23,10 +23,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "1d5f1a24233aff498fb523f3316148031be56348" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "e73e8bee" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "1d5f1a24233aff498fb523f3316148031be56348" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "1d5f1a24233aff498fb523f3316148031be56348" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "e73e8bee" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "e73e8bee" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-smithy-async = { version = "1", features = ["rt-tokio"] }

--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -2377,7 +2377,7 @@ use super::AwsccSchemaConfig;
         || has_defaults
         || has_patterns
     {
-        code.push_str("use carina_core::resource::Value;\n");
+        code.push_str("use carina_core::resource::{ConcreteValue, DeferredValue, Value};\n");
     }
     if has_patterns {
         code.push_str("use regex::Regex;\n");
@@ -7984,7 +7984,7 @@ mod tests {
             "Should emit .with_default() for string default value: {generated}"
         );
         assert!(
-            generated.contains("use carina_core::resource::Value;"),
+            generated.contains("use carina_core::resource::{ConcreteValue, DeferredValue, Value};"),
             "Should import Value when defaults are present: {generated}"
         );
     }

--- a/carina-provider-awscc/src/convert.rs
+++ b/carina-provider-awscc/src/convert.rs
@@ -11,8 +11,8 @@ use carina_core::provider::{
     UpdatePatch as CoreUpdatePatch,
 };
 use carina_core::resource::{
-    Directives as CoreDirectives, Resource as CoreResource, ResourceId as CoreResourceId,
-    State as CoreState, Value as CoreValue,
+    ConcreteValue, DeferredValue, Directives as CoreDirectives, Resource as CoreResource,
+    ResourceId as CoreResourceId, State as CoreState, Value as CoreValue,
 };
 use carina_core::schema::{
     AttributeSchema as CoreAttributeSchema, AttributeType as CoreAttributeType,
@@ -45,34 +45,66 @@ pub fn proto_to_core_resource_id(id: &ProtoResourceId) -> CoreResourceId {
 
 pub fn core_to_proto_value(v: &CoreValue) -> ProtoValue {
     match v {
-        CoreValue::String(s) => ProtoValue::String(s.clone()),
-        CoreValue::Int(i) => ProtoValue::Int(*i),
-        CoreValue::Float(f) => ProtoValue::Float(*f),
-        CoreValue::Bool(b) => ProtoValue::Bool(*b),
-        CoreValue::List(l) => ProtoValue::List(l.iter().map(core_to_proto_value).collect()),
-        CoreValue::Map(m) => ProtoValue::Map(
+        CoreValue::Concrete(ConcreteValue::String(s)) => ProtoValue::String(s.clone()),
+        CoreValue::Concrete(ConcreteValue::Int(i)) => ProtoValue::Int(*i),
+        CoreValue::Concrete(ConcreteValue::Float(f)) => ProtoValue::Float(*f),
+        CoreValue::Concrete(ConcreteValue::Bool(b)) => ProtoValue::Bool(*b),
+        // Duration: emit integer seconds; the WIT contract has no Duration variant today.
+        CoreValue::Concrete(ConcreteValue::Duration(d)) => ProtoValue::Int(d.as_secs() as i64),
+        CoreValue::Concrete(ConcreteValue::List(l)) => {
+            ProtoValue::List(l.iter().map(core_to_proto_value).collect())
+        }
+        CoreValue::Concrete(ConcreteValue::StringList(items)) => ProtoValue::List(
+            items
+                .iter()
+                .map(|s| ProtoValue::String(s.clone()))
+                .collect(),
+        ),
+        CoreValue::Concrete(ConcreteValue::Map(m)) => ProtoValue::Map(
             m.iter()
                 .map(|(k, v)| (k.clone(), core_to_proto_value(v)))
                 .collect(),
         ),
-        // ResourceRef, Interpolation, FunctionCall, Closure, Secret
-        // should be resolved before reaching the provider.
-        _ => ProtoValue::String(format!("{v:?}")),
+        // Deferred-axis values must be resolved before reaching the provider.
+        // Phase 5a of RFC #2972 makes the axis explicit; we emit redacted
+        // sentinels instead of `format!("{v:?}")` so Secret plaintext never
+        // leaks into a ProtoValue::String. New deferred variants break
+        // compilation rather than silently leaking via Debug.
+        CoreValue::Deferred(DeferredValue::Secret(_)) => {
+            ProtoValue::String("<redacted-secret>".to_string())
+        }
+        CoreValue::Deferred(DeferredValue::ResourceRef { path }) => {
+            ProtoValue::String(format!("<unresolved-ref:{}>", path.to_dot_string()))
+        }
+        CoreValue::Deferred(DeferredValue::BindingRef { binding }) => {
+            ProtoValue::String(format!("<unresolved-binding:{binding}>"))
+        }
+        CoreValue::Deferred(DeferredValue::Interpolation(_)) => {
+            ProtoValue::String("<unresolved-interpolation>".to_string())
+        }
+        CoreValue::Deferred(DeferredValue::FunctionCall { name, .. }) => {
+            ProtoValue::String(format!("<unresolved-fn:{name}>"))
+        }
+        CoreValue::Deferred(DeferredValue::Unknown(_)) => {
+            ProtoValue::String("<unknown>".to_string())
+        }
     }
 }
 
 pub fn proto_to_core_value(v: &ProtoValue) -> CoreValue {
     match v {
-        ProtoValue::String(s) => CoreValue::String(s.clone()),
-        ProtoValue::Int(i) => CoreValue::Int(*i),
-        ProtoValue::Float(f) => CoreValue::Float(*f),
-        ProtoValue::Bool(b) => CoreValue::Bool(*b),
-        ProtoValue::List(l) => CoreValue::List(l.iter().map(proto_to_core_value).collect()),
-        ProtoValue::Map(m) => CoreValue::Map(
+        ProtoValue::String(s) => CoreValue::Concrete(ConcreteValue::String(s.clone())),
+        ProtoValue::Int(i) => CoreValue::Concrete(ConcreteValue::Int(*i)),
+        ProtoValue::Float(f) => CoreValue::Concrete(ConcreteValue::Float(*f)),
+        ProtoValue::Bool(b) => CoreValue::Concrete(ConcreteValue::Bool(*b)),
+        ProtoValue::List(l) => CoreValue::Concrete(ConcreteValue::List(
+            l.iter().map(proto_to_core_value).collect(),
+        )),
+        ProtoValue::Map(m) => CoreValue::Concrete(ConcreteValue::Map(
             m.iter()
                 .map(|(k, v)| (k.clone(), proto_to_core_value(v)))
                 .collect(),
-        ),
+        )),
     }
 }
 
@@ -145,6 +177,7 @@ pub fn proto_to_core_resource(r: &ProtoResource) -> CoreResource {
         force_delete: r.directives.force_delete,
         create_before_destroy: r.directives.create_before_destroy,
         prevent_destroy: r.directives.prevent_destroy,
+        depends_on: Vec::new(),
     };
     resource
 }
@@ -260,6 +293,8 @@ pub fn proto_to_core_schema(s: &ProtoResourceSchema) -> CoreResourceSchema {
             }
         }),
         exclusive_required: s.exclusive_required.clone(),
+        default_wait_timeout: None,
+        default_wait_interval: None,
     }
 }
 
@@ -269,6 +304,8 @@ fn core_to_proto_attribute_type(t: &CoreAttributeType) -> ProtoAttributeType {
         CoreAttributeType::Int => ProtoAttributeType::Int,
         CoreAttributeType::Float => ProtoAttributeType::Float,
         CoreAttributeType::Bool => ProtoAttributeType::Bool,
+        // Duration isn't representable on the WIT wire today; map to Int seconds.
+        CoreAttributeType::Duration => ProtoAttributeType::Int,
         CoreAttributeType::StringEnum {
             name,
             values,

--- a/carina-provider-awscc/src/lib.rs
+++ b/carina-provider-awscc/src/lib.rs
@@ -24,7 +24,7 @@ use carina_core::provider::{
     ProviderNormalizer, ProviderResult, ReadRequest, SavedAttrs, UpdateRequest,
     merge_default_tags_for_provider,
 };
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use carina_core::schema::SchemaRegistry;
 
 use crate::provider::AwsccProviderConfig;
@@ -138,7 +138,7 @@ impl ProviderFactory for AwsccProviderFactory {
     }
 
     fn extract_region(&self, attributes: &IndexMap<String, Value>) -> String {
-        if let Some(Value::String(region)) = attributes.get("region") {
+        if let Some(Value::Concrete(ConcreteValue::String(region))) = attributes.get("region") {
             return carina_core::utils::convert_region_value(region);
         }
         "ap-northeast-1".to_string()
@@ -202,10 +202,10 @@ impl ProviderFactory for AwsccProviderFactory {
 pub(crate) fn extract_provider_config(attributes: &IndexMap<String, Value>) -> AwsccProviderConfig {
     fn extract_string_list(attributes: &IndexMap<String, Value>, key: &str) -> Vec<String> {
         match attributes.get(key) {
-            Some(Value::List(items)) => items
+            Some(Value::Concrete(ConcreteValue::List(items))) => items
                 .iter()
                 .filter_map(|v| match v {
-                    Value::String(s) => Some(s.clone()),
+                    Value::Concrete(ConcreteValue::String(s)) => Some(s.clone()),
                     _ => None,
                 })
                 .collect(),
@@ -346,14 +346,16 @@ mod tests {
         let mut attrs: IndexMap<String, Value> = IndexMap::new();
         attrs.insert(
             "allowed_account_ids".to_string(),
-            Value::List(vec![
+            Value::Concrete(ConcreteValue::List(vec![
                 Value::String("111111111111".to_string()),
                 Value::String("222222222222".to_string()),
-            ]),
+            ])),
         );
         attrs.insert(
             "forbidden_account_ids".to_string(),
-            Value::List(vec![Value::String("999999999999".to_string())]),
+            Value::Concrete(ConcreteValue::List(vec![Value::String(
+                "999999999999".to_string(),
+            )])),
         );
 
         let cfg = extract_provider_config(&attrs);
@@ -394,45 +396,65 @@ mod tests {
         let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "test-vpc");
         resource.set_attr(
             "cidr_block".to_string(),
-            Value::String("10.0.0.0/16".to_string()),
+            Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
         );
         let mut resource_tags: IndexMap<String, Value> = IndexMap::new();
-        resource_tags.insert("Name".to_string(), Value::String("my-vpc".to_string()));
+        resource_tags.insert(
+            "Name".to_string(),
+            Value::Concrete(ConcreteValue::String("my-vpc".to_string())),
+        );
         resource_tags.insert(
             "Environment".to_string(),
-            Value::String("staging".to_string()),
+            Value::Concrete(ConcreteValue::String("staging".to_string())),
         );
-        resource.set_attr("tags".to_string(), Value::Map(resource_tags));
+        resource.set_attr(
+            "tags".to_string(),
+            Value::Concrete(ConcreteValue::Map(resource_tags)),
+        );
 
         let mut default_tags: IndexMap<String, Value> = IndexMap::new();
         default_tags.insert(
             "Environment".to_string(),
-            Value::String("production".to_string()),
+            Value::Concrete(ConcreteValue::String("production".to_string())),
         );
-        default_tags.insert("Team".to_string(), Value::String("platform".to_string()));
+        default_tags.insert(
+            "Team".to_string(),
+            Value::Concrete(ConcreteValue::String("platform".to_string())),
+        );
 
         let mut resources = vec![resource];
         normalizer.merge_default_tags(&mut resources, &default_tags, &schemas);
 
-        if let Some(Value::Map(tags)) = resources[0].get_attr("tags") {
+        if let Some(Value::Concrete(ConcreteValue::Map(tags))) = resources[0].get_attr("tags") {
             assert_eq!(
                 tags.get("Environment"),
-                Some(&Value::String("staging".to_string()))
+                Some(&Value::Concrete(ConcreteValue::String(
+                    "staging".to_string()
+                )))
             );
-            assert_eq!(tags.get("Name"), Some(&Value::String("my-vpc".to_string())));
+            assert_eq!(
+                tags.get("Name"),
+                Some(&Value::Concrete(ConcreteValue::String(
+                    "my-vpc".to_string()
+                )))
+            );
             assert_eq!(
                 tags.get("Team"),
-                Some(&Value::String("platform".to_string()))
+                Some(&Value::Concrete(ConcreteValue::String(
+                    "platform".to_string()
+                )))
             );
         } else {
             panic!("Expected tags to be a Map");
         }
 
-        if let Some(Value::List(keys)) = resources[0].get_attr("_default_tag_keys") {
+        if let Some(Value::Concrete(ConcreteValue::List(keys))) =
+            resources[0].get_attr("_default_tag_keys")
+        {
             let key_strs: Vec<&str> = keys
                 .iter()
                 .filter_map(|v| match v {
-                    Value::String(s) => Some(s.as_str()),
+                    Value::Concrete(ConcreteValue::String(s)) => Some(s.as_str()),
                     _ => None,
                 })
                 .collect();
@@ -450,32 +472,36 @@ mod tests {
         let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "test-vpc");
         resource.set_attr(
             "cidr_block".to_string(),
-            Value::String("10.0.0.0/16".to_string()),
+            Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
         );
 
         let mut default_tags: IndexMap<String, Value> = IndexMap::new();
         default_tags.insert(
             "Environment".to_string(),
-            Value::String("production".to_string()),
+            Value::Concrete(ConcreteValue::String("production".to_string())),
         );
 
         let mut resources = vec![resource];
         normalizer.merge_default_tags(&mut resources, &default_tags, &schemas);
 
-        if let Some(Value::Map(tags)) = resources[0].get_attr("tags") {
+        if let Some(Value::Concrete(ConcreteValue::Map(tags))) = resources[0].get_attr("tags") {
             assert_eq!(
                 tags.get("Environment"),
-                Some(&Value::String("production".to_string()))
+                Some(&Value::Concrete(ConcreteValue::String(
+                    "production".to_string()
+                )))
             );
         } else {
             panic!("Expected tags to be set from default_tags");
         }
 
-        if let Some(Value::List(keys)) = resources[0].get_attr("_default_tag_keys") {
+        if let Some(Value::Concrete(ConcreteValue::List(keys))) =
+            resources[0].get_attr("_default_tag_keys")
+        {
             let key_strs: Vec<&str> = keys
                 .iter()
                 .filter_map(|v| match v {
-                    Value::String(s) => Some(s.as_str()),
+                    Value::Concrete(ConcreteValue::String(s)) => Some(s.as_str()),
                     _ => None,
                 })
                 .collect();
@@ -493,13 +519,13 @@ mod tests {
         let mut resource = Resource::with_provider("awscc", "ec2.Route", "test-route");
         resource.set_attr(
             "route_table_id".to_string(),
-            Value::String("rtb-123".to_string()),
+            Value::Concrete(ConcreteValue::String("rtb-123".to_string())),
         );
 
         let mut default_tags: IndexMap<String, Value> = IndexMap::new();
         default_tags.insert(
             "Environment".to_string(),
-            Value::String("production".to_string()),
+            Value::Concrete(ConcreteValue::String("production".to_string())),
         );
 
         let mut resources = vec![resource];
@@ -517,20 +543,31 @@ mod tests {
         let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "test-vpc");
         resource.set_attr(
             "cidr_block".to_string(),
-            Value::String("10.0.0.0/16".to_string()),
+            Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
         );
         let mut resource_tags: IndexMap<String, Value> = IndexMap::new();
-        resource_tags.insert("Name".to_string(), Value::String("my-vpc".to_string()));
-        resource.set_attr("tags".to_string(), Value::Map(resource_tags));
+        resource_tags.insert(
+            "Name".to_string(),
+            Value::Concrete(ConcreteValue::String("my-vpc".to_string())),
+        );
+        resource.set_attr(
+            "tags".to_string(),
+            Value::Concrete(ConcreteValue::Map(resource_tags)),
+        );
 
         let default_tags: IndexMap<String, Value> = IndexMap::new();
 
         let mut resources = vec![resource];
         normalizer.merge_default_tags(&mut resources, &default_tags, &schemas);
 
-        if let Some(Value::Map(tags)) = resources[0].get_attr("tags") {
+        if let Some(Value::Concrete(ConcreteValue::Map(tags))) = resources[0].get_attr("tags") {
             assert_eq!(tags.len(), 1);
-            assert_eq!(tags.get("Name"), Some(&Value::String("my-vpc".to_string())));
+            assert_eq!(
+                tags.get("Name"),
+                Some(&Value::Concrete(ConcreteValue::String(
+                    "my-vpc".to_string()
+                )))
+            );
         } else {
             panic!("Expected tags to be unchanged");
         }

--- a/carina-provider-awscc/src/main.rs
+++ b/carina-provider-awscc/src/main.rs
@@ -9,7 +9,9 @@ use carina_core::provider::{
     ProviderError as CoreProviderError, ProviderNormalizer, ReadRequest as CoreReadRequest,
     SavedAttrs, UpdateRequest as CoreUpdateRequest,
 };
-use carina_core::resource::{ResourceId as CoreResourceId, State as CoreState, Value as CoreValue};
+use carina_core::resource::{
+    ConcreteValue, ResourceId as CoreResourceId, State as CoreState, Value as CoreValue,
+};
 
 use carina_provider_awscc::AwsccNormalizer;
 use carina_provider_awscc::provider::{AwsccProvider, AwsccProviderConfig};
@@ -123,7 +125,9 @@ impl CarinaProvider for AwsccProcessProvider {
 
     fn initialize(&mut self, attrs: &HashMap<String, proto::Value>) -> Result<(), String> {
         let core_attrs = convert::proto_to_core_value_map(attrs);
-        let region = if let Some(CoreValue::String(region)) = core_attrs.get("region") {
+        let region = if let Some(CoreValue::Concrete(ConcreteValue::String(region))) =
+            core_attrs.get("region")
+        {
             carina_core::utils::convert_region_value(region)
         } else {
             "ap-northeast-1".to_string()
@@ -259,6 +263,7 @@ impl CarinaProvider for AwsccProcessProvider {
             force_delete: request.directives.force_delete,
             create_before_destroy: request.directives.create_before_destroy,
             prevent_destroy: request.directives.prevent_destroy,
+            depends_on: Vec::new(),
         };
         let result = self.runtime.block_on(self.provider().delete(
             &core_id,
@@ -371,10 +376,10 @@ impl CarinaProvider for AwsccProcessProvider {
 fn extract_account_guard_config(core_attrs: &HashMap<String, CoreValue>) -> AwsccProviderConfig {
     fn extract_string_list(attrs: &HashMap<String, CoreValue>, key: &str) -> Vec<String> {
         match attrs.get(key) {
-            Some(CoreValue::List(items)) => items
+            Some(CoreValue::Concrete(ConcreteValue::List(items))) => items
                 .iter()
                 .filter_map(|v| match v {
-                    CoreValue::String(s) => Some(s.clone()),
+                    CoreValue::Concrete(ConcreteValue::String(s)) => Some(s.clone()),
                     _ => None,
                 })
                 .collect(),

--- a/carina-provider-awscc/src/provider/conversion.rs
+++ b/carina-provider-awscc/src/provider/conversion.rs
@@ -6,7 +6,7 @@
 
 use indexmap::IndexMap;
 
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, Value};
 use carina_core::schema::AttributeType;
 use serde_json::json;
 
@@ -42,7 +42,7 @@ pub(crate) fn aws_value_to_dsl(
         // closure. `DslMap::dsl_for` unifies both.
         let dsl_val = to_dsl.dsl_for(&canonical);
         let namespaced = format!("{}.{}.{}", ns, type_name, dsl_val);
-        return Some(Value::String(namespaced));
+        return Some(Value::Concrete(ConcreteValue::String(namespaced)));
     }
 
     // For List types, recurse into each item with the inner type for type-aware conversion
@@ -63,7 +63,7 @@ pub(crate) fn aws_value_to_dsl(
                 result
             })
             .collect();
-        return Some(Value::List(items));
+        return Some(Value::Concrete(ConcreteValue::List(items)));
     }
 
     // For Union types, try each member type and use the first that produces a type-aware result
@@ -91,7 +91,7 @@ pub(crate) fn aws_value_to_dsl(
             })
             .collect();
         if !map.is_empty() {
-            return Some(Value::Map(map));
+            return Some(Value::Concrete(ConcreteValue::Map(map)));
         }
     }
 
@@ -119,7 +119,7 @@ pub(crate) fn aws_value_to_dsl(
                 result.map(|val| (key, val))
             })
             .collect();
-        return Some(Value::Map(map));
+        return Some(Value::Concrete(ConcreteValue::Map(map)));
     }
 
     // For non-namespaced Custom types with to_dsl, apply the transformation on read.
@@ -132,7 +132,7 @@ pub(crate) fn aws_value_to_dsl(
     } = attr_type
         && let Some(s) = value.as_str()
     {
-        return Some(Value::String(transform(s)));
+        return Some(Value::Concrete(ConcreteValue::String(transform(s))));
     }
 
     json_to_value(value)
@@ -141,11 +141,11 @@ pub(crate) fn aws_value_to_dsl(
 /// Convert JSON value to DSL Value
 pub(crate) fn json_to_value(value: &serde_json::Value) -> Option<Value> {
     match value {
-        serde_json::Value::String(s) => Some(Value::String(s.clone())),
-        serde_json::Value::Bool(b) => Some(Value::Bool(*b)),
+        serde_json::Value::String(s) => Some(Value::Concrete(ConcreteValue::String(s.clone()))),
+        serde_json::Value::Bool(b) => Some(Value::Concrete(ConcreteValue::Bool(*b))),
         serde_json::Value::Number(n) => {
             if let Some(i) = n.as_i64() {
-                Some(Value::Int(i))
+                Some(Value::Concrete(ConcreteValue::Int(i)))
             } else {
                 n.as_f64().map(Value::Float)
             }
@@ -166,7 +166,7 @@ pub(crate) fn json_to_value(value: &serde_json::Value) -> Option<Value> {
                     result
                 })
                 .collect();
-            Some(Value::List(items))
+            Some(Value::Concrete(ConcreteValue::List(items)))
         }
         serde_json::Value::Object(obj) => {
             let map: IndexMap<String, Value> = obj
@@ -183,7 +183,7 @@ pub(crate) fn json_to_value(value: &serde_json::Value) -> Option<Value> {
                     result.map(|val| (k.clone(), val))
                 })
                 .collect();
-            Some(Value::Map(map))
+            Some(Value::Concrete(ConcreteValue::Map(map)))
         }
         _ => None,
     }
@@ -199,7 +199,7 @@ pub(crate) fn dsl_value_to_aws(
     // For schema-level string enums, convert namespaced DSL values back to provider values.
     if attr_type.namespaced_enum_parts().is_some() {
         match value {
-            Value::String(s) => {
+            Value::Concrete(ConcreteValue::String(s)) => {
                 // Extract the raw enum value from the namespaced identifier, using
                 // known valid values for disambiguation when enum values contain dots
                 // (e.g., "ipsec.1" in "awscc.ec2.VpnGateway.Type.ipsec.1").
@@ -227,7 +227,7 @@ pub(crate) fn dsl_value_to_aws(
             _ => value_to_json(value),
         }
     } else if let AttributeType::List { inner, .. } = attr_type
-        && let Value::List(items) = value
+        && let Value::Concrete(ConcreteValue::List(items)) = value
     {
         // Recurse into list items with inner type for type-aware conversion
         let arr: Vec<serde_json::Value> = items
@@ -254,7 +254,7 @@ pub(crate) fn dsl_value_to_aws(
         }
         value_to_json(value)
     } else if let AttributeType::Struct { fields, .. } = attr_type
-        && let Value::Map(map) = value
+        && let Value::Concrete(ConcreteValue::Map(map)) = value
     {
         // Recurse into bare struct fields for type-aware conversion (map assignment syntax)
         let obj: serde_json::Map<String, serde_json::Value> = fields
@@ -273,9 +273,9 @@ pub(crate) fn dsl_value_to_aws(
             .collect();
         Some(serde_json::Value::Object(obj))
     } else if let AttributeType::Struct { fields, .. } = attr_type
-        && let Value::List(items) = value
+        && let Value::Concrete(ConcreteValue::List(items)) = value
         && items.len() == 1
-        && let Value::Map(map) = &items[0]
+        && let Value::Concrete(ConcreteValue::Map(map)) = &items[0]
     {
         // Recurse into bare struct fields for type-aware conversion (block syntax)
         let obj: serde_json::Map<String, serde_json::Value> = fields
@@ -294,7 +294,7 @@ pub(crate) fn dsl_value_to_aws(
             .collect();
         Some(serde_json::Value::Object(obj))
     } else if let AttributeType::Map { value: inner, .. } = attr_type
-        && let Value::Map(map) = value
+        && let Value::Concrete(ConcreteValue::Map(map)) = value
     {
         // Map type: recurse into values with inner type.
         // For IAM condition maps, convert snake_case operator keys to PascalCase.
@@ -326,12 +326,12 @@ pub(crate) fn dsl_value_to_aws(
 /// Convert DSL Value to JSON value
 pub(crate) fn value_to_json(value: &Value) -> Option<serde_json::Value> {
     match value {
-        Value::String(s) => Some(json!(s)),
-        Value::Bool(b) => Some(json!(b)),
-        Value::Int(i) => Some(json!(i)),
-        Value::Float(f) if f.is_finite() => Some(json!(f)),
-        Value::Float(_) => None,
-        Value::List(items) => {
+        Value::Concrete(ConcreteValue::String(s)) => Some(json!(s)),
+        Value::Concrete(ConcreteValue::Bool(b)) => Some(json!(b)),
+        Value::Concrete(ConcreteValue::Int(i)) => Some(json!(i)),
+        Value::Concrete(ConcreteValue::Float(f)) if f.is_finite() => Some(json!(f)),
+        Value::Concrete(ConcreteValue::Float(_)) => None,
+        Value::Concrete(ConcreteValue::List(items)) => {
             let arr: Vec<serde_json::Value> = items
                 .iter()
                 .enumerate()
@@ -349,7 +349,7 @@ pub(crate) fn value_to_json(value: &Value) -> Option<serde_json::Value> {
                 .collect();
             Some(serde_json::Value::Array(arr))
         }
-        Value::Map(map) => {
+        Value::Concrete(ConcreteValue::Map(map)) => {
             let obj: serde_json::Map<String, serde_json::Value> = map
                 .iter()
                 .filter_map(|(k, v)| {
@@ -398,10 +398,12 @@ mod tests {
         let result = result.expect("Should return Some");
 
         // Must be Value::Map(...) to match parser output for map assignment syntax
-        if let Value::Map(map) = &result {
+        if let Value::Concrete(ConcreteValue::Map(map)) = &result {
             assert_eq!(
                 map.get("status"),
-                Some(&Value::String("Enabled".to_string()))
+                Some(&Value::Concrete(ConcreteValue::String(
+                    "Enabled".to_string()
+                )))
             );
         } else {
             panic!("Expected Value::Map, got: {:?}", result);
@@ -421,8 +423,11 @@ mod tests {
 
         // Parser produces Value::Map(...) for map assignment syntax (= { ... })
         let mut map = IndexMap::new();
-        map.insert("status".to_string(), Value::String("Enabled".to_string()));
-        let dsl_value = Value::Map(map);
+        map.insert(
+            "status".to_string(),
+            Value::Concrete(ConcreteValue::String("Enabled".to_string())),
+        );
+        let dsl_value = Value::Concrete(ConcreteValue::Map(map));
 
         let result = dsl_value_to_aws(
             &dsl_value,
@@ -453,8 +458,11 @@ mod tests {
 
         // Parser produces Value::List(vec![Value::Map(...)]) for block syntax (name { ... })
         let mut map = IndexMap::new();
-        map.insert("status".to_string(), Value::String("Enabled".to_string()));
-        let dsl_value = Value::List(vec![Value::Map(map)]);
+        map.insert(
+            "status".to_string(),
+            Value::Concrete(ConcreteValue::String("Enabled".to_string())),
+        );
+        let dsl_value = Value::Concrete(ConcreteValue::List(vec![Value::Map(map)]));
 
         let result = dsl_value_to_aws(
             &dsl_value,
@@ -495,8 +503,11 @@ mod tests {
 
         // Simulate parser output (what the user wrote in .crn with map assignment syntax)
         let mut parser_map = IndexMap::new();
-        parser_map.insert("status".to_string(), Value::String("Enabled".to_string()));
-        let parser_value = Value::Map(parser_map);
+        parser_map.insert(
+            "status".to_string(),
+            Value::Concrete(ConcreteValue::String("Enabled".to_string())),
+        );
+        let parser_value = Value::Concrete(ConcreteValue::Map(parser_map));
 
         // The read value and parser value must be equal (no spurious diff)
         assert_eq!(
@@ -527,10 +538,13 @@ mod tests {
         // 1. DSL side: resolve_enum_identifiers_impl converts bare `Gateway` ident
         let mut resource =
             carina_core::resource::Resource::with_provider("awscc", "ec2.VpcEndpoint", "test");
-        resource.set_attr("vpc_id".to_string(), Value::String("vpc-123".to_string()));
+        resource.set_attr(
+            "vpc_id".to_string(),
+            Value::Concrete(ConcreteValue::String("vpc-123".to_string())),
+        );
         resource.set_attr(
             "vpc_endpoint_type".to_string(),
-            Value::String("Gateway".to_string()),
+            Value::Concrete(ConcreteValue::String("Gateway".to_string())),
         );
 
         let mut resources = vec![resource];
@@ -543,7 +557,9 @@ mod tests {
         // `resolve_enum_identifiers_impl` runs `to_dsl` on the input.
         assert_eq!(
             dsl_resolved,
-            &Value::String("awscc.ec2.VpcEndpoint.VpcEndpointType.gateway".to_string()),
+            &Value::Concrete(ConcreteValue::String(
+                "awscc.ec2.VpcEndpoint.VpcEndpointType.gateway".to_string()
+            )),
             "DSL bare ident `Gateway` should resolve to snake_case namespaced form"
         );
 
@@ -559,7 +575,9 @@ mod tests {
 
         assert_eq!(
             aws_dsl,
-            Value::String("awscc.ec2.VpcEndpoint.VpcEndpointType.gateway".to_string()),
+            Value::Concrete(ConcreteValue::String(
+                "awscc.ec2.VpcEndpoint.VpcEndpointType.gateway".to_string()
+            )),
             "AWS read-back 'Gateway' should normalize to snake_case namespaced form"
         );
 
@@ -582,8 +600,9 @@ mod tests {
             namespace: Some("awscc.logs.LogGroup".to_string()),
             dsl_aliases: vec![],
         };
-        let value =
-            Value::String("awscc.logs.LogGroup.LogGroupClass.INFREQUENT_ACCESS".to_string());
+        let value = Value::Concrete(ConcreteValue::String(
+            "awscc.logs.LogGroup.LogGroupClass.INFREQUENT_ACCESS".to_string(),
+        ));
         let result = dsl_value_to_aws(&value, &attr_type, "logs.LogGroup", "log_group_class");
         assert_eq!(result, Some(json!("INFREQUENT_ACCESS")));
     }
@@ -599,7 +618,9 @@ mod tests {
             namespace: Some("awscc".to_string()),
             to_dsl: None,
         };
-        let value = Value::String("awscc.Region.ap_northeast_1".to_string());
+        let value = Value::Concrete(ConcreteValue::String(
+            "awscc.Region.ap_northeast_1".to_string(),
+        ));
         let result = dsl_value_to_aws(&value, &attr_type, "logs.LogGroup", "region");
         assert_eq!(result, Some(json!("ap-northeast-1")));
     }
@@ -613,10 +634,10 @@ mod tests {
             dsl_aliases: vec![],
         };
         let attr_type = AttributeType::list(inner);
-        let value = Value::List(vec![
+        let value = Value::Concrete(ConcreteValue::List(vec![
             Value::String("awscc.s3.Bucket.AllowedMethod.GET".to_string()),
             Value::String("awscc.s3.Bucket.AllowedMethod.PUT".to_string()),
-        ]);
+        ]));
         let result = dsl_value_to_aws(&value, &attr_type, "s3.Bucket", "allowed_methods");
         assert_eq!(result, Some(json!(["GET", "PUT"])));
     }
@@ -634,10 +655,10 @@ mod tests {
         let result = aws_value_to_dsl("allowed_methods", &json_val, &attr_type, "s3.Bucket");
         assert_eq!(
             result,
-            Some(Value::List(vec![
+            Some(Value::Concrete(ConcreteValue::List(vec![
                 Value::String("awscc.s3.Bucket.AllowedMethod.GET".to_string()),
                 Value::String("awscc.s3.Bucket.AllowedMethod.PUT".to_string()),
-            ]))
+            ])))
         );
     }
 
@@ -670,7 +691,9 @@ mod tests {
             },
             AttributeType::String,
         ]);
-        let value = Value::String("awscc.ec2.Sg.Protocol.tcp".to_string());
+        let value = Value::Concrete(ConcreteValue::String(
+            "awscc.ec2.Sg.Protocol.tcp".to_string(),
+        ));
         let result = dsl_value_to_aws(&value, &attr_type, "ec2.Sg", "protocol");
         assert_eq!(result, Some(json!("tcp")));
     }
@@ -682,13 +705,13 @@ mod tests {
         let mut map = IndexMap::new();
         map.insert(
             "my_custom_key".to_string(),
-            Value::String("value1".to_string()),
+            Value::Concrete(ConcreteValue::String("value1".to_string())),
         );
         map.insert(
             "another-key".to_string(),
-            Value::String("value2".to_string()),
+            Value::Concrete(ConcreteValue::String("value2".to_string())),
         );
-        let dsl_value = Value::Map(map);
+        let dsl_value = Value::Concrete(ConcreteValue::Map(map));
 
         let result = dsl_value_to_aws(&dsl_value, &attr_type, "s3.Bucket", "tags");
         let result = result.expect("Should return Some");
@@ -716,9 +739,11 @@ mod tests {
         let mut map = IndexMap::new();
         map.insert(
             "item_one".to_string(),
-            Value::String("awscc.test.resource.Status.Active".to_string()),
+            Value::Concrete(ConcreteValue::String(
+                "awscc.test.resource.Status.Active".to_string(),
+            )),
         );
-        let dsl_value = Value::Map(map);
+        let dsl_value = Value::Concrete(ConcreteValue::Map(map));
 
         let result = dsl_value_to_aws(&dsl_value, &attr_type, "test.resource", "status_map");
         let result = result.expect("Should return Some");
@@ -742,14 +767,18 @@ mod tests {
         let result = aws_value_to_dsl("tags", &aws_json, &attr_type, "s3.Bucket");
         let result = result.expect("Should return Some");
 
-        if let Value::Map(map) = &result {
+        if let Value::Concrete(ConcreteValue::Map(map)) = &result {
             assert_eq!(
                 map.get("MyCustomKey"),
-                Some(&Value::String("value1".to_string()))
+                Some(&Value::Concrete(ConcreteValue::String(
+                    "value1".to_string()
+                )))
             );
             assert_eq!(
                 map.get("another-key"),
-                Some(&Value::String("value2".to_string()))
+                Some(&Value::Concrete(ConcreteValue::String(
+                    "value2".to_string()
+                )))
             );
             assert!(map.get("my_custom_key").is_none());
         } else {
@@ -772,7 +801,9 @@ mod tests {
         let result = aws_value_to_dsl("protocol", &json_val, &attr_type, "ec2.Sg");
         assert_eq!(
             result,
-            Some(Value::String("awscc.ec2.Sg.Protocol.tcp".to_string()))
+            Some(Value::Concrete(ConcreteValue::String(
+                "awscc.ec2.Sg.Protocol.tcp".to_string()
+            )))
         );
     }
 
@@ -789,7 +820,7 @@ mod tests {
         ]);
         let json_val = json!(42);
         let result = aws_value_to_dsl("protocol", &json_val, &attr_type, "ec2.Sg");
-        assert_eq!(result, Some(Value::Int(42)));
+        assert_eq!(result, Some(Value::Concrete(ConcreteValue::Int(42))));
     }
 
     #[test]
@@ -797,7 +828,7 @@ mod tests {
         use carina_aws_types::iam_policy_document;
 
         let attr_type = iam_policy_document();
-        let value = Value::Map(
+        let value = Value::Concrete(ConcreteValue::Map(
             vec![
                 (
                     "version".to_string(),
@@ -831,7 +862,7 @@ mod tests {
             ]
             .into_iter()
             .collect(),
-        );
+        ));
 
         let result = dsl_value_to_aws(
             &value,
@@ -895,30 +926,38 @@ mod tests {
         );
         let result = result.expect("Should return Some");
 
-        if let Value::Map(map) = &result {
+        if let Value::Concrete(ConcreteValue::Map(map)) = &result {
             assert_eq!(
                 map.get("version"),
-                Some(&Value::String("2012-10-17".to_string()))
+                Some(&Value::Concrete(ConcreteValue::String(
+                    "2012-10-17".to_string()
+                )))
             );
             assert!(
                 map.get("Version").is_none(),
                 "PascalCase 'Version' should not exist"
             );
 
-            if let Some(Value::List(stmts)) = map.get("statement") {
-                if let Some(Value::Map(stmt)) = stmts.first() {
+            if let Some(Value::Concrete(ConcreteValue::List(stmts))) = map.get("statement") {
+                if let Some(Value::Concrete(ConcreteValue::Map(stmt))) = stmts.first() {
                     assert_eq!(
                         stmt.get("effect"),
-                        Some(&Value::String("Allow".to_string()))
+                        Some(&Value::Concrete(ConcreteValue::String("Allow".to_string())))
                     );
                     assert_eq!(
                         stmt.get("action"),
-                        Some(&Value::String("sts:AssumeRole".to_string()))
+                        Some(&Value::Concrete(ConcreteValue::String(
+                            "sts:AssumeRole".to_string()
+                        )))
                     );
-                    if let Some(Value::Map(principal)) = stmt.get("principal") {
+                    if let Some(Value::Concrete(ConcreteValue::Map(principal))) =
+                        stmt.get("principal")
+                    {
                         assert_eq!(
                             principal.get("service"),
-                            Some(&Value::String("lambda.amazonaws.com".to_string()))
+                            Some(&Value::Concrete(ConcreteValue::String(
+                                "lambda.amazonaws.com".to_string()
+                            )))
                         );
                     } else {
                         panic!("Expected principal to be a Map");
@@ -950,10 +989,10 @@ mod tests {
         let json_val = json!([{"RegionName": "ap-northeast-1"}]);
 
         let result = aws_value_to_dsl("operating_regions", &json_val, &attr_type, "ec2.Ipam");
-        let expected = Value::List(vec![Value::Map(IndexMap::from([(
+        let expected = Value::Concrete(ConcreteValue::List(vec![Value::Map(IndexMap::from([(
             "region_name".to_string(),
             Value::String("awscc.Region.ap_northeast_1".to_string()),
-        )]))]);
+        )]))]));
         assert_eq!(result, Some(expected));
     }
 
@@ -970,9 +1009,9 @@ mod tests {
         let result = aws_value_to_dsl("type", &json_val, &attr_type, "ec2.VpnGateway");
         assert_eq!(
             result,
-            Some(Value::String(
+            Some(Value::Concrete(ConcreteValue::String(
                 "awscc.ec2.VpnGateway.Type.ipsec.1".to_string()
-            ))
+            )))
         );
     }
 
@@ -984,7 +1023,9 @@ mod tests {
             namespace: Some("awscc.ec2.VpnGateway".to_string()),
             dsl_aliases: vec![],
         };
-        let value = Value::String("awscc.ec2.VpnGateway.Type.ipsec.1".to_string());
+        let value = Value::Concrete(ConcreteValue::String(
+            "awscc.ec2.VpnGateway.Type.ipsec.1".to_string(),
+        ));
 
         let result = dsl_value_to_aws(&value, &attr_type, "ec2.VpnGateway", "type");
         assert_eq!(result, Some(json!("ipsec.1")));
@@ -998,7 +1039,7 @@ mod tests {
             namespace: Some("awscc.ec2.VpnGateway".to_string()),
             dsl_aliases: vec![],
         };
-        let value = Value::String("ipsec.1".to_string());
+        let value = Value::Concrete(ConcreteValue::String("ipsec.1".to_string()));
 
         let result = dsl_value_to_aws(&value, &attr_type, "ec2.VpnGateway", "type");
         assert_eq!(result, Some(json!("ipsec.1")));
@@ -1017,9 +1058,9 @@ mod tests {
         let dsl_val = aws_value_to_dsl("type", &aws_val, &attr_type, "ec2.VpnGateway");
         assert_eq!(
             dsl_val,
-            Some(Value::String(
+            Some(Value::Concrete(ConcreteValue::String(
                 "awscc.ec2.VpnGateway.Type.ipsec.1".to_string()
-            ))
+            )))
         );
 
         let back_to_aws = dsl_value_to_aws(&dsl_val.unwrap(), &attr_type, "ec2.VpnGateway", "type");
@@ -1028,25 +1069,25 @@ mod tests {
 
     #[test]
     fn test_value_to_json_nan_returns_none() {
-        let value = Value::Float(f64::NAN);
+        let value = Value::Concrete(ConcreteValue::Float(f64::NAN));
         assert_eq!(value_to_json(&value), None);
     }
 
     #[test]
     fn test_value_to_json_infinity_returns_none() {
-        let value = Value::Float(f64::INFINITY);
+        let value = Value::Concrete(ConcreteValue::Float(f64::INFINITY));
         assert_eq!(value_to_json(&value), None);
     }
 
     #[test]
     fn test_value_to_json_neg_infinity_returns_none() {
-        let value = Value::Float(f64::NEG_INFINITY);
+        let value = Value::Concrete(ConcreteValue::Float(f64::NEG_INFINITY));
         assert_eq!(value_to_json(&value), None);
     }
 
     #[test]
     fn test_value_to_json_finite_float() {
-        let value = Value::Float(1.5);
+        let value = Value::Concrete(ConcreteValue::Float(1.5));
         let result = value_to_json(&value);
         assert!(result.is_some());
         assert_eq!(result.unwrap(), serde_json::json!(1.5));
@@ -1056,10 +1097,10 @@ mod tests {
     fn test_json_to_value_array_with_null_drops_null_items() {
         let json = serde_json::json!(["a", null, "b"]);
         let result = json_to_value(&json);
-        let expected = Value::List(vec![
+        let expected = Value::Concrete(ConcreteValue::List(vec![
             Value::String("a".to_string()),
             Value::String("b".to_string()),
-        ]);
+        ]));
         assert_eq!(result, Some(expected));
     }
 
@@ -1068,9 +1109,12 @@ mod tests {
         let json = serde_json::json!({"key1": "val1", "key2": null});
         let result = json_to_value(&json);
         match result {
-            Some(Value::Map(map)) => {
+            Some(Value::Concrete(ConcreteValue::Map(map))) => {
                 assert_eq!(map.len(), 1);
-                assert_eq!(map.get("key1"), Some(&Value::String("val1".to_string())));
+                assert_eq!(
+                    map.get("key1"),
+                    Some(&Value::Concrete(ConcreteValue::String("val1".to_string())))
+                );
                 assert!(!map.contains_key("key2"));
             }
             other => panic!("Expected Some(Value::Map), got {:?}", other),
@@ -1082,20 +1126,20 @@ mod tests {
         let json = serde_json::json!(["a", null, "b"]);
         let attr_type = AttributeType::list(AttributeType::String);
         let result = aws_value_to_dsl("test_attr", &json, &attr_type, "test.resource");
-        let expected = Value::List(vec![
+        let expected = Value::Concrete(ConcreteValue::List(vec![
             Value::String("a".to_string()),
             Value::String("b".to_string()),
-        ]);
+        ]));
         assert_eq!(result, Some(expected));
     }
 
     #[test]
     fn test_value_to_json_list_with_nan_drops_nan_items() {
-        let value = Value::List(vec![
+        let value = Value::Concrete(ConcreteValue::List(vec![
             Value::Float(1.0),
             Value::Float(f64::NAN),
             Value::Float(2.0),
-        ]);
+        ]));
         let result = value_to_json(&value);
         let expected = serde_json::json!([1.0, 2.0]);
         assert_eq!(result, Some(expected));
@@ -1153,10 +1197,10 @@ mod tests {
         .expect("aws_value_to_dsl should succeed for lifecycle_configuration");
 
         // Verify the converted value has the expected structure
-        let Value::Map(top_map) = &dsl_value else {
+        let Value::Concrete(ConcreteValue::Map(top_map)) = &dsl_value else {
             panic!("Expected Value::Map, got: {:?}", dsl_value);
         };
-        let Some(Value::List(rules)) = top_map.get("rules") else {
+        let Some(Value::Concrete(ConcreteValue::List(rules))) = top_map.get("rules") else {
             panic!("Expected 'rules' key with Value::List, got: {:?}", top_map);
         };
         assert_eq!(rules.len(), 2, "Should have 2 lifecycle rules");
@@ -1165,44 +1209,51 @@ mod tests {
         // naming-conventions design D7 / issue #199, the AWS-side spelling
         // (`Enabled`, `GLACIER`) is mapped to the snake_case DSL spelling
         // by the StringEnum's `to_dsl` closure on read.
-        if let Value::Map(rule0) = &rules[0] {
+        if let Value::Concrete(ConcreteValue::Map(rule0)) = &rules[0] {
             assert_eq!(
                 rule0.get("status"),
-                Some(&Value::String(
+                Some(&Value::Concrete(ConcreteValue::String(
                     "awscc.s3.Bucket.RuleStatus.enabled".to_string()
-                )),
+                ))),
                 "status should be namespaced enum"
             );
             assert_eq!(
                 rule0.get("expiration_in_days"),
-                Some(&Value::Int(90)),
+                Some(&Value::Concrete(ConcreteValue::Int(90))),
                 "expiration_in_days should be Int"
             );
             assert_eq!(
                 rule0.get("id"),
-                Some(&Value::String("expire-old-objects".to_string())),
+                Some(&Value::Concrete(ConcreteValue::String(
+                    "expire-old-objects".to_string()
+                ))),
             );
         } else {
             panic!("Expected rule[0] to be a Map");
         }
 
-        if let Value::Map(rule1) = &rules[1] {
+        if let Value::Concrete(ConcreteValue::Map(rule1)) = &rules[1] {
             assert_eq!(
                 rule1.get("status"),
-                Some(&Value::String(
+                Some(&Value::Concrete(ConcreteValue::String(
                     "awscc.s3.Bucket.RuleStatus.enabled".to_string()
-                )),
+                ))),
             );
-            if let Some(Value::List(transitions)) = rule1.get("transitions") {
+            if let Some(Value::Concrete(ConcreteValue::List(transitions))) =
+                rule1.get("transitions")
+            {
                 assert_eq!(transitions.len(), 1);
-                if let Value::Map(t) = &transitions[0] {
+                if let Value::Concrete(ConcreteValue::Map(t)) = &transitions[0] {
                     assert_eq!(
                         t.get("storage_class"),
-                        Some(&Value::String(
+                        Some(&Value::Concrete(ConcreteValue::String(
                             "awscc.s3.Bucket.TransitionStorageClass.glacier".to_string()
-                        )),
+                        ))),
                     );
-                    assert_eq!(t.get("transition_in_days"), Some(&Value::Int(30)),);
+                    assert_eq!(
+                        t.get("transition_in_days"),
+                        Some(&Value::Concrete(ConcreteValue::Int(30))),
+                    );
                 } else {
                     panic!("Expected transition to be a Map");
                 }
@@ -1263,8 +1314,9 @@ mod tests {
             .unwrap();
 
         // Validate the snake_case form (the canonical DSL spelling per D7).
-        let snake_case_value =
-            Value::String("awscc.s3.Bucket.ObjectOwnership.bucket_owner_enforced".to_string());
+        let snake_case_value = Value::Concrete(ConcreteValue::String(
+            "awscc.s3.Bucket.ObjectOwnership.bucket_owner_enforced".to_string(),
+        ));
         object_ownership
             .field_type
             .validate(&snake_case_value)
@@ -1272,8 +1324,9 @@ mod tests {
 
         // The PascalCase API spelling is also accepted as a transition
         // convenience (matches_alias in the validator).
-        let pascal_value =
-            Value::String("awscc.s3.Bucket.ObjectOwnership.BucketOwnerEnforced".to_string());
+        let pascal_value = Value::Concrete(ConcreteValue::String(
+            "awscc.s3.Bucket.ObjectOwnership.BucketOwnerEnforced".to_string(),
+        ));
         object_ownership
             .field_type
             .validate(&pascal_value)
@@ -1302,11 +1355,11 @@ mod tests {
 
     #[test]
     fn test_dsl_value_to_aws_list_with_nan_drops_nan_items() {
-        let value = Value::List(vec![
+        let value = Value::Concrete(ConcreteValue::List(vec![
             Value::Float(1.0),
             Value::Float(f64::NAN),
             Value::Float(2.0),
-        ]);
+        ]));
         let attr_type = AttributeType::list(AttributeType::Float);
         let result = dsl_value_to_aws(&value, &attr_type, "test.resource", "test_attr");
         let expected = serde_json::json!([1.0, 2.0]);
@@ -1326,7 +1379,12 @@ mod tests {
         };
         let json_val = serde_json::json!("carina-rs.dev.");
         let result = aws_value_to_dsl("name", &json_val, &attr_type, "route53.HostedZone");
-        assert_eq!(result, Some(Value::String("carina-rs.dev".to_string())));
+        assert_eq!(
+            result,
+            Some(Value::Concrete(ConcreteValue::String(
+                "carina-rs.dev".to_string()
+            )))
+        );
     }
 
     #[test]
@@ -1342,6 +1400,11 @@ mod tests {
         };
         let json_val = serde_json::json!("carina-rs.dev.");
         let result = aws_value_to_dsl("name", &json_val, &attr_type, "route53.HostedZone");
-        assert_eq!(result, Some(Value::String("carina-rs.dev.".to_string())));
+        assert_eq!(
+            result,
+            Some(Value::Concrete(ConcreteValue::String(
+                "carina-rs.dev.".to_string()
+            )))
+        );
     }
 }

--- a/carina-provider-awscc/src/provider/normalizer.rs
+++ b/carina-provider-awscc/src/provider/normalizer.rs
@@ -6,7 +6,7 @@
 use indexmap::IndexMap;
 use std::collections::HashMap;
 
-use carina_core::resource::{Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use carina_core::schema::{AttributeType, StructField};
 
 /// Resolve enum identifiers in resources to their fully-qualified DSL format.
@@ -76,14 +76,14 @@ pub fn resolve_enum_identifiers_impl(resources: &mut [Resource]) {
 /// for struct fields that have StringEnum type with namespace.
 fn resolve_struct_enum_values(value: &Value, fields: &[StructField]) -> Value {
     match value {
-        Value::List(items) => {
+        Value::Concrete(ConcreteValue::List(items)) => {
             let resolved_items: Vec<Value> = items
                 .iter()
                 .map(|item| resolve_struct_enum_values(item, fields))
                 .collect();
-            Value::List(resolved_items)
+            Value::Concrete(ConcreteValue::List(resolved_items))
         }
-        Value::Map(map) => {
+        Value::Concrete(ConcreteValue::Map(map)) => {
             let mut resolved_map = IndexMap::new();
             for (field_key, field_value) in map {
                 if let Some(field) = fields.iter().find(|f| f.name == *field_key) {
@@ -98,7 +98,7 @@ fn resolve_struct_enum_values(value: &Value, fields: &[StructField]) -> Value {
                     // List(StringEnum): resolve each element
                     if let AttributeType::List { inner, .. } = &field.field_type
                         && let Some(parts) = inner.namespaced_enum_parts()
-                        && let Value::List(items) = field_value
+                        && let Value::Concrete(ConcreteValue::List(items)) = field_value
                     {
                         let resolved_items: Vec<Value> = items
                             .iter()
@@ -107,7 +107,10 @@ fn resolve_struct_enum_values(value: &Value, fields: &[StructField]) -> Value {
                                     .unwrap_or_else(|| item.clone())
                             })
                             .collect();
-                        resolved_map.insert(field_key.clone(), Value::List(resolved_items));
+                        resolved_map.insert(
+                            field_key.clone(),
+                            Value::Concrete(ConcreteValue::List(resolved_items)),
+                        );
                         continue;
                     }
                     // Recurse into nested Struct or List(Struct) fields
@@ -132,7 +135,7 @@ fn resolve_struct_enum_values(value: &Value, fields: &[StructField]) -> Value {
                 }
                 resolved_map.insert(field_key.clone(), field_value.clone());
             }
-            Value::Map(resolved_map)
+            Value::Concrete(ConcreteValue::Map(resolved_map))
         }
         _ => value.clone(),
     }
@@ -274,13 +277,13 @@ mod tests {
         let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "test");
         resource.set_attr(
             "instance_tenancy".to_string(),
-            Value::String("dedicated".to_string()),
+            Value::Concrete(ConcreteValue::String("dedicated".to_string())),
         );
 
         let mut resources = vec![resource];
         resolve_enum_identifiers_impl(&mut resources);
         match resources[0].get_attr("instance_tenancy").unwrap() {
-            Value::String(s) => assert!(
+            Value::Concrete(ConcreteValue::String(s)) => assert!(
                 s.contains("InstanceTenancy") && s.contains("dedicated"),
                 "Expected namespaced enum, got: {}",
                 s
@@ -294,13 +297,15 @@ mod tests {
         let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "test");
         resource.set_attr(
             "instance_tenancy".to_string(),
-            Value::String("InstanceTenancy.dedicated".to_string()),
+            Value::Concrete(ConcreteValue::String(
+                "InstanceTenancy.dedicated".to_string(),
+            )),
         );
 
         let mut resources = vec![resource];
         resolve_enum_identifiers_impl(&mut resources);
         match resources[0].get_attr("instance_tenancy").unwrap() {
-            Value::String(s) => assert!(
+            Value::Concrete(ConcreteValue::String(s)) => assert!(
                 s.contains("InstanceTenancy") && s.contains("dedicated"),
                 "Expected namespaced enum, got: {}",
                 s
@@ -314,14 +319,14 @@ mod tests {
         let mut resource = Resource::with_provider("aws", "s3.Bucket", "test");
         resource.set_attr(
             "instance_tenancy".to_string(),
-            Value::String("dedicated".to_string()),
+            Value::Concrete(ConcreteValue::String("dedicated".to_string())),
         );
 
         let mut resources = vec![resource];
         resolve_enum_identifiers_impl(&mut resources);
         assert!(matches!(
             resources[0].get_attr("instance_tenancy").unwrap(),
-            Value::String(_)
+            Value::Concrete(ConcreteValue::String(_))
         ));
     }
 
@@ -330,13 +335,13 @@ mod tests {
         let mut resource = Resource::with_provider("awscc", "ec2.FlowLog", "test");
         resource.set_attr(
             "log_destination_type".to_string(),
-            Value::String("cloud_watch_logs".to_string()),
+            Value::Concrete(ConcreteValue::String("cloud_watch_logs".to_string())),
         );
 
         let mut resources = vec![resource];
         resolve_enum_identifiers_impl(&mut resources);
         match resources[0].get_attr("log_destination_type").unwrap() {
-            Value::String(s) => {
+            Value::Concrete(ConcreteValue::String(s)) => {
                 assert_eq!(
                     s, "awscc.ec2.FlowLog.LogDestinationType.cloud_watch_logs",
                     "Expected underscored namespaced enum, got: {}",
@@ -352,13 +357,13 @@ mod tests {
         let mut resource = Resource::with_provider("awscc", "ec2.FlowLog", "test");
         resource.set_attr(
             "log_destination_type".to_string(),
-            Value::String("cloud-watch-logs".to_string()),
+            Value::Concrete(ConcreteValue::String("cloud-watch-logs".to_string())),
         );
 
         let mut resources = vec![resource];
         resolve_enum_identifiers_impl(&mut resources);
         match resources[0].get_attr("log_destination_type").unwrap() {
-            Value::String(s) => {
+            Value::Concrete(ConcreteValue::String(s)) => {
                 assert_eq!(
                     s, "awscc.ec2.FlowLog.LogDestinationType.cloud_watch_logs",
                     "Hyphenated string should be converted to underscore form, got: {}",
@@ -375,7 +380,7 @@ mod tests {
         let mut state = State::existing(id.clone(), HashMap::new());
         state.attributes.insert(
             "nat_gateway_id".to_string(),
-            Value::String("nat-123".to_string()),
+            Value::Concrete(ConcreteValue::String("nat-123".to_string())),
         );
 
         let mut current_states = HashMap::new();
@@ -384,7 +389,7 @@ mod tests {
         let mut saved = HashMap::new();
         saved.insert(
             "subnet_id".to_string(),
-            Value::String("subnet-abc".to_string()),
+            Value::Concrete(ConcreteValue::String("subnet-abc".to_string())),
         );
         let mut saved_attrs = HashMap::new();
         saved_attrs.insert(id.clone(), saved);
@@ -393,7 +398,9 @@ mod tests {
 
         assert_eq!(
             current_states[&id].attributes.get("subnet_id"),
-            Some(&Value::String("subnet-abc".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String(
+                "subnet-abc".to_string()
+            )))
         );
     }
 
@@ -406,7 +413,10 @@ mod tests {
         current_states.insert(id.clone(), state);
 
         let mut saved = HashMap::new();
-        saved.insert("some_attr".to_string(), Value::String("value".to_string()));
+        saved.insert(
+            "some_attr".to_string(),
+            Value::Concrete(ConcreteValue::String("value".to_string())),
+        );
         let mut saved_attrs = HashMap::new();
         saved_attrs.insert(id.clone(), saved);
 
@@ -421,7 +431,7 @@ mod tests {
         let mut attrs = HashMap::new();
         attrs.insert(
             "subnet_id".to_string(),
-            Value::String("subnet-current".to_string()),
+            Value::Concrete(ConcreteValue::String("subnet-current".to_string())),
         );
         let state = State::existing(id.clone(), attrs);
 
@@ -431,7 +441,7 @@ mod tests {
         let mut saved = HashMap::new();
         saved.insert(
             "subnet_id".to_string(),
-            Value::String("subnet-saved".to_string()),
+            Value::Concrete(ConcreteValue::String("subnet-saved".to_string())),
         );
         let mut saved_attrs = HashMap::new();
         saved_attrs.insert(id.clone(), saved);
@@ -440,7 +450,9 @@ mod tests {
 
         assert_eq!(
             current_states[&id].attributes.get("subnet_id"),
-            Some(&Value::String("subnet-current".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String(
+                "subnet-current".to_string()
+            )))
         );
     }
 
@@ -450,7 +462,9 @@ mod tests {
         let mut state = State::existing(id.clone(), HashMap::new());
         state.attributes.insert(
             "ip_protocol".to_string(),
-            Value::String("awscc.ec2.SecurityGroupEgress.IpProtocol.all".to_string()),
+            Value::Concrete(ConcreteValue::String(
+                "awscc.ec2.SecurityGroupEgress.IpProtocol.all".to_string(),
+            )),
         );
 
         let mut current_states = HashMap::new();
@@ -459,7 +473,7 @@ mod tests {
         let mut saved = HashMap::new();
         saved.insert(
             "description".to_string(),
-            Value::String("Allow all outbound".to_string()),
+            Value::Concrete(ConcreteValue::String("Allow all outbound".to_string())),
         );
         let mut saved_attrs = HashMap::new();
         saved_attrs.insert(id.clone(), saved);
@@ -468,19 +482,24 @@ mod tests {
 
         assert_eq!(
             current_states[&id].attributes.get("description"),
-            Some(&Value::String("Allow all outbound".to_string()))
+            Some(&Value::Concrete(ConcreteValue::String(
+                "Allow all outbound".to_string()
+            )))
         );
     }
 
     #[test]
     fn test_resolve_enum_identifiers_ip_protocol_all_alias() {
         let mut resource = Resource::with_provider("awscc", "ec2.SecurityGroupEgress", "test");
-        resource.set_attr("ip_protocol".to_string(), Value::String("all".to_string()));
+        resource.set_attr(
+            "ip_protocol".to_string(),
+            Value::Concrete(ConcreteValue::String("all".to_string())),
+        );
 
         let mut resources = vec![resource];
         resolve_enum_identifiers_impl(&mut resources);
         match resources[0].get_attr("ip_protocol").unwrap() {
-            Value::String(s) => {
+            Value::Concrete(ConcreteValue::String(s)) => {
                 assert_eq!(
                     s, "awscc.ec2.SecurityGroupEgress.IpProtocol.all",
                     "Expected namespaced IpProtocol.all, got: {}",
@@ -494,12 +513,15 @@ mod tests {
     #[test]
     fn test_resolve_enum_identifiers_ip_protocol_tcp() {
         let mut resource = Resource::with_provider("awscc", "ec2.SecurityGroupEgress", "test");
-        resource.set_attr("ip_protocol".to_string(), Value::String("tcp".to_string()));
+        resource.set_attr(
+            "ip_protocol".to_string(),
+            Value::Concrete(ConcreteValue::String("tcp".to_string())),
+        );
 
         let mut resources = vec![resource];
         resolve_enum_identifiers_impl(&mut resources);
         match resources[0].get_attr("ip_protocol").unwrap() {
-            Value::String(s) => {
+            Value::Concrete(ConcreteValue::String(s)) => {
                 assert_eq!(
                     s, "awscc.ec2.SecurityGroupEgress.IpProtocol.tcp",
                     "Expected namespaced IpProtocol.tcp, got: {}",
@@ -538,20 +560,26 @@ mod tests {
     fn test_resolve_struct_enum_values_bare_ident() {
         let fields = test_ip_protocol_fields();
         let mut map = IndexMap::new();
-        map.insert("ip_protocol".to_string(), Value::String("all".to_string()));
-        map.insert("from_port".to_string(), Value::Int(443));
-        let value = Value::List(vec![Value::Map(map)]);
+        map.insert(
+            "ip_protocol".to_string(),
+            Value::Concrete(ConcreteValue::String("all".to_string())),
+        );
+        map.insert(
+            "from_port".to_string(),
+            Value::Concrete(ConcreteValue::Int(443)),
+        );
+        let value = Value::Concrete(ConcreteValue::List(vec![Value::Map(map)]));
 
         let resolved = resolve_struct_enum_values(&value, &fields);
-        if let Value::List(items) = resolved {
-            if let Value::Map(m) = &items[0] {
+        if let Value::Concrete(ConcreteValue::List(items)) = resolved {
+            if let Value::Concrete(ConcreteValue::Map(m)) = &items[0] {
                 match &m["ip_protocol"] {
-                    Value::String(s) => {
+                    Value::Concrete(ConcreteValue::String(s)) => {
                         assert_eq!(s, "awscc.ec2.SecurityGroup.IpProtocol.all");
                     }
                     other => panic!("Expected String, got: {:?}", other),
                 }
-                assert_eq!(m["from_port"], Value::Int(443));
+                assert_eq!(m["from_port"], Value::Concrete(ConcreteValue::Int(443)));
             } else {
                 panic!("Expected Map");
             }
@@ -566,15 +594,15 @@ mod tests {
         let mut map = IndexMap::new();
         map.insert(
             "ip_protocol".to_string(),
-            Value::String("IpProtocol.tcp".to_string()),
+            Value::Concrete(ConcreteValue::String("IpProtocol.tcp".to_string())),
         );
-        let value = Value::List(vec![Value::Map(map)]);
+        let value = Value::Concrete(ConcreteValue::List(vec![Value::Map(map)]));
 
         let resolved = resolve_struct_enum_values(&value, &fields);
-        if let Value::List(items) = resolved {
-            if let Value::Map(m) = &items[0] {
+        if let Value::Concrete(ConcreteValue::List(items)) = resolved {
+            if let Value::Concrete(ConcreteValue::Map(m)) = &items[0] {
                 match &m["ip_protocol"] {
-                    Value::String(s) => {
+                    Value::Concrete(ConcreteValue::String(s)) => {
                         assert_eq!(s, "awscc.ec2.SecurityGroup.IpProtocol.tcp");
                     }
                     other => panic!("Expected String, got: {:?}", other),
@@ -593,15 +621,17 @@ mod tests {
         let mut map = IndexMap::new();
         map.insert(
             "ip_protocol".to_string(),
-            Value::String("awscc.ec2.SecurityGroup.IpProtocol.tcp".to_string()),
+            Value::Concrete(ConcreteValue::String(
+                "awscc.ec2.SecurityGroup.IpProtocol.tcp".to_string(),
+            )),
         );
-        let value = Value::List(vec![Value::Map(map)]);
+        let value = Value::Concrete(ConcreteValue::List(vec![Value::Map(map)]));
 
         let resolved = resolve_struct_enum_values(&value, &fields);
-        if let Value::List(items) = resolved {
-            if let Value::Map(m) = &items[0] {
+        if let Value::Concrete(ConcreteValue::List(items)) = resolved {
+            if let Value::Concrete(ConcreteValue::Map(m)) = &items[0] {
                 match &m["ip_protocol"] {
-                    Value::String(s) => {
+                    Value::Concrete(ConcreteValue::String(s)) => {
                         assert_eq!(s, "awscc.ec2.SecurityGroup.IpProtocol.tcp");
                     }
                     other => panic!("Expected String, got: {:?}", other),
@@ -619,26 +649,31 @@ mod tests {
         let mut resource = Resource::with_provider("awscc", "ec2.SecurityGroup", "test-sg");
         resource.set_attr(
             "group_description".to_string(),
-            Value::String("test".to_string()),
+            Value::Concrete(ConcreteValue::String("test".to_string())),
         );
         let mut egress_map = IndexMap::new();
-        egress_map.insert("ip_protocol".to_string(), Value::String("all".to_string()));
+        egress_map.insert(
+            "ip_protocol".to_string(),
+            Value::Concrete(ConcreteValue::String("all".to_string())),
+        );
         egress_map.insert(
             "cidr_ip".to_string(),
-            Value::String("0.0.0.0/0".to_string()),
+            Value::Concrete(ConcreteValue::String("0.0.0.0/0".to_string())),
         );
         resource.set_attr(
             "security_group_egress".to_string(),
-            Value::List(vec![Value::Map(egress_map)]),
+            Value::Concrete(ConcreteValue::List(vec![Value::Map(egress_map)])),
         );
 
         let mut resources = vec![resource];
         resolve_enum_identifiers_impl(&mut resources);
 
-        if let Value::List(items) = resources[0].get_attr("security_group_egress").unwrap() {
-            if let Value::Map(m) = &items[0] {
+        if let Value::Concrete(ConcreteValue::List(items)) =
+            resources[0].get_attr("security_group_egress").unwrap()
+        {
+            if let Value::Concrete(ConcreteValue::Map(m)) = &items[0] {
                 match &m["ip_protocol"] {
-                    Value::String(s) => {
+                    Value::Concrete(ConcreteValue::String(s)) => {
                         assert_eq!(
                             s, "awscc.ec2.SecurityGroup.IpProtocol.all",
                             "Expected namespaced IpProtocol.all in struct field, got: {}",
@@ -648,7 +683,7 @@ mod tests {
                     other => panic!("Expected String for ip_protocol, got: {:?}", other),
                 }
                 match &m["cidr_ip"] {
-                    Value::String(s) => assert_eq!(s, "0.0.0.0/0"),
+                    Value::Concrete(ConcreteValue::String(s)) => assert_eq!(s, "0.0.0.0/0"),
                     other => panic!("Expected String for cidr_ip, got: {:?}", other),
                 }
             } else {
@@ -819,35 +854,44 @@ mod tests {
         let mut inner_map = IndexMap::new();
         inner_map.insert(
             "encryption_type".to_string(),
-            Value::List(vec![Value::String("SSE-C".to_string())]),
+            Value::Concrete(ConcreteValue::List(vec![Value::String(
+                "SSE-C".to_string(),
+            )])),
         );
         let mut map = IndexMap::new();
         map.insert(
             "blocked_encryption_types".to_string(),
-            Value::Map(inner_map),
+            Value::Concrete(ConcreteValue::Map(inner_map)),
         );
-        map.insert("bucket_key_enabled".to_string(), Value::Bool(false));
+        map.insert(
+            "bucket_key_enabled".to_string(),
+            Value::Concrete(ConcreteValue::Bool(false)),
+        );
         let mut sse_map = IndexMap::new();
         sse_map.insert(
             "sse_algorithm".to_string(),
-            Value::String("AES256".to_string()),
+            Value::Concrete(ConcreteValue::String("AES256".to_string())),
         );
         map.insert(
             "server_side_encryption_by_default".to_string(),
-            Value::Map(sse_map),
+            Value::Concrete(ConcreteValue::Map(sse_map)),
         );
 
-        let value = Value::List(vec![Value::Map(map)]);
+        let value = Value::Concrete(ConcreteValue::List(vec![Value::Map(map)]));
         let resolved = resolve_struct_enum_values(&value, &fields);
 
         // Verify the nested enum was resolved
-        if let Value::List(items) = &resolved {
-            if let Value::Map(m) = &items[0] {
-                if let Value::Map(blocked) = &m["blocked_encryption_types"] {
-                    if let Value::List(types) = &blocked["encryption_type"] {
+        if let Value::Concrete(ConcreteValue::List(items)) = &resolved {
+            if let Value::Concrete(ConcreteValue::Map(m)) = &items[0] {
+                if let Value::Concrete(ConcreteValue::Map(blocked)) = &m["blocked_encryption_types"]
+                {
+                    if let Value::Concrete(ConcreteValue::List(types)) = &blocked["encryption_type"]
+                    {
                         assert_eq!(
                             types[0],
-                            Value::String("awscc.s3.Bucket.EncryptionType.sse_c".to_string()),
+                            Value::Concrete(ConcreteValue::String(
+                                "awscc.s3.Bucket.EncryptionType.sse_c".to_string()
+                            )),
                             "Nested struct enum should be resolved to its snake_case DSL form"
                         );
                     } else {
@@ -859,10 +903,14 @@ mod tests {
                 // Also verify sse_algorithm in sibling struct.
                 // SHOUTY_SNAKE values follow the same D7 transform: API
                 // `AES256` -> DSL `aes256`.
-                if let Value::Map(sse) = &m["server_side_encryption_by_default"] {
+                if let Value::Concrete(ConcreteValue::Map(sse)) =
+                    &m["server_side_encryption_by_default"]
+                {
                     assert_eq!(
                         sse["sse_algorithm"],
-                        Value::String("awscc.s3.Bucket.SseAlgorithm.aes256".to_string()),
+                        Value::Concrete(ConcreteValue::String(
+                            "awscc.s3.Bucket.SseAlgorithm.aes256".to_string()
+                        )),
                         "Sibling struct enum should also be resolved to its snake_case DSL form"
                     );
                 } else {
@@ -916,7 +964,7 @@ mod tests {
         let mut policy_map = IndexMap::new();
         policy_map.insert(
             "Statement".to_string(),
-            Value::List(vec![Value::Map({
+            Value::Concrete(ConcreteValue::List(vec![Value::Map({
                 let mut stmt = IndexMap::new();
                 stmt.insert("Effect".to_string(), Value::String("Allow".to_string()));
                 stmt.insert(
@@ -928,7 +976,7 @@ mod tests {
                     Value::String("arn:aws:s3:::my-bucket/*".to_string()),
                 );
                 stmt
-            })]),
+            })])),
         );
 
         let (id, state) = make_state(
@@ -936,8 +984,14 @@ mod tests {
             "iam.RolePolicy",
             "test-policy",
             vec![
-                ("policy_name", Value::String("test-policy".to_string())),
-                ("policy_document", Value::Map(policy_map)),
+                (
+                    "policy_name",
+                    Value::Concrete(ConcreteValue::String("test-policy".to_string())),
+                ),
+                (
+                    "policy_document",
+                    Value::Concrete(ConcreteValue::Map(policy_map)),
+                ),
             ],
         );
         let mut current_states: HashMap<ResourceId, State> = HashMap::new();
@@ -951,25 +1005,29 @@ mod tests {
             .attributes
             .get("policy_document")
             .expect("policy_document present");
-        let Value::Map(pd) = policy_document else {
+        let Value::Concrete(ConcreteValue::Map(pd)) = policy_document else {
             panic!("expected Map for policy_document");
         };
-        let Value::List(stmts) = pd.get("Statement").expect("Statement present") else {
+        let Value::Concrete(ConcreteValue::List(stmts)) =
+            pd.get("Statement").expect("Statement present")
+        else {
             panic!("expected List for Statement");
         };
-        let Value::Map(stmt) = &stmts[0] else {
+        let Value::Concrete(ConcreteValue::Map(stmt)) = &stmts[0] else {
             panic!("expected Map for Statement[0]");
         };
         assert_eq!(
             stmt.get("Action"),
-            Some(&Value::StringList(vec!["s3:GetObject".to_string()])),
+            Some(&Value::Concrete(ConcreteValue::StringList(vec![
+                "s3:GetObject".to_string()
+            ]))),
             "Action should be canonicalized to StringList"
         );
         assert_eq!(
             stmt.get("Resource"),
-            Some(&Value::StringList(vec![
+            Some(&Value::Concrete(ConcreteValue::StringList(vec![
                 "arn:aws:s3:::my-bucket/*".to_string()
-            ])),
+            ]))),
             "Resource should be canonicalized to StringList"
         );
     }
@@ -980,7 +1038,10 @@ mod tests {
             "aws",
             "iam.RolePolicy",
             "test",
-            vec![("policy_name", Value::String("test".to_string()))],
+            vec![(
+                "policy_name",
+                Value::Concrete(ConcreteValue::String("test".to_string())),
+            )],
         );
         let mut current_states: HashMap<ResourceId, State> = HashMap::new();
         current_states.insert(id.clone(), state);
@@ -990,7 +1051,7 @@ mod tests {
         let state = &current_states[&id];
         assert_eq!(
             state.attributes.get("policy_name"),
-            Some(&Value::String("test".to_string())),
+            Some(&Value::Concrete(ConcreteValue::String("test".to_string()))),
             "non-awscc state untouched"
         );
     }
@@ -1001,7 +1062,10 @@ mod tests {
             "awscc",
             "unknown.UnknownType",
             "test",
-            vec![("attr", Value::String("x".to_string()))],
+            vec![(
+                "attr",
+                Value::Concrete(ConcreteValue::String("x".to_string())),
+            )],
         );
         let mut current_states: HashMap<ResourceId, State> = HashMap::new();
         current_states.insert(id.clone(), state);
@@ -1011,7 +1075,7 @@ mod tests {
         let state = &current_states[&id];
         assert_eq!(
             state.attributes.get("attr"),
-            Some(&Value::String("x".to_string())),
+            Some(&Value::Concrete(ConcreteValue::String("x".to_string()))),
             "unknown resource types pass through unchanged"
         );
     }

--- a/carina-provider-awscc/src/provider/operations.rs
+++ b/carina-provider-awscc/src/provider/operations.rs
@@ -7,7 +7,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult, UpdatePatch};
-use carina_core::resource::{Directives, Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Directives, Resource, ResourceId, State, Value};
 use carina_core::schema::{AttributeSchema, AttributeType};
 use indexmap::IndexMap;
 use serde_json::json;
@@ -53,7 +53,10 @@ impl AwsccProvider {
         {
             let tags_map = self.parse_tags(tags_array);
             if !tags_map.is_empty() {
-                attributes.insert("tags".to_string(), Value::Map(tags_map));
+                attributes.insert(
+                    "tags".to_string(),
+                    Value::Concrete(ConcreteValue::Map(tags_map)),
+                );
             }
         }
 
@@ -280,10 +283,16 @@ fn map_aws_props_to_attributes(
             None if !attr_schema.required && !attr_schema.write_only => {
                 match &attr_schema.attr_type {
                     AttributeType::List { .. } => {
-                        attributes.insert(dsl_name.clone(), Value::List(Vec::new()));
+                        attributes.insert(
+                            dsl_name.clone(),
+                            Value::Concrete(ConcreteValue::List(Vec::new())),
+                        );
                     }
                     AttributeType::Map { .. } => {
-                        attributes.insert(dsl_name.clone(), Value::Map(IndexMap::new()));
+                        attributes.insert(
+                            dsl_name.clone(),
+                            Value::Concrete(ConcreteValue::Map(IndexMap::new())),
+                        );
                     }
                     _ => {}
                 }
@@ -363,7 +372,7 @@ mod tests {
 
         assert_eq!(
             result.get("managed_policy_arns"),
-            Some(&Value::List(Vec::new())),
+            Some(&Value::Concrete(ConcreteValue::List(Vec::new()))),
             "absent optional list-typed attribute must canonicalize to empty list, not be dropped"
         );
     }
@@ -383,7 +392,9 @@ mod tests {
 
         assert_eq!(
             result.get("metadata"),
-            Some(&Value::Map(indexmap::IndexMap::new())),
+            Some(&Value::Concrete(ConcreteValue::Map(
+                indexmap::IndexMap::new()
+            ))),
             "absent optional map-typed attribute must canonicalize to empty map"
         );
     }
@@ -446,9 +457,9 @@ mod tests {
 
         assert_eq!(
             result.get("managed_policy_arns"),
-            Some(&Value::List(vec![Value::String(
+            Some(&Value::Concrete(ConcreteValue::List(vec![Value::String(
                 "arn:aws:iam::aws:policy/ReadOnlyAccess".to_string()
-            )])),
+            )]))),
         );
     }
 

--- a/carina-provider-awscc/src/provider/special_cases.rs
+++ b/carina-provider-awscc/src/provider/special_cases.rs
@@ -7,7 +7,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{Resource, ResourceId, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, Value};
 use serde_json::json;
 
 use super::AwsccProvider;
@@ -28,7 +28,10 @@ impl AwsccProvider {
                     && let Some(first) = attachments.first()
                     && let Some(vpc_id) = first.get("VpcId").and_then(|v| v.as_str())
                 {
-                    attributes.insert("vpc_id".to_string(), Value::String(vpc_id.to_string()));
+                    attributes.insert(
+                        "vpc_id".to_string(),
+                        Value::Concrete(ConcreteValue::String(vpc_id.to_string())),
+                    );
                 }
             }
             "ec2.VpcEndpoint" => {
@@ -36,10 +39,16 @@ impl AwsccProvider {
                 if let Some(rt_ids) = props.get("RouteTableIds").and_then(|v| v.as_array()) {
                     let ids: Vec<Value> = rt_ids
                         .iter()
-                        .filter_map(|v| v.as_str().map(|s| Value::String(s.to_string())))
+                        .filter_map(|v| {
+                            v.as_str()
+                                .map(|s| Value::Concrete(ConcreteValue::String(s.to_string())))
+                        })
                         .collect();
                     if !ids.is_empty() {
-                        attributes.insert("route_table_ids".to_string(), Value::List(ids));
+                        attributes.insert(
+                            "route_table_ids".to_string(),
+                            Value::Concrete(ConcreteValue::List(ids)),
+                        );
                     }
                 }
             }

--- a/carina-provider-awscc/src/provider/tags.rs
+++ b/carina-provider-awscc/src/provider/tags.rs
@@ -6,7 +6,7 @@
 
 use indexmap::IndexMap;
 
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, Value};
 use serde_json::json;
 
 use super::AwsccProvider;
@@ -15,9 +15,9 @@ impl AwsccProvider {
     /// Build tags array for CloudFormation format
     pub(crate) fn build_tags(&self, user_tags: Option<&Value>) -> Vec<serde_json::Value> {
         let mut tags = Vec::new();
-        if let Some(Value::Map(user_tags)) = user_tags {
+        if let Some(Value::Concrete(ConcreteValue::Map(user_tags))) = user_tags {
             for (key, value) in user_tags {
-                if let Value::String(v) = value {
+                if let Value::Concrete(ConcreteValue::String(v)) = value {
                     tags.push(json!({"Key": key, "Value": v}));
                 }
             }
@@ -33,7 +33,10 @@ impl AwsccProvider {
                 tag.get("Key").and_then(|v| v.as_str()),
                 tag.get("Value").and_then(|v| v.as_str()),
             ) {
-                tags_map.insert(key.to_string(), Value::String(value.to_string()));
+                tags_map.insert(
+                    key.to_string(),
+                    Value::Concrete(ConcreteValue::String(value.to_string())),
+                );
             }
         }
         tags_map

--- a/carina-provider-awscc/src/provider/update.rs
+++ b/carina-provider-awscc/src/provider/update.rs
@@ -9,7 +9,7 @@
 //! `carina-rs/carina#2559`).
 
 use carina_core::provider::{PatchOp, PatchOpKind, ProviderError, ProviderResult, UpdatePatch};
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, Value};
 use serde_json::json;
 
 use super::conversion::dsl_value_to_aws;
@@ -110,10 +110,13 @@ pub(crate) fn build_update_patches(
 /// CloudControl `[{"Key": ..., "Value": ...}]` shape.
 fn push_tags_op(patch_ops: &mut Vec<serde_json::Value>, op: &PatchOp) {
     match (op.kind, &op.value) {
-        (PatchOpKind::Add | PatchOpKind::Replace, Some(Value::Map(user_tags))) => {
+        (
+            PatchOpKind::Add | PatchOpKind::Replace,
+            Some(Value::Concrete(ConcreteValue::Map(user_tags))),
+        ) => {
             let mut tags = Vec::new();
             for (key, value) in user_tags {
-                if let Value::String(v) = value {
+                if let Value::Concrete(ConcreteValue::String(v)) = value {
                     tags.push(json!({"Key": key, "Value": v}));
                 }
             }
@@ -215,9 +218,12 @@ mod tests {
         let config = get_schema_config("iam.Role").expect("iam.role schema should exist");
 
         let mut tags = IndexMap::new();
-        tags.insert("Env".to_string(), Value::String("staging".to_string()));
+        tags.insert(
+            "Env".to_string(),
+            Value::Concrete(ConcreteValue::String("staging".to_string())),
+        );
         let patch = UpdatePatch {
-            ops: vec![replace("tags", Value::Map(tags))],
+            ops: vec![replace("tags", Value::Concrete(ConcreteValue::Map(tags)))],
         };
 
         let patches = build_update_patches(config, "iam.Role", &patch);
@@ -260,7 +266,9 @@ mod tests {
         let patch = UpdatePatch {
             ops: vec![replace(
                 "instance_tenancy",
-                Value::String("awscc.ec2.Vpc.InstanceTenancy.dedicated".to_string()),
+                Value::Concrete(ConcreteValue::String(
+                    "awscc.ec2.Vpc.InstanceTenancy.dedicated".to_string(),
+                )),
             )],
         };
         let patches = build_update_patches(config, "ec2.Vpc", &patch);
@@ -279,7 +287,10 @@ mod tests {
         let config =
             get_schema_config("logs.LogGroup").expect("logs.log_group schema should exist");
         let patch = UpdatePatch {
-            ops: vec![add("retention_in_days", Value::Int(14))],
+            ops: vec![add(
+                "retention_in_days",
+                Value::Concrete(ConcreteValue::Int(14)),
+            )],
         };
         let patches = build_update_patches(config, "logs.LogGroup", &patch);
 
@@ -324,7 +335,7 @@ mod tests {
         let patch = UpdatePatch {
             ops: vec![replace(
                 "arn",
-                Value::String("arn:aws:logs:::*".to_string()),
+                Value::Concrete(ConcreteValue::String("arn:aws:logs:::*".to_string())),
             )],
         };
         let patches = build_update_patches(config, "logs.LogGroup", &patch);
@@ -352,10 +363,16 @@ mod tests {
     fn test_replace_tags_projects_to_aws_shape() {
         let config = get_vpc_config();
         let mut tags = IndexMap::new();
-        tags.insert("Name".to_string(), Value::String("my-vpc".to_string()));
-        tags.insert("Env".to_string(), Value::String("prod".to_string()));
+        tags.insert(
+            "Name".to_string(),
+            Value::Concrete(ConcreteValue::String("my-vpc".to_string())),
+        );
+        tags.insert(
+            "Env".to_string(),
+            Value::Concrete(ConcreteValue::String("prod".to_string())),
+        );
         let patch = UpdatePatch {
-            ops: vec![replace("tags", Value::Map(tags))],
+            ops: vec![replace("tags", Value::Concrete(ConcreteValue::Map(tags)))],
         };
         let patches = build_update_patches(config, "ec2.Vpc", &patch);
 
@@ -379,7 +396,10 @@ mod tests {
     fn test_unknown_attribute_is_dropped() {
         let config = get_vpc_config();
         let patch = UpdatePatch {
-            ops: vec![replace("not_a_real_attr", Value::String("x".to_string()))],
+            ops: vec![replace(
+                "not_a_real_attr",
+                Value::Concrete(ConcreteValue::String("x".to_string())),
+            )],
         };
         let patches = build_update_patches(config, "ec2.Vpc", &patch);
         assert!(

--- a/carina-provider-awscc/src/resources.rs
+++ b/carina-provider-awscc/src/resources.rs
@@ -134,7 +134,7 @@ mod tests {
     /// See: https://github.com/carina-rs/carina/issues/925
     #[test]
     fn vpc_gateway_attachment_rejects_both_internet_and_vpn_gateway() {
-        use carina_core::resource::Value;
+        use carina_core::resource::{ConcreteValue, Value};
         use std::collections::HashMap;
 
         let config = get_config("ec2.VpcGatewayAttachment").unwrap();
@@ -144,15 +144,15 @@ mod tests {
         let mut attrs = HashMap::new();
         attrs.insert(
             "vpc_id".to_string(),
-            Value::String("vpc-12345678".to_string()),
+            Value::Concrete(ConcreteValue::String("vpc-12345678".to_string())),
         );
         attrs.insert(
             "internet_gateway_id".to_string(),
-            Value::String("igw-12345678".to_string()),
+            Value::Concrete(ConcreteValue::String("igw-12345678".to_string())),
         );
         attrs.insert(
             "vpn_gateway_id".to_string(),
-            Value::String("vgw-12345678".to_string()),
+            Value::Concrete(ConcreteValue::String("vgw-12345678".to_string())),
         );
 
         let result = schema.validate(&attrs);
@@ -176,7 +176,7 @@ mod tests {
     /// See: https://github.com/carina-rs/carina/issues/925
     #[test]
     fn vpc_gateway_attachment_accepts_single_gateway() {
-        use carina_core::resource::Value;
+        use carina_core::resource::{ConcreteValue, Value};
         use std::collections::HashMap;
 
         let config = get_config("ec2.VpcGatewayAttachment").unwrap();
@@ -186,11 +186,11 @@ mod tests {
         let mut attrs_igw = HashMap::new();
         attrs_igw.insert(
             "vpc_id".to_string(),
-            Value::String("vpc-12345678".to_string()),
+            Value::Concrete(ConcreteValue::String("vpc-12345678".to_string())),
         );
         attrs_igw.insert(
             "internet_gateway_id".to_string(),
-            Value::String("igw-12345678".to_string()),
+            Value::Concrete(ConcreteValue::String("igw-12345678".to_string())),
         );
         assert!(
             schema.validate(&attrs_igw).is_ok(),
@@ -201,11 +201,11 @@ mod tests {
         let mut attrs_vpn = HashMap::new();
         attrs_vpn.insert(
             "vpc_id".to_string(),
-            Value::String("vpc-12345678".to_string()),
+            Value::Concrete(ConcreteValue::String("vpc-12345678".to_string())),
         );
         attrs_vpn.insert(
             "vpn_gateway_id".to_string(),
-            Value::String("vgw-12345678".to_string()),
+            Value::Concrete(ConcreteValue::String("vgw-12345678".to_string())),
         );
         assert!(
             schema.validate(&attrs_vpn).is_ok(),
@@ -217,7 +217,7 @@ mod tests {
     /// See: https://github.com/carina-rs/carina/issues/925
     #[test]
     fn vpc_gateway_attachment_rejects_neither_gateway() {
-        use carina_core::resource::Value;
+        use carina_core::resource::{ConcreteValue, Value};
         use std::collections::HashMap;
 
         let config = get_config("ec2.VpcGatewayAttachment").unwrap();
@@ -227,7 +227,7 @@ mod tests {
         let mut attrs = HashMap::new();
         attrs.insert(
             "vpc_id".to_string(),
-            Value::String("vpc-12345678".to_string()),
+            Value::Concrete(ConcreteValue::String("vpc-12345678".to_string())),
         );
 
         let result = schema.validate(&attrs);

--- a/carina-provider-awscc/src/schemas/awscc_types.rs
+++ b/carina-provider-awscc/src/schemas/awscc_types.rs
@@ -9,7 +9,7 @@ pub use carina_aws_types::*;
 use std::collections::HashMap;
 
 use carina_core::parser::ValidatorFn;
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, Value};
 use carina_core::schema::{AttributeType, ResourceSchema, legacy_validator};
 use carina_core::utils::{extract_enum_value, validate_enum_namespace};
 
@@ -110,7 +110,7 @@ pub(crate) fn validate_namespaced_enum(
     namespace: &str,
     valid_values: &[&str],
 ) -> Result<(), String> {
-    if let Value::String(s) = value {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
         validate_enum_namespace(s, type_name, namespace)?;
 
         let normalized = extract_enum_value(s);
@@ -136,7 +136,7 @@ pub fn awscc_region() -> AttributeType {
         length: None,
         base: Box::new(AttributeType::String),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_enum_namespace(s, "Region", "awscc")
                     .map_err(|reason| format!("Invalid region '{}': {}", s, reason))?;
                 let normalized = extract_enum_value(s).replace('_', "-");
@@ -167,7 +167,7 @@ pub fn availability_zone() -> AttributeType {
         length: None,
         base: Box::new(AttributeType::String),
         validate: legacy_validator(|value| {
-            if let Value::String(s) = value {
+            if let Value::Concrete(ConcreteValue::String(s)) = value {
                 validate_enum_namespace(s, "AvailabilityZone", "awscc")
                     .map_err(|reason| format!("Invalid availability zone '{}': {}", s, reason))?;
                 let extracted = extract_enum_value(s);
@@ -195,29 +195,41 @@ mod tests {
         let t = availability_zone();
         // Full namespace format
         assert!(
-            t.validate(&Value::String(
+            t.validate(&Value::Concrete(ConcreteValue::String(
                 "awscc.AvailabilityZone.us_east_1a".to_string()
-            ))
+            )))
             .is_ok()
         );
         // Type.value format
         assert!(
-            t.validate(&Value::String("AvailabilityZone.us_east_1a".to_string()))
-                .is_ok()
+            t.validate(&Value::Concrete(ConcreteValue::String(
+                "AvailabilityZone.us_east_1a".to_string()
+            )))
+            .is_ok()
         );
         // Shorthand format
-        assert!(t.validate(&Value::String("us_east_1a".to_string())).is_ok());
+        assert!(
+            t.validate(&Value::Concrete(ConcreteValue::String(
+                "us_east_1a".to_string()
+            )))
+            .is_ok()
+        );
         // AWS format
-        assert!(t.validate(&Value::String("us-east-1a".to_string())).is_ok());
+        assert!(
+            t.validate(&Value::Concrete(ConcreteValue::String(
+                "us-east-1a".to_string()
+            )))
+            .is_ok()
+        );
     }
 
     #[test]
     fn validate_availability_zone_rejects_wrong_namespace() {
         let t = availability_zone();
         assert!(
-            t.validate(&Value::String(
+            t.validate(&Value::Concrete(ConcreteValue::String(
                 "aws.AvailabilityZone.us_east_1a".to_string()
-            ))
+            )))
             .is_err()
         );
     }
@@ -225,8 +237,18 @@ mod tests {
     #[test]
     fn validate_availability_zone_rejects_invalid() {
         let t = availability_zone();
-        assert!(t.validate(&Value::String("us-east-1".to_string())).is_err()); // no zone letter
-        assert!(t.validate(&Value::String("invalid".to_string())).is_err());
+        assert!(
+            t.validate(&Value::Concrete(ConcreteValue::String(
+                "us-east-1".to_string()
+            )))
+            .is_err()
+        ); // no zone letter
+        assert!(
+            t.validate(&Value::Concrete(ConcreteValue::String(
+                "invalid".to_string()
+            )))
+            .is_err()
+        );
     }
 
     #[test]
@@ -246,12 +268,16 @@ mod tests {
         let region_type = awscc_region();
         assert!(
             region_type
-                .validate(&Value::String("awscc.Region.ap_northeast_1".to_string()))
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "awscc.Region.ap_northeast_1".to_string()
+                )))
                 .is_ok()
         );
         assert!(
             region_type
-                .validate(&Value::String("ap-northeast-1".to_string()))
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "ap-northeast-1".to_string()
+                )))
                 .is_ok()
         );
     }
@@ -261,7 +287,9 @@ mod tests {
         let region_type = awscc_region();
         assert!(
             region_type
-                .validate(&Value::String("aws.Region.ap_northeast_1".to_string()))
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "aws.Region.ap_northeast_1".to_string()
+                )))
                 .is_err()
         );
     }
@@ -269,7 +297,9 @@ mod tests {
     #[test]
     fn validate_namespaced_enum_basic() {
         let result = validate_namespaced_enum(
-            &Value::String("awscc.ec2.Vpc.InstanceTenancy.default".to_string()),
+            &Value::Concrete(ConcreteValue::String(
+                "awscc.ec2.Vpc.InstanceTenancy.default".to_string(),
+            )),
             "InstanceTenancy",
             "awscc.ec2.Vpc",
             &["default", "dedicated", "host"],
@@ -387,7 +417,7 @@ mod tests {
 
     #[test]
     fn validate_iam_policy_document_basic() {
-        let doc = Value::Map(
+        let doc = Value::Concrete(ConcreteValue::Map(
             vec![
                 (
                     "version".to_string(),
@@ -411,7 +441,7 @@ mod tests {
             ]
             .into_iter()
             .collect(),
-        );
+        ));
         assert!(validate_iam_policy_document(&doc).is_ok());
     }
 }

--- a/carina-provider-awscc/src/schemas/generated/cloudfront/origin_access_control.rs
+++ b/carina-provider-awscc/src/schemas/generated/cloudfront/origin_access_control.rs
@@ -5,7 +5,7 @@
 //! DO NOT EDIT MANUALLY - regenerate with carina-codegen
 
 use super::AwsccSchemaConfig;
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, Value};
 use carina_core::schema::{
     AttributeSchema, AttributeType, ResourceSchema, StructField, legacy_validator,
 };
@@ -16,7 +16,7 @@ const VALID_ORIGIN_ACCESS_CONTROL_CONFIG_SIGNING_BEHAVIOR: &[&str] =
 
 #[allow(dead_code)]
 fn validate_string_pattern_597c12a2d8028697(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
         static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
             Regex::new("^(s3|mediastore|lambda|mediapackagev2)$").expect("invalid pattern regex")
         });
@@ -35,7 +35,7 @@ fn validate_string_pattern_597c12a2d8028697(value: &Value) -> Result<(), String>
 
 #[allow(dead_code)]
 fn validate_string_pattern_e0706e45c974b71e(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
         static RE: std::sync::LazyLock<Regex> =
             std::sync::LazyLock::new(|| Regex::new("^(sigv4)$").expect("invalid pattern regex"));
         if RE.is_match(s) {

--- a/carina-provider-awscc/src/schemas/generated/ec2/flow_log.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/flow_log.rs
@@ -7,7 +7,7 @@
 use super::AwsccSchemaConfig;
 use super::tags_type;
 use super::validate_tags_map;
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, Value};
 use carina_core::schema::{
     AttributeSchema, AttributeType, ResourceSchema, StructField, legacy_validator,
 };
@@ -28,7 +28,7 @@ const VALID_TRAFFIC_TYPE: &[&str] = &["ACCEPT", "ALL", "REJECT"];
 const VALID_MAX_AGGREGATION_INTERVAL_VALUES: &[i64] = &[60, 600];
 
 fn validate_max_aggregation_interval_int_enum(value: &Value) -> Result<(), String> {
-    if let Value::Int(n) = value {
+    if let Value::Concrete(ConcreteValue::Int(n)) = value {
         if VALID_MAX_AGGREGATION_INTERVAL_VALUES.contains(n) {
             Ok(())
         } else {

--- a/carina-provider-awscc/src/schemas/generated/ec2/ipam.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/ipam.rs
@@ -7,7 +7,7 @@
 use super::AwsccSchemaConfig;
 use super::tags_type;
 use super::validate_tags_map;
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, Value};
 use carina_core::schema::{
     AttributeSchema, AttributeType, OperationConfig, ResourceSchema, StructField, legacy_validator,
 };
@@ -17,7 +17,7 @@ const VALID_METERED_ACCOUNT: &[&str] = &["ipam-owner", "resource-owner"];
 const VALID_TIER: &[&str] = &["free", "advanced"];
 
 fn validate_string_length_min_1(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
         let len = s.chars().count();
         if len < 1 {
             Err(format!("String length {} is out of range 1..", len))
@@ -30,7 +30,7 @@ fn validate_string_length_min_1(value: &Value) -> Result<(), String> {
 }
 
 fn validate_string_length_max_255(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
         let len = s.chars().count();
         if len > 255 {
             Err(format!("String length {} is out of range ..=255", len))

--- a/carina-provider-awscc/src/schemas/generated/ec2/nat_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/nat_gateway.rs
@@ -7,7 +7,7 @@
 use super::AwsccSchemaConfig;
 use super::tags_type;
 use super::validate_tags_map;
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, Value};
 use carina_core::schema::{
     AttributeSchema, AttributeType, OperationConfig, ResourceSchema, StructField, legacy_validator,
     types,
@@ -18,7 +18,7 @@ const VALID_AVAILABILITY_MODE: &[&str] = &["zonal", "regional"];
 const VALID_CONNECTIVITY_TYPE: &[&str] = &["public", "private"];
 
 fn validate_secondary_private_ip_address_count_range(value: &Value) -> Result<(), String> {
-    if let Value::Int(n) = value {
+    if let Value::Concrete(ConcreteValue::Int(n)) = value {
         if *n < 1 {
             Err(format!("Value {} is out of range 1..", n))
         } else {

--- a/carina-provider-awscc/src/schemas/generated/ec2/security_group.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/security_group.rs
@@ -7,7 +7,7 @@
 use super::AwsccSchemaConfig;
 use super::tags_type;
 use super::validate_tags_map;
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, Value};
 use carina_core::schema::{
     AttributeSchema, AttributeType, ResourceSchema, StructField, legacy_validator, types,
 };
@@ -17,7 +17,7 @@ const VALID_EGRESS_IP_PROTOCOL: &[&str] = &["tcp", "udp", "icmp", "icmpv6", "-1"
 const VALID_INGRESS_IP_PROTOCOL: &[&str] = &["tcp", "udp", "icmp", "icmpv6", "-1", "all"];
 
 fn validate_from_port_range(value: &Value) -> Result<(), String> {
-    if let Value::Int(n) = value {
+    if let Value::Concrete(ConcreteValue::Int(n)) = value {
         if *n < -1 || *n > 65535 {
             Err(format!("Value {} is out of range -1..=65535", n))
         } else {
@@ -29,7 +29,7 @@ fn validate_from_port_range(value: &Value) -> Result<(), String> {
 }
 
 fn validate_to_port_range(value: &Value) -> Result<(), String> {
-    if let Value::Int(n) = value {
+    if let Value::Concrete(ConcreteValue::Int(n)) = value {
         if *n < -1 || *n > 65535 {
             Err(format!("Value {} is out of range -1..=65535", n))
         } else {

--- a/carina-provider-awscc/src/schemas/generated/ec2/security_group_egress.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/security_group_egress.rs
@@ -5,7 +5,7 @@
 //! DO NOT EDIT MANUALLY - regenerate with carina-codegen
 
 use super::AwsccSchemaConfig;
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, Value};
 use carina_core::schema::{
     AttributeSchema, AttributeType, ResourceSchema, legacy_validator, types,
 };
@@ -13,7 +13,7 @@ use carina_core::schema::{
 const VALID_IP_PROTOCOL: &[&str] = &["tcp", "udp", "icmp", "icmpv6", "-1", "all"];
 
 fn validate_from_port_range(value: &Value) -> Result<(), String> {
-    if let Value::Int(n) = value {
+    if let Value::Concrete(ConcreteValue::Int(n)) = value {
         if *n < -1 || *n > 65535 {
             Err(format!("Value {} is out of range -1..=65535", n))
         } else {
@@ -25,7 +25,7 @@ fn validate_from_port_range(value: &Value) -> Result<(), String> {
 }
 
 fn validate_to_port_range(value: &Value) -> Result<(), String> {
-    if let Value::Int(n) = value {
+    if let Value::Concrete(ConcreteValue::Int(n)) = value {
         if *n < -1 || *n > 65535 {
             Err(format!("Value {} is out of range -1..=65535", n))
         } else {

--- a/carina-provider-awscc/src/schemas/generated/ec2/security_group_ingress.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/security_group_ingress.rs
@@ -5,7 +5,7 @@
 //! DO NOT EDIT MANUALLY - regenerate with carina-codegen
 
 use super::AwsccSchemaConfig;
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, Value};
 use carina_core::schema::{
     AttributeSchema, AttributeType, ResourceSchema, legacy_validator, types,
 };
@@ -13,7 +13,7 @@ use carina_core::schema::{
 const VALID_IP_PROTOCOL: &[&str] = &["tcp", "udp", "icmp", "icmpv6", "-1", "all"];
 
 fn validate_from_port_range(value: &Value) -> Result<(), String> {
-    if let Value::Int(n) = value {
+    if let Value::Concrete(ConcreteValue::Int(n)) = value {
         if *n < -1 || *n > 65535 {
             Err(format!("Value {} is out of range -1..=65535", n))
         } else {
@@ -25,7 +25,7 @@ fn validate_from_port_range(value: &Value) -> Result<(), String> {
 }
 
 fn validate_to_port_range(value: &Value) -> Result<(), String> {
-    if let Value::Int(n) = value {
+    if let Value::Concrete(ConcreteValue::Int(n)) = value {
         if *n < -1 || *n > 65535 {
             Err(format!("Value {} is out of range -1..=65535", n))
         } else {

--- a/carina-provider-awscc/src/schemas/generated/ec2/subnet.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/subnet.rs
@@ -7,13 +7,13 @@
 use super::AwsccSchemaConfig;
 use super::tags_type;
 use super::validate_tags_map;
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, Value};
 use carina_core::schema::{
     AttributeSchema, AttributeType, ResourceSchema, StructField, legacy_validator, types,
 };
 
 fn validate_ipv4_netmask_length_range(value: &Value) -> Result<(), String> {
-    if let Value::Int(n) = value {
+    if let Value::Concrete(ConcreteValue::Int(n)) = value {
         if *n < 0 || *n > 32 {
             Err(format!("Value {} is out of range 0..=32", n))
         } else {
@@ -25,7 +25,7 @@ fn validate_ipv4_netmask_length_range(value: &Value) -> Result<(), String> {
 }
 
 fn validate_ipv6_netmask_length_range(value: &Value) -> Result<(), String> {
-    if let Value::Int(n) = value {
+    if let Value::Concrete(ConcreteValue::Int(n)) = value {
         if *n < 0 || *n > 128 {
             Err(format!("Value {} is out of range 0..=128", n))
         } else {

--- a/carina-provider-awscc/src/schemas/generated/ec2/transit_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/transit_gateway.rs
@@ -7,7 +7,7 @@
 use super::AwsccSchemaConfig;
 use super::tags_type;
 use super::validate_tags_map;
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, Value};
 use carina_core::schema::{
     AttributeSchema, AttributeType, OperationConfig, ResourceSchema, legacy_validator, types,
 };
@@ -31,7 +31,7 @@ const VALID_SECURITY_GROUP_REFERENCING_SUPPORT: &[&str] = &["enable", "disable"]
 const VALID_VPN_ECMP_SUPPORT: &[&str] = &["enable", "disable"];
 
 fn validate_amazon_side_asn_range(value: &Value) -> Result<(), String> {
-    if let Value::Int(n) = value {
+    if let Value::Concrete(ConcreteValue::Int(n)) = value {
         if *n < 1 || *n > 4294967294 {
             Err(format!("Value {} is out of range 1..=4294967294", n))
         } else {

--- a/carina-provider-awscc/src/schemas/generated/ec2/vpc.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/vpc.rs
@@ -7,7 +7,7 @@
 use super::AwsccSchemaConfig;
 use super::tags_type;
 use super::validate_tags_map;
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, Value};
 use carina_core::schema::{
     AttributeSchema, AttributeType, ResourceSchema, legacy_validator, types,
 };
@@ -15,7 +15,7 @@ use carina_core::schema::{
 const VALID_INSTANCE_TENANCY: &[&str] = &["default", "dedicated", "host"];
 
 fn validate_ipv4_netmask_length_range(value: &Value) -> Result<(), String> {
-    if let Value::Int(n) = value {
+    if let Value::Concrete(ConcreteValue::Int(n)) = value {
         if *n < 0 || *n > 32 {
             Err(format!("Value {} is out of range 0..=32", n))
         } else {

--- a/carina-provider-awscc/src/schemas/generated/ec2/vpc_endpoint.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/vpc_endpoint.rs
@@ -7,7 +7,7 @@
 use super::AwsccSchemaConfig;
 use super::tags_type;
 use super::validate_tags_map;
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, Value};
 use carina_core::schema::{
     AttributeSchema, AttributeType, ResourceSchema, StructField, legacy_validator,
 };
@@ -42,7 +42,7 @@ const VALID_VPC_ENDPOINT_TYPE: &[&str] = &[
 
 #[allow(dead_code)]
 fn validate_list_items_1_10(value: &Value) -> Result<(), String> {
-    if let Value::List(items) = value {
+    if let Value::Concrete(ConcreteValue::List(items)) = value {
         let len = items.len();
         if !(1..=10).contains(&len) {
             Err(format!("List has {} items, expected 1..=10", len))
@@ -55,7 +55,7 @@ fn validate_list_items_1_10(value: &Value) -> Result<(), String> {
 }
 
 fn validate_string_length_1_255(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
         let len = s.chars().count();
         if !(1..=255).contains(&len) {
             Err(format!("String length {} is out of range 1..=255", len))

--- a/carina-provider-awscc/src/schemas/generated/ec2/vpn_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/vpn_gateway.rs
@@ -7,13 +7,13 @@
 use super::AwsccSchemaConfig;
 use super::tags_type;
 use super::validate_tags_map;
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, Value};
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, legacy_validator};
 
 const VALID_TYPE: &[&str] = &["ipsec.1"];
 
 fn validate_amazon_side_asn_range(value: &Value) -> Result<(), String> {
-    if let Value::Int(n) = value {
+    if let Value::Concrete(ConcreteValue::Int(n)) = value {
         if *n < 1 || *n > 4294967294 {
             Err(format!("Value {} is out of range 1..=4294967294", n))
         } else {

--- a/carina-provider-awscc/src/schemas/generated/iam/oidc_provider.rs
+++ b/carina-provider-awscc/src/schemas/generated/iam/oidc_provider.rs
@@ -7,13 +7,13 @@
 use super::AwsccSchemaConfig;
 use super::tags_type;
 use super::validate_tags_map;
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, Value};
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, legacy_validator};
 use regex::Regex;
 
 #[allow(dead_code)]
 fn validate_list_items_max_5(value: &Value) -> Result<(), String> {
-    if let Value::List(items) = value {
+    if let Value::Concrete(ConcreteValue::List(items)) = value {
         let len = items.len();
         if len > 5 {
             Err(format!("List has {} items, expected ..=5", len))
@@ -26,7 +26,7 @@ fn validate_list_items_max_5(value: &Value) -> Result<(), String> {
 }
 
 fn validate_string_length_1_255(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
         let len = s.chars().count();
         if !(1..=255).contains(&len) {
             Err(format!("String length {} is out of range 1..=255", len))
@@ -40,7 +40,7 @@ fn validate_string_length_1_255(value: &Value) -> Result<(), String> {
 
 #[allow(dead_code)]
 fn validate_string_pattern_57ee0c44b504b839_len_40_40(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
         static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
             Regex::new("[0-9A-Fa-f]{40}").expect("invalid pattern regex")
         });

--- a/carina-provider-awscc/src/schemas/generated/iam/role.rs
+++ b/carina-provider-awscc/src/schemas/generated/iam/role.rs
@@ -7,13 +7,13 @@
 use super::AwsccSchemaConfig;
 use super::tags_type;
 use super::validate_tags_map;
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, Value};
 use carina_core::schema::{
     AttributeSchema, AttributeType, ResourceSchema, StructField, legacy_validator,
 };
 
 fn validate_max_session_duration_range(value: &Value) -> Result<(), String> {
-    if let Value::Int(n) = value {
+    if let Value::Concrete(ConcreteValue::Int(n)) = value {
         if *n < 3600 || *n > 43200 {
             Err(format!("Value {} is out of range 3600..=43200", n))
         } else {
@@ -72,7 +72,7 @@ pub fn iam_role_config() -> AwsccSchemaConfig {
                 .create_only()
                 .with_description("The path to the role. For more information about paths, see [IAM Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html) in the *IAM User Guide*. This parameter is optional. If it is not included, it defaults to a slash (/). This parameter allows (through its [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex)) a string of characters consisting of either a forward slash (/) by itself or a string that must begin and end with forward slashes. In addition, it can contain any ASCII character from the ! (``\\u0021``) through the DEL character (``\\u007F``), including most punctuation characters, digits, and upper and lowercased letters.")
                 .with_provider_name("Path")
-                .with_default(Value::String("/".to_string())),
+                .with_default(Value::Concrete(ConcreteValue::String("/".to_string()))),
         )
         .attribute(
             AttributeSchema::new("permissions_boundary", super::iam_policy_arn())

--- a/carina-provider-awscc/src/schemas/generated/identitystore/group.rs
+++ b/carina-provider-awscc/src/schemas/generated/identitystore/group.rs
@@ -5,13 +5,13 @@
 //! DO NOT EDIT MANUALLY - regenerate with carina-codegen
 
 use super::AwsccSchemaConfig;
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, Value};
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, legacy_validator};
 use regex::Regex;
 
 #[allow(dead_code)]
 fn validate_string_pattern_a301e45ae2f7df12_len_1_1024(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
         static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
             Regex::new("^[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}\\t\\n\\r  ]+$")
                 .expect("invalid pattern regex")
@@ -34,7 +34,7 @@ fn validate_string_pattern_a301e45ae2f7df12_len_1_1024(value: &Value) -> Result<
 
 #[allow(dead_code)]
 fn validate_string_pattern_3e29f1c0497511f3_len_1_1024(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
         static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
             Regex::new("^[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}\\t\\n\\r  　]+$")
                 .expect("invalid pattern regex")

--- a/carina-provider-awscc/src/schemas/generated/identitystore/group_membership.rs
+++ b/carina-provider-awscc/src/schemas/generated/identitystore/group_membership.rs
@@ -5,7 +5,7 @@
 //! DO NOT EDIT MANUALLY - regenerate with carina-codegen
 
 use super::AwsccSchemaConfig;
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, Value};
 use carina_core::schema::{
     AttributeSchema, AttributeType, ResourceSchema, StructField, legacy_validator,
 };
@@ -13,7 +13,7 @@ use regex::Regex;
 
 #[allow(dead_code)]
 fn validate_string_pattern_2a77a2e32f71b5f3_len_1_47(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
         static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
             Regex::new("^([0-9a-f]{10}-|)[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$").expect("invalid pattern regex")
         });

--- a/carina-provider-awscc/src/schemas/generated/logs/log_group.rs
+++ b/carina-provider-awscc/src/schemas/generated/logs/log_group.rs
@@ -7,7 +7,7 @@
 use super::AwsccSchemaConfig;
 use super::tags_type;
 use super::validate_tags_map;
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, Value};
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, legacy_validator};
 use regex::Regex;
 
@@ -19,7 +19,7 @@ const VALID_RETENTION_IN_DAYS_VALUES: &[i64] = &[
 ];
 
 fn validate_retention_in_days_int_enum(value: &Value) -> Result<(), String> {
-    if let Value::Int(n) = value {
+    if let Value::Concrete(ConcreteValue::Int(n)) = value {
         if VALID_RETENTION_IN_DAYS_VALUES.contains(n) {
             Ok(())
         } else {
@@ -32,7 +32,7 @@ fn validate_retention_in_days_int_enum(value: &Value) -> Result<(), String> {
 
 #[allow(dead_code)]
 fn validate_string_pattern_b6dfbc56753dfe38_len_1_512(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
         static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
             Regex::new("^[.\\-_/#A-Za-z0-9]{1,512}\\z").expect("invalid pattern regex")
         });
@@ -75,7 +75,7 @@ pub fn logs_log_group_config() -> AwsccSchemaConfig {
             AttributeSchema::new("deletion_protection_enabled", AttributeType::Bool)
                 .with_description("Indicates whether deletion protection is enabled for this log group. When enabled, deletion protection blocks all deletion operations until it is explicitly disabled.")
                 .with_provider_name("DeletionProtectionEnabled")
-                .with_default(Value::Bool(false)),
+                .with_default(Value::Concrete(ConcreteValue::Bool(false))),
         )
         .attribute(
             AttributeSchema::new("field_index_policies", AttributeType::unordered_list(AttributeType::map(AttributeType::String)))
@@ -96,7 +96,7 @@ pub fn logs_log_group_config() -> AwsccSchemaConfig {
             })
                 .with_description("Specifies the log group class for this log group. There are two classes: + The ``Standard`` log class supports all CWL features. + The ``Infrequent Access`` log class supports a subset of CWL features and incurs lower costs. For details about the features supported by each class, see [Log classes](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CloudWatch_Logs_Log_Classes.html)")
                 .with_provider_name("LogGroupClass")
-                .with_default(Value::String("STANDARD".to_string())),
+                .with_default(Value::Concrete(ConcreteValue::String("STANDARD".to_string()))),
         )
         .attribute(
             AttributeSchema::new("log_group_name", AttributeType::Custom {

--- a/carina-provider-awscc/src/schemas/generated/organizations/account.rs
+++ b/carina-provider-awscc/src/schemas/generated/organizations/account.rs
@@ -7,7 +7,7 @@
 use super::AwsccSchemaConfig;
 use super::tags_type;
 use super::validate_tags_map;
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, Value};
 use carina_core::schema::{
     AttributeSchema, AttributeType, ResourceSchema, legacy_validator, types,
 };
@@ -27,7 +27,7 @@ const VALID_STATUS: &[&str] = &["ACTIVE", "SUSPENDED", "PENDING_CLOSURE"];
 
 #[allow(dead_code)]
 fn validate_string_pattern_6fa92970742ee8e6(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
         static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
             Regex::new("^(r-[0-9a-z]{4,32})|(ou-[0-9a-z]{4,32}-[a-z0-9]{8,32})$")
                 .expect("invalid pattern regex")
@@ -47,7 +47,7 @@ fn validate_string_pattern_6fa92970742ee8e6(value: &Value) -> Result<(), String>
 
 #[allow(dead_code)]
 fn validate_string_pattern_f777bea2efc17af6(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
         static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
             Regex::new("^(o-[a-z0-9]{10,32}/r-[0-9a-z]{4,32}(/ou-[0-9a-z]{4,32}-[a-z0-9]{8,32})*(/\\d{12})*)/").expect("invalid pattern regex")
         });
@@ -66,7 +66,7 @@ fn validate_string_pattern_f777bea2efc17af6(value: &Value) -> Result<(), String>
 
 #[allow(dead_code)]
 fn validate_string_pattern_9329bdea96a93739_len_max_256(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
         static RE: std::sync::LazyLock<Regex> =
             std::sync::LazyLock::new(|| Regex::new("[\\s\\S]*").expect("invalid pattern regex"));
         if !RE.is_match(s) {
@@ -84,7 +84,7 @@ fn validate_string_pattern_9329bdea96a93739_len_max_256(value: &Value) -> Result
 
 #[allow(dead_code)]
 fn validate_string_pattern_9329bdea96a93739_len_1_128(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
         static RE: std::sync::LazyLock<Regex> =
             std::sync::LazyLock::new(|| Regex::new("[\\s\\S]*").expect("invalid pattern regex"));
         if !RE.is_match(s) {
@@ -102,7 +102,7 @@ fn validate_string_pattern_9329bdea96a93739_len_1_128(value: &Value) -> Result<(
 
 #[allow(dead_code)]
 fn validate_string_pattern_3af299ea99241fab_len_1_50(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
         static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
             Regex::new("[\\u0020-\\u007E]+").expect("invalid pattern regex")
         });
@@ -124,7 +124,7 @@ fn validate_string_pattern_3af299ea99241fab_len_1_50(value: &Value) -> Result<()
 
 #[allow(dead_code)]
 fn validate_string_pattern_253e7eb79a4beec5_len_1_64(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
         static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
             Regex::new("[\\w+=,.@-]{1,64}").expect("invalid pattern regex")
         });
@@ -241,7 +241,7 @@ pub fn organizations_account_config() -> AwsccSchemaConfig {
                 .write_only()
                 .with_description("The name of an IAM role that AWS Organizations automatically preconfigures in the new member account. Default name is OrganizationAccountAccessRole if not specified.")
                 .with_provider_name("RoleName")
-                .with_default(Value::String("OrganizationAccountAccessRole".to_string())),
+                .with_default(Value::Concrete(ConcreteValue::String("OrganizationAccountAccessRole".to_string()))),
         )
         .attribute(
             AttributeSchema::new("state", AttributeType::StringEnum {

--- a/carina-provider-awscc/src/schemas/generated/organizations/organization.rs
+++ b/carina-provider-awscc/src/schemas/generated/organizations/organization.rs
@@ -5,7 +5,7 @@
 //! DO NOT EDIT MANUALLY - regenerate with carina-codegen
 
 use super::AwsccSchemaConfig;
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, Value};
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, legacy_validator};
 use regex::Regex;
 
@@ -13,7 +13,7 @@ const VALID_FEATURE_SET: &[&str] = &["ALL", "CONSOLIDATED_BILLING"];
 
 #[allow(dead_code)]
 fn validate_string_pattern_2fd01fd52b67fc75(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
         static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
             Regex::new("^o-[a-z0-9]{10,32}$").expect("invalid pattern regex")
         });
@@ -32,7 +32,7 @@ fn validate_string_pattern_2fd01fd52b67fc75(value: &Value) -> Result<(), String>
 
 #[allow(dead_code)]
 fn validate_string_pattern_ec4d9bee0dcd262b_len_6_64(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
         static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
             Regex::new("[^\\s@]+@[^\\s@]+\\.[^\\s@]+").expect("invalid pattern regex")
         });
@@ -54,7 +54,7 @@ fn validate_string_pattern_ec4d9bee0dcd262b_len_6_64(value: &Value) -> Result<()
 
 #[allow(dead_code)]
 fn validate_string_pattern_0cb01cbc89d38ae3_len_max_64(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
         static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
             Regex::new("^r-[0-9a-z]{4,32}$").expect("invalid pattern regex")
         });
@@ -97,7 +97,7 @@ pub fn organizations_organization_config() -> AwsccSchemaConfig {
             })
                 .with_description("Specifies the feature set supported by the new organization. Each feature set supports different levels of functionality.")
                 .with_provider_name("FeatureSet")
-                .with_default(Value::String("ALL".to_string())),
+                .with_default(Value::Concrete(ConcreteValue::String("ALL".to_string()))),
         )
         .attribute(
             AttributeSchema::new("id", AttributeType::Custom {

--- a/carina-provider-awscc/src/schemas/generated/route53/hosted_zone.rs
+++ b/carina-provider-awscc/src/schemas/generated/route53/hosted_zone.rs
@@ -6,13 +6,13 @@
 
 use super::AwsccSchemaConfig;
 use super::validate_tags_map;
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, Value};
 use carina_core::schema::{
     AttributeSchema, AttributeType, ResourceSchema, StructField, legacy_validator,
 };
 
 fn validate_string_length_max_256(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
         let len = s.chars().count();
         if len > 256 {
             Err(format!("String length {} is out of range ..=256", len))
@@ -25,7 +25,7 @@ fn validate_string_length_max_256(value: &Value) -> Result<(), String> {
 }
 
 fn validate_string_length_max_128(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
         let len = s.chars().count();
         if len > 128 {
             Err(format!("String length {} is out of range ..=128", len))
@@ -38,7 +38,7 @@ fn validate_string_length_max_128(value: &Value) -> Result<(), String> {
 }
 
 fn validate_string_length_max_1024(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
         let len = s.chars().count();
         if len > 1024 {
             Err(format!("String length {} is out of range ..=1024", len))

--- a/carina-provider-awscc/src/schemas/generated/s3/bucket.rs
+++ b/carina-provider-awscc/src/schemas/generated/s3/bucket.rs
@@ -7,7 +7,7 @@
 use super::AwsccSchemaConfig;
 use super::tags_type;
 use super::validate_tags_map;
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, Value};
 use carina_core::schema::{
     AttributeSchema, AttributeType, ResourceSchema, StructField, legacy_validator, noop_validator,
 };
@@ -141,7 +141,7 @@ const VALID_TRANSITION_STORAGE_CLASS: &[&str] = &[
 const VALID_VERSIONING_CONFIGURATION_STATUS: &[&str] = &["Enabled", "Suspended"];
 
 fn validate_days_after_initiation_range(value: &Value) -> Result<(), String> {
-    if let Value::Int(n) = value {
+    if let Value::Concrete(ConcreteValue::Int(n)) = value {
         if *n < 0 {
             Err(format!("Value {} is out of range 0..", n))
         } else {
@@ -153,7 +153,7 @@ fn validate_days_after_initiation_range(value: &Value) -> Result<(), String> {
 }
 
 fn validate_max_age_range(value: &Value) -> Result<(), String> {
-    if let Value::Int(n) = value {
+    if let Value::Concrete(ConcreteValue::Int(n)) = value {
         if *n < 0 {
             Err(format!("Value {} is out of range 0..", n))
         } else {
@@ -166,7 +166,7 @@ fn validate_max_age_range(value: &Value) -> Result<(), String> {
 
 #[allow(dead_code)]
 fn validate_string_pattern_cc806c69dc4cdaf7(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
         static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
             Regex::new("^(\\d{4})-(0[0-9]|1[0-2])-([0-2]\\d|3[01])T([01]\\d|2[0-4]):([0-5]\\d):([0-6]\\d)((\\.\\d{3})?)Z$").expect("invalid pattern regex")
         });
@@ -184,7 +184,7 @@ fn validate_string_pattern_cc806c69dc4cdaf7(value: &Value) -> Result<(), String>
 }
 
 fn validate_string_length_max_255(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
         let len = s.chars().count();
         if len > 255 {
             Err(format!("String length {} is out of range ..=255", len))
@@ -197,7 +197,7 @@ fn validate_string_length_max_255(value: &Value) -> Result<(), String> {
 }
 
 fn validate_string_length_max_1024(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
         let len = s.chars().count();
         if len > 1024 {
             Err(format!("String length {} is out of range ..=1024", len))
@@ -211,7 +211,7 @@ fn validate_string_length_max_1024(value: &Value) -> Result<(), String> {
 
 #[allow(dead_code)]
 fn validate_string_pattern_3ee03875337c12ab_len_max_20(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
         static RE: std::sync::LazyLock<Regex> =
             std::sync::LazyLock::new(|| Regex::new("[0-9]+").expect("invalid pattern regex"));
         if !RE.is_match(s) {

--- a/carina-provider-awscc/src/schemas/generated/sso/instance.rs
+++ b/carina-provider-awscc/src/schemas/generated/sso/instance.rs
@@ -7,7 +7,7 @@
 use super::AwsccSchemaConfig;
 use super::tags_type;
 use super::validate_tags_map;
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, Value};
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, legacy_validator};
 use regex::Regex;
 
@@ -15,7 +15,7 @@ const VALID_STATUS: &[&str] = &["CREATE_IN_PROGRESS", "DELETE_IN_PROGRESS", "ACT
 
 #[allow(dead_code)]
 fn validate_list_items_max_75(value: &Value) -> Result<(), String> {
-    if let Value::List(items) = value {
+    if let Value::Concrete(ConcreteValue::List(items)) = value {
         let len = items.len();
         if len > 75 {
             Err(format!("List has {} items, expected ..=75", len))
@@ -29,7 +29,7 @@ fn validate_list_items_max_75(value: &Value) -> Result<(), String> {
 
 #[allow(dead_code)]
 fn validate_string_pattern_9b83f4f8f3673df5_len_max_256(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
         static RE: std::sync::LazyLock<Regex> =
             std::sync::LazyLock::new(|| Regex::new("[\\w+=,.@-]+").expect("invalid pattern regex"));
         if !RE.is_match(s) {
@@ -47,7 +47,7 @@ fn validate_string_pattern_9b83f4f8f3673df5_len_max_256(value: &Value) -> Result
 
 #[allow(dead_code)]
 fn validate_string_pattern_9b83f4f8f3673df5_len_1_128(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
         static RE: std::sync::LazyLock<Regex> =
             std::sync::LazyLock::new(|| Regex::new("[\\w+=,.@-]+").expect("invalid pattern regex"));
         if !RE.is_match(s) {
@@ -65,7 +65,7 @@ fn validate_string_pattern_9b83f4f8f3673df5_len_1_128(value: &Value) -> Result<(
 
 #[allow(dead_code)]
 fn validate_string_pattern_5a2bd7daee6344f1_len_1_32(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
         static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
             Regex::new("^[\\w+=,.@-]+$").expect("invalid pattern regex")
         });

--- a/carina-provider-awscc/src/schemas/generated/sso/permission_set.rs
+++ b/carina-provider-awscc/src/schemas/generated/sso/permission_set.rs
@@ -7,7 +7,7 @@
 use super::AwsccSchemaConfig;
 use super::tags_type;
 use super::validate_tags_map;
-use carina_core::resource::Value;
+use carina_core::resource::{ConcreteValue, Value};
 use carina_core::schema::{
     AttributeSchema, AttributeType, ResourceSchema, StructField, legacy_validator,
 };
@@ -15,7 +15,7 @@ use regex::Regex;
 
 #[allow(dead_code)]
 fn validate_list_items_max_20(value: &Value) -> Result<(), String> {
-    if let Value::List(items) = value {
+    if let Value::Concrete(ConcreteValue::List(items)) = value {
         let len = items.len();
         if len > 20 {
             Err(format!("List has {} items, expected ..=20", len))
@@ -29,7 +29,7 @@ fn validate_list_items_max_20(value: &Value) -> Result<(), String> {
 
 #[allow(dead_code)]
 fn validate_list_items_max_50(value: &Value) -> Result<(), String> {
-    if let Value::List(items) = value {
+    if let Value::Concrete(ConcreteValue::List(items)) = value {
         let len = items.len();
         if len > 50 {
             Err(format!("List has {} items, expected ..=50", len))
@@ -43,7 +43,7 @@ fn validate_list_items_max_50(value: &Value) -> Result<(), String> {
 
 #[allow(dead_code)]
 fn validate_string_pattern_b84fa12576539ca9_len_1_512(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
         static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
             Regex::new("((/[A-Za-z0-9\\.,\\+@=_-]+)*)/").expect("invalid pattern regex")
         });
@@ -65,7 +65,7 @@ fn validate_string_pattern_b84fa12576539ca9_len_1_512(value: &Value) -> Result<(
 
 #[allow(dead_code)]
 fn validate_string_pattern_9863be410e005e12_len_1_700(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
         static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
             Regex::new("[\\u0009\\u000A\\u000D\\u0020-\\u007E\\u00A1-\\u00FF]*")
                 .expect("invalid pattern regex")
@@ -88,7 +88,7 @@ fn validate_string_pattern_9863be410e005e12_len_1_700(value: &Value) -> Result<(
 
 #[allow(dead_code)]
 fn validate_string_pattern_9b83f4f8f3673df5_len_max_256(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
         static RE: std::sync::LazyLock<Regex> =
             std::sync::LazyLock::new(|| Regex::new("[\\w+=,.@-]+").expect("invalid pattern regex"));
         if !RE.is_match(s) {
@@ -106,7 +106,7 @@ fn validate_string_pattern_9b83f4f8f3673df5_len_max_256(value: &Value) -> Result
 
 #[allow(dead_code)]
 fn validate_string_pattern_9b83f4f8f3673df5_len_1_32(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
         static RE: std::sync::LazyLock<Regex> =
             std::sync::LazyLock::new(|| Regex::new("[\\w+=,.@-]+").expect("invalid pattern regex"));
         if !RE.is_match(s) {
@@ -124,7 +124,7 @@ fn validate_string_pattern_9b83f4f8f3673df5_len_1_32(value: &Value) -> Result<()
 
 #[allow(dead_code)]
 fn validate_string_pattern_9b83f4f8f3673df5_len_1_128(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
         static RE: std::sync::LazyLock<Regex> =
             std::sync::LazyLock::new(|| Regex::new("[\\w+=,.@-]+").expect("invalid pattern regex"));
         if !RE.is_match(s) {
@@ -142,7 +142,7 @@ fn validate_string_pattern_9b83f4f8f3673df5_len_1_128(value: &Value) -> Result<(
 
 #[allow(dead_code)]
 fn validate_string_pattern_4d6d630589930649_len_1_240(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
         static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
             Regex::new("[a-zA-Z0-9&amp;$@#\\/%?=~\\-_'&quot;|!:,.;*+\\[\\]\\ \\(\\)\\{\\}]+")
                 .expect("invalid pattern regex")
@@ -165,7 +165,7 @@ fn validate_string_pattern_4d6d630589930649_len_1_240(value: &Value) -> Result<(
 
 #[allow(dead_code)]
 fn validate_string_pattern_1e58d8243b46a2f1_len_1_100(value: &Value) -> Result<(), String> {
-    if let Value::String(s) = value {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
         static RE: std::sync::LazyLock<Regex> =
             std::sync::LazyLock::new(|| Regex::new(".*").expect("invalid pattern regex"));
         if !RE.is_match(s) {


### PR DESCRIPTION
## Summary

Bumps the `carina-core` git rev from `1d5f1a24` to `e73e8bee` (Phase 5a merge commit). Structurally identical to the `carina-provider-aws` sync ([PR #253](https://github.com/carina-rs/carina-provider-aws/pull/253)).

## What changed

- Every `Value` pattern site now matches `Value::Concrete(ConcreteValue::X(...))` or `Value::Deferred(DeferredValue::X(...))`.
- `core_to_proto_value` is now **exhaustive** over the new axis. Previous `_ => format!("{v:?}")` catch-all was a latent **Secret-plaintext leak** (`Debug` on `Value::Deferred(Secret(inner))` included the inner plaintext). Replaced with per-variant redacted sentinels.
- `Duration` mapped to integer seconds at the WIT boundary.
- New `Directives.depends_on` and `ResourceSchema.default_wait_*` fields wired with defaults.
- Generated schemas regenerated.

## Test plan

- [x] `cargo nextest run --workspace` — 437 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace --doc` — green
- [x] `cargo fmt --all --check` — clean

WIT contract unchanged.

Refs carina-rs/carina#2972.

🤖 Generated with [Claude Code](https://claude.com/claude-code)