### PR TITLE
hand-written: switch all Value::X(...) emission to nested ConcreteValue form

### DIFF
--- a/carina-provider-awscc/src/lib.rs
+++ b/carina-provider-awscc/src/lib.rs
@@ -347,14 +347,14 @@ mod tests {
         attrs.insert(
             "allowed_account_ids".to_string(),
             Value::Concrete(ConcreteValue::List(vec![
-                Value::String("111111111111".to_string()),
-                Value::String("222222222222".to_string()),
+                Value::Concrete(ConcreteValue::String("111111111111".to_string())),
+                Value::Concrete(ConcreteValue::String("222222222222".to_string())),
             ])),
         );
         attrs.insert(
             "forbidden_account_ids".to_string(),
-            Value::Concrete(ConcreteValue::List(vec![Value::String(
-                "999999999999".to_string(),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::String("999999999999".to_string()),
             )])),
         );
 

--- a/carina-provider-awscc/src/provider/conversion.rs
+++ b/carina-provider-awscc/src/provider/conversion.rs
@@ -397,7 +397,7 @@ mod tests {
         );
         let result = result.expect("Should return Some");
 
-        // Must be Value::Map(...) to match parser output for map assignment syntax
+        // Must be Value::Concrete(ConcreteValue::Map(...)) to match parser output for map assignment syntax
         if let Value::Concrete(ConcreteValue::Map(map)) = &result {
             assert_eq!(
                 map.get("status"),
@@ -421,7 +421,7 @@ mod tests {
             fields,
         };
 
-        // Parser produces Value::Map(...) for map assignment syntax (= { ... })
+        // Parser produces Value::Concrete(ConcreteValue::Map(...)) for map assignment syntax (= { ... })
         let mut map = IndexMap::new();
         map.insert(
             "status".to_string(),
@@ -456,13 +456,15 @@ mod tests {
             fields,
         };
 
-        // Parser produces Value::List(vec![Value::Map(...)]) for block syntax (name { ... })
+        // Parser produces Value::Concrete(ConcreteValue::List(vec![Value::Concrete(ConcreteValue::Map(...))])) for block syntax (name { ... })
         let mut map = IndexMap::new();
         map.insert(
             "status".to_string(),
             Value::Concrete(ConcreteValue::String("Enabled".to_string())),
         );
-        let dsl_value = Value::Concrete(ConcreteValue::List(vec![Value::Map(map)]));
+        let dsl_value = Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::Map(map),
+        )]));
 
         let result = dsl_value_to_aws(
             &dsl_value,
@@ -635,8 +637,12 @@ mod tests {
         };
         let attr_type = AttributeType::list(inner);
         let value = Value::Concrete(ConcreteValue::List(vec![
-            Value::String("awscc.s3.Bucket.AllowedMethod.GET".to_string()),
-            Value::String("awscc.s3.Bucket.AllowedMethod.PUT".to_string()),
+            Value::Concrete(ConcreteValue::String(
+                "awscc.s3.Bucket.AllowedMethod.GET".to_string(),
+            )),
+            Value::Concrete(ConcreteValue::String(
+                "awscc.s3.Bucket.AllowedMethod.PUT".to_string(),
+            )),
         ]));
         let result = dsl_value_to_aws(&value, &attr_type, "s3.Bucket", "allowed_methods");
         assert_eq!(result, Some(json!(["GET", "PUT"])));
@@ -656,8 +662,12 @@ mod tests {
         assert_eq!(
             result,
             Some(Value::Concrete(ConcreteValue::List(vec![
-                Value::String("awscc.s3.Bucket.AllowedMethod.GET".to_string()),
-                Value::String("awscc.s3.Bucket.AllowedMethod.PUT".to_string()),
+                Value::Concrete(ConcreteValue::String(
+                    "awscc.s3.Bucket.AllowedMethod.GET".to_string()
+                )),
+                Value::Concrete(ConcreteValue::String(
+                    "awscc.s3.Bucket.AllowedMethod.PUT".to_string()
+                )),
             ])))
         );
     }
@@ -832,32 +842,41 @@ mod tests {
             vec![
                 (
                     "version".to_string(),
-                    Value::String("2012-10-17".to_string()),
+                    Value::Concrete(ConcreteValue::String("2012-10-17".to_string())),
                 ),
                 (
                     "statement".to_string(),
-                    Value::List(vec![Value::Map(
-                        vec![
-                            ("effect".to_string(), Value::String("Allow".to_string())),
-                            (
-                                "action".to_string(),
-                                Value::String("sts:AssumeRole".to_string()),
-                            ),
-                            (
-                                "principal".to_string(),
-                                Value::Map(
-                                    vec![(
-                                        "service".to_string(),
-                                        Value::String("lambda.amazonaws.com".to_string()),
-                                    )]
-                                    .into_iter()
-                                    .collect(),
+                    Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                        ConcreteValue::Map(
+                            vec![
+                                (
+                                    "effect".to_string(),
+                                    Value::Concrete(ConcreteValue::String("Allow".to_string())),
                                 ),
-                            ),
-                        ]
-                        .into_iter()
-                        .collect(),
-                    )]),
+                                (
+                                    "action".to_string(),
+                                    Value::Concrete(ConcreteValue::String(
+                                        "sts:AssumeRole".to_string(),
+                                    )),
+                                ),
+                                (
+                                    "principal".to_string(),
+                                    Value::Concrete(ConcreteValue::Map(
+                                        vec![(
+                                            "service".to_string(),
+                                            Value::Concrete(ConcreteValue::String(
+                                                "lambda.amazonaws.com".to_string(),
+                                            )),
+                                        )]
+                                        .into_iter()
+                                        .collect(),
+                                    )),
+                                ),
+                            ]
+                            .into_iter()
+                            .collect(),
+                        ),
+                    )])),
                 ),
             ]
             .into_iter()
@@ -989,10 +1008,14 @@ mod tests {
         let json_val = json!([{"RegionName": "ap-northeast-1"}]);
 
         let result = aws_value_to_dsl("operating_regions", &json_val, &attr_type, "ec2.Ipam");
-        let expected = Value::Concrete(ConcreteValue::List(vec![Value::Map(IndexMap::from([(
-            "region_name".to_string(),
-            Value::String("awscc.Region.ap_northeast_1".to_string()),
-        )]))]));
+        let expected = Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::Map(IndexMap::from([(
+                "region_name".to_string(),
+                Value::Concrete(ConcreteValue::String(
+                    "awscc.Region.ap_northeast_1".to_string(),
+                )),
+            )])),
+        )]));
         assert_eq!(result, Some(expected));
     }
 
@@ -1098,8 +1121,8 @@ mod tests {
         let json = serde_json::json!(["a", null, "b"]);
         let result = json_to_value(&json);
         let expected = Value::Concrete(ConcreteValue::List(vec![
-            Value::String("a".to_string()),
-            Value::String("b".to_string()),
+            Value::Concrete(ConcreteValue::String("a".to_string())),
+            Value::Concrete(ConcreteValue::String("b".to_string())),
         ]));
         assert_eq!(result, Some(expected));
     }
@@ -1127,8 +1150,8 @@ mod tests {
         let attr_type = AttributeType::list(AttributeType::String);
         let result = aws_value_to_dsl("test_attr", &json, &attr_type, "test.resource");
         let expected = Value::Concrete(ConcreteValue::List(vec![
-            Value::String("a".to_string()),
-            Value::String("b".to_string()),
+            Value::Concrete(ConcreteValue::String("a".to_string())),
+            Value::Concrete(ConcreteValue::String("b".to_string())),
         ]));
         assert_eq!(result, Some(expected));
     }
@@ -1136,9 +1159,9 @@ mod tests {
     #[test]
     fn test_value_to_json_list_with_nan_drops_nan_items() {
         let value = Value::Concrete(ConcreteValue::List(vec![
-            Value::Float(1.0),
-            Value::Float(f64::NAN),
-            Value::Float(2.0),
+            Value::Concrete(ConcreteValue::Float(1.0)),
+            Value::Concrete(ConcreteValue::Float(f64::NAN)),
+            Value::Concrete(ConcreteValue::Float(2.0)),
         ]));
         let result = value_to_json(&value);
         let expected = serde_json::json!([1.0, 2.0]);
@@ -1356,9 +1379,9 @@ mod tests {
     #[test]
     fn test_dsl_value_to_aws_list_with_nan_drops_nan_items() {
         let value = Value::Concrete(ConcreteValue::List(vec![
-            Value::Float(1.0),
-            Value::Float(f64::NAN),
-            Value::Float(2.0),
+            Value::Concrete(ConcreteValue::Float(1.0)),
+            Value::Concrete(ConcreteValue::Float(f64::NAN)),
+            Value::Concrete(ConcreteValue::Float(2.0)),
         ]));
         let attr_type = AttributeType::list(AttributeType::Float);
         let result = dsl_value_to_aws(&value, &attr_type, "test.resource", "test_attr");

--- a/carina-provider-awscc/src/provider/normalizer.rs
+++ b/carina-provider-awscc/src/provider/normalizer.rs
@@ -568,7 +568,9 @@ mod tests {
             "from_port".to_string(),
             Value::Concrete(ConcreteValue::Int(443)),
         );
-        let value = Value::Concrete(ConcreteValue::List(vec![Value::Map(map)]));
+        let value = Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::Map(map),
+        )]));
 
         let resolved = resolve_struct_enum_values(&value, &fields);
         if let Value::Concrete(ConcreteValue::List(items)) = resolved {
@@ -596,7 +598,9 @@ mod tests {
             "ip_protocol".to_string(),
             Value::Concrete(ConcreteValue::String("IpProtocol.tcp".to_string())),
         );
-        let value = Value::Concrete(ConcreteValue::List(vec![Value::Map(map)]));
+        let value = Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::Map(map),
+        )]));
 
         let resolved = resolve_struct_enum_values(&value, &fields);
         if let Value::Concrete(ConcreteValue::List(items)) = resolved {
@@ -625,7 +629,9 @@ mod tests {
                 "awscc.ec2.SecurityGroup.IpProtocol.tcp".to_string(),
             )),
         );
-        let value = Value::Concrete(ConcreteValue::List(vec![Value::Map(map)]));
+        let value = Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::Map(map),
+        )]));
 
         let resolved = resolve_struct_enum_values(&value, &fields);
         if let Value::Concrete(ConcreteValue::List(items)) = resolved {
@@ -662,7 +668,9 @@ mod tests {
         );
         resource.set_attr(
             "security_group_egress".to_string(),
-            Value::Concrete(ConcreteValue::List(vec![Value::Map(egress_map)])),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::Map(egress_map),
+            )])),
         );
 
         let mut resources = vec![resource];
@@ -854,8 +862,8 @@ mod tests {
         let mut inner_map = IndexMap::new();
         inner_map.insert(
             "encryption_type".to_string(),
-            Value::Concrete(ConcreteValue::List(vec![Value::String(
-                "SSE-C".to_string(),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::String("SSE-C".to_string()),
             )])),
         );
         let mut map = IndexMap::new();
@@ -877,7 +885,9 @@ mod tests {
             Value::Concrete(ConcreteValue::Map(sse_map)),
         );
 
-        let value = Value::Concrete(ConcreteValue::List(vec![Value::Map(map)]));
+        let value = Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::Map(map),
+        )]));
         let resolved = resolve_struct_enum_values(&value, &fields);
 
         // Verify the nested enum was resolved
@@ -964,19 +974,26 @@ mod tests {
         let mut policy_map = IndexMap::new();
         policy_map.insert(
             "Statement".to_string(),
-            Value::Concrete(ConcreteValue::List(vec![Value::Map({
-                let mut stmt = IndexMap::new();
-                stmt.insert("Effect".to_string(), Value::String("Allow".to_string()));
-                stmt.insert(
-                    "Action".to_string(),
-                    Value::String("s3:GetObject".to_string()),
-                );
-                stmt.insert(
-                    "Resource".to_string(),
-                    Value::String("arn:aws:s3:::my-bucket/*".to_string()),
-                );
-                stmt
-            })])),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::Map({
+                    let mut stmt = IndexMap::new();
+                    stmt.insert(
+                        "Effect".to_string(),
+                        Value::Concrete(ConcreteValue::String("Allow".to_string())),
+                    );
+                    stmt.insert(
+                        "Action".to_string(),
+                        Value::Concrete(ConcreteValue::String("s3:GetObject".to_string())),
+                    );
+                    stmt.insert(
+                        "Resource".to_string(),
+                        Value::Concrete(ConcreteValue::String(
+                            "arn:aws:s3:::my-bucket/*".to_string(),
+                        )),
+                    );
+                    stmt
+                }),
+            )])),
         );
 
         let (id, state) = make_state(

--- a/carina-provider-awscc/src/provider/operations.rs
+++ b/carina-provider-awscc/src/provider/operations.rs
@@ -356,7 +356,7 @@ mod tests {
 
     /// carina-rs/carina#2544: CloudControl omits empty optional list
     /// fields from `GetResource`. The provider read path must canonicalize
-    /// these absent-but-empty fields to `Value::List(vec![])` so the
+    /// these absent-but-empty fields to `Value::Concrete(ConcreteValue::List(vec![]))` so the
     /// differ does not see `(none) → []` against a user-specified `= []`.
     #[test]
     fn absent_optional_list_becomes_empty_list() {
@@ -457,9 +457,11 @@ mod tests {
 
         assert_eq!(
             result.get("managed_policy_arns"),
-            Some(&Value::Concrete(ConcreteValue::List(vec![Value::String(
-                "arn:aws:iam::aws:policy/ReadOnlyAccess".to_string()
-            )]))),
+            Some(&Value::Concrete(ConcreteValue::List(vec![
+                Value::Concrete(ConcreteValue::String(
+                    "arn:aws:iam::aws:policy/ReadOnlyAccess".to_string()
+                ))
+            ]))),
         );
     }
 

--- a/carina-provider-awscc/src/schemas/awscc_types.rs
+++ b/carina-provider-awscc/src/schemas/awscc_types.rs
@@ -421,22 +421,32 @@ mod tests {
             vec![
                 (
                     "version".to_string(),
-                    Value::String("2012-10-17".to_string()),
+                    Value::Concrete(ConcreteValue::String("2012-10-17".to_string())),
                 ),
                 (
                     "statement".to_string(),
-                    Value::List(vec![Value::Map(
-                        vec![
-                            ("effect".to_string(), Value::String("Allow".to_string())),
-                            (
-                                "action".to_string(),
-                                Value::String("sts:AssumeRole".to_string()),
-                            ),
-                            ("resource".to_string(), Value::String("*".to_string())),
-                        ]
-                        .into_iter()
-                        .collect(),
-                    )]),
+                    Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                        ConcreteValue::Map(
+                            vec![
+                                (
+                                    "effect".to_string(),
+                                    Value::Concrete(ConcreteValue::String("Allow".to_string())),
+                                ),
+                                (
+                                    "action".to_string(),
+                                    Value::Concrete(ConcreteValue::String(
+                                        "sts:AssumeRole".to_string(),
+                                    )),
+                                ),
+                                (
+                                    "resource".to_string(),
+                                    Value::Concrete(ConcreteValue::String("*".to_string())),
+                                ),
+                            ]
+                            .into_iter()
+                            .collect(),
+                        ),
+                    )])),
                 ),
             ]
             .into_iter()


### PR DESCRIPTION
## Summary

Mirrors `carina-provider-aws#256`.

- The helper-method shim (`Value::String(s)`, `Value::Int(n)`, ...) was added during the RFC #2972 Value Concrete/Deferred split for source-compatibility.
- With the codegen template fix in #213, machine-emitted code is on the nested form, but the hand-written sites still used the helpers, blocking removal of the helpers from carina-core.
- Switch every hand-written `Value::X(expr)` site to `Value::Concrete(ConcreteValue::X(expr))`. Skips `serde_json::Value::*`, `ConcreteValue::*`, `EnumValue::*`.
- After this change, no live caller in carina-provider-awscc uses the helper methods.

## Test plan

- [x] `cargo nextest run --workspace` → 437/437 pass
- [x] `cargo test --workspace --doc` → pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] CI green

Once this and #256 are merged, the helper methods (`#[allow(non_snake_case)] impl Value { fn String(...), ... }`) can be removed from carina-core in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
