### PR TITLE
cloudfront.Distribution: synthesize top-level arn

### DIFF
--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -49,6 +49,6 @@ http = "1"
 tokio = { version = "1", features = ["full"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-tokio = { version = "1", default-features = false, features = ["rt", "macros", "time"] }
+tokio = { version = "1", default-features = false, features = ["rt", "macros", "time", "sync"] }
 wit-bindgen = { version = "0.54", default-features = false, features = ["macros"] }
 wasi = "0.14"

--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -1075,10 +1075,15 @@ fn generate_markdown(schema: &CfnSchema, type_name: &str) -> Result<String> {
     }
 
     // Attribute Reference (read-only attributes)
+    let synth_for_type: Vec<&SyntheticAttribute> = synthetic_attributes()
+        .iter()
+        .filter(|s| s.cfn_type == type_name)
+        .collect();
     let has_read_only = schema
         .properties
         .keys()
-        .any(|name| read_only.contains(name));
+        .any(|name| read_only.contains(name))
+        || !synth_for_type.is_empty();
     if has_read_only {
         md.push_str("## Attribute Reference\n\n");
 
@@ -1099,6 +1104,15 @@ fn generate_markdown(schema: &CfnSchema, type_name: &str) -> Result<String> {
             } else {
                 md.push('\n');
             }
+        }
+
+        for synth in synth_for_type {
+            md.push_str(&format!("### `{}`\n\n", synth.attr_name));
+            md.push_str("- **Type:** String\n\n");
+            md.push_str(&format!(
+                "{}\n\n",
+                collapse_whitespace(&synth.description.replace('\n', " "))
+            ));
         }
     }
 
@@ -2156,6 +2170,30 @@ pub fn {}() -> AwsccSchemaConfig {{
 
         attr_code.push_str(",\n        )\n");
         body.push_str(&attr_code);
+    }
+
+    // Emit synthetic attributes — values the Cloud Control read path does
+    // not return because the CFN schema omits them. The provider fills
+    // these in on the read path; the schema entry exists so DSL references
+    // (e.g. `distribution.arn`) resolve at validate time.
+    for synth in synthetic_attributes() {
+        if synth.cfn_type != type_name {
+            continue;
+        }
+        let escaped = collapse_whitespace(
+            &synth
+                .description
+                .replace('\\', "\\\\")
+                .replace('"', "\\\"")
+                .replace('\n', " "),
+        );
+        body.push_str(&format!(
+            "        .attribute(\n            \
+             AttributeSchema::new(\"{}\", {})\n                \
+             .read_only()\n                \
+             .with_description(\"{} (read-only)\"),\n        )\n",
+            synth.attr_name, synth.attr_type, escaped,
+        ));
     }
 
     // Determine name_attribute from primaryIdentifier:
@@ -3291,6 +3329,41 @@ fn deferred_populate_properties() -> &'static HashSet<(&'static str, &'static st
         s
     });
     &DEFERRED
+}
+
+/// Attributes that do **not** exist in the CloudFormation schema but that
+/// the provider synthesizes on the read path so downstream `.crn`
+/// references can resolve. Each entry expands into an extra
+/// `AttributeSchema::new(...).read_only()` block in the generated schema
+/// with no `provider_name` (the missing `provider_name` is what tells the
+/// read-path mapper to skip CFN lookup and rely on synthesis instead).
+///
+/// Closes carina-rs/carina-provider-awscc#240 for cloudfront.Distribution.
+///
+/// If AWS later updates a CFN type to surface one of these attributes
+/// natively, drop the entry from this list so the regular CFN-driven
+/// emission takes over — otherwise the synthesis path becomes dead code
+/// silently (the value AWS would return and the one we'd synthesize are
+/// identical, so a regression here would not be observable).
+fn synthetic_attributes() -> &'static [SyntheticAttribute] {
+    static ATTRS: LazyLock<Vec<SyntheticAttribute>> = LazyLock::new(|| {
+        vec![SyntheticAttribute {
+            cfn_type: "AWS::CloudFront::Distribution",
+            attr_name: "arn",
+            attr_type: "super::arn()",
+            description: "The ARN of the CloudFront distribution. Synthesized by the provider \
+                 from the distribution id; CloudFront's CloudFormation type does not \
+                 expose ARN through the Cloud Control API.",
+        }]
+    });
+    &ATTRS
+}
+
+struct SyntheticAttribute {
+    cfn_type: &'static str,
+    attr_name: &'static str,
+    attr_type: &'static str,
+    description: &'static str,
 }
 
 /// Infer the Carina type string for a property based on its name.

--- a/carina-provider-awscc/src/provider/arn_synthesis.rs
+++ b/carina-provider-awscc/src/provider/arn_synthesis.rs
@@ -1,0 +1,210 @@
+//! Synthesize ARNs for resources whose CloudFormation type schema does not
+//! expose them as a top-level property.
+//!
+//! Cloud Control API returns only what the resource type's CFN schema
+//! declares; some resources (notably `AWS::CloudFront::Distribution`) omit
+//! `Arn` from their schema even though the ARN exists and has a
+//! deterministic format. Downstream `.crn` references like
+//! `distribution.arn` would otherwise fail at validate time. This module
+//! reconstructs those ARNs from the resource id plus the caller's account
+//! id.
+
+use std::collections::HashMap;
+
+use carina_core::provider::ProviderResult;
+use carina_core::resource::{ConcreteValue, Value};
+
+use super::AwsccProvider;
+
+/// Build the ARN for `AWS::CloudFront::Distribution`.
+///
+/// CloudFront is a global service: the region segment is empty.
+pub(crate) fn cloudfront_distribution_arn(account_id: &str, distribution_id: &str) -> String {
+    format!("arn:aws:cloudfront::{account_id}:distribution/{distribution_id}")
+}
+
+/// If `attributes` is missing the `arn` slot for a
+/// `cloudfront.Distribution` read-back but `id` is present, return the
+/// synthesized ARN value to insert. Returns `None` when nothing is
+/// needed (different resource, `arn` already populated, or `id`
+/// missing/non-string) — in that case the caller should skip the STS
+/// call entirely.
+pub(crate) fn pending_cloudfront_distribution_arn(
+    resource_type: &str,
+    attributes: &HashMap<String, Value>,
+    account_id: &str,
+) -> Option<Value> {
+    if resource_type != "cloudfront.Distribution" {
+        return None;
+    }
+    if attributes.contains_key("arn") {
+        return None;
+    }
+    let Some(Value::Concrete(ConcreteValue::String(id))) = attributes.get("id") else {
+        return None;
+    };
+    Some(Value::Concrete(ConcreteValue::String(
+        cloudfront_distribution_arn(account_id, id),
+    )))
+}
+
+/// Whether `synthesize_read_attributes` would mutate `attributes` for this
+/// `(resource_type, attributes)` pair. Extracted as a pure predicate so the
+/// "non-distribution reads — and distribution reads with no id — never call
+/// STS" invariant can be unit-tested without instantiating a real provider.
+pub(crate) fn needs_synthesis(resource_type: &str, attributes: &HashMap<String, Value>) -> bool {
+    resource_type == "cloudfront.Distribution"
+        && !attributes.contains_key("arn")
+        && matches!(
+            attributes.get("id"),
+            Some(Value::Concrete(ConcreteValue::String(_)))
+        )
+}
+
+impl AwsccProvider {
+    /// Populate read-side attributes whose value is not returned by Cloud
+    /// Control but is derivable from data we already have. Today this is
+    /// just `cloudfront.Distribution.arn`; the function is a switch on
+    /// resource type so adding the next case stays a few lines.
+    pub(crate) async fn synthesize_read_attributes(
+        &self,
+        resource_type: &str,
+        attributes: &mut HashMap<String, Value>,
+    ) -> ProviderResult<()> {
+        if !needs_synthesis(resource_type, attributes) {
+            return Ok(());
+        }
+        let account_id = self.account_id().await?;
+        if let Some(value) =
+            pending_cloudfront_distribution_arn(resource_type, attributes, account_id)
+        {
+            attributes.insert("arn".to_string(), value);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schemas::generated::get_config_by_type;
+
+    #[test]
+    fn cloudfront_distribution_arn_uses_empty_region_segment() {
+        let arn = cloudfront_distribution_arn("123456789012", "E1U5RQF7T870K0");
+        assert_eq!(
+            arn,
+            "arn:aws:cloudfront::123456789012:distribution/E1U5RQF7T870K0"
+        );
+    }
+
+    /// `AWS::CloudFront::Distribution`'s CFN schema does not expose `Arn`,
+    /// but downstream `.crn` files reference `distribution.arn` (e.g. for
+    /// CloudFront/S3 OAC bucket policies). The schema must therefore
+    /// declare `arn` as a read-only attribute the provider synthesizes.
+    /// Closes carina-rs/carina-provider-awscc#240.
+    #[test]
+    fn cloudfront_distribution_schema_exposes_arn_attribute() {
+        let config = get_config_by_type("cloudfront.Distribution")
+            .expect("cloudfront.Distribution schema must be registered");
+        let arn = config
+            .schema
+            .attributes
+            .get("arn")
+            .expect("cloudfront.Distribution must expose an `arn` attribute");
+        assert!(arn.read_only, "synthesized `arn` must be read_only");
+        assert!(
+            arn.provider_name.is_none(),
+            "synthesized `arn` must not declare a CFN provider_name; \
+             the value is built on the provider side from id + account id"
+        );
+    }
+
+    fn attrs_with_id(id: &str) -> HashMap<String, Value> {
+        let mut a = HashMap::new();
+        a.insert(
+            "id".to_string(),
+            Value::Concrete(ConcreteValue::String(id.to_string())),
+        );
+        a
+    }
+
+    #[test]
+    fn pending_arn_builds_value_when_id_present_and_arn_missing() {
+        let attrs = attrs_with_id("E1U5RQF7T870K0");
+        let v =
+            pending_cloudfront_distribution_arn("cloudfront.Distribution", &attrs, "123456789012")
+                .expect("ARN must be synthesizable when id is present");
+        match v {
+            Value::Concrete(ConcreteValue::String(s)) => assert_eq!(
+                s,
+                "arn:aws:cloudfront::123456789012:distribution/E1U5RQF7T870K0"
+            ),
+            other => panic!("expected concrete string ARN, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn pending_arn_returns_none_when_arn_already_populated() {
+        let mut attrs = attrs_with_id("E1U5RQF7T870K0");
+        attrs.insert(
+            "arn".to_string(),
+            Value::Concrete(ConcreteValue::String("preexisting".to_string())),
+        );
+        assert!(
+            pending_cloudfront_distribution_arn("cloudfront.Distribution", &attrs, "123456789012",)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn pending_arn_returns_none_when_id_missing() {
+        let attrs = HashMap::new();
+        assert!(
+            pending_cloudfront_distribution_arn("cloudfront.Distribution", &attrs, "123456789012",)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn pending_arn_returns_none_for_unrelated_resource_type() {
+        let attrs = attrs_with_id("E1U5RQF7T870K0");
+        assert!(
+            pending_cloudfront_distribution_arn("cloudfront.OriginAccessControl", &attrs, "123",)
+                .is_none()
+        );
+    }
+
+    /// `needs_synthesis` is the gate `synthesize_read_attributes` checks
+    /// before touching STS. These cases must short-circuit to `false` so
+    /// reads of unrelated resource types — or distribution reads that
+    /// arrive with no `id` — never trigger a `sts:GetCallerIdentity` call.
+    #[test]
+    fn needs_synthesis_false_for_unrelated_resource_type() {
+        let attrs = attrs_with_id("E1U5RQF7T870K0");
+        assert!(!needs_synthesis("s3.Bucket", &attrs));
+        assert!(!needs_synthesis("cloudfront.OriginAccessControl", &attrs));
+    }
+
+    #[test]
+    fn needs_synthesis_false_when_arn_already_present() {
+        let mut attrs = attrs_with_id("E1U5RQF7T870K0");
+        attrs.insert(
+            "arn".to_string(),
+            Value::Concrete(ConcreteValue::String("preexisting".to_string())),
+        );
+        assert!(!needs_synthesis("cloudfront.Distribution", &attrs));
+    }
+
+    #[test]
+    fn needs_synthesis_false_when_id_missing() {
+        let attrs = HashMap::new();
+        assert!(!needs_synthesis("cloudfront.Distribution", &attrs));
+    }
+
+    #[test]
+    fn needs_synthesis_true_for_distribution_with_id_and_no_arn() {
+        let attrs = attrs_with_id("E1U5RQF7T870K0");
+        assert!(needs_synthesis("cloudfront.Distribution", &attrs));
+    }
+}

--- a/carina-provider-awscc/src/provider/mod.rs
+++ b/carina-provider-awscc/src/provider/mod.rs
@@ -15,6 +15,7 @@
 //! - `update` - Update patch building and resource property parsing
 
 pub(crate) mod account_guard;
+mod arn_synthesis;
 mod cloudcontrol;
 pub(crate) mod conversion;
 mod normalizer;
@@ -27,6 +28,8 @@ pub(crate) mod update;
 use aws_config::Region;
 use aws_sdk_cloudcontrol::Client as CloudControlClient;
 use aws_sdk_sts::Client as StsClient;
+use carina_core::provider::{ProviderError, ProviderResult};
+use tokio::sync::OnceCell;
 
 use crate::schemas::generated::AwsccSchemaConfig;
 
@@ -76,6 +79,11 @@ pub struct AwsccProvider {
     /// touching CloudControl, so a wrong-account `apply` aborts before
     /// any read/refresh/mutation.
     init_error: Option<String>,
+    /// Caller's AWS account id, fetched lazily via `sts:GetCallerIdentity`
+    /// the first time a synthesized attribute (e.g.
+    /// `cloudfront.Distribution.arn`) needs it, then cached for the
+    /// lifetime of the provider instance.
+    account_id: OnceCell<String>,
 }
 
 impl AwsccProvider {
@@ -110,7 +118,26 @@ impl AwsccProvider {
             cloudcontrol_client: CloudControlClient::new(&config),
             aws_config: config,
             init_error,
+            account_id: OnceCell::new(),
         }
+    }
+
+    /// Return the caller's AWS account id, fetching it via
+    /// `sts:GetCallerIdentity` on first call and caching the result on
+    /// the provider for subsequent reads.
+    pub(crate) async fn account_id(&self) -> ProviderResult<&str> {
+        self.account_id
+            .get_or_try_init(|| async {
+                let sts = StsClient::new(&self.aws_config);
+                let identity = sts.get_caller_identity().send().await.map_err(|e| {
+                    ProviderError::api_error(format!("Failed to call sts:GetCallerIdentity: {e}"))
+                })?;
+                identity.account().map(|s| s.to_string()).ok_or_else(|| {
+                    ProviderError::api_error("sts:GetCallerIdentity returned no account id")
+                })
+            })
+            .await
+            .map(String::as_str)
     }
 
     /// Look up the caller's AWS account ID via STS and validate it

--- a/carina-provider-awscc/src/provider/operations.rs
+++ b/carina-provider-awscc/src/provider/operations.rs
@@ -63,6 +63,11 @@ impl AwsccProvider {
         // Handle special cases
         self.read_special_attributes(resource_type, &props, &mut attributes);
 
+        // Synthesize attributes the Cloud Control read does not return
+        // (e.g. cloudfront.Distribution.arn). Reads STS once, then caches.
+        self.synthesize_read_attributes(resource_type, &mut attributes)
+            .await?;
+
         Ok(State::existing(id, attributes).with_identifier(identifier))
     }
 

--- a/carina-provider-awscc/src/schemas/generated/cloudfront/distribution.rs
+++ b/carina-provider-awscc/src/schemas/generated/cloudfront/distribution.rs
@@ -484,6 +484,11 @@ pub fn cloudfront_distribution_config() -> AwsccSchemaConfig {
                 .with_description("A complex type that contains zero or more ``Tag`` elements.")
                 .with_provider_name("Tags"),
         )
+        .attribute(
+            AttributeSchema::new("arn", super::arn())
+                .read_only()
+                .with_description("The ARN of the CloudFront distribution. Synthesized by the provider from the distribution id; CloudFront's CloudFormation type does not expose ARN through the Cloud Control API. (read-only)"),
+        )
         .with_validator(|attrs| {
             let mut errors = Vec::new();
             if let Err(mut e) = validate_tags_map(attrs) {

--- a/generated-docs/awscc/cloudfront/distribution.md
+++ b/generated-docs/awscc/cloudfront/distribution.md
@@ -490,3 +490,9 @@ Shorthand formats: `required` or `ViewerMtlsMode.required`
 
 
 
+### `arn`
+
+- **Type:** String
+
+The ARN of the CloudFront distribution. Synthesized by the provider from the distribution id; CloudFront's CloudFormation type does not expose ARN through the Cloud Control API.
+


### PR DESCRIPTION
## Summary

Closes #240.

`awscc.cloudfront.Distribution` was missing a top-level `arn` attribute, which blocked the CloudFront/S3 OAC pattern (`AWS:SourceArn = distribution.arn` in a bucket policy condition). The fix exposes `arn` as a read-only synthesized attribute.

## Why synthesis, not codegen-only

The issue body assumed the CFN schema for `AWS::CloudFront::Distribution` exposed `Arn` and that codegen was dropping it. I verified against both the cached `cfn-schema-cache/AWS__CloudFront__Distribution.json` and a fresh `aws cloudformation describe-type` fetch — top-level `properties` keys are `[DistributionConfig, DomainName, Id, Tags]` with no `Arn`. The CloudFormation public docs' `Fn::GetAtt` section likewise lists only `DomainName` and `Id`. So Cloud Control will never return `Arn` for this type; the value has to be synthesized.

CloudFront ARNs have a deterministic format: `arn:aws:cloudfront::<account-id>:distribution/<id>` (empty region segment because CloudFront is a global service). So we can rebuild it from the `id` Cloud Control already returns plus the caller's AWS account id (one `sts:GetCallerIdentity` per provider, cached).

## Changes

- **codegen** (`carina-provider-awscc/src/bin/codegen.rs`): new ``synthetic_attributes()`` registry declaring ``(cfn_type, attr_name, attr_type, description)`` for attributes the CFN schema omits but the provider fills in. Drives both the generated Rust schema (`AttributeSchema::new("arn", super::arn()).read_only().with_description(...)` with no `provider_name`) and the markdown ``## Attribute Reference`` section. The missing `provider_name` is what tells `map_aws_props_to_attributes` to skip CFN lookup for this slot.
- **runtime** (`carina-provider-awscc/src/provider/arn_synthesis.rs`, new): `cloudfront_distribution_arn(...)` pure formatter, `needs_synthesis(...)` pure STS-gate predicate, `pending_cloudfront_distribution_arn(...)` pure builder, and ``impl AwsccProvider { synthesize_read_attributes(...) }`` async method called from ``read_resource`` after `read_special_attributes`.
- **AwsccProvider** (`carina-provider-awscc/src/provider/mod.rs`): adds `tokio::sync::OnceCell<String>` field caching the caller's account id; ``async fn account_id()`` does one `sts:GetCallerIdentity` per provider instance, concurrent-safe.
- **Cargo.toml**: add ``"sync"`` to the WASM target tokio features so `OnceCell` compiles for ``wasm32-wasip2``.
- **regenerated artifacts**: ``carina-provider-awscc/src/schemas/generated/cloudfront/distribution.rs``, ``generated-docs/awscc/cloudfront/distribution.md``.

10 unit tests in `arn_synthesis.rs` cover the ARN formatter, schema registration, and every short-circuit branch of `needs_synthesis`. The STS-call invariant ("non-distribution reads — and distribution reads with no `id` — never call STS") is locked in by the predicate's unit tests.

## Notes for future maintenance

- **If AWS adds `Arn` to the CFN schema later**, drop the entry from `synthetic_attributes()` and CFN-driven emission takes over; the synthesized value would otherwise be identical so the regression would be silent. The doc-comment on ``synthetic_attributes()`` reminds future maintainers of this.
- **An STS failure on first read of a `cloudfront.Distribution` now surfaces as a read error** rather than yielding a partial state. Acceptable: any real `plan`/`apply` already requires STS for many other things.
- **Out-of-scope follow-ups noted during review** (will file as separate issues post-merge):
  - Other CFN resources also lack `Arn` despite having deterministic ARN formats: `EC2.VPC`, `EC2.Subnet`, `EC2.SecurityGroup`, `EC2.InternetGateway`, `EC2.NatGateway`, `EC2.RouteTable`, `EC2.TransitGateway`, `Route53.HostedZone`, `IAM.RolePolicy`, `SSO.{Instance,PermissionSet,Assignment}`, `CloudFront.OriginAccessControl`, etc.
  - `check_account_guard` already calls `sts:GetCallerIdentity` and discards the account id; could seed the same `OnceCell` to coalesce.

## Test plan

- [x] `cargo nextest run -p carina-provider-awscc` — 355 tests pass (10 new in `arn_synthesis::tests`)
- [x] `cargo clippy -p carina-provider-awscc --all-targets -- -D warnings` — clean
- [x] `cargo build -p carina-provider-awscc --target wasm32-wasip2 --release` — OK
- [x] `bash scripts/check-docs-drift.sh` — OK (schemas and docs in sync, 37 resources)
- [x] `cargo fmt --check` — passes (pre-commit hook)
- [ ] Real-infra smoke (T6e CloudFront + OAC + BucketPolicy in `carina-rs/infra`) — user-driven, deferred.