### PR TITLE
codegen: emit StringEnum for alternation-only patterns (closes #245)

### DIFF
--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -2878,6 +2878,57 @@ fn is_numeric_string_pattern(pattern: &str) -> bool {
     )
 }
 
+/// Detect a regex pattern that is a pure alternation of literal values
+/// and return those literals in source order.
+///
+/// Recognized shapes (anchors required):
+///   - `^(a|b|c)$`  -> Some(vec!["a", "b", "c"])
+///   - `^(only)$`   -> Some(vec!["only"])
+///   - `^only$`     -> Some(vec!["only"])
+///
+/// An "alternative" must be a literal: ASCII letters, digits, or any of
+/// the few separator characters that real CFN enum-as-pattern values use
+/// (`-`, `_`, `:`, `.`, `/`). Any regex metacharacter (`[`, `]`, `(`,
+/// `)`, `*`, `+`, `?`, `\`, `{`, `}`, `^`, `$`, `|` inside the alt) or
+/// an empty alternative disqualifies the pattern; it then flows through
+/// the existing `Custom { pattern }` path. See awscc#245.
+fn extract_enum_from_alternation_pattern(pattern: &str) -> Option<Vec<String>> {
+    let inner = pattern
+        .strip_prefix('^')
+        .and_then(|s| s.strip_suffix('$'))?;
+    // Two recognized shapes:
+    //   1. `^(alt1|alt2|...)$` — one outer paren group, `|` only inside.
+    //   2. `^literal$`         — no parens, no `|`.
+    // Anything else (nested groups, top-level alternation without parens
+    // like `^a|b$` which regex-parses as `(^a)|(b$)`, regex meta inside
+    // alts, etc.) flows through the existing `Custom { pattern }` path.
+    let alternatives: Vec<&str> = if let Some(stripped) =
+        inner.strip_prefix('(').and_then(|s| s.strip_suffix(')'))
+    {
+        if stripped.is_empty() || stripped.contains('(') || stripped.contains(')') {
+            return None;
+        }
+        stripped.split('|').collect()
+    } else {
+        if inner.is_empty() || inner.contains('(') || inner.contains(')') || inner.contains('|') {
+            return None;
+        }
+        vec![inner]
+    };
+    if alternatives.iter().any(|alt| !is_literal_enum_value(alt)) {
+        return None;
+    }
+    Some(alternatives.into_iter().map(|s| s.to_string()).collect())
+}
+
+/// True when `s` is a non-empty literal value safe to treat as an enum
+/// member: ASCII letters, digits, or one of `-`, `_`, `:`, `.`, `/`.
+fn is_literal_enum_value(s: &str) -> bool {
+    !s.is_empty()
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | ':' | '.' | '/'))
+}
+
 /// Recursively collect string length constraints from a property and its array items.
 /// Treats minLength=0 as no constraint since usize is always >= 0.
 fn collect_string_length_constraints(
@@ -3881,6 +3932,13 @@ fn cfn_type_to_carina_type_with_enum(
             {
                 // Check if name-based heuristics would override the type
                 if infer_string_type(prop_name, &schema.type_name).is_none() {
+                    // Promote alternation-only patterns to a real StringEnum.
+                    // See awscc#245.
+                    if let Some(values) = extract_enum_from_alternation_pattern(pattern) {
+                        let type_name = prop_name.to_pascal_case();
+                        let enum_info = EnumInfo { type_name, values };
+                        return ("/* enum */".to_string(), Some(enum_info));
+                    }
                     let effective_min = def.min_length.filter(|&m| m > 0);
                     let has_length = effective_min.is_some() || def.max_length.is_some();
                     let validate_fn = if has_length {
@@ -4038,6 +4096,18 @@ fn cfn_type_to_carina_type_with_enum(
                     ),
                     None,
                 );
+            }
+
+            // Check for alternation-only pattern (e.g., "^(a|b|c)$") and
+            // promote it to a real StringEnum so users get bare-identifier
+            // syntax, did-you-mean diagnostics, and LSP completion. See
+            // awscc#245.
+            if let Some(ref pattern) = prop.pattern
+                && let Some(values) = extract_enum_from_alternation_pattern(pattern)
+            {
+                let type_name = prop_name.to_pascal_case();
+                let enum_info = EnumInfo { type_name, values };
+                return ("/* enum */".to_string(), Some(enum_info));
             }
 
             // Check for regex pattern constraint
@@ -11005,5 +11075,140 @@ mod tests {
             md.contains("`BucketOwnerEnforced`"),
             "Value column should retain the API spelling for round-trip clarity: {md}"
         );
+    }
+
+    // === awscc#245: alternation-only patterns become real enums ===
+
+    #[test]
+    fn test_extract_enum_from_alternation_pattern_multi() {
+        assert_eq!(
+            extract_enum_from_alternation_pattern("^(s3|mediastore|lambda|mediapackagev2)$"),
+            Some(vec![
+                "s3".to_string(),
+                "mediastore".to_string(),
+                "lambda".to_string(),
+                "mediapackagev2".to_string(),
+            ])
+        );
+        assert_eq!(
+            extract_enum_from_alternation_pattern("^(never|no-override|always)$"),
+            Some(vec![
+                "never".to_string(),
+                "no-override".to_string(),
+                "always".to_string(),
+            ])
+        );
+    }
+
+    #[test]
+    fn test_extract_enum_from_alternation_pattern_single_value() {
+        // Parenthesized single value.
+        assert_eq!(
+            extract_enum_from_alternation_pattern("^(sigv4)$"),
+            Some(vec!["sigv4".to_string()])
+        );
+        // Bare single value, no parens.
+        assert_eq!(
+            extract_enum_from_alternation_pattern("^sigv4$"),
+            Some(vec!["sigv4".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_extract_enum_from_alternation_pattern_rejects_non_alternation() {
+        // Missing anchors.
+        assert_eq!(extract_enum_from_alternation_pattern("(a|b|c)"), None);
+        assert_eq!(extract_enum_from_alternation_pattern("a|b"), None);
+        // Character classes / quantifiers / escapes.
+        assert_eq!(extract_enum_from_alternation_pattern("^[0-9]+$"), None);
+        assert_eq!(extract_enum_from_alternation_pattern("^(a|b)+$"), None);
+        assert_eq!(extract_enum_from_alternation_pattern("^(a|b\\d)$"), None);
+        // Empty alternative (trailing `|`).
+        assert_eq!(extract_enum_from_alternation_pattern("^(a|b|)$"), None);
+        // Nested groups.
+        assert_eq!(extract_enum_from_alternation_pattern("^((a)|b)$"), None);
+        // Real-world non-alternation patterns from the CFN cache.
+        assert_eq!(
+            extract_enum_from_alternation_pattern(
+                "^([0-9a-f]{10}-|)[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}$"
+            ),
+            None
+        );
+        // Top-level alternation without an outer group is NOT equivalent to
+        // `^(a|b)$`: regex parses `^a|b$` as `(^a)|(b$)`. Reject it.
+        assert_eq!(extract_enum_from_alternation_pattern("^a|b$"), None);
+        assert_eq!(extract_enum_from_alternation_pattern("^a|b|c$"), None);
+        // Empty parens.
+        assert_eq!(extract_enum_from_alternation_pattern("^()$"), None);
+        assert_eq!(extract_enum_from_alternation_pattern("^$"), None);
+    }
+
+    #[test]
+    fn test_alternation_pattern_emits_string_enum_not_custom() {
+        // Mirrors the awscc#245 reproducer: a CFN string property whose only
+        // constraint is `pattern: "^(a|b|c)$"` must become a real
+        // StringEnum, not Custom { pattern, base: String }.
+        let mut properties = BTreeMap::new();
+        properties.insert(
+            "OriginAccessControlOriginType".to_string(),
+            CfnProperty {
+                prop_type: Some(TypeValue::Single("string".to_string())),
+                description: None,
+                enum_values: None,
+                items: None,
+                ref_path: None,
+                insertion_order: None,
+                properties: None,
+                required: vec![],
+                minimum: None,
+                maximum: None,
+                additional_properties: None,
+                const_value: None,
+                default_value: None,
+                pattern: Some("^(s3|mediastore|lambda|mediapackagev2)$".to_string()),
+                min_items: None,
+                max_items: None,
+                min_length: None,
+                max_length: None,
+                format: None,
+            },
+        );
+        let schema = CfnSchema {
+            type_name: "AWS::CloudFront::OriginAccessControl".to_string(),
+            description: None,
+            properties,
+            required: vec![],
+            read_only_properties: vec![],
+            create_only_properties: vec![],
+            write_only_properties: vec![],
+            primary_identifier: None,
+            definitions: None,
+            tagging: None,
+            one_of: vec![],
+            any_of: vec![],
+            handlers: BTreeMap::new(),
+        };
+        let generated =
+            generate_schema_code(&schema, "AWS::CloudFront::OriginAccessControl").unwrap();
+        assert!(
+            generated.contains("AttributeType::StringEnum {"),
+            "alternation pattern should produce StringEnum: {generated}"
+        );
+        // Must not fall back to a Custom { pattern, ... } emission.
+        assert!(
+            !generated.contains("pattern: Some(\"^(s3|mediastore|lambda|mediapackagev2)$\""),
+            "alternation pattern should not flow through Custom: {generated}"
+        );
+        assert!(
+            !generated.contains("validate_string_pattern_"),
+            "alternation pattern should not emit a per-pattern validator: {generated}"
+        );
+        // All four literals must appear in the StringEnum values list.
+        for v in ["s3", "mediastore", "lambda", "mediapackagev2"] {
+            assert!(
+                generated.contains(&format!("\"{}\".to_string()", v)),
+                "missing enum value {v} in: {generated}"
+            );
+        }
     }
 }

--- a/carina-provider-awscc/src/schemas/generated/cloudfront/origin_access_control.rs
+++ b/carina-provider-awscc/src/schemas/generated/cloudfront/origin_access_control.rs
@@ -5,48 +5,15 @@
 //! DO NOT EDIT MANUALLY - regenerate with carina-codegen
 
 use super::AwsccSchemaConfig;
-use carina_core::resource::{ConcreteValue, Value};
-use carina_core::schema::{
-    AttributeSchema, AttributeType, ResourceSchema, StructField, legacy_validator,
-};
-use regex::Regex;
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
+
+const VALID_ORIGIN_ACCESS_CONTROL_CONFIG_ORIGIN_ACCESS_CONTROL_ORIGIN_TYPE: &[&str] =
+    &["s3", "mediastore", "lambda", "mediapackagev2"];
 
 const VALID_ORIGIN_ACCESS_CONTROL_CONFIG_SIGNING_BEHAVIOR: &[&str] =
     &["always", "never", "no-override"];
 
-#[allow(dead_code)]
-fn validate_string_pattern_597c12a2d8028697(value: &Value) -> Result<(), String> {
-    if let Value::Concrete(ConcreteValue::String(s)) = value {
-        static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
-            Regex::new("^(s3|mediastore|lambda|mediapackagev2)$").expect("invalid pattern regex")
-        });
-        if RE.is_match(s) {
-            Ok(())
-        } else {
-            Err(format!(
-                "Value '{}' does not match pattern ^(s3|mediastore|lambda|mediapackagev2)$",
-                s
-            ))
-        }
-    } else {
-        Err("Expected string".to_string())
-    }
-}
-
-#[allow(dead_code)]
-fn validate_string_pattern_e0706e45c974b71e(value: &Value) -> Result<(), String> {
-    if let Value::Concrete(ConcreteValue::String(s)) = value {
-        static RE: std::sync::LazyLock<Regex> =
-            std::sync::LazyLock::new(|| Regex::new("^(sigv4)$").expect("invalid pattern regex"));
-        if RE.is_match(s) {
-            Ok(())
-        } else {
-            Err(format!("Value '{}' does not match pattern ^(sigv4)$", s))
-        }
-    } else {
-        Err("Expected string".to_string())
-    }
-}
+const VALID_ORIGIN_ACCESS_CONTROL_CONFIG_SIGNING_PROTOCOL: &[&str] = &["sigv4"];
 
 /// Returns the schema config for cloudfront_origin_access_control (AWS::CloudFront::OriginAccessControl)
 pub fn cloudfront_origin_access_control_config() -> AwsccSchemaConfig {
@@ -68,14 +35,11 @@ pub fn cloudfront_origin_access_control_config() -> AwsccSchemaConfig {
                     fields: vec![
                     StructField::new("description", AttributeType::String).with_description("A description of the origin access control.").with_provider_name("Description"),
                     StructField::new("name", AttributeType::String).required().with_description("A name to identify the origin access control. You can specify up to 64 characters.").with_provider_name("Name"),
-                    StructField::new("origin_access_control_origin_type", AttributeType::Custom {
-                semantic_name: None,
-                pattern: Some("^(s3|mediastore|lambda|mediapackagev2)$".to_string()),
-                length: None,
-                base: Box::new(AttributeType::String),
-                validate: legacy_validator(validate_string_pattern_597c12a2d8028697),
-                namespace: None,
-                to_dsl: None,
+                    StructField::new("origin_access_control_origin_type", AttributeType::StringEnum {
+                name: "OriginAccessControlOriginType".to_string(),
+                values: vec!["s3".to_string(), "mediastore".to_string(), "lambda".to_string(), "mediapackagev2".to_string()],
+                namespace: Some("awscc.cloudfront.OriginAccessControl".to_string()),
+                dsl_aliases: vec![("s3".to_string(), "s3".to_string()), ("mediastore".to_string(), "mediastore".to_string()), ("lambda".to_string(), "lambda".to_string()), ("mediapackagev2".to_string(), "mediapackagev2".to_string())],
             }).required().with_description("The type of origin that this origin access control is for.").with_provider_name("OriginAccessControlOriginType"),
                     StructField::new("signing_behavior", AttributeType::StringEnum {
                 name: "SigningBehavior".to_string(),
@@ -83,14 +47,11 @@ pub fn cloudfront_origin_access_control_config() -> AwsccSchemaConfig {
                 namespace: Some("awscc.cloudfront.OriginAccessControl".to_string()),
                 dsl_aliases: vec![("always".to_string(), "always".to_string()), ("never".to_string(), "never".to_string()), ("no-override".to_string(), "no_override".to_string())],
             }).required().with_description("Specifies which requests CloudFront signs (adds authentication information to). Specify ``always`` for the most common use case. For more information, see [origin access control advanced settings](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html#oac-advanced-settings) in the *Amazon CloudFront Developer Guide*. This field can have one of the following values: + ``always`` – CloudFront signs all origin requests, overwriting the ``Authorization`` header from the viewer request if one exists. + ``never`` – CloudFront doesn't sign any origin requests. This value turns off origin access control for all origins in all distributions that use this origin access control. + ``no-override`` – If the viewer request doesn't contain the ``Authorization`` header, then CloudFront signs the origin request. If the viewer request contains the ``Authorization`` header, then CloudFront doesn't sign the origin request and instead passes along the ``Authorization`` header from the viewer request. *WARNING: To pass along the Authorization header from the viewer request, you must add the Authorization header to a cache policy for all cache behaviors that use origins associated with this origin access control.*").with_provider_name("SigningBehavior"),
-                    StructField::new("signing_protocol", AttributeType::Custom {
-                semantic_name: None,
-                pattern: Some("^(sigv4)$".to_string()),
-                length: None,
-                base: Box::new(AttributeType::String),
-                validate: legacy_validator(validate_string_pattern_e0706e45c974b71e),
-                namespace: None,
-                to_dsl: None,
+                    StructField::new("signing_protocol", AttributeType::StringEnum {
+                name: "SigningProtocol".to_string(),
+                values: vec!["sigv4".to_string()],
+                namespace: Some("awscc.cloudfront.OriginAccessControl".to_string()),
+                dsl_aliases: vec![("sigv4".to_string(), "sigv4".to_string())],
             }).required().with_description("The signing protocol of the origin access control, which determines how CloudFront signs (authenticates) requests. The only valid value is ``sigv4``.").with_provider_name("SigningProtocol")
                     ],
                 })
@@ -108,9 +69,19 @@ pub fn enum_valid_values() -> (
 ) {
     (
         "cloudfront.OriginAccessControl",
-        &[(
-            "signing_behavior",
-            VALID_ORIGIN_ACCESS_CONTROL_CONFIG_SIGNING_BEHAVIOR,
-        )],
+        &[
+            (
+                "origin_access_control_origin_type",
+                VALID_ORIGIN_ACCESS_CONTROL_CONFIG_ORIGIN_ACCESS_CONTROL_ORIGIN_TYPE,
+            ),
+            (
+                "signing_behavior",
+                VALID_ORIGIN_ACCESS_CONTROL_CONFIG_SIGNING_BEHAVIOR,
+            ),
+            (
+                "signing_protocol",
+                VALID_ORIGIN_ACCESS_CONTROL_CONFIG_SIGNING_PROTOCOL,
+            ),
+        ],
     )
 }

--- a/generated-docs/awscc/cloudfront/origin_access_control.md
+++ b/generated-docs/awscc/cloudfront/origin_access_control.md
@@ -21,6 +21,17 @@ The origin access control.
 
 ## Enum Values
 
+### origin_access_control_origin_type (OriginAccessControlOriginType)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `s3` | `awscc.cloudfront.OriginAccessControl.OriginAccessControlOriginType.s3` |
+| `mediastore` | `awscc.cloudfront.OriginAccessControl.OriginAccessControlOriginType.mediastore` |
+| `lambda` | `awscc.cloudfront.OriginAccessControl.OriginAccessControlOriginType.lambda` |
+| `mediapackagev2` | `awscc.cloudfront.OriginAccessControl.OriginAccessControlOriginType.mediapackagev2` |
+
+Shorthand formats: `s3` or `OriginAccessControlOriginType.s3`
+
 ### signing_behavior (SigningBehavior)
 
 | Value | DSL Identifier |
@@ -31,6 +42,14 @@ The origin access control.
 
 Shorthand formats: `always` or `SigningBehavior.always`
 
+### signing_protocol (SigningProtocol)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `sigv4` | `awscc.cloudfront.OriginAccessControl.SigningProtocol.sigv4` |
+
+Shorthand formats: `sigv4` or `SigningProtocol.sigv4`
+
 ## Struct Definitions
 
 ### OriginAccessControlConfig
@@ -39,9 +58,9 @@ Shorthand formats: `always` or `SigningBehavior.always`
 |-------|------|----------|-------------|
 | `description` | String | No | A description of the origin access control. |
 | `name` | String | Yes | A name to identify the origin access control. You can specify up to 64 characters. |
-| `origin_access_control_origin_type` | String | Yes | The type of origin that this origin access control is for. |
+| `origin_access_control_origin_type` | [Enum (OriginAccessControlOriginType)](#origin_access_control_origin_type-originaccesscontrolorigintype) | Yes | The type of origin that this origin access control is for. |
 | `signing_behavior` | [Enum (SigningBehavior)](#signing_behavior-signingbehavior) | Yes | Specifies which requests CloudFront signs (adds authentication information to). Specify ``always`` for the most common use case. For more information, see [origin access control advanced settings](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html#oac-advanced-settings) in the *Amazon CloudFront Developer Guide*. This field can have one of the following values: + ``always`` – CloudFront signs all origin requests, overwriting the ``Authorization`` header from the viewer request if one exists. + ``never`` – CloudFront doesn't sign any origin requests. This value turns off origin access control for all origins in all distributions that use this origin access control. + ``no-override`` – If the viewer request doesn't contain the ``Authorization`` header, then CloudFront signs the origin request. If the viewer request contains the ``Authorization`` header, then CloudFront doesn't sign the origin request and instead passes along the ``Authorization`` header from the viewer request. *WARNING: To pass along the Authorization header from the viewer request, you must add the Authorization header to a cache policy for all cache behaviors that use origins associated with this origin access control.* |
-| `signing_protocol` | String | Yes | The signing protocol of the origin access control, which determines how CloudFront signs (authenticates) requests. The only valid value is ``sigv4``. |
+| `signing_protocol` | [Enum (SigningProtocol)](#signing_protocol-signingprotocol) | Yes | The signing protocol of the origin access control, which determines how CloudFront signs (authenticates) requests. The only valid value is ``sigv4``. |
 
 ## Attribute Reference
 


### PR DESCRIPTION
## Summary

CFN schemas frequently express finite value sets as `pattern: \"^(a|b|c)$\"` instead of a real `enum`. Codegen previously mapped these to `AttributeType::Custom { pattern, base: String }`, forcing users to quote the value and giving up the type-safety, did-you-mean diagnostics, and LSP completion that real enums get.

This change detects alternation-only patterns during type inference and routes them through the existing `StringEnum` emission machinery.

Two recognized shapes (anchors required):

- `` `^(alt1|alt2|...)$` `` — one outer paren group, alternatives separated by `|`, each alt a literal (alphanumerics + `- _ : . /`)
- `` `^literal$` `` — single bare literal, no parens, no `|`

Anything else (nested groups, top-level alternation without an outer group like `` `^a|b$` ``, character classes, quantifiers, escapes, empty alternatives) flows through the existing `Custom { pattern }` path unchanged. Conversion is opt-in based on shape.

## Concrete impact

`awscc.cloudfront.OriginAccessControl`'s `signing_protocol` (`` `^(sigv4)$` ``) and `origin_access_control_origin_type` (`` `^(s3|mediastore|lambda|mediapackagev2)$` ``) now generate as `StringEnum` alongside `signing_behavior`, removing the mismatch where one struct mixed bare-enum and quoted-string fields for semantically identical shapes.

Generated diff for `cloudfront/origin_access_control.rs`: two `Custom { pattern, ... }` fields converted to `StringEnum`, two pattern validators removed, two `VALID_*` constants added, `enum_valid_values()` lookup updated.

## Test plan

- [x] Unit tests for `extract_enum_from_alternation_pattern`: positive (`^(a|b|c)$`, `^(only)$`, `^only$`), negative (missing anchors, character classes, quantifiers, escapes, empty alternatives, nested groups, top-level alternation without an outer group like `` `^a|b$` ``, real-world CFN cache patterns)
- [x] Integration test: a `CfnSchema` with a property whose only constraint is an alternation pattern produces `StringEnum`, not `Custom { pattern, ... }`
- [x] `cargo nextest run -p carina-provider-awscc` (360 pass)
- [x] `cargo clippy -p carina-provider-awscc --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --check` (clean)
- [x] `cargo build -p carina-provider-awscc --target wasm32-wasip2 --release` (clean)
- [x] `bash scripts/check-docs-drift.sh` (37 resources in sync)
- [x] Schemas + docs regenerated (`generate-schemas.sh --from-cache-only` + `generate-docs.sh`); only `cloudfront/origin_access_control.{rs,md}` changed