### PR TITLE
fix: make AwsccNormalizer async to follow ProviderNormalizer trait change (carina#3112)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=741f7afc#741f7afc1c366ab41fdc614f77a7582954885390"
+source = "git+https://github.com/carina-rs/carina?rev=7705f3c7#7705f3c7178e8e840480a346c772b584d006a23f"
 dependencies = [
  "argon2",
  "futures",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=741f7afc#741f7afc1c366ab41fdc614f77a7582954885390"
+source = "git+https://github.com/carina-rs/carina?rev=7705f3c7#7705f3c7178e8e840480a346c772b584d006a23f"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -579,7 +579,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=741f7afc#741f7afc1c366ab41fdc614f77a7582954885390"
+source = "git+https://github.com/carina-rs/carina?rev=7705f3c7#7705f3c7178e8e840480a346c772b584d006a23f"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "741f7afc" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "7705f3c7" }

--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -23,10 +23,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "741f7afc" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "7705f3c7" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "741f7afc" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "741f7afc" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "7705f3c7" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "7705f3c7" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-smithy-async = { version = "1", features = ["rt-tokio"] }

--- a/carina-provider-awscc/src/lib.rs
+++ b/carina-provider-awscc/src/lib.rs
@@ -36,34 +36,50 @@ use crate::provider::AwsccProviderConfig;
 pub struct AwsccNormalizer;
 
 impl ProviderNormalizer for AwsccNormalizer {
-    fn normalize_desired(&self, resources: &mut [Resource]) {
-        crate::provider::resolve_enum_identifiers_impl(resources);
+    // The trait is async (carina#3112) only so the WASM host impl can
+    // `.await` the guest directly. These bodies are pure (enum
+    // resolution, state canonicalization, attr hydration, tag merge —
+    // no I/O), so wrapping the existing sync logic in a ready future is
+    // sufficient; no logic change.
+    fn normalize_desired<'a>(&'a self, resources: &'a mut [Resource]) -> BoxFuture<'a, ()> {
+        Box::pin(async move {
+            crate::provider::resolve_enum_identifiers_impl(resources);
+        })
     }
 
-    fn normalize_state(&self, current_states: &mut HashMap<ResourceId, State>) {
-        crate::provider::normalize_state_enums_impl(current_states);
-        // Canonicalize `Union[String, list(String)]` typed values
-        // (IAM-style `string_or_list_of_strings`) so AWS's silent
-        // scalar normalization no longer leaks past the provider
-        // boundary. See carina-rs/carina#2481, sub-issue 5.
-        crate::provider::canonicalize_string_or_list_states_impl(current_states);
+    fn normalize_state<'a>(
+        &'a self,
+        current_states: &'a mut HashMap<ResourceId, State>,
+    ) -> BoxFuture<'a, ()> {
+        Box::pin(async move {
+            crate::provider::normalize_state_enums_impl(current_states);
+            // Canonicalize `Union[String, list(String)]` typed values
+            // (IAM-style `string_or_list_of_strings`) so AWS's silent
+            // scalar normalization no longer leaks past the provider
+            // boundary. See carina-rs/carina#2481, sub-issue 5.
+            crate::provider::canonicalize_string_or_list_states_impl(current_states);
+        })
     }
 
-    fn hydrate_read_state(
-        &self,
-        current_states: &mut HashMap<ResourceId, State>,
-        saved_attrs: &SavedAttrs,
-    ) {
-        crate::provider::restore_unreturned_attrs_impl(current_states, saved_attrs);
+    fn hydrate_read_state<'a>(
+        &'a self,
+        current_states: &'a mut HashMap<ResourceId, State>,
+        saved_attrs: &'a SavedAttrs,
+    ) -> BoxFuture<'a, ()> {
+        Box::pin(async move {
+            crate::provider::restore_unreturned_attrs_impl(current_states, saved_attrs);
+        })
     }
 
-    fn merge_default_tags(
-        &self,
-        resources: &mut [Resource],
-        default_tags: &IndexMap<String, Value>,
-        registry: &SchemaRegistry,
-    ) {
-        merge_default_tags_for_provider("awscc", resources, default_tags, registry);
+    fn merge_default_tags<'a>(
+        &'a self,
+        resources: &'a mut [Resource],
+        default_tags: &'a IndexMap<String, Value>,
+        registry: &'a SchemaRegistry,
+    ) -> BoxFuture<'a, ()> {
+        Box::pin(async move {
+            merge_default_tags_for_provider("awscc", resources, default_tags, registry);
+        })
     }
 }
 
@@ -455,8 +471,8 @@ mod tests {
         assert!(found.iter().any(|(n, _)| n == "cached_methods"));
     }
 
-    #[test]
-    fn test_merge_default_tags_resource_tags_win() {
+    #[tokio::test]
+    async fn test_merge_default_tags_resource_tags_win() {
         let schemas = build_schemas();
         let normalizer = AwsccNormalizer;
 
@@ -490,7 +506,9 @@ mod tests {
         );
 
         let mut resources = vec![resource];
-        normalizer.merge_default_tags(&mut resources, &default_tags, &schemas);
+        normalizer
+            .merge_default_tags(&mut resources, &default_tags, &schemas)
+            .await;
 
         if let Some(Value::Concrete(ConcreteValue::Map(tags))) = resources[0].get_attr("tags") {
             assert_eq!(
@@ -531,8 +549,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_merge_default_tags_no_explicit_tags() {
+    #[tokio::test]
+    async fn test_merge_default_tags_no_explicit_tags() {
         let schemas = build_schemas();
         let normalizer = AwsccNormalizer;
 
@@ -549,7 +567,9 @@ mod tests {
         );
 
         let mut resources = vec![resource];
-        normalizer.merge_default_tags(&mut resources, &default_tags, &schemas);
+        normalizer
+            .merge_default_tags(&mut resources, &default_tags, &schemas)
+            .await;
 
         if let Some(Value::Concrete(ConcreteValue::Map(tags))) = resources[0].get_attr("tags") {
             assert_eq!(
@@ -578,8 +598,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_merge_default_tags_skips_no_tag_schema() {
+    #[tokio::test]
+    async fn test_merge_default_tags_skips_no_tag_schema() {
         let schemas = build_schemas();
         let normalizer = AwsccNormalizer;
 
@@ -596,14 +616,16 @@ mod tests {
         );
 
         let mut resources = vec![resource];
-        normalizer.merge_default_tags(&mut resources, &default_tags, &schemas);
+        normalizer
+            .merge_default_tags(&mut resources, &default_tags, &schemas)
+            .await;
 
         assert!(!resources[0].attributes.contains_key("tags"));
         assert!(!resources[0].attributes.contains_key("_default_tag_keys"));
     }
 
-    #[test]
-    fn test_merge_default_tags_no_default_tags() {
+    #[tokio::test]
+    async fn test_merge_default_tags_no_default_tags() {
         let schemas = build_schemas();
         let normalizer = AwsccNormalizer;
 
@@ -625,7 +647,9 @@ mod tests {
         let default_tags: IndexMap<String, Value> = IndexMap::new();
 
         let mut resources = vec![resource];
-        normalizer.merge_default_tags(&mut resources, &default_tags, &schemas);
+        normalizer
+            .merge_default_tags(&mut resources, &default_tags, &schemas)
+            .await;
 
         if let Some(Value::Concrete(ConcreteValue::Map(tags))) = resources[0].get_attr("tags") {
             assert_eq!(tags.len(), 1);

--- a/carina-provider-awscc/src/main.rs
+++ b/carina-provider-awscc/src/main.rs
@@ -286,7 +286,12 @@ impl CarinaProvider for AwsccProcessProvider {
             .iter()
             .map(convert::proto_to_core_resource)
             .collect();
-        self.normalizer.normalize_desired(&mut core_resources);
+        // Guest-side: drive the now-async normalizer on the guest's own
+        // outermost runtime — same pattern as the guest's `Provider`
+        // CRUD methods. Not a nested runtime: the host drives the WASM
+        // call, the guest drives its internal async (carina#3112).
+        self.runtime
+            .block_on(self.normalizer.normalize_desired(&mut core_resources));
         core_resources
             .iter()
             .map(convert::core_to_proto_resource)
@@ -304,7 +309,8 @@ impl CarinaProvider for AwsccProcessProvider {
                 (core_state.id.clone(), core_state)
             })
             .collect();
-        self.normalizer.normalize_state(&mut core_states);
+        self.runtime
+            .block_on(self.normalizer.normalize_state(&mut core_states));
         core_states
             .iter()
             .map(|(id, state)| (id.to_string(), convert::core_to_proto_state(state)))
@@ -337,8 +343,10 @@ impl CarinaProvider for AwsccProcessProvider {
                 Some((id, attrs))
             })
             .collect();
-        self.normalizer
-            .hydrate_read_state(&mut core_states, &core_saved);
+        self.runtime.block_on(
+            self.normalizer
+                .hydrate_read_state(&mut core_states, &core_saved),
+        );
         *states = core_states
             .iter()
             .map(|(id, state)| (id.to_string(), convert::core_to_proto_state(state)))
@@ -363,8 +371,11 @@ impl CarinaProvider for AwsccProcessProvider {
         for s in proto_schemas {
             registry.insert("awscc", convert::proto_to_core_schema(s));
         }
-        self.normalizer
-            .merge_default_tags(&mut core_resources, &core_tags, &registry);
+        self.runtime.block_on(self.normalizer.merge_default_tags(
+            &mut core_resources,
+            &core_tags,
+            &registry,
+        ));
         *resources = core_resources
             .iter()
             .map(convert::core_to_proto_resource)


### PR DESCRIPTION
## Why

carina#3112 / carina-rs/carina#3114 (merged) made `carina_core::provider::ProviderNormalizer` an **async trait** (methods return `BoxFuture<'a, ()>`) to remove a nested-`block_on` self-deadlock in the WASM host. `AwsccNormalizer` implements that trait — without this change carina-provider-awscc no longer builds against carina-core.

## What

- `AwsccNormalizer`'s four methods become `fn name<'a>(...) -> BoxFuture<'a, ()>`. The bodies are pure (enum resolution, state canonicalization, attr hydration, default-tag merge — no I/O), so each wraps its existing sync logic in `Box::pin(async move { ... })`. No logic change.
- Guest-side (`main.rs`): the WASM guest's sync normalizer methods drive the now-async normalizer via `self.runtime.block_on(...)` — the same pattern the guest's `Provider` CRUD methods already use. Not a nested runtime: the host drives the WASM call, the guest drives its internal async with its own runtime (per the carina#3112 design Non-goal).
- The four `merge_default_tags` unit tests become `#[tokio::test]` and `.await` the call.
- carina-core git pin bumped `741f7afc` → `7705f3c7` (the merged carina#3114 commit) in carina-provider-awscc and carina-aws-types.

## Verify

- `cargo test`: all suites pass
- `cargo clippy -- -D warnings`: clean
- `cargo fmt --check`: clean
- `cargo build -p carina-provider-awscc --target wasm32-wasip2 --release`: **green** (the WASM component registry actually loads)

## Context

Final PR of the carina#3112 cross-repo series: carina#3114 (core, merged) → carina-provider-aws#338 (CI green) → **this PR (awscc)**. Once this merges, all three repos' mains build against the new async trait and the user-driven real-infra smoke (`carina apply registry/dev/registry` without the deadlock) becomes meaningful.

Refs carina-rs/carina#3112

🤖 Generated with [Claude Code](https://claude.com/claude-code)