### PR TITLE
acceptance-tests: spell ec2_flow_log enum values namespacedly (closes #216)

### DIFF
--- a/acceptance-tests/ec2_flow_log/cloudwatch.crn
+++ b/acceptance-tests/ec2_flow_log/cloudwatch.crn
@@ -35,9 +35,9 @@ let flow_log_role = awscc.iam.Role {
 
 awscc.ec2.FlowLog {
   resource_id                 = vpc.vpc_id
-  resource_type               = vpc
-  traffic_type                = all
-  log_destination_type        = cloud_watch_logs
+  resource_type               = awscc.ec2.FlowLog.ResourceType.VPC
+  traffic_type                = awscc.ec2.FlowLog.TrafficType.ALL
+  log_destination_type        = awscc.ec2.FlowLog.LogDestinationType.cloud_watch_logs
   log_group_name              = log_group.log_group_name
   deliver_logs_permission_arn = flow_log_role.arn
 

--- a/acceptance-tests/ec2_flow_log/s3.crn
+++ b/acceptance-tests/ec2_flow_log/s3.crn
@@ -12,16 +12,16 @@ let vpc = awscc.ec2.Vpc {
 }
 
 let bucket = awscc.s3.Bucket {
-  lifecycle {
+  directives {
     force_delete = true
   }
 }
 
 awscc.ec2.FlowLog {
   resource_id          = vpc.vpc_id
-  resource_type        = vpc
-  traffic_type         = all
-  log_destination_type = s3
+  resource_type        = awscc.ec2.FlowLog.ResourceType.VPC
+  traffic_type         = awscc.ec2.FlowLog.TrafficType.ALL
+  log_destination_type = awscc.ec2.FlowLog.LogDestinationType.s3
   log_destination      = bucket.arn
 
   destination_options = {


### PR DESCRIPTION
Closes #216.

## Summary

The fixtures wrote enum attributes as bare identifiers that collide with local `let` bindings:

```
let vpc = awscc.ec2.Vpc { ... }
awscc.ec2.FlowLog {
  resource_type = vpc       # ← parser saw this as ${vpc}, not
                            #   awscc.ec2.FlowLog.ResourceType.VPC.
  ...
}
```

The DSL parser correctly resolved `vpc` as a binding reference, producing the interpolated form `${vpc}` which the enum validator rejected with `Invalid value '${vpc}' for 'resource_type'`.

## Changes

Use the fully qualified namespaced enum identifiers:
- `resource_type` → `awscc.ec2.FlowLog.ResourceType.VPC`
- `traffic_type` → `awscc.ec2.FlowLog.TrafficType.ALL`
- `log_destination_type` → `awscc.ec2.FlowLog.LogDestinationType.cloud_watch_logs` / `.s3`

Also rename the leftover `lifecycle { force_delete = true }` block in `s3.crn` to `directives` (same project-wide rename addressed in #218).

## Test plan

- [x] `carina fmt --check acceptance-tests/ec2_flow_log` clean
- [ ] CI green
- [ ] Acceptance: re-run `./acceptance-tests/run-tests.sh full ec2_flow_log`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
