### PR TITLE
deps: bump carina-core to be719d86 (Union validator fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=e73e8bee#e73e8bee97531037bdbe2bd3b1cfab42d1a9794c"
+source = "git+https://github.com/carina-rs/carina?rev=be719d86#be719d8626e9cbc0bf22368297949219a446c701"
 dependencies = [
  "argon2",
  "futures",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=e73e8bee#e73e8bee97531037bdbe2bd3b1cfab42d1a9794c"
+source = "git+https://github.com/carina-rs/carina?rev=be719d86#be719d8626e9cbc0bf22368297949219a446c701"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -579,7 +579,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=e73e8bee#e73e8bee97531037bdbe2bd3b1cfab42d1a9794c"
+source = "git+https://github.com/carina-rs/carina?rev=be719d86#be719d8626e9cbc0bf22368297949219a446c701"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "e73e8bee" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "be719d86" }

--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -2342,22 +2342,32 @@ mod tests {
             vec![
                 (
                     "version".to_string(),
-                    Value::String("2012-10-17".to_string()),
+                    Value::Concrete(ConcreteValue::String("2012-10-17".to_string())),
                 ),
                 (
                     "statement".to_string(),
-                    Value::List(vec![Value::Map(
-                        vec![
-                            ("effect".to_string(), Value::String("Allow".to_string())),
-                            (
-                                "action".to_string(),
-                                Value::String("sts:AssumeRole".to_string()),
-                            ),
-                            ("resource".to_string(), Value::String("*".to_string())),
-                        ]
-                        .into_iter()
-                        .collect(),
-                    )]),
+                    Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                        ConcreteValue::Map(
+                            vec![
+                                (
+                                    "effect".to_string(),
+                                    Value::Concrete(ConcreteValue::String("Allow".to_string())),
+                                ),
+                                (
+                                    "action".to_string(),
+                                    Value::Concrete(ConcreteValue::String(
+                                        "sts:AssumeRole".to_string(),
+                                    )),
+                                ),
+                                (
+                                    "resource".to_string(),
+                                    Value::Concrete(ConcreteValue::String("*".to_string())),
+                                ),
+                            ]
+                            .into_iter()
+                            .collect(),
+                        ),
+                    )])),
                 ),
             ]
             .into_iter()
@@ -2371,7 +2381,7 @@ mod tests {
         let doc = Value::Concrete(ConcreteValue::Map(
             vec![(
                 "version".to_string(),
-                Value::String("2020-01-01".to_string()),
+                Value::Concrete(ConcreteValue::String("2020-01-01".to_string())),
             )]
             .into_iter()
             .collect(),
@@ -2384,11 +2394,16 @@ mod tests {
         let doc = Value::Concrete(ConcreteValue::Map(
             vec![(
                 "statement".to_string(),
-                Value::List(vec![Value::Map(
-                    vec![("effect".to_string(), Value::String("Grant".to_string()))]
+                Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                    ConcreteValue::Map(
+                        vec![(
+                            "effect".to_string(),
+                            Value::Concrete(ConcreteValue::String("Grant".to_string())),
+                        )]
                         .into_iter()
                         .collect(),
-                )]),
+                    ),
+                )])),
             )]
             .into_iter()
             .collect(),
@@ -2403,19 +2418,30 @@ mod tests {
             vec![
                 (
                     "version".to_string(),
-                    Value::String("2012-10-17".to_string()),
+                    Value::Concrete(ConcreteValue::String("2012-10-17".to_string())),
                 ),
                 (
                     "statement".to_string(),
-                    Value::List(vec![Value::Map(
-                        vec![
-                            ("effect".to_string(), Value::String("Deny".to_string())),
-                            ("action".to_string(), Value::String("s3:*".to_string())),
-                            ("resource".to_string(), Value::String("*".to_string())),
-                        ]
-                        .into_iter()
-                        .collect(),
-                    )]),
+                    Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                        ConcreteValue::Map(
+                            vec![
+                                (
+                                    "effect".to_string(),
+                                    Value::Concrete(ConcreteValue::String("Deny".to_string())),
+                                ),
+                                (
+                                    "action".to_string(),
+                                    Value::Concrete(ConcreteValue::String("s3:*".to_string())),
+                                ),
+                                (
+                                    "resource".to_string(),
+                                    Value::Concrete(ConcreteValue::String("*".to_string())),
+                                ),
+                            ]
+                            .into_iter()
+                            .collect(),
+                        ),
+                    )])),
                 ),
             ]
             .into_iter()
@@ -2432,32 +2458,41 @@ mod tests {
             vec![
                 (
                     "version".to_string(),
-                    Value::String("2012-10-17".to_string()),
+                    Value::Concrete(ConcreteValue::String("2012-10-17".to_string())),
                 ),
                 (
                     "statement".to_string(),
-                    Value::List(vec![Value::Map(
-                        vec![
-                            ("effect".to_string(), Value::String("Allow".to_string())),
-                            (
-                                "principal".to_string(),
-                                Value::Map(
-                                    vec![(
-                                        "service".to_string(),
-                                        Value::String("ec2.amazonaws.com".to_string()),
-                                    )]
-                                    .into_iter()
-                                    .collect(),
+                    Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                        ConcreteValue::Map(
+                            vec![
+                                (
+                                    "effect".to_string(),
+                                    Value::Concrete(ConcreteValue::String("Allow".to_string())),
                                 ),
-                            ),
-                            (
-                                "action".to_string(),
-                                Value::String("sts:AssumeRole".to_string()),
-                            ),
-                        ]
-                        .into_iter()
-                        .collect(),
-                    )]),
+                                (
+                                    "principal".to_string(),
+                                    Value::Concrete(ConcreteValue::Map(
+                                        vec![(
+                                            "service".to_string(),
+                                            Value::Concrete(ConcreteValue::String(
+                                                "ec2.amazonaws.com".to_string(),
+                                            )),
+                                        )]
+                                        .into_iter()
+                                        .collect(),
+                                    )),
+                                ),
+                                (
+                                    "action".to_string(),
+                                    Value::Concrete(ConcreteValue::String(
+                                        "sts:AssumeRole".to_string(),
+                                    )),
+                                ),
+                            ]
+                            .into_iter()
+                            .collect(),
+                        ),
+                    )])),
                 ),
             ]
             .into_iter()
@@ -2478,22 +2513,32 @@ mod tests {
             vec![
                 (
                     "version".to_string(),
-                    Value::String("2012-10-17".to_string()),
+                    Value::Concrete(ConcreteValue::String("2012-10-17".to_string())),
                 ),
                 (
                     "statement".to_string(),
-                    Value::List(vec![Value::Map(
-                        vec![
-                            ("effect".to_string(), Value::String("Allow".to_string())),
-                            ("principal".to_string(), Value::String("*".to_string())),
-                            (
-                                "action".to_string(),
-                                Value::String("sts:AssumeRole".to_string()),
-                            ),
-                        ]
-                        .into_iter()
-                        .collect(),
-                    )]),
+                    Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                        ConcreteValue::Map(
+                            vec![
+                                (
+                                    "effect".to_string(),
+                                    Value::Concrete(ConcreteValue::String("Allow".to_string())),
+                                ),
+                                (
+                                    "principal".to_string(),
+                                    Value::Concrete(ConcreteValue::String("*".to_string())),
+                                ),
+                                (
+                                    "action".to_string(),
+                                    Value::Concrete(ConcreteValue::String(
+                                        "sts:AssumeRole".to_string(),
+                                    )),
+                                ),
+                            ]
+                            .into_iter()
+                            .collect(),
+                        ),
+                    )])),
                 ),
             ]
             .into_iter()
@@ -2600,8 +2645,14 @@ mod tests {
             "tags".to_string(),
             Value::Concrete(ConcreteValue::Map(
                 [
-                    ("key".to_string(), Value::String("Project".to_string())),
-                    ("value".to_string(), Value::String("carina".to_string())),
+                    (
+                        "key".to_string(),
+                        Value::Concrete(ConcreteValue::String("Project".to_string())),
+                    ),
+                    (
+                        "value".to_string(),
+                        Value::Concrete(ConcreteValue::String("carina".to_string())),
+                    ),
                 ]
                 .into_iter()
                 .collect(),
@@ -2617,8 +2668,14 @@ mod tests {
             "tags".to_string(),
             Value::Concrete(ConcreteValue::Map(
                 [
-                    ("Key".to_string(), Value::String("Project".to_string())),
-                    ("Value".to_string(), Value::String("carina".to_string())),
+                    (
+                        "Key".to_string(),
+                        Value::Concrete(ConcreteValue::String("Project".to_string())),
+                    ),
+                    (
+                        "Value".to_string(),
+                        Value::Concrete(ConcreteValue::String("carina".to_string())),
+                    ),
                 ]
                 .into_iter()
                 .collect(),
@@ -2634,8 +2691,14 @@ mod tests {
             "tags".to_string(),
             Value::Concrete(ConcreteValue::Map(
                 [
-                    ("Project".to_string(), Value::String("carina".to_string())),
-                    ("ManagedBy".to_string(), Value::String("carina".to_string())),
+                    (
+                        "Project".to_string(),
+                        Value::Concrete(ConcreteValue::String("carina".to_string())),
+                    ),
+                    (
+                        "ManagedBy".to_string(),
+                        Value::Concrete(ConcreteValue::String("carina".to_string())),
+                    ),
                 ]
                 .into_iter()
                 .collect(),
@@ -2722,28 +2785,32 @@ mod tests {
         let doc = Value::Concrete(ConcreteValue::Map(
             vec![(
                 "statement".to_string(),
-                Value::List(vec![Value::Map(
-                    vec![(
-                        "condition".to_string(),
-                        Value::Map(
-                            vec![(
-                                "string_equals".to_string(),
-                                Value::Map(
-                                    vec![(
-                                        "aws:RequestedRegion".to_string(),
-                                        Value::String("us-east-1".to_string()),
-                                    )]
-                                    .into_iter()
-                                    .collect(),
-                                ),
-                            )]
-                            .into_iter()
-                            .collect(),
-                        ),
-                    )]
-                    .into_iter()
-                    .collect(),
-                )]),
+                Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                    ConcreteValue::Map(
+                        vec![(
+                            "condition".to_string(),
+                            Value::Concrete(ConcreteValue::Map(
+                                vec![(
+                                    "string_equals".to_string(),
+                                    Value::Concrete(ConcreteValue::Map(
+                                        vec![(
+                                            "aws:RequestedRegion".to_string(),
+                                            Value::Concrete(ConcreteValue::String(
+                                                "us-east-1".to_string(),
+                                            )),
+                                        )]
+                                        .into_iter()
+                                        .collect(),
+                                    )),
+                                )]
+                                .into_iter()
+                                .collect(),
+                            )),
+                        )]
+                        .into_iter()
+                        .collect(),
+                    ),
+                )])),
             )]
             .into_iter()
             .collect(),
@@ -2756,21 +2823,23 @@ mod tests {
         let doc = Value::Concrete(ConcreteValue::Map(
             vec![(
                 "statement".to_string(),
-                Value::List(vec![Value::Map(
-                    vec![(
-                        "condition".to_string(),
-                        Value::Map(
-                            vec![(
-                                "StringEquals".to_string(),
-                                Value::Map(indexmap::IndexMap::new()),
-                            )]
-                            .into_iter()
-                            .collect(),
-                        ),
-                    )]
-                    .into_iter()
-                    .collect(),
-                )]),
+                Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                    ConcreteValue::Map(
+                        vec![(
+                            "condition".to_string(),
+                            Value::Concrete(ConcreteValue::Map(
+                                vec![(
+                                    "StringEquals".to_string(),
+                                    Value::Concrete(ConcreteValue::Map(indexmap::IndexMap::new())),
+                                )]
+                                .into_iter()
+                                .collect(),
+                            )),
+                        )]
+                        .into_iter()
+                        .collect(),
+                    ),
+                )])),
             )]
             .into_iter()
             .collect(),
@@ -2787,18 +2856,23 @@ mod tests {
         let doc = Value::Concrete(ConcreteValue::Map(
             vec![(
                 "statement".to_string(),
-                Value::List(vec![Value::Map(
-                    vec![(
-                        "condition".to_string(),
-                        Value::Map(
-                            vec![("foo_bar".to_string(), Value::Map(indexmap::IndexMap::new()))]
+                Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                    ConcreteValue::Map(
+                        vec![(
+                            "condition".to_string(),
+                            Value::Concrete(ConcreteValue::Map(
+                                vec![(
+                                    "foo_bar".to_string(),
+                                    Value::Concrete(ConcreteValue::Map(indexmap::IndexMap::new())),
+                                )]
                                 .into_iter()
                                 .collect(),
-                        ),
-                    )]
-                    .into_iter()
-                    .collect(),
-                )]),
+                            )),
+                        )]
+                        .into_iter()
+                        .collect(),
+                    ),
+                )])),
             )]
             .into_iter()
             .collect(),
@@ -2811,21 +2885,23 @@ mod tests {
         let doc = Value::Concrete(ConcreteValue::Map(
             vec![(
                 "statement".to_string(),
-                Value::List(vec![Value::Map(
-                    vec![(
-                        "condition".to_string(),
-                        Value::Map(
-                            vec![(
-                                "string_equals_if_exists".to_string(),
-                                Value::Map(indexmap::IndexMap::new()),
-                            )]
-                            .into_iter()
-                            .collect(),
-                        ),
-                    )]
-                    .into_iter()
-                    .collect(),
-                )]),
+                Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                    ConcreteValue::Map(
+                        vec![(
+                            "condition".to_string(),
+                            Value::Concrete(ConcreteValue::Map(
+                                vec![(
+                                    "string_equals_if_exists".to_string(),
+                                    Value::Concrete(ConcreteValue::Map(indexmap::IndexMap::new())),
+                                )]
+                                .into_iter()
+                                .collect(),
+                            )),
+                        )]
+                        .into_iter()
+                        .collect(),
+                    ),
+                )])),
             )]
             .into_iter()
             .collect(),

--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -23,10 +23,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "e73e8bee" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "be719d86" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "e73e8bee" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "e73e8bee" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "be719d86" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "be719d86" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-smithy-async = { version = "1", features = ["rt-tokio"] }

--- a/carina-provider-awscc/src/provider/conversion.rs
+++ b/carina-provider-awscc/src/provider/conversion.rs
@@ -147,7 +147,7 @@ pub(crate) fn json_to_value(value: &serde_json::Value) -> Option<Value> {
             if let Some(i) = n.as_i64() {
                 Some(Value::Concrete(ConcreteValue::Int(i)))
             } else {
-                n.as_f64().map(Value::Float)
+                n.as_f64().map(|f| Value::Concrete(ConcreteValue::Float(f)))
             }
         }
         serde_json::Value::Array(arr) => {


### PR DESCRIPTION
Closes #217.

## Summary

`carina-rs/carina#2984` fixed the host-side `walk_custom_lookup` Union arm so `types::cidr()` (which is `Union(ipv4_cidr(), ipv6_cidr())`) no longer surfaces the sibling IPv6 validator's `expected 8 groups, got 1` failure for an IPv4 CIDR like `"10.0.0.0/8"`. The IPAM Pool fixture (`acceptance-tests/ec2_ipam_pool/basic.crn`) was the user-facing reproduction.

Bumping the `carina-core` rev to `be719d86` pulls in the fix; no awscc code change is needed for the bug itself.

## Bundled fix (post-RFC #2972 cleanup)

The rev bump exposed pre-RFC #2972 helper usage that survived the previous migration (awscc#213 / #214 covered hand-written 91 sites; test fixtures and one production constructor were missed):

- `carina-aws-types/src/lib.rs`: 52 occurrences of `Value::String(...)` / `Value::List(...)` / `Value::Map(...)` / `Value::Bool(...)` / `Value::Int(...)` / `Value::Float(...)` in test fixtures
- `carina-provider-awscc/src/provider/conversion.rs:150`: a stray `Value::Float` constructor reference used as `.map(Value::Float)`

All rewritten to the nested `Value::Concrete(ConcreteValue::X(...))` form. Same shape as the aws-provider fix in `carina-rs/carina-provider-aws#264`.

## Test plan

- [x] `cargo nextest run` — 437 passed
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] Acceptance: `ec2_ipam_pool/basic.crn` apply phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)
