### PR TITLE
factory: thread binding into create_provider/create_normalizer (carina#2191 Phase 4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=2f403317#2f403317beee97d087baa076284fce2d6e9fd804"
+source = "git+https://github.com/carina-rs/carina?rev=86eaa70a#86eaa70a1e74ede704adc4fa97550ed129c3d3bd"
 dependencies = [
  "argon2",
  "futures",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=2f403317#2f403317beee97d087baa076284fce2d6e9fd804"
+source = "git+https://github.com/carina-rs/carina?rev=86eaa70a#86eaa70a1e74ede704adc4fa97550ed129c3d3bd"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -579,7 +579,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=2f403317#2f403317beee97d087baa076284fce2d6e9fd804"
+source = "git+https://github.com/carina-rs/carina?rev=86eaa70a#86eaa70a1e74ede704adc4fa97550ed129c3d3bd"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "2f403317" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "86eaa70a" }

--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -23,10 +23,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "2f403317" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "86eaa70a" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "2f403317" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "2f403317" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "86eaa70a" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "86eaa70a" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-smithy-async = { version = "1", features = ["rt-tokio"] }

--- a/carina-provider-awscc/src/convert.rs
+++ b/carina-provider-awscc/src/convert.rs
@@ -185,6 +185,7 @@ pub fn proto_to_core_resource(r: &ProtoResource) -> CoreResource {
         create_before_destroy: r.directives.create_before_destroy,
         prevent_destroy: r.directives.prevent_destroy,
         depends_on: Vec::new(),
+        provider_instance: None,
     };
     resource
 }

--- a/carina-provider-awscc/src/lib.rs
+++ b/carina-provider-awscc/src/lib.rs
@@ -146,8 +146,14 @@ impl ProviderFactory for AwsccProviderFactory {
 
     fn create_provider(
         &self,
+        _binding: Option<&str>,
         attributes: &IndexMap<String, Value>,
     ) -> BoxFuture<'_, Result<Box<dyn Provider>, carina_core::provider::ProviderError>> {
+        // `_binding` is intentionally unused: the AWS Cloud Control
+        // factory does not cache instances, so each call already
+        // produces an independent `AwsccProvider`. The host uses the
+        // binding name as a cache key in `WasmProviderFactory`; for
+        // in-process factories the constructed-fresh shape is enough.
         let region = self.extract_region(attributes);
         let cfg = extract_provider_config(attributes);
         Box::pin(async move {
@@ -157,6 +163,7 @@ impl ProviderFactory for AwsccProviderFactory {
 
     fn create_normalizer(
         &self,
+        _binding: Option<&str>,
         _attributes: &IndexMap<String, Value>,
     ) -> BoxFuture<'_, Box<dyn ProviderNormalizer>> {
         Box::pin(async { Box::new(AwsccNormalizer) as Box<dyn ProviderNormalizer> })

--- a/carina-provider-awscc/src/main.rs
+++ b/carina-provider-awscc/src/main.rs
@@ -266,6 +266,7 @@ impl CarinaProvider for AwsccProcessProvider {
             create_before_destroy: request.directives.create_before_destroy,
             prevent_destroy: request.directives.prevent_destroy,
             depends_on: Vec::new(),
+            provider_instance: None,
         };
         let result = self.runtime.block_on(self.provider().delete(
             &core_id,

--- a/carina-provider-awscc/src/provider/normalizer.rs
+++ b/carina-provider-awscc/src/provider/normalizer.rs
@@ -949,6 +949,7 @@ mod tests {
             provider: provider.to_string(),
             resource_type: resource_type.to_string(),
             name: ResourceName::Bound(name.to_string()),
+            provider_instance: None,
         };
         let mut attributes = HashMap::new();
         for (k, v) in attrs {


### PR DESCRIPTION
## Summary

Adapts the AWS Cloud Control factory to the new
`ProviderFactory::create_provider` / `create_normalizer` signature
introduced in carina-rs/carina#3018 (Phase 4 of carina#2191 — named
provider instances).

- Bumps `carina-core` / `carina-plugin-sdk` /
  `carina-provider-protocol` git rev to the carina Phase 4 merge
  commit.
- Adds `binding: Option<&str>` parameter to `create_provider` and
  `create_normalizer`. The AWS Cloud Control factory constructs a
  fresh `AwsccProvider` per call, so it ignores the binding — the
  cache key is only load-bearing for the WASM host. Documented in
  code.
- Adds `provider_instance: None` to local `Directives` / `ResourceId`
  constructions in `convert.rs`, `main.rs`, and
  `provider/normalizer.rs` (parser-side addition in carina #3016 /
  #3017).

Refs carina-rs/carina#2191.

## Test plan

- [x] `cargo nextest run` — 437 passed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] Real-infra T6c — gated on carina Phase 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
