### PR TITLE
examples: rewrite quoted enum literals to bare/FQ identifiers + regen docs (#234)

### DIFF
--- a/examples/ec2_eip/main.crn
+++ b/examples/ec2_eip/main.crn
@@ -7,7 +7,7 @@ provider awscc {
 }
 
 awscc.ec2.Eip {
-  domain = 'vpc'
+  domain = vpc
 
   tags = {
     Environment = 'example'

--- a/examples/ec2_ipam_pool/main.crn
+++ b/examples/ec2_ipam_pool/main.crn
@@ -17,7 +17,7 @@ let ipam = awscc.ec2.Ipam {
 
 awscc.ec2.IpamPool {
   ipam_scope_id  = ipam.private_default_scope_id
-  address_family = 'IPv4'
+  address_family = ipv4
   locale         = 'ap-northeast-1'
   description    = 'Example IPv4 IPAM Pool'
 

--- a/examples/ec2_nat_gateway/main.crn
+++ b/examples/ec2_nat_gateway/main.crn
@@ -20,7 +20,7 @@ let public_subnet = awscc.ec2.Subnet {
 }
 
 let eip = awscc.ec2.Eip {
-  domain = 'vpc'
+  domain = awscc.ec2.Eip.Domain.vpc
 }
 
 awscc.ec2.NatGateway {

--- a/examples/ec2_security_group/main.crn
+++ b/examples/ec2_security_group/main.crn
@@ -15,14 +15,14 @@ awscc.ec2.SecurityGroup {
   group_description = 'Example security group'
 
   security_group_ingress {
-    ip_protocol = 'tcp'
+    ip_protocol = tcp
     from_port   = 80
     to_port     = 80
     cidr_ip     = '0.0.0.0/0'
   }
 
   security_group_ingress {
-    ip_protocol = 'tcp'
+    ip_protocol = tcp
     from_port   = 443
     to_port     = 443
     cidr_ip     = '0.0.0.0/0'

--- a/examples/ec2_security_group_ingress/main.crn
+++ b/examples/ec2_security_group_ingress/main.crn
@@ -19,7 +19,7 @@ let sg = awscc.ec2.SecurityGroup {
 awscc.ec2.SecurityGroupIngress {
   group_id    = sg.group_id
   description = 'Allow HTTPS from VPC'
-  ip_protocol = 'tcp'
+  ip_protocol = tcp
   from_port   = 443
   to_port     = 443
   cidr_ip     = '10.0.0.0/16'

--- a/examples/ec2_vpc_endpoint/main.crn
+++ b/examples/ec2_vpc_endpoint/main.crn
@@ -27,7 +27,7 @@ let sg = awscc.ec2.SecurityGroup {
 awscc.ec2.SecurityGroupIngress {
   group_id    = sg.group_id
   description = 'Allow HTTPS from VPC'
-  ip_protocol = 'tcp'
+  ip_protocol = tcp
   from_port   = 443
   to_port     = 443
   cidr_ip     = '10.0.0.0/16'

--- a/examples/vpc_full/main.crn
+++ b/examples/vpc_full/main.crn
@@ -109,7 +109,7 @@ awscc.ec2.SubnetRouteTableAssociation {
 # --- Elastic IPs and NAT Gateways ---
 
 let eip_1a = awscc.ec2.Eip {
-  domain = 'vpc'
+  domain = awscc.ec2.Eip.Domain.vpc
 
   tags = {
     Name = 'nat-gw-ap-northeast-1a'
@@ -117,7 +117,7 @@ let eip_1a = awscc.ec2.Eip {
 }
 
 let eip_1c = awscc.ec2.Eip {
-  domain = 'vpc'
+  domain = awscc.ec2.Eip.Domain.vpc
 
   tags = {
     Name = 'nat-gw-ap-northeast-1c'
@@ -125,7 +125,7 @@ let eip_1c = awscc.ec2.Eip {
 }
 
 let eip_1d = awscc.ec2.Eip {
-  domain = 'vpc'
+  domain = awscc.ec2.Eip.Domain.vpc
 
   tags = {
     Name = 'nat-gw-ap-northeast-1d'
@@ -321,7 +321,7 @@ let endpoint_sg = awscc.ec2.SecurityGroup {
 awscc.ec2.SecurityGroupIngress {
   group_id    = endpoint_sg.group_id
   description = 'Allow HTTPS from VPC'
-  ip_protocol = 'tcp'
+  ip_protocol = tcp
   from_port   = 443
   to_port     = 443
   cidr_ip     = '10.0.0.0/16'

--- a/generated-docs/awscc/ec2/eip.md
+++ b/generated-docs/awscc/ec2/eip.md
@@ -14,7 +14,7 @@ Specifies an Elastic IP (EIP) address and can, optionally, associate it with an 
 
 ```crn
 awscc.ec2.Eip {
-  domain = 'vpc'
+  domain = vpc
 
   tags = {
     Environment = 'example'

--- a/generated-docs/awscc/ec2/ipam_pool.md
+++ b/generated-docs/awscc/ec2/ipam_pool.md
@@ -22,7 +22,7 @@ let ipam = awscc.ec2.Ipam {
 
 awscc.ec2.IpamPool {
   ipam_scope_id  = ipam.private_default_scope_id
-  address_family = 'IPv4'
+  address_family = ipv4
   locale         = 'ap-northeast-1'
   description    = 'Example IPv4 IPAM Pool'
 

--- a/generated-docs/awscc/ec2/nat_gateway.md
+++ b/generated-docs/awscc/ec2/nat_gateway.md
@@ -28,7 +28,7 @@ let public_subnet = awscc.ec2.Subnet {
 }
 
 let eip = awscc.ec2.Eip {
-  domain = 'vpc'
+  domain = awscc.ec2.Eip.Domain.vpc
 }
 
 awscc.ec2.NatGateway {

--- a/generated-docs/awscc/ec2/security_group.md
+++ b/generated-docs/awscc/ec2/security_group.md
@@ -20,14 +20,14 @@ awscc.ec2.SecurityGroup {
   group_description = 'Example security group'
 
   security_group_ingress {
-    ip_protocol = 'tcp'
+    ip_protocol = tcp
     from_port   = 80
     to_port     = 80
     cidr_ip     = '0.0.0.0/0'
   }
 
   security_group_ingress {
-    ip_protocol = 'tcp'
+    ip_protocol = tcp
     from_port   = 443
     to_port     = 443
     cidr_ip     = '0.0.0.0/0'

--- a/generated-docs/awscc/ec2/security_group_ingress.md
+++ b/generated-docs/awscc/ec2/security_group_ingress.md
@@ -23,7 +23,7 @@ let sg = awscc.ec2.SecurityGroup {
 awscc.ec2.SecurityGroupIngress {
   group_id    = sg.group_id
   description = 'Allow HTTPS from VPC'
-  ip_protocol = 'tcp'
+  ip_protocol = tcp
   from_port   = 443
   to_port     = 443
   cidr_ip     = '10.0.0.0/16'

--- a/generated-docs/awscc/ec2/vpc_endpoint.md
+++ b/generated-docs/awscc/ec2/vpc_endpoint.md
@@ -34,7 +34,7 @@ let sg = awscc.ec2.SecurityGroup {
 awscc.ec2.SecurityGroupIngress {
   group_id    = sg.group_id
   description = 'Allow HTTPS from VPC'
-  ip_protocol = 'tcp'
+  ip_protocol = tcp
   from_port   = 443
   to_port     = 443
   cidr_ip     = '10.0.0.0/16'


### PR DESCRIPTION
## Summary

Closes #234. Phase 6 follow-up to carina#2986: the `examples/` tree
needed the same quoted-string → bare-identifier sweep that
`acceptance-tests/` got in #233.

## Changes

7 example `.crn` files modified (11 enum-literal rewrites):

| Pattern | Form | Files |
|---------|------|-------|
| `'vpc'` → `vpc` | bare (no `let vpc =`) | `examples/ec2_eip/` |
| `'vpc'` → `awscc.ec2.Eip.Domain.vpc` | FQ (shadowed by `let vpc =`) | `examples/ec2_nat_gateway/`, `examples/vpc_full/` (3 sites) |
| `'tcp'` → `tcp` | bare | `examples/ec2_security_group/` (2), `examples/ec2_security_group_ingress/`, `examples/ec2_vpc_endpoint/`, `examples/vpc_full/` |
| `'IPv4'` → `ipv4` | bare alias | `examples/ec2_ipam_pool/` |

Mixed bare/FQ is intentional context-sensitive application of the
binding-shadow rule (parser's `get_variable` arm wins over the
`EnumIdentifier` fallback when a `let <name> =` exists in scope).

Also regenerates `generated-docs/awscc/ec2/{eip,ipam_pool,nat_gateway,
security_group,security_group_ingress,vpc_endpoint}.md` to reflect the
embedded examples (`scripts/generate-docs.sh` ingests `examples/<r>/
main.crn` verbatim, so doc regen is part of the same atomic change).

## Review

5-round self-review applied. Round 4 caught the stale-doc embed
(addressed via `generate-docs.sh` regen) and a false-positive
"inconsistent style" claim that Round 5 dismissed (the bare/FQ mix
*is* the correct rule application, not a style nit).

Follow-up filed as #235: extend `check-docs-drift.sh` to catch
example-content drift in CI so this class of stale-embed bug fails
the gate automatically.

## Test plan

- [x] `cargo nextest run --workspace` — 437 passed, 0 failed
- [x] `let`-binding shadow audit on every modified file — files binding `let vpc` use FQ
- [x] Doc regen via `aws-vault exec mizzy -- ./scripts/generate-docs.sh`
- [x] Manual diff review of `generated-docs/awscc/ec2/*.md` — only the embedded example block changes
