### PR TITLE
deps: bump carina pin to 2f403317 (carina#2986 strict enum identifier)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=8de52fd1#8de52fd1d75431e67d284ca9b2302c5958b233b6"
+source = "git+https://github.com/carina-rs/carina?rev=2f403317#2f403317beee97d087baa076284fce2d6e9fd804"
 dependencies = [
  "argon2",
  "futures",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=8de52fd1#8de52fd1d75431e67d284ca9b2302c5958b233b6"
+source = "git+https://github.com/carina-rs/carina?rev=2f403317#2f403317beee97d087baa076284fce2d6e9fd804"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -579,7 +579,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=8de52fd1#8de52fd1d75431e67d284ca9b2302c5958b233b6"
+source = "git+https://github.com/carina-rs/carina?rev=2f403317#2f403317beee97d087baa076284fce2d6e9fd804"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "8de52fd1" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "2f403317" }

--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -23,10 +23,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "8de52fd1" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "2f403317" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "8de52fd1" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "8de52fd1" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "2f403317" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "2f403317" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-smithy-async = { version = "1", features = ["rt-tokio"] }

--- a/carina-provider-awscc/src/convert.rs
+++ b/carina-provider-awscc/src/convert.rs
@@ -45,7 +45,14 @@ pub fn proto_to_core_resource_id(id: &ProtoResourceId) -> CoreResourceId {
 
 pub fn core_to_proto_value(v: &CoreValue) -> ProtoValue {
     match v {
-        CoreValue::Concrete(ConcreteValue::String(s)) => ProtoValue::String(s.clone()),
+        // `EnumIdentifier` carries identifier-shape text (parser-level
+        // distinction from quoted-string literals, carina#2986). The
+        // provider wire protocol has no native identifier variant, so we
+        // emit it as `ProtoValue::String` — identical to the `String`
+        // arm. The shape distinction is consumed at the validator entry
+        // before reaching this conversion.
+        CoreValue::Concrete(ConcreteValue::String(s))
+        | CoreValue::Concrete(ConcreteValue::EnumIdentifier(s)) => ProtoValue::String(s.clone()),
         CoreValue::Concrete(ConcreteValue::Int(i)) => ProtoValue::Int(*i),
         CoreValue::Concrete(ConcreteValue::Float(f)) => ProtoValue::Float(*f),
         CoreValue::Concrete(ConcreteValue::Bool(b)) => ProtoValue::Bool(*b),

--- a/carina-provider-awscc/src/provider/conversion.rs
+++ b/carina-provider-awscc/src/provider/conversion.rs
@@ -198,7 +198,14 @@ pub(crate) fn dsl_value_to_aws(
     // For schema-level string enums, convert namespaced DSL values back to provider values.
     if attr_type.namespaced_enum_parts().is_some() {
         match value {
-            Value::Concrete(ConcreteValue::String(s)) => {
+            // Phase 3 of carina#2986 routes DSL-source enum values to
+            // `EnumIdentifier`; the same text payload also still arrives
+            // as `String` from state-loader / aws_value_to_dsl paths
+            // that haven't been promoted yet. Accept both — the
+            // namespace-strip / `api_for` lookup below is text-based
+            // and shape-agnostic.
+            Value::Concrete(ConcreteValue::String(s))
+            | Value::Concrete(ConcreteValue::EnumIdentifier(s)) => {
                 // For StringEnum: extract the trailing segment (handling
                 // dotted values like the legacy `ipsec.1` shape that may
                 // still arrive from older state) and look up the
@@ -321,7 +328,8 @@ pub(crate) fn dsl_value_to_aws(
 /// Convert DSL Value to JSON value
 pub(crate) fn value_to_json(value: &Value) -> Option<serde_json::Value> {
     match value {
-        Value::Concrete(ConcreteValue::String(s)) => Some(json!(s)),
+        Value::Concrete(ConcreteValue::String(s))
+        | Value::Concrete(ConcreteValue::EnumIdentifier(s)) => Some(json!(s)),
         Value::Concrete(ConcreteValue::Bool(b)) => Some(json!(b)),
         Value::Concrete(ConcreteValue::Int(i)) => Some(json!(i)),
         Value::Concrete(ConcreteValue::Float(f)) if f.is_finite() => Some(json!(f)),
@@ -1332,7 +1340,10 @@ mod tests {
             .unwrap();
 
         // Validate the snake_case form (the canonical DSL spelling per D7).
-        let snake_case_value = Value::Concrete(ConcreteValue::String(
+        // Phase 4 of carina#2986: DSL-source enum values arrive as
+        // `EnumIdentifier`; a `String` here would route to
+        // `StringLiteralExpectedEnum`.
+        let snake_case_value = Value::Concrete(ConcreteValue::EnumIdentifier(
             "awscc.s3.Bucket.ObjectOwnership.bucket_owner_enforced".to_string(),
         ));
         object_ownership
@@ -1344,7 +1355,7 @@ mod tests {
         // strict on DSL input — the PascalCase API spelling is
         // rejected. State JSON still flows through `aws_value_to_dsl`
         // separately, so this only gates DSL-source values.
-        let pascal_value = Value::Concrete(ConcreteValue::String(
+        let pascal_value = Value::Concrete(ConcreteValue::EnumIdentifier(
             "awscc.s3.Bucket.ObjectOwnership.BucketOwnerEnforced".to_string(),
         ));
         assert!(


### PR DESCRIPTION
## Summary

Pulls in carina#2988 + #2989 + #2990 from the carina main: the `ConcreteValue::EnumIdentifier` variant and the strict-mode validator that rejects quoted string literals on `StringEnum`-typed attributes.

## Provider-side changes

- `convert.rs::core_to_proto_value` handles `EnumIdentifier` the same as `String` — the wire protocol has no identifier variant, so we flatten to `ProtoValue::String`. The shape distinction is consumed at the validator entry before reaching this conversion.
- `provider/conversion.rs::dsl_value_to_aws` accepts both `String` and `EnumIdentifier` for the StringEnum-namespaced path. DSL-source enum values now arrive as `EnumIdentifier` from the parser, while `aws_value_to_dsl` (the state-read path) still emits plain `String`; the namespace-strip + `api_for` lookup is text-based and shape-agnostic.
- `provider/conversion.rs::value_to_json` accepts `EnumIdentifier` alongside `String` — same textual payload, JSON encodes identically.
- `tests::test_object_ownership_snake_case_validates_and_roundtrips` now constructs `EnumIdentifier` inputs rather than `String`. The return-equality assertion still passes because carina#2986 Phase 5 makes `PartialEq for Value` treat `String(s) == EnumIdentifier(s)` when the text matches.

## Fixture sweep — no changes needed

Every enum value under `acceptance-tests/**/*.crn` already uses the identifier form (e.g. `awscc.s3.Bucket.VersioningStatus.enabled`) — the snake_case rollout through #223 covered this.

## Test plan

- [x] `cargo nextest run --workspace` — 437 passed, 0 failed
- [x] `cargo test --workspace --doc` — passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean

Refs carina-rs/carina#2986.