### PR TITLE
acceptance-tests: rewrite API enum spellings to DSL spellings

### DIFF
--- a/acceptance-tests/ec2_flow_log/s3.crn
+++ b/acceptance-tests/ec2_flow_log/s3.crn
@@ -25,7 +25,7 @@ awscc.ec2.FlowLog {
   log_destination      = bucket.arn
 
   destination_options = {
-    file_format                = 'plain-text'
+    file_format                = 'plain_text'
     hive_compatible_partitions = false
     per_hour_partition         = false
   }

--- a/acceptance-tests/ec2_security_group/ipv6_rules.crn
+++ b/acceptance-tests/ec2_security_group/ipv6_rules.crn
@@ -23,7 +23,7 @@ awscc.ec2.SecurityGroup {
   }
 
   security_group_egress {
-    ip_protocol = '-1'
+    ip_protocol = 'all'
     cidr_ipv6   = '::/0'
     description = 'Allow all IPv6 outbound'
   }

--- a/acceptance-tests/ec2_subnet/with_dns_options.crn
+++ b/acceptance-tests/ec2_subnet/with_dns_options.crn
@@ -19,7 +19,7 @@ awscc.ec2.Subnet {
 
   private_dns_name_options_on_launch = {
     enable_resource_name_dns_a_record = true
-    hostname_type                     = 'ip-name'
+    hostname_type                     = 'ip_name'
   }
 
   tags = {


### PR DESCRIPTION
## Summary

After `carina#2985` tightened the StringEnum validator to reject API spellings whenever `dsl_aliases` registers a DSL rewrite, three acceptance-test fixtures still used the API form and now fail `apply` with `Invalid value '<X>' for ...`.

Rewrite the three values to the DSL spelling that the strict validator accepts.

## Changes

| File | Attribute | Before | After |
|------|-----------|--------|-------|
| `ec2_security_group/ipv6_rules.crn` | `ip_protocol` | `'-1'` | `'all'` |
| `ec2_subnet/with_dns_options.crn` | `hostname_type` | `'ip-name'` | `'ip_name'` |
| `ec2_flow_log/s3.crn` | `file_format` | `'plain-text'` | `'plain_text'` |

`dsl_aliases` registers each pair as `(api, dsl)`. The strict rule from `carina#2985` correctly rejects the API form; the DSL form is the canonical user-facing spelling.

## Test plan

- [ ] CI: lint passes
- [ ] Acceptance run picks up the three tests and they pass `apply` (verified by next full run; the runner picks up the source-injected fixtures directly)

Closes #227.