### PR TITLE
acceptance-tests: rewrite enum values to identifier form

### DIFF
--- a/acceptance-tests/ec2_flow_log/s3.crn
+++ b/acceptance-tests/ec2_flow_log/s3.crn
@@ -25,7 +25,7 @@ awscc.ec2.FlowLog {
   log_destination      = bucket.arn
 
   destination_options = {
-    file_format                = 'plain-text'
+    file_format                = plain_text
     hive_compatible_partitions = false
     per_hour_partition         = false
   }

--- a/acceptance-tests/ec2_security_group/ipv6_rules.crn
+++ b/acceptance-tests/ec2_security_group/ipv6_rules.crn
@@ -15,7 +15,7 @@ awscc.ec2.SecurityGroup {
   group_description = 'Acceptance test - IPv6 rules'
 
   security_group_ingress {
-    ip_protocol = 'tcp'
+    ip_protocol = tcp
     from_port   = 443
     to_port     = 443
     cidr_ipv6   = '::/0'
@@ -23,7 +23,7 @@ awscc.ec2.SecurityGroup {
   }
 
   security_group_egress {
-    ip_protocol = '-1'
+    ip_protocol = all
     cidr_ipv6   = '::/0'
     description = 'Allow all IPv6 outbound'
   }

--- a/acceptance-tests/ec2_subnet/with_dns_options.crn
+++ b/acceptance-tests/ec2_subnet/with_dns_options.crn
@@ -19,7 +19,7 @@ awscc.ec2.Subnet {
 
   private_dns_name_options_on_launch = {
     enable_resource_name_dns_a_record = true
-    hostname_type                     = 'ip-name'
+    hostname_type                     = ip_name
   }
 
   tags = {


### PR DESCRIPTION
## Summary

Three acceptance-test fixtures used string-quoted API enum spellings that `carina#2985` now correctly rejects. The DSL canonical form is the namespaced enum identifier — written either fully qualified (e.g. `awscc.ec2.SecurityGroup.IpProtocol.all`) or as the short identifier (`all`) when the type can be inferred from the attribute. Sibling fixtures (e.g. `ec2_security_group_egress/*.crn`) already use the bare-identifier form for these attributes.

## Rewrites

| File | Attribute | Before | After |
|------|-----------|--------|-------|
| `ec2_security_group/ipv6_rules.crn` | `ip_protocol` (ingress) | `'tcp'` | `tcp` |
| `ec2_security_group/ipv6_rules.crn` | `ip_protocol` (egress)  | `'-1'`  | `all` |
| `ec2_subnet/with_dns_options.crn`   | `hostname_type` | `'ip-name'` | `ip_name` |
| `ec2_flow_log/s3.crn` | `file_format` | `'plain-text'` | `plain_text` |

The bare-identifier form is the established convention; the string-quoted form (especially with API spellings like `-1`, `ip-name`, `plain-text`) was the convention violation that `carina#2985` finally surfaced.

## Test plan

- [ ] CI: lint passes
- [ ] Acceptance run picks up the three tests and they pass `apply` (verified by next full run)

Closes #227.