### PR TITLE
fix: wire IAM policy StringEnum namespace on awscc (aws#313)

### DIFF
--- a/acceptance-tests/attribute_removal/ec2_vpc_endpoint_step1.crn
+++ b/acceptance-tests/attribute_removal/ec2_vpc_endpoint_step1.crn
@@ -21,7 +21,7 @@ awscc.ec2.VpcEndpoint {
   route_table_ids   = [rt.route_table_id]
 
   policy_document = {
-    version = '2012-10-17'
+    version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
       effect    = 'Allow'
       principal = '*'

--- a/acceptance-tests/create_before_destroy/iam_role_step1.crn
+++ b/acceptance-tests/create_before_destroy/iam_role_step1.crn
@@ -13,9 +13,9 @@ awscc.iam.Role {
   path      = '/'
 
   assume_role_policy_document = {
-    version = '2012-10-17'
+    version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = 'Allow'
+      effect = aws.iam.PolicyDocument.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/create_before_destroy/iam_role_step2.crn
+++ b/acceptance-tests/create_before_destroy/iam_role_step2.crn
@@ -20,9 +20,9 @@ awscc.iam.Role {
   }
 
   assume_role_policy_document = {
-    version = '2012-10-17'
+    version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = 'Allow'
+      effect = aws.iam.PolicyDocument.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/ec2_flow_log/cloudwatch.crn
+++ b/acceptance-tests/ec2_flow_log/cloudwatch.crn
@@ -20,9 +20,9 @@ let flow_log_role = awscc.iam.Role {
   role_name = 'acceptance-test-flow-log-role'
 
   assume_role_policy_document = {
-    version = '2012-10-17'
+    version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = 'Allow'
+      effect = aws.iam.PolicyDocument.Effect.allow
 
       principal = {
         service = 'vpc-flow-logs.amazonaws.com'

--- a/acceptance-tests/ec2_vpc_endpoint/gateway.crn
+++ b/acceptance-tests/ec2_vpc_endpoint/gateway.crn
@@ -21,7 +21,7 @@ awscc.ec2.VpcEndpoint {
   route_table_ids   = [rt.route_table_id]
 
   policy_document = {
-    version = '2012-10-17'
+    version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
       effect    = 'Allow'
       principal = '*'

--- a/acceptance-tests/iam_role/managed_policy.crn
+++ b/acceptance-tests/iam_role/managed_policy.crn
@@ -10,9 +10,9 @@ awscc.iam.Role {
   role_name_prefix = 'carina-acc-test-'
 
   assume_role_policy_document = {
-    version = '2012-10-17'
+    version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = 'Allow'
+      effect = aws.iam.PolicyDocument.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/iam_role/prefix.crn
+++ b/acceptance-tests/iam_role/prefix.crn
@@ -12,9 +12,9 @@ awscc.iam.Role {
   role_name_prefix = 'carina-acc-test-'
 
   assume_role_policy_document = {
-    version = '2012-10-17'
+    version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = 'Allow'
+      effect = aws.iam.PolicyDocument.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/iam_role/with_path.crn
+++ b/acceptance-tests/iam_role/with_path.crn
@@ -11,9 +11,9 @@ awscc.iam.Role {
   path             = '/carina/acceptance-test/'
 
   assume_role_policy_document = {
-    version = '2012-10-17'
+    version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = 'Allow'
+      effect = aws.iam.PolicyDocument.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/iam_role/with_policy.crn
+++ b/acceptance-tests/iam_role/with_policy.crn
@@ -13,9 +13,9 @@ awscc.iam.Role {
   max_session_duration = 7200
 
   assume_role_policy_document = {
-    version = '2012-10-17'
+    version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = 'Allow'
+      effect = aws.iam.PolicyDocument.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'
@@ -29,7 +29,7 @@ awscc.iam.Role {
     policy_name = 'test-policy'
 
     policy_document = {
-      version = '2012-10-17'
+      version = aws.iam.PolicyDocument.Version.2012_10_17
       statement {
         effect   = 'Allow'
         action   = 'logs:CreateLogGroup'

--- a/acceptance-tests/in_place_update/ec2_flow_log_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_flow_log_step1.crn
@@ -19,9 +19,9 @@ let flow_log_role = awscc.iam.Role {
   role_name = 'carina-acc-test-update-flow-log-role'
 
   assume_role_policy_document = {
-    version = '2012-10-17'
+    version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = 'Allow'
+      effect = aws.iam.PolicyDocument.Effect.allow
 
       principal = {
         service = 'vpc-flow-logs.amazonaws.com'

--- a/acceptance-tests/in_place_update/ec2_flow_log_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_flow_log_step2.crn
@@ -19,9 +19,9 @@ let flow_log_role = awscc.iam.Role {
   role_name = 'carina-acc-test-update-flow-log-role'
 
   assume_role_policy_document = {
-    version = '2012-10-17'
+    version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = 'Allow'
+      effect = aws.iam.PolicyDocument.Effect.allow
 
       principal = {
         service = 'vpc-flow-logs.amazonaws.com'

--- a/acceptance-tests/in_place_update/ec2_vpc_endpoint_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_vpc_endpoint_step2.crn
@@ -21,7 +21,7 @@ awscc.ec2.VpcEndpoint {
   route_table_ids   = [rt.route_table_id]
 
   policy_document = {
-    version = '2012-10-17'
+    version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
       effect    = 'Allow'
       principal = '*'

--- a/acceptance-tests/in_place_update/iam_role_step1.crn
+++ b/acceptance-tests/in_place_update/iam_role_step1.crn
@@ -10,9 +10,9 @@ awscc.iam.Role {
   role_name_prefix = 'carina-acc-test-update-'
 
   assume_role_policy_document = {
-    version = '2012-10-17'
+    version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = 'Allow'
+      effect = aws.iam.PolicyDocument.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/in_place_update/iam_role_step2.crn
+++ b/acceptance-tests/in_place_update/iam_role_step2.crn
@@ -10,9 +10,9 @@ awscc.iam.Role {
   role_name_prefix = 'carina-acc-test-update-'
 
   assume_role_policy_document = {
-    version = '2012-10-17'
+    version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = 'Allow'
+      effect = aws.iam.PolicyDocument.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/tag_deletion/iam_role_step1.crn
+++ b/acceptance-tests/tag_deletion/iam_role_step1.crn
@@ -11,9 +11,9 @@ awscc.iam.Role {
   role_name_prefix = 'carina-acc-test-tag-del-'
 
   assume_role_policy_document = {
-    version = '2012-10-17'
+    version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = 'Allow'
+      effect = aws.iam.PolicyDocument.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/tag_deletion/iam_role_step2.crn
+++ b/acceptance-tests/tag_deletion/iam_role_step2.crn
@@ -12,9 +12,9 @@ awscc.iam.Role {
   role_name_prefix = 'carina-acc-test-tag-del-'
 
   assume_role_policy_document = {
-    version = '2012-10-17'
+    version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = 'Allow'
+      effect = aws.iam.PolicyDocument.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/tag_deletion/iam_role_step3.crn
+++ b/acceptance-tests/tag_deletion/iam_role_step3.crn
@@ -12,9 +12,9 @@ awscc.iam.Role {
   role_name_prefix = 'carina-acc-test-tag-del-'
 
   assume_role_policy_document = {
-    version = '2012-10-17'
+    version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = 'Allow'
+      effect = aws.iam.PolicyDocument.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -1437,55 +1437,50 @@ fn string_or_principal_struct() -> AttributeType {
     ])
 }
 
-/// IAM Policy Effect enum type
-/// Only allows "Allow" or "Deny"
+/// IAM Policy Effect enum type. Allows `Allow` or `Deny` (AWS
+/// canonical) and their snake_case DSL aliases `allow` / `deny`, so
+/// users can write `effect = allow` as a bare identifier, matching the
+/// bare-identifier convention used by every other enum field in the
+/// same `.crn` file. The namespace also makes the fully-qualified form
+/// `aws.iam.PolicyDocument.Effect.allow` parse and resolve: the
+/// resolver's canonical shape is namespace then type_name then value,
+/// so `type_name` is the trailing `Effect` segment and `namespace` is
+/// `aws.iam.PolicyDocument`. Mirrors carina-provider-aws #311 so the
+/// shared `iam_policy_document()` Struct canonicalizes identically on
+/// both providers (aws#313).
 fn iam_policy_effect() -> AttributeType {
-    AttributeType::Custom {
-        semantic_name: Some("IamPolicyEffect".to_string()),
-        pattern: None,
-        length: None,
-        base: Box::new(AttributeType::String),
-        validate: legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                match s.as_str() {
-                    "Allow" | "Deny" => Ok(()),
-                    _ => Err(format!(
-                        "Invalid IAM policy effect: \"{}\". Must be \"Allow\" or \"Deny\"",
-                        s
-                    )),
-                }
-            } else {
-                Err(format!("Expected string, got {:?}", value))
-            }
-        }),
-        namespace: None,
-        to_dsl: None,
+    AttributeType::StringEnum {
+        name: "Effect".to_string(),
+        values: vec!["Allow".to_string(), "Deny".to_string()],
+        namespace: Some("aws.iam.PolicyDocument".to_string()),
+        dsl_aliases: vec![
+            ("Allow".to_string(), "allow".to_string()),
+            ("Deny".to_string(), "deny".to_string()),
+        ],
     }
 }
 
-/// IAM Policy Document Version enum type
-/// Only allows "2012-10-17" or "2008-10-17"
+/// IAM Policy Document Version enum type. Allows `2012-10-17` or
+/// `2008-10-17` (AWS canonical) with snake_case DSL aliases
+/// `2012_10_17` / `2008_10_17`, so users can write `version` as
+/// `2012_10_17`. The fully-qualified form
+/// `aws.iam.PolicyDocument.Version.2012_10_17` parses via the
+/// `namespaced_id` numeric-tail extension from `carina-rs/carina#3051`
+/// and resolves through this namespace: the resolver's canonical shape
+/// is namespace then type_name then value, so `type_name` is the
+/// trailing `Version` segment and `namespace` is
+/// `aws.iam.PolicyDocument`. Mirrors carina-provider-aws #311 so the
+/// shared `iam_policy_document()` Struct canonicalizes identically on
+/// both providers (aws#313).
 fn iam_policy_version() -> AttributeType {
-    AttributeType::Custom {
-        semantic_name: Some("IamPolicyVersion".to_string()),
-        pattern: None,
-        length: None,
-        base: Box::new(AttributeType::String),
-        validate: legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                match s.as_str() {
-                    "2012-10-17" | "2008-10-17" => Ok(()),
-                    _ => Err(format!(
-                        "Invalid IAM policy version: \"{}\". Must be \"2012-10-17\" or \"2008-10-17\"",
-                        s
-                    )),
-                }
-            } else {
-                Err(format!("Expected string, got {:?}", value))
-            }
-        }),
-        namespace: None,
-        to_dsl: None,
+    AttributeType::StringEnum {
+        name: "Version".to_string(),
+        values: vec!["2012-10-17".to_string(), "2008-10-17".to_string()],
+        namespace: Some("aws.iam.PolicyDocument".to_string()),
+        dsl_aliases: vec![
+            ("2012-10-17".to_string(), "2012_10_17".to_string()),
+            ("2008-10-17".to_string(), "2008_10_17".to_string()),
+        ],
     }
 }
 
@@ -2342,7 +2337,7 @@ mod tests {
             vec![
                 (
                     "version".to_string(),
-                    Value::Concrete(ConcreteValue::String("2012-10-17".to_string())),
+                    Value::Concrete(ConcreteValue::EnumIdentifier("2012_10_17".to_string())),
                 ),
                 (
                     "statement".to_string(),
@@ -2351,7 +2346,9 @@ mod tests {
                             vec![
                                 (
                                     "effect".to_string(),
-                                    Value::Concrete(ConcreteValue::String("Allow".to_string())),
+                                    Value::Concrete(ConcreteValue::EnumIdentifier(
+                                        "allow".to_string(),
+                                    )),
                                 ),
                                 (
                                     "action".to_string(),
@@ -2418,7 +2415,7 @@ mod tests {
             vec![
                 (
                     "version".to_string(),
-                    Value::Concrete(ConcreteValue::String("2012-10-17".to_string())),
+                    Value::Concrete(ConcreteValue::EnumIdentifier("2012_10_17".to_string())),
                 ),
                 (
                     "statement".to_string(),
@@ -2427,7 +2424,9 @@ mod tests {
                             vec![
                                 (
                                     "effect".to_string(),
-                                    Value::Concrete(ConcreteValue::String("Deny".to_string())),
+                                    Value::Concrete(ConcreteValue::EnumIdentifier(
+                                        "deny".to_string(),
+                                    )),
                                 ),
                                 (
                                     "action".to_string(),
@@ -2458,7 +2457,7 @@ mod tests {
             vec![
                 (
                     "version".to_string(),
-                    Value::Concrete(ConcreteValue::String("2012-10-17".to_string())),
+                    Value::Concrete(ConcreteValue::EnumIdentifier("2012_10_17".to_string())),
                 ),
                 (
                     "statement".to_string(),
@@ -2467,7 +2466,9 @@ mod tests {
                             vec![
                                 (
                                     "effect".to_string(),
-                                    Value::Concrete(ConcreteValue::String("Allow".to_string())),
+                                    Value::Concrete(ConcreteValue::EnumIdentifier(
+                                        "allow".to_string(),
+                                    )),
                                 ),
                                 (
                                     "principal".to_string(),
@@ -2513,7 +2514,7 @@ mod tests {
             vec![
                 (
                     "version".to_string(),
-                    Value::Concrete(ConcreteValue::String("2012-10-17".to_string())),
+                    Value::Concrete(ConcreteValue::EnumIdentifier("2012_10_17".to_string())),
                 ),
                 (
                     "statement".to_string(),
@@ -2522,7 +2523,9 @@ mod tests {
                             vec![
                                 (
                                     "effect".to_string(),
-                                    Value::Concrete(ConcreteValue::String("Allow".to_string())),
+                                    Value::Concrete(ConcreteValue::EnumIdentifier(
+                                        "allow".to_string(),
+                                    )),
                                 ),
                                 (
                                     "principal".to_string(),

--- a/carina-provider-awscc/src/provider/conversion.rs
+++ b/carina-provider-awscc/src/provider/conversion.rs
@@ -953,10 +953,16 @@ mod tests {
         let result = result.expect("Should return Some");
 
         if let Value::Concrete(ConcreteValue::Map(map)) = &result {
+            // After aws#313 (mirroring aws #311) the IAM policy doc's
+            // `version` / `statement[].effect` StringEnums carry
+            // `namespace: Some("aws.iam.PolicyDocument")`, so the read
+            // path canonicalizes them to the fully-qualified DSL form —
+            // identical to what the parsed desired side produces — so
+            // the differ reports no diff. Keys stay snake_case.
             assert_eq!(
                 map.get("version"),
                 Some(&Value::Concrete(ConcreteValue::String(
-                    "2012-10-17".to_string()
+                    "aws.iam.PolicyDocument.Version.2012_10_17".to_string()
                 )))
             );
             assert!(
@@ -968,7 +974,9 @@ mod tests {
                 if let Some(Value::Concrete(ConcreteValue::Map(stmt))) = stmts.first() {
                     assert_eq!(
                         stmt.get("effect"),
-                        Some(&Value::Concrete(ConcreteValue::String("Allow".to_string())))
+                        Some(&Value::Concrete(ConcreteValue::String(
+                            "aws.iam.PolicyDocument.Effect.allow".to_string()
+                        )))
                     );
                     assert_eq!(
                         stmt.get("action"),
@@ -997,6 +1005,86 @@ mod tests {
         } else {
             panic!("Expected Value::Map, got: {:?}", result);
         }
+    }
+
+    /// Regression for aws#313: the IAM policy doc's `version` /
+    /// `statement[].effect` must converge between the parsed-desired
+    /// side and the AWS-read side. Before the fix the awscc copy of
+    /// `iam_policy_{effect,version}()` was an `AttributeType::Custom`
+    /// with `namespace: None`, so `aws_value_to_dsl` left the read
+    /// values raw (`"2012-10-17"`, `"Allow"`) while the parsed desired
+    /// side carried `aws.iam.PolicyDocument.Version.2012_10_17` /
+    /// `aws.iam.PolicyDocument.Effect.allow` — a perpetual differ diff
+    /// that never converged. After mirroring aws #311 (StringEnum +
+    /// `namespace: Some("aws.iam.PolicyDocument")`) both sides reduce
+    /// to the identical fully-qualified DSL form.
+    #[test]
+    fn test_aws313_iam_policy_doc_read_matches_parsed_desired() {
+        use carina_aws_types::iam_policy_document;
+
+        let attr_type = iam_policy_document();
+
+        // AWS-read side: Cloud Control returns the raw API spelling.
+        let aws_json = json!({
+            "Version": "2012-10-17",
+            "Statement": [{
+                "Effect": "Allow",
+                "Action": "sts:AssumeRole"
+            }]
+        });
+        let read_side = aws_value_to_dsl(
+            "assume_role_policy_document",
+            &aws_json,
+            &attr_type,
+            "iam.Role",
+        )
+        .expect("read conversion should return Some");
+
+        // Parsed-desired side: the parser emits the fully-qualified DSL
+        // form (`version` *must* be namespaced to parse the numeric
+        // tail; `effect` shown namespaced too for symmetry).
+        let desired_side = Value::Concrete(ConcreteValue::Map(
+            vec![
+                (
+                    "version".to_string(),
+                    Value::Concrete(ConcreteValue::String(
+                        "aws.iam.PolicyDocument.Version.2012_10_17".to_string(),
+                    )),
+                ),
+                (
+                    "statement".to_string(),
+                    Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                        ConcreteValue::Map(
+                            vec![
+                                (
+                                    "effect".to_string(),
+                                    Value::Concrete(ConcreteValue::String(
+                                        "aws.iam.PolicyDocument.Effect.allow".to_string(),
+                                    )),
+                                ),
+                                (
+                                    "action".to_string(),
+                                    Value::Concrete(ConcreteValue::String(
+                                        "sts:AssumeRole".to_string(),
+                                    )),
+                                ),
+                            ]
+                            .into_iter()
+                            .collect(),
+                        ),
+                    )])),
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        ));
+
+        assert_eq!(
+            read_side, desired_side,
+            "read-side and parsed-desired IAM policy docs must be \
+             byte-identical so the differ reports no diff; \
+             got read={read_side:?} desired={desired_side:?}"
+        );
     }
 
     #[test]

--- a/carina-provider-awscc/src/provider/normalizer.rs
+++ b/carina-provider-awscc/src/provider/normalizer.rs
@@ -330,6 +330,70 @@ mod tests {
         ));
     }
 
+    /// aws#313 bare-`effect` path: the issue notes `effect` is
+    /// typically written bare (`effect = allow`) — the parser emits
+    /// `ConcreteValue::EnumIdentifier("allow")`, which exercises
+    /// `resolve_enum_value` Case 1 (no dots), a different branch than
+    /// the already-fully-qualified `version` path. The desired side
+    /// must resolve to the same fully-qualified DSL form that the
+    /// AWS-read side produces from raw `"Allow"`
+    /// (`aws.iam.PolicyDocument.Effect.allow`), or the differ diverges.
+    #[test]
+    fn test_aws313_bare_effect_desired_resolves_to_namespaced() {
+        use indexmap::IndexMap;
+
+        let mut stmt = IndexMap::new();
+        stmt.insert(
+            "effect".to_string(),
+            Value::Concrete(ConcreteValue::EnumIdentifier("allow".to_string())),
+        );
+        stmt.insert(
+            "action".to_string(),
+            Value::Concrete(ConcreteValue::String("sts:AssumeRole".to_string())),
+        );
+        let mut policy = IndexMap::new();
+        policy.insert(
+            "version".to_string(),
+            Value::Concrete(ConcreteValue::String(
+                "aws.iam.PolicyDocument.Version.2012_10_17".to_string(),
+            )),
+        );
+        policy.insert(
+            "statement".to_string(),
+            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                ConcreteValue::Map(stmt),
+            )])),
+        );
+        let mut resource = Resource::with_provider("awscc", "iam.Role", "rd-role", None);
+        resource.set_attr(
+            "assume_role_policy_document".to_string(),
+            Value::Concrete(ConcreteValue::Map(policy)),
+        );
+
+        let mut resources = vec![resource];
+        resolve_enum_identifiers_impl(&mut resources);
+
+        let Some(Value::Concrete(ConcreteValue::Map(doc))) =
+            resources[0].get_attr("assume_role_policy_document")
+        else {
+            panic!("expected assume_role_policy_document Map");
+        };
+        let Some(Value::Concrete(ConcreteValue::List(stmts))) = doc.get("statement") else {
+            panic!("expected statement List");
+        };
+        let Some(Value::Concrete(ConcreteValue::Map(s0))) = stmts.first() else {
+            panic!("expected statement[0] Map");
+        };
+        assert_eq!(
+            s0.get("effect"),
+            Some(&Value::Concrete(ConcreteValue::String(
+                "aws.iam.PolicyDocument.Effect.allow".to_string()
+            ))),
+            "bare `effect = allow` desired must resolve to the same \
+             fully-qualified form the read side produces from \"Allow\""
+        );
+    }
+
     #[test]
     fn test_resolve_enum_identifiers_hyphen_to_underscore() {
         let mut resource = Resource::with_provider("awscc", "ec2.FlowLog", "test", None);

--- a/carina-provider-awscc/src/schemas/awscc_types.rs
+++ b/carina-provider-awscc/src/schemas/awscc_types.rs
@@ -421,7 +421,7 @@ mod tests {
             vec![
                 (
                     "version".to_string(),
-                    Value::Concrete(ConcreteValue::String("2012-10-17".to_string())),
+                    Value::Concrete(ConcreteValue::EnumIdentifier("2012_10_17".to_string())),
                 ),
                 (
                     "statement".to_string(),
@@ -430,7 +430,9 @@ mod tests {
                             vec![
                                 (
                                     "effect".to_string(),
-                                    Value::Concrete(ConcreteValue::String("Allow".to_string())),
+                                    Value::Concrete(ConcreteValue::EnumIdentifier(
+                                        "allow".to_string(),
+                                    )),
                                 ),
                                 (
                                     "action".to_string(),


### PR DESCRIPTION
## Summary

Fixes `carina-rs/carina-provider-aws#313` — the awscc-side IAM policy document canonicalization bug. (Cross-repo: GitHub won't auto-close it; will close manually with a summary comment after merge.)

**Root cause (dual):**

1. `carina-aws-types` is **triplicated**, not shared. carina-provider-aws's copy got #303/#309/#310/#311 (Custom → StringEnum → namespace); the **awscc copy never did** — it was still `AttributeType::Custom` with `namespace: None`. So `aws_value_to_dsl` left the IAM policy doc's `version`/`effect` raw on the AWS-read side (`"2012-10-17"`, `"Allow"`) while the parsed-desired side carried the fully-qualified DSL form. The differ reported a **perpetual non-converging diff** on `awscc.iam.Role.assume_role_policy_document` (blocking `carina-rs/infra#58`).
2. Even after the StringEnum port, the **bare** `effect = allow` form (the common real-world spelling) stayed unresolved: post-carina#2986 the parser emits bare enums as `ConcreteValue::EnumIdentifier`, but `carina_core::utils::resolve_enum_value` only matched `String`. Fixed in **carina#3053** (merged), reached here via the carina-core dep bump in **awscc #249** (merged).

This PR is the third in the chain:

| PR | Repo | Content | State |
|----|------|---------|-------|
| carina#3053 | carina-core | `resolve_enum_value` handles `EnumIdentifier` (root cause 2) | merged |
| awscc#249 | awscc | carina-core dep bump `455e6fa1`→`5c600ddf` + carina#3038 `ResourceId` adaptation | merged |
| **this** | awscc | StringEnum/namespace port (root cause 1) + 17 fixture migrations + tests | — |

## Changes (mirroring carina-provider-aws #311)

- `iam_policy_effect()`/`iam_policy_version()`: `Custom` → `StringEnum`, `name` `"Effect"`/`"Version"`, `namespace: Some("aws.iam.PolicyDocument")`, inline `dsl_aliases`. Resolver canonical shape is `<namespace>.<type_name>.<value>`, so the trailing segment is `name`.
- 17 acceptance fixtures migrated from quoted `version = '2012-10-17'` / `effect = 'Allow'` (now rejected by StringEnum per carina#2986 Phase 4) to the namespaced form.
- Stale validation tests updated: raw `String` → `EnumIdentifier` (post-carina#2986 parser emission).
- Regression tests: read-side == parsed-desired convergence; the bare `effect = allow` path.

## Verification

- `cargo test --workspace` → 92 + 165 + 6 + 194 passed, **0 failed** (incl. `test_aws313_iam_policy_doc_read_matches_parsed_desired`, `test_aws313_bare_effect_desired_resolves_to_namespaced`).
- `cargo clippy --workspace --all-targets -- -D warnings` → clean.
- `cargo fmt --check` → clean.
- `bash scripts/check-docs-drift.sh` → OK.
- 5-round self-review completed (found and fixed: the bare-effect gap → carina#3053; 17 fixtures; the EnumIdentifier root cause).

## Test plan

- [ ] CI green
- [ ] `carina-rs/infra#58` unblocked (user-driven real-infra smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)