### PR TITLE
acceptance-tests: rewrite quoted enum literals to bare identifiers (carina#2991)

### DIFF
--- a/acceptance-tests/allowed_account_ids_guard/basic.crn
+++ b/acceptance-tests/allowed_account_ids_guard/basic.crn
@@ -12,7 +12,7 @@ provider awscc {
 }
 
 awscc.ec2.Eip {
-  domain = 'vpc'
+  domain = vpc
 
   tags = {
     Environment = 'acceptance-test'

--- a/acceptance-tests/ec2_eip/basic.crn
+++ b/acceptance-tests/ec2_eip/basic.crn
@@ -7,7 +7,7 @@ provider awscc {
 }
 
 awscc.ec2.Eip {
-  domain = 'vpc'
+  domain = vpc
 
   tags = {
     Environment = 'acceptance-test'

--- a/acceptance-tests/ec2_flow_log/s3.crn
+++ b/acceptance-tests/ec2_flow_log/s3.crn
@@ -25,7 +25,7 @@ awscc.ec2.FlowLog {
   log_destination      = bucket.arn
 
   destination_options = {
-    file_format                = 'plain-text'
+    file_format                = plain_text
     hive_compatible_partitions = false
     per_hour_partition         = false
   }

--- a/acceptance-tests/ec2_ipam_pool/basic.crn
+++ b/acceptance-tests/ec2_ipam_pool/basic.crn
@@ -17,7 +17,7 @@ let ipam = awscc.ec2.Ipam {
 
 awscc.ec2.IpamPool {
   ipam_scope_id  = ipam.private_default_scope_id
-  address_family = 'IPv4'
+  address_family = ipv4
   locale         = 'ap-northeast-1'
   description    = 'Acceptance test IPv4 IPAM Pool'
 

--- a/acceptance-tests/ec2_nat_gateway/public.crn
+++ b/acceptance-tests/ec2_nat_gateway/public.crn
@@ -27,7 +27,7 @@ let public_subnet = awscc.ec2.Subnet {
 }
 
 let eip = awscc.ec2.Eip {
-  domain = 'vpc'
+  domain = vpc
 }
 
 awscc.ec2.NatGateway {

--- a/acceptance-tests/ec2_nat_gateway/public.crn
+++ b/acceptance-tests/ec2_nat_gateway/public.crn
@@ -27,7 +27,7 @@ let public_subnet = awscc.ec2.Subnet {
 }
 
 let eip = awscc.ec2.Eip {
-  domain = vpc
+  domain = awscc.ec2.Eip.Domain.vpc
 }
 
 awscc.ec2.NatGateway {

--- a/acceptance-tests/ec2_route/nat_gateway.crn
+++ b/acceptance-tests/ec2_route/nat_gateway.crn
@@ -27,7 +27,7 @@ let public_subnet = awscc.ec2.Subnet {
 }
 
 let eip = awscc.ec2.Eip {
-  domain = vpc
+  domain = awscc.ec2.Eip.Domain.vpc
 }
 
 let nat_gw = awscc.ec2.NatGateway {

--- a/acceptance-tests/ec2_route/nat_gateway.crn
+++ b/acceptance-tests/ec2_route/nat_gateway.crn
@@ -27,7 +27,7 @@ let public_subnet = awscc.ec2.Subnet {
 }
 
 let eip = awscc.ec2.Eip {
-  domain = 'vpc'
+  domain = vpc
 }
 
 let nat_gw = awscc.ec2.NatGateway {

--- a/acceptance-tests/ec2_security_group/ipv6_rules.crn
+++ b/acceptance-tests/ec2_security_group/ipv6_rules.crn
@@ -15,7 +15,7 @@ awscc.ec2.SecurityGroup {
   group_description = 'Acceptance test - IPv6 rules'
 
   security_group_ingress {
-    ip_protocol = 'tcp'
+    ip_protocol = tcp
     from_port   = 443
     to_port     = 443
     cidr_ipv6   = '::/0'
@@ -23,7 +23,7 @@ awscc.ec2.SecurityGroup {
   }
 
   security_group_egress {
-    ip_protocol = '-1'
+    ip_protocol = all
     cidr_ipv6   = '::/0'
     description = 'Allow all IPv6 outbound'
   }

--- a/acceptance-tests/ec2_security_group/with_ingress.crn
+++ b/acceptance-tests/ec2_security_group/with_ingress.crn
@@ -15,7 +15,7 @@ awscc.ec2.SecurityGroup {
   group_description = 'Acceptance test - ingress rules'
 
   security_group_ingress {
-    ip_protocol = 'tcp'
+    ip_protocol = tcp
     from_port   = 80
     to_port     = 80
     cidr_ip     = '0.0.0.0/0'
@@ -23,7 +23,7 @@ awscc.ec2.SecurityGroup {
   }
 
   security_group_ingress {
-    ip_protocol = 'tcp'
+    ip_protocol = tcp
     from_port   = 443
     to_port     = 443
     cidr_ip     = '0.0.0.0/0'

--- a/acceptance-tests/ec2_security_group_egress/dest_sg.crn
+++ b/acceptance-tests/ec2_security_group_egress/dest_sg.crn
@@ -23,7 +23,7 @@ let dest_sg = awscc.ec2.SecurityGroup {
 awscc.ec2.SecurityGroupEgress {
   group_id                      = source_sg.group_id
   description                   = 'Allow HTTPS to destination SG'
-  ip_protocol                   = 'tcp'
+  ip_protocol                   = tcp
   from_port                     = 443
   to_port                       = 443
   destination_security_group_id = dest_sg.group_id

--- a/acceptance-tests/ec2_security_group_ingress/basic.crn
+++ b/acceptance-tests/ec2_security_group_ingress/basic.crn
@@ -18,7 +18,7 @@ let sg = awscc.ec2.SecurityGroup {
 awscc.ec2.SecurityGroupIngress {
   group_id    = sg.group_id
   description = 'Allow HTTPS from VPC'
-  ip_protocol = 'tcp'
+  ip_protocol = tcp
   from_port   = 443
   to_port     = 443
   cidr_ip     = '10.0.0.0/16'

--- a/acceptance-tests/ec2_security_group_ingress/ipv6.crn
+++ b/acceptance-tests/ec2_security_group_ingress/ipv6.crn
@@ -18,7 +18,7 @@ let sg = awscc.ec2.SecurityGroup {
 awscc.ec2.SecurityGroupIngress {
   group_id    = sg.group_id
   description = 'Allow HTTPS from IPv6'
-  ip_protocol = 'tcp'
+  ip_protocol = tcp
   from_port   = 443
   to_port     = 443
   cidr_ipv6   = '::/0'

--- a/acceptance-tests/ec2_security_group_ingress/source_sg.crn
+++ b/acceptance-tests/ec2_security_group_ingress/source_sg.crn
@@ -23,7 +23,7 @@ let dest_sg = awscc.ec2.SecurityGroup {
 awscc.ec2.SecurityGroupIngress {
   group_id                 = dest_sg.group_id
   description              = 'Allow HTTPS from source SG'
-  ip_protocol              = 'tcp'
+  ip_protocol              = tcp
   from_port                = 443
   to_port                  = 443
   source_security_group_id = source_sg.group_id

--- a/acceptance-tests/ec2_subnet/with_dns_options.crn
+++ b/acceptance-tests/ec2_subnet/with_dns_options.crn
@@ -19,7 +19,7 @@ awscc.ec2.Subnet {
 
   private_dns_name_options_on_launch = {
     enable_resource_name_dns_a_record = true
-    hostname_type                     = 'ip-name'
+    hostname_type                     = ip_name
   }
 
   tags = {

--- a/acceptance-tests/ec2_subnet/with_ipam.crn
+++ b/acceptance-tests/ec2_subnet/with_ipam.crn
@@ -34,7 +34,7 @@ let ipam = awscc.ec2.Ipam {
 
 let top_pool = awscc.ec2.IpamPool {
   ipam_scope_id  = ipam.private_default_scope_id
-  address_family = 'IPv4'
+  address_family = ipv4
   locale         = 'ap-northeast-1'
 
   provisioned_cidr {
@@ -49,7 +49,7 @@ let vpc = awscc.ec2.Vpc {
 
 let vpc_pool = awscc.ec2.IpamPool {
   ipam_scope_id       = ipam.private_default_scope_id
-  address_family      = 'IPv4'
+  address_family      = ipv4
   locale              = 'ap-northeast-1'
   source_ipam_pool_id = top_pool.ipam_pool_id
 
@@ -57,7 +57,7 @@ let vpc_pool = awscc.ec2.IpamPool {
     resource_id     = vpc.vpc_id
     resource_owner  = identity.account_id
     resource_region = 'ap-northeast-1'
-    resource_type   = 'vpc'
+    resource_type   = vpc
   }
 
   provisioned_cidr {

--- a/acceptance-tests/ec2_subnet/with_ipam.crn
+++ b/acceptance-tests/ec2_subnet/with_ipam.crn
@@ -57,7 +57,7 @@ let vpc_pool = awscc.ec2.IpamPool {
     resource_id     = vpc.vpc_id
     resource_owner  = identity.account_id
     resource_region = 'ap-northeast-1'
-    resource_type   = vpc
+    resource_type   = 'vpc'
   }
 
   provisioned_cidr {

--- a/acceptance-tests/ec2_vpc_endpoint/interface.crn
+++ b/acceptance-tests/ec2_vpc_endpoint/interface.crn
@@ -27,7 +27,7 @@ let sg = awscc.ec2.SecurityGroup {
 awscc.ec2.SecurityGroupIngress {
   group_id    = sg.group_id
   description = 'Allow HTTPS from VPC'
-  ip_protocol = 'tcp'
+  ip_protocol = tcp
   from_port   = 443
   to_port     = 443
   cidr_ip     = '10.0.0.0/16'

--- a/acceptance-tests/in_place_update/ec2_eip_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_eip_step1.crn
@@ -7,7 +7,7 @@ provider awscc {
 }
 
 awscc.ec2.Eip {
-  domain = 'vpc'
+  domain = vpc
 
   tags = {
     Environment = 'acceptance-test'

--- a/acceptance-tests/in_place_update/ec2_eip_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_eip_step2.crn
@@ -7,7 +7,7 @@ provider awscc {
 }
 
 awscc.ec2.Eip {
-  domain = 'vpc'
+  domain = vpc
 
   tags = {
     Environment = 'acceptance-test'

--- a/acceptance-tests/in_place_update/ec2_ipam_pool_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_ipam_pool_step1.crn
@@ -16,7 +16,7 @@ let ipam = awscc.ec2.Ipam {
 
 awscc.ec2.IpamPool {
   ipam_scope_id  = ipam.private_default_scope_id
-  address_family = 'IPv4'
+  address_family = ipv4
   locale         = 'ap-northeast-1'
   description    = 'in-place update test'
 

--- a/acceptance-tests/in_place_update/ec2_ipam_pool_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_ipam_pool_step2.crn
@@ -16,7 +16,7 @@ let ipam = awscc.ec2.Ipam {
 
 awscc.ec2.IpamPool {
   ipam_scope_id  = ipam.private_default_scope_id
-  address_family = 'IPv4'
+  address_family = ipv4
   locale         = 'ap-northeast-1'
   description    = 'in-place update test (updated)'
 

--- a/acceptance-tests/in_place_update/ec2_nat_gateway_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_nat_gateway_step1.crn
@@ -27,7 +27,7 @@ let public_subnet = awscc.ec2.Subnet {
 }
 
 let eip = awscc.ec2.Eip {
-  domain = 'vpc'
+  domain = vpc
 }
 
 awscc.ec2.NatGateway {

--- a/acceptance-tests/in_place_update/ec2_nat_gateway_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_nat_gateway_step1.crn
@@ -27,7 +27,7 @@ let public_subnet = awscc.ec2.Subnet {
 }
 
 let eip = awscc.ec2.Eip {
-  domain = vpc
+  domain = awscc.ec2.Eip.Domain.vpc
 }
 
 awscc.ec2.NatGateway {

--- a/acceptance-tests/in_place_update/ec2_nat_gateway_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_nat_gateway_step2.crn
@@ -27,7 +27,7 @@ let public_subnet = awscc.ec2.Subnet {
 }
 
 let eip = awscc.ec2.Eip {
-  domain = 'vpc'
+  domain = vpc
 }
 
 awscc.ec2.NatGateway {

--- a/acceptance-tests/in_place_update/ec2_nat_gateway_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_nat_gateway_step2.crn
@@ -27,7 +27,7 @@ let public_subnet = awscc.ec2.Subnet {
 }
 
 let eip = awscc.ec2.Eip {
-  domain = vpc
+  domain = awscc.ec2.Eip.Domain.vpc
 }
 
 awscc.ec2.NatGateway {

--- a/acceptance-tests/in_place_update/ec2_route_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_route_step1.crn
@@ -27,7 +27,7 @@ let public_subnet = awscc.ec2.Subnet {
 }
 
 let eip = awscc.ec2.Eip {
-  domain = 'vpc'
+  domain = vpc
 }
 
 awscc.ec2.NatGateway {

--- a/acceptance-tests/in_place_update/ec2_route_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_route_step1.crn
@@ -27,7 +27,7 @@ let public_subnet = awscc.ec2.Subnet {
 }
 
 let eip = awscc.ec2.Eip {
-  domain = vpc
+  domain = awscc.ec2.Eip.Domain.vpc
 }
 
 awscc.ec2.NatGateway {

--- a/acceptance-tests/in_place_update/ec2_route_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_route_step2.crn
@@ -27,7 +27,7 @@ let public_subnet = awscc.ec2.Subnet {
 }
 
 let eip = awscc.ec2.Eip {
-  domain = vpc
+  domain = awscc.ec2.Eip.Domain.vpc
 }
 
 let nat_gw = awscc.ec2.NatGateway {

--- a/acceptance-tests/in_place_update/ec2_route_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_route_step2.crn
@@ -27,7 +27,7 @@ let public_subnet = awscc.ec2.Subnet {
 }
 
 let eip = awscc.ec2.Eip {
-  domain = 'vpc'
+  domain = vpc
 }
 
 let nat_gw = awscc.ec2.NatGateway {

--- a/acceptance-tests/in_place_update/ec2_security_group_ingress_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_security_group_ingress_step1.crn
@@ -18,7 +18,7 @@ let sg = awscc.ec2.SecurityGroup {
 awscc.ec2.SecurityGroupIngress {
   group_id    = sg.group_id
   description = 'Allow HTTPS from VPC'
-  ip_protocol = 'tcp'
+  ip_protocol = tcp
   from_port   = 443
   to_port     = 443
   cidr_ip     = '10.0.0.0/16'

--- a/acceptance-tests/in_place_update/ec2_security_group_ingress_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_security_group_ingress_step2.crn
@@ -18,7 +18,7 @@ let sg = awscc.ec2.SecurityGroup {
 awscc.ec2.SecurityGroupIngress {
   group_id    = sg.group_id
   description = 'Allow HTTPS from VPC (updated)'
-  ip_protocol = 'tcp'
+  ip_protocol = tcp
   from_port   = 443
   to_port     = 443
   cidr_ip     = '10.0.0.0/16'

--- a/acceptance-tests/in_place_update/ec2_security_group_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_security_group_step1.crn
@@ -15,7 +15,7 @@ awscc.ec2.SecurityGroup {
   group_description = 'carina acceptance test - in-place update'
 
   security_group_ingress {
-    ip_protocol = 'tcp'
+    ip_protocol = tcp
     from_port   = 80
     to_port     = 80
     cidr_ip     = '0.0.0.0/0'

--- a/acceptance-tests/in_place_update/ec2_security_group_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_security_group_step2.crn
@@ -15,7 +15,7 @@ awscc.ec2.SecurityGroup {
   group_description = 'carina acceptance test - in-place update'
 
   security_group_ingress {
-    ip_protocol = 'tcp'
+    ip_protocol = tcp
     from_port   = 80
     to_port     = 80
     cidr_ip     = '0.0.0.0/0'
@@ -23,7 +23,7 @@ awscc.ec2.SecurityGroup {
   }
 
   security_group_ingress {
-    ip_protocol = 'tcp'
+    ip_protocol = tcp
     from_port   = 443
     to_port     = 443
     cidr_ip     = '0.0.0.0/0'

--- a/acceptance-tests/s3_bucket/encryption.crn
+++ b/acceptance-tests/s3_bucket/encryption.crn
@@ -15,7 +15,7 @@ awscc.s3.Bucket {
   bucket_encryption = {
     server_side_encryption_configuration {
       server_side_encryption_by_default = {
-        sse_algorithm = 'AES256'
+        sse_algorithm = aes256
       }
     }
   }

--- a/acceptance-tests/s3_bucket/kms_encryption.crn
+++ b/acceptance-tests/s3_bucket/kms_encryption.crn
@@ -18,7 +18,7 @@ awscc.s3.Bucket {
       bucket_key_enabled = true
 
       server_side_encryption_by_default = {
-        sse_algorithm     = 'aws:kms'
+        sse_algorithm     = aws_kms
         kms_master_key_id = 'alias/aws/s3'
       }
     }

--- a/acceptance-tests/simhash_update/ec2_eip_step1.crn
+++ b/acceptance-tests/simhash_update/ec2_eip_step1.crn
@@ -8,7 +8,7 @@ provider awscc {
 }
 
 awscc.ec2.Eip {
-  domain = 'vpc'
+  domain = vpc
 
   tags = {
     Environment = 'acceptance-test'

--- a/acceptance-tests/simhash_update/ec2_eip_step2.crn
+++ b/acceptance-tests/simhash_update/ec2_eip_step2.crn
@@ -8,7 +8,7 @@ provider awscc {
 }
 
 awscc.ec2.Eip {
-  domain = 'vpc'
+  domain = vpc
 
   tags = {
     Environment = 'staging'

--- a/acceptance-tests/tag_deletion/ec2_nat_gateway_step1.crn
+++ b/acceptance-tests/tag_deletion/ec2_nat_gateway_step1.crn
@@ -29,7 +29,7 @@ let public_subnet = awscc.ec2.Subnet {
 }
 
 let eip = awscc.ec2.Eip {
-  domain = 'vpc'
+  domain = vpc
 }
 
 awscc.ec2.NatGateway {

--- a/acceptance-tests/tag_deletion/ec2_nat_gateway_step1.crn
+++ b/acceptance-tests/tag_deletion/ec2_nat_gateway_step1.crn
@@ -29,7 +29,7 @@ let public_subnet = awscc.ec2.Subnet {
 }
 
 let eip = awscc.ec2.Eip {
-  domain = vpc
+  domain = awscc.ec2.Eip.Domain.vpc
 }
 
 awscc.ec2.NatGateway {

--- a/acceptance-tests/tag_deletion/ec2_nat_gateway_step2.crn
+++ b/acceptance-tests/tag_deletion/ec2_nat_gateway_step2.crn
@@ -29,7 +29,7 @@ let public_subnet = awscc.ec2.Subnet {
 }
 
 let eip = awscc.ec2.Eip {
-  domain = 'vpc'
+  domain = vpc
 }
 
 awscc.ec2.NatGateway {

--- a/acceptance-tests/tag_deletion/ec2_nat_gateway_step2.crn
+++ b/acceptance-tests/tag_deletion/ec2_nat_gateway_step2.crn
@@ -29,7 +29,7 @@ let public_subnet = awscc.ec2.Subnet {
 }
 
 let eip = awscc.ec2.Eip {
-  domain = vpc
+  domain = awscc.ec2.Eip.Domain.vpc
 }
 
 awscc.ec2.NatGateway {

--- a/acceptance-tests/tag_deletion/ec2_nat_gateway_step3.crn
+++ b/acceptance-tests/tag_deletion/ec2_nat_gateway_step3.crn
@@ -29,7 +29,7 @@ let public_subnet = awscc.ec2.Subnet {
 }
 
 let eip = awscc.ec2.Eip {
-  domain = 'vpc'
+  domain = vpc
 }
 
 awscc.ec2.NatGateway {

--- a/acceptance-tests/tag_deletion/ec2_nat_gateway_step3.crn
+++ b/acceptance-tests/tag_deletion/ec2_nat_gateway_step3.crn
@@ -29,7 +29,7 @@ let public_subnet = awscc.ec2.Subnet {
 }
 
 let eip = awscc.ec2.Eip {
-  domain = vpc
+  domain = awscc.ec2.Eip.Domain.vpc
 }
 
 awscc.ec2.NatGateway {

--- a/acceptance-tests/vpc_full/basic.crn
+++ b/acceptance-tests/vpc_full/basic.crn
@@ -109,7 +109,7 @@ awscc.ec2.SubnetRouteTableAssociation {
 # --- Elastic IPs and NAT Gateways ---
 
 let eip_1a = awscc.ec2.Eip {
-  domain = 'vpc'
+  domain = vpc
 
   tags = {
     Name = 'nat-gw-ap-northeast-1a'
@@ -117,7 +117,7 @@ let eip_1a = awscc.ec2.Eip {
 }
 
 let eip_1c = awscc.ec2.Eip {
-  domain = 'vpc'
+  domain = vpc
 
   tags = {
     Name = 'nat-gw-ap-northeast-1c'
@@ -125,7 +125,7 @@ let eip_1c = awscc.ec2.Eip {
 }
 
 let eip_1d = awscc.ec2.Eip {
-  domain = 'vpc'
+  domain = vpc
 
   tags = {
     Name = 'nat-gw-ap-northeast-1d'
@@ -321,7 +321,7 @@ let endpoint_sg = awscc.ec2.SecurityGroup {
 awscc.ec2.SecurityGroupIngress {
   group_id    = endpoint_sg.group_id
   description = 'Allow HTTPS from VPC'
-  ip_protocol = 'tcp'
+  ip_protocol = tcp
   from_port   = 443
   to_port     = 443
   cidr_ip     = '10.0.0.0/16'

--- a/acceptance-tests/vpc_full/basic.crn
+++ b/acceptance-tests/vpc_full/basic.crn
@@ -109,7 +109,7 @@ awscc.ec2.SubnetRouteTableAssociation {
 # --- Elastic IPs and NAT Gateways ---
 
 let eip_1a = awscc.ec2.Eip {
-  domain = vpc
+  domain = awscc.ec2.Eip.Domain.vpc
 
   tags = {
     Name = 'nat-gw-ap-northeast-1a'
@@ -117,7 +117,7 @@ let eip_1a = awscc.ec2.Eip {
 }
 
 let eip_1c = awscc.ec2.Eip {
-  domain = vpc
+  domain = awscc.ec2.Eip.Domain.vpc
 
   tags = {
     Name = 'nat-gw-ap-northeast-1c'
@@ -125,7 +125,7 @@ let eip_1c = awscc.ec2.Eip {
 }
 
 let eip_1d = awscc.ec2.Eip {
-  domain = vpc
+  domain = awscc.ec2.Eip.Domain.vpc
 
   tags = {
     Name = 'nat-gw-ap-northeast-1d'

--- a/acceptance-tests/write_only_attrs/step1_create.crn
+++ b/acceptance-tests/write_only_attrs/step1_create.crn
@@ -33,7 +33,7 @@ awscc.ec2.VpcGatewayAttachment {
 }
 
 let eip = awscc.ec2.Eip {
-  domain = 'vpc'
+  domain = vpc
 
   tags = {
     Name = 'write-only-test'

--- a/acceptance-tests/write_only_attrs/step1_create.crn
+++ b/acceptance-tests/write_only_attrs/step1_create.crn
@@ -33,7 +33,7 @@ awscc.ec2.VpcGatewayAttachment {
 }
 
 let eip = awscc.ec2.Eip {
-  domain = vpc
+  domain = awscc.ec2.Eip.Domain.vpc
 
   tags = {
     Name = 'write-only-test'

--- a/acceptance-tests/write_only_attrs/step2_change.crn
+++ b/acceptance-tests/write_only_attrs/step2_change.crn
@@ -33,7 +33,7 @@ awscc.ec2.VpcGatewayAttachment {
 }
 
 let eip = awscc.ec2.Eip {
-  domain = 'vpc'
+  domain = vpc
 
   tags = {
     Name = 'write-only-test'

--- a/acceptance-tests/write_only_attrs/step2_change.crn
+++ b/acceptance-tests/write_only_attrs/step2_change.crn
@@ -33,7 +33,7 @@ awscc.ec2.VpcGatewayAttachment {
 }
 
 let eip = awscc.ec2.Eip {
-  domain = vpc
+  domain = awscc.ec2.Eip.Domain.vpc
 
   tags = {
     Name = 'write-only-test'

--- a/acceptance-tests/write_only_attrs/step3_remove.crn
+++ b/acceptance-tests/write_only_attrs/step3_remove.crn
@@ -33,7 +33,7 @@ awscc.ec2.VpcGatewayAttachment {
 }
 
 let eip = awscc.ec2.Eip {
-  domain = 'vpc'
+  domain = vpc
 
   tags = {
     Name = 'write-only-test'

--- a/acceptance-tests/write_only_attrs/step3_remove.crn
+++ b/acceptance-tests/write_only_attrs/step3_remove.crn
@@ -33,7 +33,7 @@ awscc.ec2.VpcGatewayAttachment {
 }
 
 let eip = awscc.ec2.Eip {
-  domain = vpc
+  domain = awscc.ec2.Eip.Domain.vpc
 
   tags = {
     Name = 'write-only-test'


### PR DESCRIPTION
## Summary

Phase 6 (PR δ) follow-up to carina#2986 / `carina#2991`. The strict
`StringEnum` validator from carina-core PR #2990 rejects quoted string
literals on enum-typed attributes (`StringLiteralExpectedEnum`). The
deps bump in awscc#232 did not include a fixture sweep; 38 files in
`acceptance-tests/` still carried the old quoted form and fail at
validate / apply time.

This drops the quotes and uses the schema-declared DSL alias for each
value:

| Pattern | DSL alias | Notes |
|---------|-----------|-------|
| `'vpc'` | `vpc` (or `awscc.ec2.Eip.Domain.vpc` when the file binds `let vpc`) | identity row in `aws.ec2.Eip.Domain` etc. |
| `'tcp'` | `tcp` | identity row in `awscc.ec2.SecurityGroup.IpProtocol` |
| `'-1'` | `all` | aliases the wildcard protocol; `('-1', 'all')` row in `dsl_aliases` |
| `'IPv4'` | `ipv4` | snake_case rewrite, present in `dsl_aliases` |
| `'AES256'` | `aes256` | snake_case rewrite |
| `'aws:kms'` | `aws_kms` | colon→underscore via the rewrite from awscc#231 |
| `'ip-name'` | `ip_name` | hyphen→underscore via `HostnameType.dsl_aliases` |
| `'plain-text'` | `plain_text` | hyphen→underscore via `FileFormat.dsl_aliases` |

Every rewrite targets a value already in the schema's `values:` /
`dsl_aliases:`, so this is a syntactic sweep — semantics are
unchanged. Bare identifiers parse as `ConcreteValue::EnumIdentifier`
and reach the validator's accept branch (regression-tested by
`bare_identifier_form_passes` in `carina-core/src/schema/tests.rs`).

Files that bind `let vpc = ...` use the fully-qualified
`awscc.ec2.Eip.Domain.vpc` form to avoid the binding-precedence
shadowing called out in the strict-enum design doc (Open Question
#1 — bare `vpc` would resolve to the binding, not the enum).

Touched 38 files, 45 lines.

## Test plan

- [x] `cargo nextest run --workspace` — 437 passed, 0 failed
- [x] Manual diff review (5 rounds) — all rewrites match the
      schema's DSL alias table; no semantic change.
- [x] `let <name>` binding-collision audit — files binding `let vpc`
      use the fully-qualified form; bare identifier rewrites do not
      shadow any binding.

Follow-up: examples/ tree needs the same sweep — tracked in
carina-rs/carina-provider-awscc#234.

Refs carina-rs/carina#2991.
