### PR TITLE
acceptance-tests: rename lifecycle to directives in s3_bucket fixtures (closes #215)

### DIFF
--- a/acceptance-tests/s3_bucket/encryption.crn
+++ b/acceptance-tests/s3_bucket/encryption.crn
@@ -20,7 +20,7 @@ awscc.s3.Bucket {
     }
   }
 
-  lifecycle {
+  directives {
     force_delete = true
   }
 }

--- a/acceptance-tests/s3_bucket/kms_encryption.crn
+++ b/acceptance-tests/s3_bucket/kms_encryption.crn
@@ -24,7 +24,7 @@ awscc.s3.Bucket {
     }
   }
 
-  lifecycle {
+  directives {
     force_delete = true
   }
 }

--- a/acceptance-tests/s3_bucket/lifecycle.crn
+++ b/acceptance-tests/s3_bucket/lifecycle.crn
@@ -29,7 +29,7 @@ awscc.s3.Bucket {
     }
   }
 
-  lifecycle {
+  directives {
     force_delete = true
   }
 }

--- a/acceptance-tests/s3_bucket/logging.crn
+++ b/acceptance-tests/s3_bucket/logging.crn
@@ -12,7 +12,7 @@ provider awscc {
 let log_bucket = awscc.s3.Bucket {
   bucket_name_prefix = 'carina-acc-test-log-'
 
-  lifecycle {
+  directives {
     force_delete = true
   }
 }
@@ -25,7 +25,7 @@ awscc.s3.Bucket {
     log_file_prefix         = 'access-logs/'
   }
 
-  lifecycle {
+  directives {
     force_delete = true
   }
 }

--- a/acceptance-tests/s3_bucket/prefix.crn
+++ b/acceptance-tests/s3_bucket/prefix.crn
@@ -11,7 +11,7 @@ provider awscc {
 awscc.s3.Bucket {
   bucket_name_prefix = 'carina-acc-test-'
 
-  lifecycle {
+  directives {
     force_delete = true
   }
 }

--- a/acceptance-tests/s3_bucket/public_access_block.crn
+++ b/acceptance-tests/s3_bucket/public_access_block.crn
@@ -18,7 +18,7 @@ awscc.s3.Bucket {
     restrict_public_buckets = true
   }
 
-  lifecycle {
+  directives {
     force_delete = true
   }
 }

--- a/acceptance-tests/s3_bucket/versioning.crn
+++ b/acceptance-tests/s3_bucket/versioning.crn
@@ -15,7 +15,7 @@ awscc.s3.Bucket {
     status = awscc.s3.Bucket.VersioningConfigurationStatus.Enabled
   }
 
-  lifecycle {
+  directives {
     force_delete = true
   }
 }

--- a/acceptance-tests/s3_bucket/website.crn
+++ b/acceptance-tests/s3_bucket/website.crn
@@ -16,7 +16,7 @@ awscc.s3.Bucket {
     error_document = 'error.html'
   }
 
-  lifecycle {
+  directives {
     force_delete = true
   }
 }


### PR DESCRIPTION
Closes #215.

## Summary

- carina#2826 (merged 2026-05-09) renamed the DSL meta-argument block from `lifecycle { ... }` to `directives { ... }` across the WIT contract, carina core, and both providers.
- The acceptance-test fixtures for `awscc.s3.Bucket` were not updated and the 8 affected tests have been failing with `Unknown attribute 'lifecycle'`.

## Changes

Rename the block in:
- `encryption.crn`, `kms_encryption.crn`, `lifecycle.crn`, `logging.crn`, `prefix.crn`, `public_access_block.crn`, `versioning.crn`, `website.crn`

The `lifecycle_configuration = { ... }` attribute (S3 lifecycle policy on the bucket) is **unchanged** — only the directives meta-block was renamed.

## Test plan

- [x] `carina fmt --check` on each fixture: all files are properly formatted.
- [ ] CI green
- [ ] Acceptance: re-run `./acceptance-tests/run-tests.sh full s3_bucket` to confirm all 8 tests recover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
