### PR TITLE
acceptance-tests: rename lifecycle to directives across 9 fixtures

### DIFF
--- a/acceptance-tests/create_before_destroy/ec2_transit_gateway_attachment_step2.crn
+++ b/acceptance-tests/create_before_destroy/ec2_transit_gateway_attachment_step2.crn
@@ -52,7 +52,7 @@ awscc.ec2.TransitGatewayAttachment {
   transit_gateway_id = tgw_b.id
   vpc_id             = vpc.vpc_id
 
-  lifecycle {
+  directives {
     create_before_destroy = true
   }
 

--- a/acceptance-tests/create_before_destroy/ec2_vpc_step2.crn
+++ b/acceptance-tests/create_before_destroy/ec2_vpc_step2.crn
@@ -13,7 +13,7 @@ awscc.ec2.Vpc {
   enable_dns_support   = true
   enable_dns_hostnames = true
 
-  lifecycle {
+  directives {
     create_before_destroy = true
   }
 

--- a/acceptance-tests/create_before_destroy/iam_role_step2.crn
+++ b/acceptance-tests/create_before_destroy/iam_role_step2.crn
@@ -15,7 +15,7 @@ awscc.iam.Role {
   role_name = 'carina-acc-test-cbd-role'
   path      = '/carina/'
 
-  lifecycle {
+  directives {
     create_before_destroy = true
   }
 

--- a/acceptance-tests/ec2_flow_log/s3.crn
+++ b/acceptance-tests/ec2_flow_log/s3.crn
@@ -12,7 +12,7 @@ let vpc = awscc.ec2.Vpc {
 }
 
 let bucket = awscc.s3.Bucket {
-  lifecycle {
+  directives {
     force_delete = true
   }
 }

--- a/acceptance-tests/in_place_update/s3_bucket_step1.crn
+++ b/acceptance-tests/in_place_update/s3_bucket_step1.crn
@@ -13,7 +13,7 @@ awscc.s3.Bucket {
     status = awscc.s3.Bucket.VersioningConfigurationStatus.enabled
   }
 
-  lifecycle {
+  directives {
     force_delete = true
   }
 }

--- a/acceptance-tests/in_place_update/s3_bucket_step2.crn
+++ b/acceptance-tests/in_place_update/s3_bucket_step2.crn
@@ -13,7 +13,7 @@ awscc.s3.Bucket {
     status = awscc.s3.Bucket.VersioningConfigurationStatus.suspended
   }
 
-  lifecycle {
+  directives {
     force_delete = true
   }
 }

--- a/acceptance-tests/tag_deletion/s3_bucket_step1.crn
+++ b/acceptance-tests/tag_deletion/s3_bucket_step1.crn
@@ -15,7 +15,7 @@ awscc.s3.Bucket {
     ToBeRemoved = 'this-tag-will-be-deleted'
   }
 
-  lifecycle {
+  directives {
     force_delete = true
   }
 }

--- a/acceptance-tests/tag_deletion/s3_bucket_step2.crn
+++ b/acceptance-tests/tag_deletion/s3_bucket_step2.crn
@@ -15,7 +15,7 @@ awscc.s3.Bucket {
     Environment = 'acceptance-test'
   }
 
-  lifecycle {
+  directives {
     force_delete = true
   }
 }

--- a/acceptance-tests/tag_deletion/s3_bucket_step3.crn
+++ b/acceptance-tests/tag_deletion/s3_bucket_step3.crn
@@ -11,7 +11,7 @@ provider awscc {
 awscc.s3.Bucket {
   bucket_name_prefix = 'carina-acc-test-tag-del-'
 
-  lifecycle {
+  directives {
     force_delete = true
   }
 }


### PR DESCRIPTION
## Summary

Rename the meta-argument block from `lifecycle { ... }` to `directives { ... }` in 9 acceptance fixtures missed during the carina#2826 sweep (merged 2026-05-09).

Before this PR:

```
Error: awscc.s3.Bucket.bucket: Unknown attribute 'lifecycle'
```

Mechanical rename only — no semantic change. `carina fmt --check` passes on every touched directory. Also audited `examples/` and `docs/` for stale `lifecycle { ... }` blocks; none remain.

## Affected fixtures

- `acceptance-tests/create_before_destroy/ec2_transit_gateway_attachment_step2.crn`
- `acceptance-tests/create_before_destroy/ec2_vpc_step2.crn`
- `acceptance-tests/create_before_destroy/iam_role_step2.crn`
- `acceptance-tests/ec2_flow_log/s3.crn`
- `acceptance-tests/in_place_update/s3_bucket_step1.crn`
- `acceptance-tests/in_place_update/s3_bucket_step2.crn`
- `acceptance-tests/tag_deletion/s3_bucket_step1.crn`
- `acceptance-tests/tag_deletion/s3_bucket_step2.crn`
- `acceptance-tests/tag_deletion/s3_bucket_step3.crn`

## Closes

- Closes #225

## Test plan

- [x] `carina fmt --check` on every touched directory — passes
- [ ] Full acceptance run on each affected fixture — deferred to user
