### PR TITLE
chore: bump carina-core to 5c600ddf, adapt to carina#3038 ResourceId API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=455e6fa1#455e6fa1e0666578a595806a41c4dfeb5f5e38e4"
+source = "git+https://github.com/carina-rs/carina?rev=5c600ddf#5c600ddf2bd17fc54f72b0cbb7c247a25b81e219"
 dependencies = [
  "argon2",
  "futures",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=455e6fa1#455e6fa1e0666578a595806a41c4dfeb5f5e38e4"
+source = "git+https://github.com/carina-rs/carina?rev=5c600ddf#5c600ddf2bd17fc54f72b0cbb7c247a25b81e219"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -579,7 +579,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=455e6fa1#455e6fa1e0666578a595806a41c4dfeb5f5e38e4"
+source = "git+https://github.com/carina-rs/carina?rev=5c600ddf#5c600ddf2bd17fc54f72b0cbb7c247a25b81e219"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "455e6fa1" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "5c600ddf" }

--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -23,10 +23,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "455e6fa1" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "5c600ddf" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "455e6fa1" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "455e6fa1" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "5c600ddf" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "5c600ddf" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-smithy-async = { version = "1", features = ["rt-tokio"] }

--- a/carina-provider-awscc/src/convert.rs
+++ b/carina-provider-awscc/src/convert.rs
@@ -38,7 +38,7 @@ pub fn core_to_proto_resource_id(id: &CoreResourceId) -> ProtoResourceId {
 }
 
 pub fn proto_to_core_resource_id(id: &ProtoResourceId) -> CoreResourceId {
-    CoreResourceId::with_provider(&id.provider, &id.resource_type, &id.name)
+    CoreResourceId::with_provider(&id.provider, &id.resource_type, &id.name, None)
 }
 
 // -- Value --
@@ -174,7 +174,8 @@ pub fn core_to_proto_directives(l: &CoreDirectives) -> ProtoDirectives {
 // -- proto_to_core_resource (reverse of core_to_proto_resource) --
 
 pub fn proto_to_core_resource(r: &ProtoResource) -> CoreResource {
-    let mut resource = CoreResource::with_provider(&r.id.provider, &r.id.resource_type, &r.id.name);
+    let mut resource =
+        CoreResource::with_provider(&r.id.provider, &r.id.resource_type, &r.id.name, None);
     resource.attributes = r
         .attributes
         .iter()

--- a/carina-provider-awscc/src/lib.rs
+++ b/carina-provider-awscc/src/lib.rs
@@ -397,7 +397,7 @@ mod tests {
         let schemas = build_schemas();
         let normalizer = AwsccNormalizer;
 
-        let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "test-vpc");
+        let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "test-vpc", None);
         resource.set_attr(
             "cidr_block".to_string(),
             Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
@@ -473,7 +473,7 @@ mod tests {
         let schemas = build_schemas();
         let normalizer = AwsccNormalizer;
 
-        let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "test-vpc");
+        let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "test-vpc", None);
         resource.set_attr(
             "cidr_block".to_string(),
             Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
@@ -520,7 +520,7 @@ mod tests {
         let schemas = build_schemas();
         let normalizer = AwsccNormalizer;
 
-        let mut resource = Resource::with_provider("awscc", "ec2.Route", "test-route");
+        let mut resource = Resource::with_provider("awscc", "ec2.Route", "test-route", None);
         resource.set_attr(
             "route_table_id".to_string(),
             Value::Concrete(ConcreteValue::String("rtb-123".to_string())),
@@ -544,7 +544,7 @@ mod tests {
         let schemas = build_schemas();
         let normalizer = AwsccNormalizer;
 
-        let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "test-vpc");
+        let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "test-vpc", None);
         resource.set_attr(
             "cidr_block".to_string(),
             Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),

--- a/carina-provider-awscc/src/provider/conversion.rs
+++ b/carina-provider-awscc/src/provider/conversion.rs
@@ -541,8 +541,12 @@ mod tests {
         let attr_schema = config.schema.attributes.get("vpc_endpoint_type").unwrap();
 
         // 1. DSL side: resolve_enum_identifiers_impl converts bare `Gateway` ident
-        let mut resource =
-            carina_core::resource::Resource::with_provider("awscc", "ec2.VpcEndpoint", "test");
+        let mut resource = carina_core::resource::Resource::with_provider(
+            "awscc",
+            "ec2.VpcEndpoint",
+            "test",
+            None,
+        );
         resource.set_attr(
             "vpc_id".to_string(),
             Value::Concrete(ConcreteValue::String("vpc-123".to_string())),

--- a/carina-provider-awscc/src/provider/normalizer.rs
+++ b/carina-provider-awscc/src/provider/normalizer.rs
@@ -274,7 +274,7 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_bare_ident() {
-        let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "test");
+        let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "test", None);
         resource.set_attr(
             "instance_tenancy".to_string(),
             Value::Concrete(ConcreteValue::String("dedicated".to_string())),
@@ -294,7 +294,7 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_typename_value() {
-        let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "test");
+        let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "test", None);
         resource.set_attr(
             "instance_tenancy".to_string(),
             Value::Concrete(ConcreteValue::String(
@@ -316,7 +316,7 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_skips_non_awscc() {
-        let mut resource = Resource::with_provider("aws", "s3.Bucket", "test");
+        let mut resource = Resource::with_provider("aws", "s3.Bucket", "test", None);
         resource.set_attr(
             "instance_tenancy".to_string(),
             Value::Concrete(ConcreteValue::String("dedicated".to_string())),
@@ -332,7 +332,7 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_hyphen_to_underscore() {
-        let mut resource = Resource::with_provider("awscc", "ec2.FlowLog", "test");
+        let mut resource = Resource::with_provider("awscc", "ec2.FlowLog", "test", None);
         resource.set_attr(
             "log_destination_type".to_string(),
             Value::Concrete(ConcreteValue::String("cloud_watch_logs".to_string())),
@@ -354,7 +354,7 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_hyphen_string_to_underscore() {
-        let mut resource = Resource::with_provider("awscc", "ec2.FlowLog", "test");
+        let mut resource = Resource::with_provider("awscc", "ec2.FlowLog", "test", None);
         resource.set_attr(
             "log_destination_type".to_string(),
             Value::Concrete(ConcreteValue::String("cloud-watch-logs".to_string())),
@@ -376,7 +376,7 @@ mod tests {
 
     #[test]
     fn test_restore_unreturned_attrs_impl_create_only() {
-        let id = ResourceId::with_provider("awscc", "ec2.NatGateway", "test");
+        let id = ResourceId::with_provider("awscc", "ec2.NatGateway", "test", None);
         let mut state = State::existing(id.clone(), HashMap::new());
         state.attributes.insert(
             "nat_gateway_id".to_string(),
@@ -406,7 +406,7 @@ mod tests {
 
     #[test]
     fn test_restore_unreturned_attrs_skips_non_awscc() {
-        let id = ResourceId::with_provider("aws", "s3.Bucket", "test");
+        let id = ResourceId::with_provider("aws", "s3.Bucket", "test", None);
         let state = State::existing(id.clone(), HashMap::new());
 
         let mut current_states = HashMap::new();
@@ -427,7 +427,7 @@ mod tests {
 
     #[test]
     fn test_restore_unreturned_attrs_skips_already_present() {
-        let id = ResourceId::with_provider("awscc", "ec2.NatGateway", "test");
+        let id = ResourceId::with_provider("awscc", "ec2.NatGateway", "test", None);
         let mut attrs = HashMap::new();
         attrs.insert(
             "subnet_id".to_string(),
@@ -458,7 +458,7 @@ mod tests {
 
     #[test]
     fn test_restore_unreturned_attrs_impl_non_create_only() {
-        let id = ResourceId::with_provider("awscc", "ec2.SecurityGroupEgress", "test");
+        let id = ResourceId::with_provider("awscc", "ec2.SecurityGroupEgress", "test", None);
         let mut state = State::existing(id.clone(), HashMap::new());
         state.attributes.insert(
             "ip_protocol".to_string(),
@@ -490,7 +490,8 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_ip_protocol_all_alias() {
-        let mut resource = Resource::with_provider("awscc", "ec2.SecurityGroupEgress", "test");
+        let mut resource =
+            Resource::with_provider("awscc", "ec2.SecurityGroupEgress", "test", None);
         resource.set_attr(
             "ip_protocol".to_string(),
             Value::Concrete(ConcreteValue::String("all".to_string())),
@@ -512,7 +513,8 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_ip_protocol_tcp() {
-        let mut resource = Resource::with_provider("awscc", "ec2.SecurityGroupEgress", "test");
+        let mut resource =
+            Resource::with_provider("awscc", "ec2.SecurityGroupEgress", "test", None);
         resource.set_attr(
             "ip_protocol".to_string(),
             Value::Concrete(ConcreteValue::String("tcp".to_string())),
@@ -652,7 +654,7 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_impl_struct_field() {
-        let mut resource = Resource::with_provider("awscc", "ec2.SecurityGroup", "test-sg");
+        let mut resource = Resource::with_provider("awscc", "ec2.SecurityGroup", "test-sg", None);
         resource.set_attr(
             "group_description".to_string(),
             Value::Concrete(ConcreteValue::String("test".to_string())),

--- a/carina-provider-awscc/src/provider/operations.rs
+++ b/carina-provider-awscc/src/provider/operations.rs
@@ -24,7 +24,7 @@ impl AwsccProvider {
         name: &str,
         identifier: Option<&str>,
     ) -> ProviderResult<State> {
-        let id = ResourceId::with_provider("awscc", resource_type, name);
+        let id = ResourceId::with_provider("awscc", resource_type, name, None);
 
         let config = get_schema_config(resource_type).ok_or_else(|| {
             ProviderError::internal(format!("Unknown resource type: {}", resource_type))


### PR DESCRIPTION
## Summary

Pure dependency-catch-up + mechanical API adaptation. **No behavior change.**

awscc's `carina-rs` git deps (`carina-core`, `carina-plugin-sdk`, `carina-provider-protocol`, and `carina-aws-types`'s own `carina-core`) were pinned at `455e6fa1` — 13 commits behind carina `main`. Bumping to `5c600ddf` is a prerequisite for the aws#313 IAM-policy canonicalization fix (follow-up PR), which needs carina#3053's `resolve_enum_value` `EnumIdentifier` handling.

The bump pulls in **carina#3038** (commit `70014996`, "make provider-instance-less ResourceId unrepresentable"), which added a 4th `provider_instance: Option<String>` parameter to `Resource::with_provider` / `ResourceId::with_provider` so every call site must consciously pick a routing target. All awscc call sites pass `None` (the kind's default instance) — consistent with the existing `directives.provider_instance: None` convention already used at the protocol-conversion boundary (`convert.rs`, `main.rs`, `normalizer.rs`). awscc has no named-provider-instance support and the wire `ProtoResourceId` does not carry one.

Kept deliberately separate from the aws#313 IAM fix so each PR stays single-topic and reviewable.

## Verification

- `cargo test --workspace` → 455 passed, 0 failed (163 + 194 + 6 + 92).
- `cargo clippy --workspace --all-targets -- -D warnings` → clean.
- `cargo fmt --check` → clean.
- `bash scripts/check-docs-drift.sh` → OK (37 resources in sync).

## Cross-references

- `carina#3038` (`70014996`) — the `ResourceId` API change being adapted to.
- `carina#3053` — the `resolve_enum_value` fix this bump makes reachable; consumed by the follow-up aws#313 awscc PR.
- `carina-rs/carina-provider-aws#313` — the IAM canonicalization bug; its awscc fix rebases on this PR.

## Test plan

- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)