### PR TITLE
codegen: deferred_populate + CloudFront Distribution.DomainName (refs carina#3034)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=86eaa70a#86eaa70a1e74ede704adc4fa97550ed129c3d3bd"
+source = "git+https://github.com/carina-rs/carina?rev=455e6fa1#455e6fa1e0666578a595806a41c4dfeb5f5e38e4"
 dependencies = [
  "argon2",
  "futures",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=86eaa70a#86eaa70a1e74ede704adc4fa97550ed129c3d3bd"
+source = "git+https://github.com/carina-rs/carina?rev=455e6fa1#455e6fa1e0666578a595806a41c4dfeb5f5e38e4"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -579,7 +579,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=86eaa70a#86eaa70a1e74ede704adc4fa97550ed129c3d3bd"
+source = "git+https://github.com/carina-rs/carina?rev=455e6fa1#455e6fa1e0666578a595806a41c4dfeb5f5e38e4"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "86eaa70a" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "455e6fa1" }

--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -23,10 +23,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "86eaa70a" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "455e6fa1" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "86eaa70a" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "86eaa70a" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "455e6fa1" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "455e6fa1" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-smithy-async = { version = "1", features = ["rt-tokio"] }

--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -2030,6 +2030,7 @@ pub fn {}() -> AwsccSchemaConfig {{
         // specific nested sub-properties are omitted.
         let is_write_only = write_only.contains(prop_name);
         let is_identity = identity_properties().contains(&(type_name, prop_name));
+        let is_deferred_populate = deferred_populate_properties().contains(&(type_name, prop_name));
 
         let attr_type = if let Some(enum_info) = enums.get(prop_name) {
             // Use shared schema enum type for constrained strings.
@@ -2104,6 +2105,10 @@ pub fn {}() -> AwsccSchemaConfig {{
 
         if is_identity {
             attr_code.push_str("\n                .identity()");
+        }
+
+        if is_deferred_populate {
+            attr_code.push_str("\n                .deferred_populate()");
         }
 
         if let Some(desc) = &prop.description {
@@ -3258,6 +3263,34 @@ fn identity_properties() -> &'static HashSet<(&'static str, &'static str)> {
         s
     });
     &IDENTITY
+}
+
+/// Properties that should be marked as `deferred_populate` in the schema
+/// (carina#3034). The AWS API populates these *asynchronously after Create
+/// returns* — chained references to them from another resource will be
+/// rejected at validate time unless the user has declared a `wait` block
+/// on the binding.
+///
+/// CloudFormation `readOnlyProperties` is a coarser bucket: it includes
+/// both attributes that are echoed back synchronously (e.g. ARNs) and
+/// attributes that genuinely transition state asynchronously (e.g. ACM
+/// `Status`, CloudFront `DomainName`). This list narrows the second class
+/// so the validate-time rule does not over-flag.
+fn deferred_populate_properties() -> &'static HashSet<(&'static str, &'static str)> {
+    static DEFERRED: LazyLock<HashSet<(&'static str, &'static str)>> = LazyLock::new(|| {
+        let mut s = HashSet::new();
+        // CloudFront Distribution: `DomainName` (the
+        // `<random>.cloudfront.net` host) is computed by the service
+        // after CreateDistribution returns. Downstream consumers
+        // that wire this into, e.g., a route53 alias record need a
+        // `wait` synchronization. (`Status` transitions InProgress →
+        // Deployed asynchronously too, but CFN does not expose it
+        // as a top-level property — wait predicates that need it
+        // hit the Cloud Control read path directly.)
+        s.insert(("AWS::CloudFront::Distribution", "DomainName"));
+        s
+    });
+    &DEFERRED
 }
 
 /// Infer the Carina type string for a property based on its name.

--- a/carina-provider-awscc/src/convert.rs
+++ b/carina-provider-awscc/src/convert.rs
@@ -252,6 +252,13 @@ fn proto_to_core_struct_field(f: &ProtoStructField) -> CoreStructField {
         description: f.description.clone(),
         provider_name: f.provider_name.clone(),
         block_name: f.block_name.clone(),
+        // The WIT contract does not transmit `deferred_populate`
+        // (carina#3034). The annotation lives entirely in the host-
+        // side schema (set by codegen output in
+        // `carina-provider-awscc/src/schemas/generated/`), which is
+        // loaded directly via `SchemaRegistry` rather than crossing
+        // the WASM boundary.
+        deferred_populate: false,
     }
 }
 
@@ -270,6 +277,8 @@ fn _proto_to_core_attribute_schema(a: &ProtoAttributeSchema) -> CoreAttributeSch
         block_name: a.block_name.clone(),
         write_only: a.write_only,
         identity: a.identity,
+        // See `proto_to_core_struct_field` for the rationale.
+        deferred_populate: false,
     }
 }
 

--- a/carina-provider-awscc/src/schemas/generated/cloudfront/distribution.rs
+++ b/carina-provider-awscc/src/schemas/generated/cloudfront/distribution.rs
@@ -469,6 +469,7 @@ pub fn cloudfront_distribution_config() -> AwsccSchemaConfig {
         .attribute(
             AttributeSchema::new("domain_name", AttributeType::String)
                 .read_only()
+                .deferred_populate()
                 .with_description(" (read-only)")
                 .with_provider_name("DomainName"),
         )


### PR DESCRIPTION
## Summary

Plumbs the new `AttributeSchema::deferred_populate()` builder (carina#3034 core impl, carina-rs/carina#3036) through the AWSCC codegen pipeline, and applies the annotation to CloudFront `Distribution.DomainName`. Refs carina-rs/carina#3034.

## Codegen mechanism

- New `deferred_populate_properties()` `LazyLock<HashSet<(type, prop)>>` mirrors the existing `identity_properties()` shape.
- New `is_deferred_populate` flag in the per-property loop.
- Codegen template emits `.deferred_populate()` next to `.identity()`.

CloudFormation `readOnlyProperties` is a coarser bucket — it includes both attributes echoed back synchronously (e.g. ARNs) and attributes that genuinely transition state asynchronously. This list narrows the second class so the validate-time rule does not over-flag.

## CloudFront Distribution.DomainName

The `<random>.cloudfront.net` host is computed by the service after `CreateDistribution` returns. Downstream consumers wiring this into, e.g., a route53 alias record need a `wait` synchronization.

(`Status` transitions InProgress → Deployed asynchronously too, but CFN does not expose it as a top-level property — wait predicates that need it hit the Cloud Control read path directly.)

## convert.rs

Defaults `deferred_populate: false` when lowering proto schemas across the WASM boundary — the annotation lives entirely in the host-side schema (carina-rs/carina#3035 §"WIT contract").

## carina-core dep bump

- `86eaa70a` → `455e6fa1` (post-carina-rs/carina#3036 main).

## Test plan

- [x] `cargo nextest run` — 437/437 pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo build -p carina-provider-awscc --target wasm32-wasip2 --release` — ok
- [x] Generated diff inspected: single `+ .deferred_populate()` on CloudFront Distribution `domain_name` (no other regressions).

Schema regen ran from the committed CFN cache (`--from-cache-only`) so no AWS credentials were needed for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
