### PR TITLE
cloudfront.Distribution: pin MinimumProtocolVersion enum

### DIFF
--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -2765,6 +2765,26 @@ fn known_enum_overrides() -> &'static HashMap<&'static str, Vec<&'static str>> {
         m.insert("SecurityGroupReferencingSupport", vec!["enable", "disable"]);
         m.insert("VpnEcmpSupport", vec!["enable", "disable"]);
         m.insert("EncryptionSupportState", vec!["disable", "enable"]);
+        // CloudFront ViewerCertificate.MinimumProtocolVersion: CFN schema declares
+        // it as a free-form string, so the description-scraping heuristic in
+        // extract_enum_from_description() picked up unrelated backticked tokens
+        // from sibling fields (`sni-only` from SslSupportMethod, `true` from
+        // CloudFrontDefaultCertificate) while filtering out the real value
+        // `TLSv1` as a "property name". Pin the canonical security-policy values
+        // here so the heuristic is short-circuited (overrides are consulted
+        // before description extraction). awscc#242.
+        m.insert(
+            "MinimumProtocolVersion",
+            vec![
+                "SSLv3",
+                "TLSv1",
+                "TLSv1_2016",
+                "TLSv1.1_2016",
+                "TLSv1.2_2018",
+                "TLSv1.2_2019",
+                "TLSv1.2_2021",
+            ],
+        );
         m
     });
     &OVERRIDES
@@ -2778,6 +2798,23 @@ fn known_enum_aliases() -> &'static HashMap<&'static str, Vec<(&'static str, &'s
         LazyLock::new(|| {
             let mut m = HashMap::new();
             m.insert("IpProtocol", vec![("-1", "all")]);
+            // CloudFront security-policy values mix uppercase acronyms (`TLS`),
+            // version digits, and dotted minor versions. The mechanical D7
+            // snake_case transform splits `TLSv1_2016` as `tl_sv1_2016`, which
+            // is unreadable. Pin the human-friendly DSL spellings here so
+            // users can write `tlsv1_2_2021` etc. instead.
+            m.insert(
+                "MinimumProtocolVersion",
+                vec![
+                    ("SSLv3", "sslv3"),
+                    ("TLSv1", "tlsv1"),
+                    ("TLSv1_2016", "tlsv1_2016"),
+                    ("TLSv1.1_2016", "tlsv1_1_2016"),
+                    ("TLSv1.2_2018", "tlsv1_2_2018"),
+                    ("TLSv1.2_2019", "tlsv1_2_2019"),
+                    ("TLSv1.2_2021", "tlsv1_2_2021"),
+                ],
+            );
             m
         });
     &ALIASES
@@ -4702,6 +4739,123 @@ mod tests {
             info.values,
             vec!["tcp", "udp", "icmp", "icmpv6", "-1", "all"]
         );
+    }
+
+    #[test]
+    fn test_minimum_protocol_version_override_short_circuits_sibling_bleed() {
+        // Regression test for awscc#242. The CFN description for
+        // ViewerCertificate.MinimumProtocolVersion mentions sibling-field values
+        // (`sni-only` from SslSupportMethod, `true` from CloudFrontDefaultCertificate)
+        // in backticks, while filtering out the real value `TLSv1` as a "property
+        // name". Without the override, extract_enum_from_description picks up the
+        // sibling values and ships them as the enum membership; the override must
+        // short-circuit that path.
+        let description = "If the distribution uses ``Aliases`` (alternate domain \
+            names or CNAMEs), specify the security policy that you want CloudFront \
+            to use for HTTPS connections with viewers. When you're using SNI only \
+            (you set ``SSLSupportMethod`` to ``sni-only``), you must specify \
+            ``TLSv1`` or higher. If the distribution uses the CloudFront domain \
+            name such as ``d111111abcdef8.cloudfront.net`` (you set \
+            ``CloudFrontDefaultCertificate`` to ``true``), CloudFront automatically \
+            sets the security policy to ``TLSv1``.";
+
+        // Demonstrate the underlying heuristic still misfires on this description
+        // — overrides are the correct fix layer, not a heuristic tweak.
+        let scraped = extract_enum_from_description(description);
+        assert_eq!(
+            scraped,
+            Some(vec!["sni-only".to_string(), "true".to_string()]),
+            "heuristic still produces the bogus pair; override must short-circuit it"
+        );
+
+        let prop = CfnProperty {
+            prop_type: Some(TypeValue::Single("string".to_string())),
+            description: Some(description.to_string()),
+            enum_values: None,
+            items: None,
+            ref_path: None,
+            insertion_order: None,
+            properties: None,
+            required: vec![],
+            minimum: None,
+            maximum: None,
+            additional_properties: None,
+            const_value: None,
+            default_value: None,
+            pattern: None,
+            min_items: None,
+            max_items: None,
+            min_length: None,
+            max_length: None,
+            format: None,
+        };
+        let schema = CfnSchema {
+            type_name: "AWS::CloudFront::Distribution".to_string(),
+            description: None,
+            properties: BTreeMap::new(),
+            required: vec![],
+            read_only_properties: vec![],
+            create_only_properties: vec![],
+            write_only_properties: vec![],
+            primary_identifier: None,
+            definitions: None,
+            tagging: None,
+            one_of: vec![],
+            any_of: vec![],
+            handlers: BTreeMap::new(),
+        };
+        let (_, enum_info) = cfn_type_to_carina_type_with_enum(
+            &prop,
+            "MinimumProtocolVersion",
+            &schema,
+            "",
+            &BTreeMap::new(),
+        );
+        let info = enum_info.expect("MinimumProtocolVersion should produce EnumInfo via overrides");
+        assert_eq!(info.type_name, "MinimumProtocolVersion");
+        // The canonical AWS values must be present (the headline fix for awscc#242).
+        for canonical in [
+            "SSLv3",
+            "TLSv1",
+            "TLSv1_2016",
+            "TLSv1.1_2016",
+            "TLSv1.2_2018",
+            "TLSv1.2_2019",
+            "TLSv1.2_2021",
+        ] {
+            assert!(
+                info.values.iter().any(|v| v == canonical),
+                "MinimumProtocolVersion must carry canonical value {canonical}; got {:?}",
+                info.values
+            );
+        }
+        // The sibling-bleed values must NOT appear.
+        for bogus in ["sni-only", "true"] {
+            assert!(
+                !info.values.iter().any(|v| v == bogus),
+                "MinimumProtocolVersion must not carry sibling-bleed value {bogus}; got {:?}",
+                info.values
+            );
+        }
+        // The DSL aliases registered in known_enum_aliases for this property
+        // are merged into `values` (mirroring the existing IpProtocol "all"
+        // injection at codegen.rs:3929-3938) so the strict-DSL validator
+        // accepts both spellings.
+        for alias in [
+            "tlsv1_2_2021",
+            "tlsv1_2_2019",
+            "tlsv1_2_2018",
+            "tlsv1_1_2016",
+            "tlsv1_2016",
+            "tlsv1",
+            "sslv3",
+        ] {
+            assert!(
+                info.values.iter().any(|v| v == alias),
+                "MinimumProtocolVersion alias {alias} must be merged into values; got {:?}",
+                info.values
+            );
+        }
     }
 
     #[test]

--- a/carina-provider-awscc/src/schemas/generated/cloudfront/distribution.rs
+++ b/carina-provider-awscc/src/schemas/generated/cloudfront/distribution.rs
@@ -40,7 +40,22 @@ const VALID_LAMBDA_FUNCTION_ASSOCIATION_EVENT_TYPE: &[&str] = &[
 
 const VALID_ORIGIN_GROUP_SELECTION_CRITERIA: &[&str] = &["default", "media-quality-based"];
 
-const VALID_VIEWER_CERTIFICATE_MINIMUM_PROTOCOL_VERSION: &[&str] = &["sni-only", "true"];
+const VALID_VIEWER_CERTIFICATE_MINIMUM_PROTOCOL_VERSION: &[&str] = &[
+    "SSLv3",
+    "TLSv1",
+    "TLSv1_2016",
+    "TLSv1.1_2016",
+    "TLSv1.2_2018",
+    "TLSv1.2_2019",
+    "TLSv1.2_2021",
+    "sslv3",
+    "tlsv1",
+    "tlsv1_2016",
+    "tlsv1_1_2016",
+    "tlsv1_2_2018",
+    "tlsv1_2_2019",
+    "tlsv1_2_2021",
+];
 
 const VALID_VIEWER_CERTIFICATE_SSL_SUPPORT_METHOD: &[&str] = &["sni-only", "vip", "static-ip"];
 
@@ -427,9 +442,9 @@ pub fn cloudfront_distribution_config() -> AwsccSchemaConfig {
                     StructField::new("iam_certificate_id", AttributeType::String).with_description("This field only supports standard distributions. You can't specify this field for multi-tenant distributions. For more information, see [Unsupported features for SaaS Manager for Amazon CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-config-options.html#unsupported-saas) in the *Amazon CloudFront Developer Guide*. In CloudFormation, this field name is ``IamCertificateId``. Note the different capitalization. If the distribution uses ``Aliases`` (alternate domain names or CNAMEs) and the SSL/TLS certificate is stored in [(IAM)](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html), provide the ID of the IAM certificate. If you specify an IAM certificate ID, you must also specify values for ``MinimumProtocolVersion`` and ``SSLSupportMethod``. (In CloudFormation, the field name is ``SslSupportMethod``. Note the different capitalization.)").with_provider_name("IamCertificateId"),
                     StructField::new("minimum_protocol_version", AttributeType::StringEnum {
                 name: "MinimumProtocolVersion".to_string(),
-                values: vec!["sni-only".to_string(), "true".to_string()],
+                values: vec!["SSLv3".to_string(), "TLSv1".to_string(), "TLSv1_2016".to_string(), "TLSv1.1_2016".to_string(), "TLSv1.2_2018".to_string(), "TLSv1.2_2019".to_string(), "TLSv1.2_2021".to_string(), "sslv3".to_string(), "tlsv1".to_string(), "tlsv1_2016".to_string(), "tlsv1_1_2016".to_string(), "tlsv1_2_2018".to_string(), "tlsv1_2_2019".to_string(), "tlsv1_2_2021".to_string()],
                 namespace: Some("awscc.cloudfront.Distribution".to_string()),
-                dsl_aliases: vec![("sni-only".to_string(), "sni_only".to_string()), ("true".to_string(), "true".to_string())],
+                dsl_aliases: vec![("SSLv3".to_string(), "sslv3".to_string()), ("TLSv1".to_string(), "tlsv1".to_string()), ("TLSv1_2016".to_string(), "tlsv1_2016".to_string()), ("TLSv1.1_2016".to_string(), "tlsv1_1_2016".to_string()), ("TLSv1.2_2018".to_string(), "tlsv1_2_2018".to_string()), ("TLSv1.2_2019".to_string(), "tlsv1_2_2019".to_string()), ("TLSv1.2_2021".to_string(), "tlsv1_2_2021".to_string()), ("sslv3".to_string(), "sslv3".to_string()), ("tlsv1".to_string(), "tlsv1".to_string()), ("tlsv1_2016".to_string(), "tlsv1_2016".to_string()), ("tlsv1_1_2016".to_string(), "tlsv1_1_2016".to_string()), ("tlsv1_2_2018".to_string(), "tlsv1_2_2018".to_string()), ("tlsv1_2_2019".to_string(), "tlsv1_2_2019".to_string()), ("tlsv1_2_2021".to_string(), "tlsv1_2_2021".to_string())],
             }).with_description("If the distribution uses ``Aliases`` (alternate domain names or CNAMEs), specify the security policy that you want CloudFront to use for HTTPS connections with viewers. The security policy determines two settings: + The minimum SSL/TLS protocol that CloudFront can use to communicate with viewers. + The ciphers that CloudFront can use to encrypt the content that it returns to viewers. For more information, see [Security Policy](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html#DownloadDistValues-security-policy) and [Supported Protocols and Ciphers Between Viewers and CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/secure-connections-supported-viewer-protocols-ciphers.html#secure-connections-supported-ciphers) in the *Amazon CloudFront Developer Guide*. On the CloudFront console, this setting is called *Security Policy*. When you're using SNI only (you set ``SSLSupportMethod`` to ``sni-only``), you must specify ``TLSv1`` or higher. (In CloudFormation, the field name is ``SslSupportMethod``. Note the different capitalization.) If the distribution uses the CloudFront domain name such as ``d111111abcdef8.cloudfront.net`` (you set ``CloudFrontDefaultCertificate`` to ``true``), CloudFront automatically sets the security policy to ``TLSv1`` regardless of the value that you set here.").with_provider_name("MinimumProtocolVersion"),
                     StructField::new("ssl_support_method", AttributeType::StringEnum {
                 name: "SslSupportMethod".to_string(),

--- a/generated-docs/awscc/cloudfront/distribution.md
+++ b/generated-docs/awscc/cloudfront/distribution.md
@@ -110,10 +110,22 @@ Shorthand formats: `default` or `OriginGroupSelectionCriteria.default`
 
 | Value | DSL Identifier |
 |-------|----------------|
-| `sni-only` | `awscc.cloudfront.Distribution.MinimumProtocolVersion.sni_only` |
-| `true` | `awscc.cloudfront.Distribution.MinimumProtocolVersion.true` |
+| `SSLv3` | `awscc.cloudfront.Distribution.MinimumProtocolVersion.sslv3` |
+| `TLSv1` | `awscc.cloudfront.Distribution.MinimumProtocolVersion.tlsv1` |
+| `TLSv1_2016` | `awscc.cloudfront.Distribution.MinimumProtocolVersion.tlsv1_2016` |
+| `TLSv1.1_2016` | `awscc.cloudfront.Distribution.MinimumProtocolVersion.tlsv1_1_2016` |
+| `TLSv1.2_2018` | `awscc.cloudfront.Distribution.MinimumProtocolVersion.tlsv1_2_2018` |
+| `TLSv1.2_2019` | `awscc.cloudfront.Distribution.MinimumProtocolVersion.tlsv1_2_2019` |
+| `TLSv1.2_2021` | `awscc.cloudfront.Distribution.MinimumProtocolVersion.tlsv1_2_2021` |
+| `sslv3` | `awscc.cloudfront.Distribution.MinimumProtocolVersion.sslv3` |
+| `tlsv1` | `awscc.cloudfront.Distribution.MinimumProtocolVersion.tlsv1` |
+| `tlsv1_2016` | `awscc.cloudfront.Distribution.MinimumProtocolVersion.tlsv1_2016` |
+| `tlsv1_1_2016` | `awscc.cloudfront.Distribution.MinimumProtocolVersion.tlsv1_1_2016` |
+| `tlsv1_2_2018` | `awscc.cloudfront.Distribution.MinimumProtocolVersion.tlsv1_2_2018` |
+| `tlsv1_2_2019` | `awscc.cloudfront.Distribution.MinimumProtocolVersion.tlsv1_2_2019` |
+| `tlsv1_2_2021` | `awscc.cloudfront.Distribution.MinimumProtocolVersion.tlsv1_2_2021` |
 
-Shorthand formats: `sni_only` or `MinimumProtocolVersion.sni_only`
+Shorthand formats: `sslv3` or `MinimumProtocolVersion.sslv3`
 
 ### ssl_support_method (SslSupportMethod)
 


### PR DESCRIPTION
## Summary

Closes #242.

`awscc.cloudfront.Distribution`'s `viewer_certificate.minimum_protocol_version` was generated with the bogus enum membership `["sni-only", "true"]` because:

- The CFN schema declares the field as a free-form `string` (no `enum`).
- The codegen heuristic `extract_enum_from_description()` scrapes any double-backticked token from the field description.
- The description mentions `` `sni-only` `` (SslSupportMethod) and `` `true` `` (CloudFrontDefaultCertificate) — both kept by the filters.
- The real value `` `TLSv1` `` was wrongly classified as a property name by `looks_like_property_name` (starts uppercase + contains lowercase) and dropped.

This PR pins the canonical CloudFront security-policy values via `known_enum_overrides`, which is consulted **before** description extraction and short-circuits the bad inference.

```
SSLv3, TLSv1, TLSv1_2016, TLSv1.1_2016, TLSv1.2_2018, TLSv1.2_2019, TLSv1.2_2021
```

The mechanical D7 snake_case transform mangles these (`TLSv1_2016` → `tl_sv1_2016`), so `known_enum_aliases` is also extended with hand-curated DSL spellings (`tlsv1_2_2021` etc.) so the strict-DSL validator accepts the readable form.

## Scope

Intentionally limited to this one field to unblock infra T6e (CloudFront step). `cloudfront.Distribution` has 14 generated `StringEnum`s, of which **only `IpAddressType` has an explicit `enum` in the CFN schema** — the other 13 are heuristic guesses that happen to look right. A follow-up tracker for the broader description-scraping fragility will be filed separately.

## Test plan

- [x] Added regression test `test_minimum_protocol_version_override_short_circuits_sibling_bleed` that asserts (a) the heuristic still misfires on the original description, (b) override produces canonical values, (c) sibling-bleed values are absent, (d) DSL aliases are merged into `values`.
- [x] `cargo nextest run -p carina-provider-awscc` — 356/356 pass.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `bash scripts/check-docs-drift.sh` — schemas and docs in sync.
- [x] Schemas regenerated via `generate-schemas.sh --from-cache-only`; docs regenerated via `generate-docs.sh`.
- [ ] Real-infra smoke (T6e) is user-driven (per-repo policy: agent does not run real-infra AWS commands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)