### PR TITLE
codegen/dsl_enum_value: rewrite `:` to `_` so colon API spellings are reachable

### DIFF
--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -330,13 +330,14 @@ fn dsl_enum_value(value: &str) -> String {
     {
         return value.to_ascii_lowercase();
     }
-    // Already snake / kebab (no uppercase): normalize hyphens and
-    // dotted-numeric splits (e.g. `cloud-watch-logs` → `cloud_watch_logs`,
-    // `ipsec.1` → `ipsec_1`). The strict-DSL validator
-    // (carina-rs/carina#2980) gates acceptance on the DSL spelling,
-    // so dotted values must collapse to bare identifiers.
+    // Already snake / kebab (no uppercase): normalize hyphens, colons,
+    // and dotted-numeric splits (e.g. `cloud-watch-logs` →
+    // `cloud_watch_logs`, `ipsec.1` → `ipsec_1`, `aws:kms` → `aws_kms`).
+    // The strict-DSL validator (carina-rs/carina#2980) gates acceptance
+    // on the DSL spelling, so any non-identifier separator must collapse
+    // to `_` to keep the value reachable as a bare DSL identifier.
     if !value.chars().any(|c| c.is_ascii_uppercase()) {
-        return value.replace(['-', '.'], "_");
+        return value.replace(['-', '.', ':'], "_");
     }
     // Special case: acronym + lowercase + digits (e.g. "IPv4", "IPv6").
     // Heck's snake_case splits these as "i_pv4" which loses the acronym
@@ -10440,6 +10441,16 @@ mod tests {
         assert_eq!(dsl_enum_value("default"), "default");
         assert_eq!(dsl_enum_value("dedicated"), "dedicated");
         assert_eq!(dsl_enum_value("ap_northeast_1"), "ap_northeast_1");
+    }
+
+    #[test]
+    fn test_dsl_enum_value_colon_to_snake() {
+        // AWS S3 SSE algorithm values carry a colon (`aws:kms`, `aws:kms:dsse`).
+        // The colon makes the value unwritable as a bare DSL identifier, so
+        // codegen must rewrite it to `_` to keep the value reachable under
+        // the strict-DSL validator (carina-rs/carina#2986). See awscc#230.
+        assert_eq!(dsl_enum_value("aws:kms"), "aws_kms");
+        assert_eq!(dsl_enum_value("aws:kms:dsse"), "aws_kms_dsse");
     }
 
     #[test]

--- a/carina-provider-awscc/src/schemas/generated/s3/bucket.rs
+++ b/carina-provider-awscc/src/schemas/generated/s3/bucket.rs
@@ -347,7 +347,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 name: "ServerSideEncryptionByDefaultSseAlgorithm".to_string(),
                 values: vec!["aws:kms".to_string(), "AES256".to_string(), "aws:kms:dsse".to_string()],
                 namespace: Some("awscc.s3.Bucket".to_string()),
-                dsl_aliases: vec![("aws:kms".to_string(), "aws:kms".to_string()), ("AES256".to_string(), "aes256".to_string()), ("aws:kms:dsse".to_string(), "aws:kms:dsse".to_string())],
+                dsl_aliases: vec![("aws:kms".to_string(), "aws_kms".to_string()), ("AES256".to_string(), "aes256".to_string()), ("aws:kms:dsse".to_string(), "aws_kms_dsse".to_string())],
             }).required().with_description("Server-side encryption algorithm to use for the default encryption. For directory buckets, there are only two supported values for server-side encryption: ``AES256`` and ``aws:kms``.").with_provider_name("SSEAlgorithm")
                     ],
                 }).with_description("Specifies the default server-side encryption to apply to new objects in the bucket. If a PUT Object request doesn't specify any server-side encryption, this default encryption will be applied.").with_provider_name("ServerSideEncryptionByDefault")
@@ -717,7 +717,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 name: "MetadataTableEncryptionConfigurationSseAlgorithm".to_string(),
                 values: vec!["aws:kms".to_string(), "AES256".to_string()],
                 namespace: Some("awscc.s3.Bucket".to_string()),
-                dsl_aliases: vec![("aws:kms".to_string(), "aws:kms".to_string()), ("AES256".to_string(), "aes256".to_string())],
+                dsl_aliases: vec![("aws:kms".to_string(), "aws_kms".to_string()), ("AES256".to_string(), "aes256".to_string())],
             }).required().with_description("The encryption type specified for a metadata table. To specify server-side encryption with KMSlong (KMS) keys (SSE-KMS), use the ``aws:kms`` value. To specify server-side encryption with Amazon S3 managed keys (SSE-S3), use the ``AES256`` value.").with_provider_name("SseAlgorithm")
                     ],
                 }).with_description("The encryption configuration for the inventory table.").with_provider_name("EncryptionConfiguration"),
@@ -736,7 +736,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 name: "MetadataTableEncryptionConfigurationSseAlgorithm".to_string(),
                 values: vec!["aws:kms".to_string(), "AES256".to_string()],
                 namespace: Some("awscc.s3.Bucket".to_string()),
-                dsl_aliases: vec![("aws:kms".to_string(), "aws:kms".to_string()), ("AES256".to_string(), "aes256".to_string())],
+                dsl_aliases: vec![("aws:kms".to_string(), "aws_kms".to_string()), ("AES256".to_string(), "aes256".to_string())],
             }).required().with_description("The encryption type specified for a metadata table. To specify server-side encryption with KMSlong (KMS) keys (SSE-KMS), use the ``aws:kms`` value. To specify server-side encryption with Amazon S3 managed keys (SSE-S3), use the ``AES256`` value.").with_provider_name("SseAlgorithm")
                     ],
                 }).with_description("The encryption configuration for the journal table.").with_provider_name("EncryptionConfiguration"),

--- a/generated-docs/awscc/s3/bucket.md
+++ b/generated-docs/awscc/s3/bucket.md
@@ -372,10 +372,10 @@ Shorthand formats: `aws` or `TableBucketType.aws`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `aws:kms` | `awscc.s3.Bucket.MetadataTableEncryptionConfigurationSseAlgorithm.aws:kms` |
+| `aws:kms` | `awscc.s3.Bucket.MetadataTableEncryptionConfigurationSseAlgorithm.aws_kms` |
 | `AES256` | `awscc.s3.Bucket.MetadataTableEncryptionConfigurationSseAlgorithm.aes256` |
 
-Shorthand formats: `aws:kms` or `MetadataTableEncryptionConfigurationSseAlgorithm.aws:kms`
+Shorthand formats: `aws_kms` or `MetadataTableEncryptionConfigurationSseAlgorithm.aws_kms`
 
 ### status (MetricsStatus)
 
@@ -499,11 +499,11 @@ Shorthand formats: `enabled` or `RuleStatus.enabled`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `aws:kms` | `awscc.s3.Bucket.ServerSideEncryptionByDefaultSseAlgorithm.aws:kms` |
+| `aws:kms` | `awscc.s3.Bucket.ServerSideEncryptionByDefaultSseAlgorithm.aws_kms` |
 | `AES256` | `awscc.s3.Bucket.ServerSideEncryptionByDefaultSseAlgorithm.aes256` |
-| `aws:kms:dsse` | `awscc.s3.Bucket.ServerSideEncryptionByDefaultSseAlgorithm.aws:kms:dsse` |
+| `aws:kms:dsse` | `awscc.s3.Bucket.ServerSideEncryptionByDefaultSseAlgorithm.aws_kms_dsse` |
 
-Shorthand formats: `aws:kms` or `ServerSideEncryptionByDefaultSseAlgorithm.aws:kms`
+Shorthand formats: `aws_kms` or `ServerSideEncryptionByDefaultSseAlgorithm.aws_kms`
 
 ### status (SseKmsEncryptedObjectsStatus)
 


### PR DESCRIPTION
## Summary

Preparation for `carina#2986`. AWS S3 SSE algorithm values carry a colon (`aws:kms`, `aws:kms:dsse`) which makes them unwritable as bare DSL identifiers. Codegen was leaving them as identity rows in `dsl_aliases`, so once `carina#2986` lands those values would become unreachable from the DSL surface entirely.

## Change

Extend the existing kebab/dotted rewrite branch in `dsl_enum_value` — the one that turns `cloud-watch-logs` into `cloud_watch_logs` and `ipsec.1` into `ipsec_1` — to also replace `:` with `_`.

- `aws:kms` → `aws_kms`
- `aws:kms:dsse` → `aws_kms_dsse`

The Bucket schema is the only one affected — two `StringEnum` instances (`ServerSideEncryptionByDefaultSseAlgorithm` and `MetadataTableEncryptionConfigurationSseAlgorithm`) carried colon values; everything else was already reachable.

## Test plan

- [x] New unit test `test_dsl_enum_value_colon_to_snake` passes
- [x] `cargo nextest run -p carina-provider-awscc` — 345 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace --doc` — clean
- [x] `scripts/generate-schemas.sh` re-run — `aws:kms` aliases now map to `aws_kms`
- [x] `scripts/generate-docs.sh` re-run — docs updated
- [x] `scripts/check-docs-drift.sh` — OK: schemas and docs in sync (37 resources)

Closes #230.