### PR TITLE
feat: provider-level assume_role for cross-account sts:AssumeRole

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=7705f3c7#7705f3c7178e8e840480a346c772b584d006a23f"
+source = "git+https://github.com/carina-rs/carina?rev=5c661f78#5c661f781c46e25c4967cc941b365ec0af0d58a6"
 dependencies = [
  "argon2",
  "futures",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=7705f3c7#7705f3c7178e8e840480a346c772b584d006a23f"
+source = "git+https://github.com/carina-rs/carina?rev=5c661f78#5c661f781c46e25c4967cc941b365ec0af0d58a6"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -552,6 +552,7 @@ version = "0.5.0"
 dependencies = [
  "anyhow",
  "aws-config",
+ "aws-credential-types",
  "aws-sdk-cloudcontrol",
  "aws-sdk-s3",
  "aws-sdk-sts",
@@ -579,7 +580,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=7705f3c7#7705f3c7178e8e840480a346c772b584d006a23f"
+source = "git+https://github.com/carina-rs/carina?rev=5c661f78#5c661f781c46e25c4967cc941b365ec0af0d58a6"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "7705f3c7" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "5c661f78" }

--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -23,12 +23,13 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "7705f3c7" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "5c661f78" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "7705f3c7" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "7705f3c7" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "5c661f78" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "5c661f78" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
+aws-credential-types = { version = "1" }
 aws-smithy-async = { version = "1", features = ["rt-tokio"] }
 aws-sdk-cloudcontrol = { version = "1", default-features = false, features = ["behavior-version-latest"] }
 aws-sdk-s3 = { version = "1", default-features = false, features = ["behavior-version-latest"] }

--- a/carina-provider-awscc/src/convert.rs
+++ b/carina-provider-awscc/src/convert.rs
@@ -199,6 +199,7 @@ fn proto_to_core_attribute_type(t: &ProtoAttributeType) -> CoreAttributeType {
         ProtoAttributeType::Int => CoreAttributeType::Int,
         ProtoAttributeType::Float => CoreAttributeType::Float,
         ProtoAttributeType::Bool => CoreAttributeType::Bool,
+        ProtoAttributeType::Duration => CoreAttributeType::Duration,
         ProtoAttributeType::StringEnum {
             name,
             values,
@@ -322,8 +323,13 @@ fn core_to_proto_attribute_type(t: &CoreAttributeType) -> ProtoAttributeType {
         CoreAttributeType::Int => ProtoAttributeType::Int,
         CoreAttributeType::Float => ProtoAttributeType::Float,
         CoreAttributeType::Bool => ProtoAttributeType::Bool,
-        // Duration isn't representable on the WIT wire today; map to Int seconds.
-        CoreAttributeType::Duration => ProtoAttributeType::Int,
+        // `Duration` is now a first-class proto variant (carina#3166) so
+        // providers can declare Duration-typed schema attributes and the
+        // host's type checker accepts DSL literals like `30min` / `1h` /
+        // `15s` against them. The WIT *value* boundary is still
+        // integer-seconds (see carina-plugin-host wasm_convert.rs:60-76),
+        // but the *type* boundary now round-trips faithfully.
+        CoreAttributeType::Duration => ProtoAttributeType::Duration,
         CoreAttributeType::StringEnum {
             name,
             values,

--- a/carina-provider-awscc/src/lib.rs
+++ b/carina-provider-awscc/src/lib.rs
@@ -131,13 +131,22 @@ impl ProviderFactory for AwsccProviderFactory {
                 ordered: false,
             },
         );
+        types.insert("assume_role".to_string(), assume_role_attribute_type());
         types
     }
 
-    fn validate_config(&self, _attributes: &IndexMap<String, Value>) -> Result<(), String> {
-        // Region format/value validation is handled by the host via
-        // `provider_config_attribute_types`. No provider-specific semantic
-        // checks are needed beyond that for now.
+    fn validate_config(&self, attributes: &IndexMap<String, Value>) -> Result<(), String> {
+        // Cross-account guardrail: when `assume_role.role_arn` parses to
+        // an account id that is not in `allowed_account_ids` (when that
+        // list is configured), refuse the configuration. Avoids the
+        // foot-gun of an assume-role silently landing in the wrong AWS
+        // account (awscc#260).
+        use crate::provider::assume_role::{check_cross_account, extract_assume_role};
+        let assume_role = extract_assume_role(attributes.get("assume_role"))?;
+        if let Some(ar) = &assume_role {
+            let allowed = extract_string_list_attr(attributes, "allowed_account_ids");
+            check_cross_account(&ar.role_arn, &allowed)?;
+        }
         Ok(())
     }
 
@@ -220,21 +229,58 @@ impl ProviderFactory for AwsccProviderFactory {
 /// `provider_config_attribute_types` — the host enforces the declared
 /// types before reaching the provider, so this is a defensive parse.
 pub(crate) fn extract_provider_config(attributes: &IndexMap<String, Value>) -> AwsccProviderConfig {
-    fn extract_string_list(attributes: &IndexMap<String, Value>, key: &str) -> Vec<String> {
-        match attributes.get(key) {
-            Some(Value::Concrete(ConcreteValue::List(items))) => items
-                .iter()
-                .filter_map(|v| match v {
-                    Value::Concrete(ConcreteValue::String(s)) => Some(s.clone()),
-                    _ => None,
-                })
-                .collect(),
-            _ => Vec::new(),
-        }
-    }
+    // `assume_role` is parsed here without surfacing parse errors —
+    // `validate_config` runs first on the host side and would have
+    // rejected a malformed block before reaching this code path. Fall
+    // back to `None` defensively if it somehow slips through.
+    let assume_role =
+        crate::provider::assume_role::extract_assume_role(attributes.get("assume_role"))
+            .ok()
+            .flatten();
     AwsccProviderConfig {
-        allowed_account_ids: extract_string_list(attributes, "allowed_account_ids"),
-        forbidden_account_ids: extract_string_list(attributes, "forbidden_account_ids"),
+        allowed_account_ids: extract_string_list_attr(attributes, "allowed_account_ids"),
+        forbidden_account_ids: extract_string_list_attr(attributes, "forbidden_account_ids"),
+        assume_role,
+    }
+}
+
+/// Schema for the provider-level `assume_role` block. Mirrors the
+/// Terraform AWS provider's `assume_role` (MVP field set: `role_arn`,
+/// `session_name`, `external_id`, `duration`). When present, the
+/// provider chains an `sts:AssumeRole` call on top of the ambient
+/// credential chain (awscc#260).
+fn assume_role_attribute_type() -> carina_core::schema::AttributeType {
+    use carina_core::schema::{AttributeType, StructField};
+    AttributeType::Struct {
+        name: "AssumeRole".to_string(),
+        fields: vec![
+            StructField::new("role_arn", AttributeType::String)
+                .required()
+                .with_description("IAM role ARN to assume."),
+            StructField::new("session_name", AttributeType::String)
+                .with_description("STS session name to associate with the assumed-role session."),
+            StructField::new("external_id", AttributeType::String)
+                .with_description("External ID required by the trust policy of the assumed role."),
+            StructField::new("duration", AttributeType::Duration)
+                .with_description("Assumed-role session duration (e.g., 30min, 1h, 15s)."),
+        ],
+    }
+}
+
+/// Extract a `list(string)` provider config attribute. Non-string
+/// elements are dropped silently — the host enforces type before we
+/// see the value here. Used by both `extract_provider_config` and the
+/// cross-account guardrail in `validate_config`.
+fn extract_string_list_attr(attributes: &IndexMap<String, Value>, key: &str) -> Vec<String> {
+    match attributes.get(key) {
+        Some(Value::Concrete(ConcreteValue::List(items))) => items
+            .iter()
+            .filter_map(|v| match v {
+                Value::Concrete(ConcreteValue::String(s)) => Some(s.clone()),
+                _ => None,
+            })
+            .collect(),
+        _ => Vec::new(),
     }
 }
 
@@ -406,6 +452,146 @@ mod tests {
             types.get("forbidden_account_ids"),
             Some(carina_core::schema::AttributeType::List { .. })
         ));
+    }
+
+    #[test]
+    fn provider_config_attribute_types_declares_assume_role_struct() {
+        // The host validates the assume_role block's shape against this
+        // Struct declaration before calling `initialize`. If the
+        // declaration disappears or its required field changes, the
+        // host stops surfacing schema-level errors for malformed
+        // assume_role blocks — this test prevents that regression
+        // (awscc#260).
+        let factory = AwsccProviderFactory;
+        let types = factory.provider_config_attribute_types();
+        let ty = types
+            .get("assume_role")
+            .expect("assume_role must be declared as a provider config attribute");
+        match ty {
+            carina_core::schema::AttributeType::Struct { name, fields } => {
+                assert_eq!(name, "AssumeRole");
+                let role_arn = fields
+                    .iter()
+                    .find(|f| f.name == "role_arn")
+                    .expect("assume_role.role_arn must be declared");
+                assert!(role_arn.required, "role_arn must be required");
+                for opt in ["session_name", "external_id", "duration"] {
+                    let f = fields
+                        .iter()
+                        .find(|f| f.name == opt)
+                        .unwrap_or_else(|| panic!("assume_role.{opt} must be declared"));
+                    assert!(!f.required, "assume_role.{opt} must be optional");
+                }
+            }
+            other => panic!("assume_role must be a Struct, was {other:?}"),
+        }
+    }
+
+    fn list_of(items: &[&str]) -> Value {
+        Value::Concrete(ConcreteValue::List(
+            items
+                .iter()
+                .map(|s| Value::Concrete(ConcreteValue::String((*s).to_string())))
+                .collect(),
+        ))
+    }
+
+    fn map_of(items: &[(&str, Value)]) -> Value {
+        let mut m = IndexMap::new();
+        for (k, v) in items {
+            m.insert((*k).to_string(), v.clone());
+        }
+        Value::Concrete(ConcreteValue::Map(m))
+    }
+
+    #[test]
+    fn validate_config_accepts_assume_role_in_allowed_account() {
+        let factory = AwsccProviderFactory;
+        let mut attrs: IndexMap<String, Value> = IndexMap::new();
+        attrs.insert(
+            "allowed_account_ids".to_string(),
+            list_of(&["412038850359"]),
+        );
+        attrs.insert(
+            "assume_role".to_string(),
+            map_of(&[(
+                "role_arn",
+                Value::Concrete(ConcreteValue::String(
+                    "arn:aws:iam::412038850359:role/delegation".to_string(),
+                )),
+            )]),
+        );
+        factory
+            .validate_config(&attrs)
+            .expect("matching allowed_account_ids must validate");
+    }
+
+    #[test]
+    fn validate_config_rejects_assume_role_outside_allowed_account() {
+        let factory = AwsccProviderFactory;
+        let mut attrs: IndexMap<String, Value> = IndexMap::new();
+        attrs.insert(
+            "allowed_account_ids".to_string(),
+            list_of(&["111111111111"]),
+        );
+        attrs.insert(
+            "assume_role".to_string(),
+            map_of(&[(
+                "role_arn",
+                Value::Concrete(ConcreteValue::String(
+                    "arn:aws:iam::412038850359:role/delegation".to_string(),
+                )),
+            )]),
+        );
+        let err = factory
+            .validate_config(&attrs)
+            .expect_err("cross-account role outside allowed_account_ids must fail");
+        assert!(err.contains("412038850359"), "must name target: {err}");
+        assert!(err.contains("111111111111"), "must name allow list: {err}");
+    }
+
+    #[test]
+    fn validate_config_no_assume_role_is_noop() {
+        let factory = AwsccProviderFactory;
+        let mut attrs: IndexMap<String, Value> = IndexMap::new();
+        attrs.insert(
+            "allowed_account_ids".to_string(),
+            list_of(&["412038850359"]),
+        );
+        factory
+            .validate_config(&attrs)
+            .expect("validate_config without assume_role must be a no-op");
+    }
+
+    #[test]
+    fn extract_provider_config_reads_assume_role() {
+        let mut attrs: IndexMap<String, Value> = IndexMap::new();
+        attrs.insert(
+            "assume_role".to_string(),
+            map_of(&[
+                (
+                    "role_arn",
+                    Value::Concrete(ConcreteValue::String(
+                        "arn:aws:iam::412038850359:role/delegation".to_string(),
+                    )),
+                ),
+                (
+                    "session_name",
+                    Value::Concrete(ConcreteValue::String("carina".to_string())),
+                ),
+                (
+                    "duration",
+                    Value::Concrete(ConcreteValue::Duration(std::time::Duration::from_secs(
+                        1800,
+                    ))),
+                ),
+            ]),
+        );
+        let cfg = extract_provider_config(&attrs);
+        let ar = cfg.assume_role.expect("assume_role must be parsed");
+        assert_eq!(ar.role_arn, "arn:aws:iam::412038850359:role/delegation");
+        assert_eq!(ar.session_name.as_deref(), Some("carina"));
+        assert_eq!(ar.duration, Some(std::time::Duration::from_secs(1800)));
     }
 
     /// carina#3093 acceptance: the *generated* CloudFront Distribution

--- a/carina-provider-awscc/src/main.rs
+++ b/carina-provider-awscc/src/main.rs
@@ -113,13 +113,25 @@ impl CarinaProvider for AwsccProcessProvider {
                 ordered: false,
             },
         );
+        types.insert("assume_role".to_string(), assume_role_attribute_type());
         types
     }
 
-    fn validate_config(&self, _attrs: &HashMap<String, proto::Value>) -> Result<(), String> {
-        // Region format/value validation is handled by the host via
-        // `provider_config_attribute_types`. No provider-specific semantic
-        // checks are needed beyond that for now.
+    fn validate_config(&self, attrs: &HashMap<String, proto::Value>) -> Result<(), String> {
+        // Cross-account guardrail: when `assume_role.role_arn` parses to
+        // an account id that is not in `allowed_account_ids` (when that
+        // list is configured), refuse the configuration. Avoids the
+        // foot-gun of an assume-role silently landing in the wrong AWS
+        // account (awscc#260).
+        use carina_provider_awscc::provider::assume_role::{
+            check_cross_account, extract_assume_role,
+        };
+        let core_attrs = convert::proto_to_core_value_map(attrs);
+        let assume_role = extract_assume_role(core_attrs.get("assume_role"))?;
+        if let Some(ar) = &assume_role {
+            let allowed = extract_string_list(&core_attrs, "allowed_account_ids");
+            check_cross_account(&ar.role_arn, &allowed)?;
+        }
         Ok(())
     }
 
@@ -132,7 +144,7 @@ impl CarinaProvider for AwsccProcessProvider {
         } else {
             "ap-northeast-1".to_string()
         };
-        let cfg = extract_account_guard_config(&core_attrs);
+        let cfg = extract_account_guard_config(&core_attrs)?;
         let provider = self
             .runtime
             .block_on(AwsccProvider::new_with_config(&region, &cfg));
@@ -383,26 +395,89 @@ impl CarinaProvider for AwsccProcessProvider {
     }
 }
 
-/// Pull `allowed_account_ids` / `forbidden_account_ids` out of the
-/// provider's configured attributes. Both unset/empty means "no
-/// account check"; matching mirrors the in-process Provider wiring in
+/// Pull `allowed_account_ids` / `forbidden_account_ids` / `assume_role`
+/// out of the provider's configured attributes. Both lists unset/empty
+/// means "no account check"; `assume_role` absent means "do not chain
+/// sts:AssumeRole". Mirrors the in-process Provider wiring in
 /// `lib.rs::extract_provider_config`.
-fn extract_account_guard_config(core_attrs: &HashMap<String, CoreValue>) -> AwsccProviderConfig {
-    fn extract_string_list(attrs: &HashMap<String, CoreValue>, key: &str) -> Vec<String> {
-        match attrs.get(key) {
-            Some(CoreValue::Concrete(ConcreteValue::List(items))) => items
-                .iter()
-                .filter_map(|v| match v {
-                    CoreValue::Concrete(ConcreteValue::String(s)) => Some(s.clone()),
-                    _ => None,
-                })
-                .collect(),
-            _ => Vec::new(),
-        }
-    }
-    AwsccProviderConfig {
+fn extract_account_guard_config(
+    core_attrs: &HashMap<String, CoreValue>,
+) -> Result<AwsccProviderConfig, String> {
+    let assume_role = carina_provider_awscc::provider::assume_role::extract_assume_role(
+        core_attrs.get("assume_role"),
+    )?;
+    Ok(AwsccProviderConfig {
         allowed_account_ids: extract_string_list(core_attrs, "allowed_account_ids"),
         forbidden_account_ids: extract_string_list(core_attrs, "forbidden_account_ids"),
+        assume_role,
+    })
+}
+
+/// Shared `list(string)` extractor used by both `validate_config` and
+/// `extract_account_guard_config`. Drops non-string elements silently —
+/// the host enforces the declared `list(string)` shape before we see
+/// the value.
+fn extract_string_list(attrs: &HashMap<String, CoreValue>, key: &str) -> Vec<String> {
+    match attrs.get(key) {
+        Some(CoreValue::Concrete(ConcreteValue::List(items))) => items
+            .iter()
+            .filter_map(|v| match v {
+                CoreValue::Concrete(ConcreteValue::String(s)) => Some(s.clone()),
+                _ => None,
+            })
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// Schema for the provider-level `assume_role` block. Mirrors the
+/// Terraform AWS provider's `assume_role` (MVP field set: `role_arn`,
+/// `session_name`, `external_id`, `duration`). When present, the
+/// provider chains an `sts:AssumeRole` call on top of the ambient
+/// credential chain (awscc#260).
+fn assume_role_attribute_type() -> proto::AttributeType {
+    proto::AttributeType::Struct {
+        name: "AssumeRole".to_string(),
+        fields: vec![
+            proto::StructField {
+                name: "role_arn".to_string(),
+                field_type: proto::AttributeType::String,
+                required: true,
+                description: Some("IAM role ARN to assume.".to_string()),
+                block_name: None,
+                provider_name: None,
+            },
+            proto::StructField {
+                name: "session_name".to_string(),
+                field_type: proto::AttributeType::String,
+                required: false,
+                description: Some(
+                    "STS session name to associate with the assumed-role session.".to_string(),
+                ),
+                block_name: None,
+                provider_name: None,
+            },
+            proto::StructField {
+                name: "external_id".to_string(),
+                field_type: proto::AttributeType::String,
+                required: false,
+                description: Some(
+                    "External ID required by the trust policy of the assumed role.".to_string(),
+                ),
+                block_name: None,
+                provider_name: None,
+            },
+            proto::StructField {
+                name: "duration".to_string(),
+                field_type: proto::AttributeType::Duration,
+                required: false,
+                description: Some(
+                    "Assumed-role session duration (e.g., 30min, 1h, 15s).".to_string(),
+                ),
+                block_name: None,
+                provider_name: None,
+            },
+        ],
     }
 }
 
@@ -455,6 +530,110 @@ mod tests {
                 "untagged resource should not have TagsKeyValueCheck"
             );
         }
+    }
+
+    #[test]
+    fn provider_config_attribute_types_declares_assume_role_struct() {
+        // Mirrors the in-process Provider's assume_role declaration over
+        // the WASM/proto boundary. If the proto declaration goes missing
+        // or its required field changes, the host stops surfacing
+        // schema-level errors for malformed assume_role blocks
+        // (awscc#260).
+        let provider = AwsccProcessProvider::new();
+        let types = provider.provider_config_attribute_types();
+        let ty = types
+            .get("assume_role")
+            .expect("assume_role must be declared as a provider config attribute");
+        match ty {
+            proto::AttributeType::Struct { name, fields } => {
+                assert_eq!(name, "AssumeRole");
+                let role_arn = fields
+                    .iter()
+                    .find(|f| f.name == "role_arn")
+                    .expect("assume_role.role_arn must be declared");
+                assert!(role_arn.required, "role_arn must be required");
+                for opt in ["session_name", "external_id"] {
+                    let f = fields
+                        .iter()
+                        .find(|f| f.name == opt)
+                        .unwrap_or_else(|| panic!("assume_role.{opt} must be declared"));
+                    assert!(!f.required, "assume_role.{opt} must be optional");
+                    assert!(matches!(f.field_type, proto::AttributeType::String));
+                }
+                let duration = fields
+                    .iter()
+                    .find(|f| f.name == "duration")
+                    .expect("assume_role.duration must be declared");
+                assert!(!duration.required, "duration must be optional");
+                assert!(
+                    matches!(duration.field_type, proto::AttributeType::Duration),
+                    "duration must be a Duration so DSL literals like `30min` are accepted; \
+                     was {:?}",
+                    duration.field_type
+                );
+            }
+            other => panic!("assume_role must be a Struct, was {other:?}"),
+        }
+    }
+
+    fn proto_str(s: &str) -> proto::Value {
+        proto::Value::String(s.to_string())
+    }
+
+    fn proto_list_str(items: &[&str]) -> proto::Value {
+        proto::Value::List(items.iter().copied().map(proto_str).collect())
+    }
+
+    fn proto_map(items: &[(&str, proto::Value)]) -> proto::Value {
+        let mut m = std::collections::HashMap::new();
+        for (k, v) in items {
+            m.insert((*k).to_string(), v.clone());
+        }
+        proto::Value::Map(m)
+    }
+
+    #[test]
+    fn validate_config_accepts_assume_role_in_allowed_account() {
+        let provider = AwsccProcessProvider::new();
+        let attrs = HashMap::from([
+            (
+                "allowed_account_ids".to_string(),
+                proto_list_str(&["412038850359"]),
+            ),
+            (
+                "assume_role".to_string(),
+                proto_map(&[(
+                    "role_arn",
+                    proto_str("arn:aws:iam::412038850359:role/delegation"),
+                )]),
+            ),
+        ]);
+        provider
+            .validate_config(&attrs)
+            .expect("matching allowed_account_ids must validate");
+    }
+
+    #[test]
+    fn validate_config_rejects_assume_role_outside_allowed_account() {
+        let provider = AwsccProcessProvider::new();
+        let attrs = HashMap::from([
+            (
+                "allowed_account_ids".to_string(),
+                proto_list_str(&["111111111111"]),
+            ),
+            (
+                "assume_role".to_string(),
+                proto_map(&[(
+                    "role_arn",
+                    proto_str("arn:aws:iam::412038850359:role/delegation"),
+                )]),
+            ),
+        ]);
+        let err = provider
+            .validate_config(&attrs)
+            .expect_err("cross-account role outside allowed_account_ids must fail");
+        assert!(err.contains("412038850359"), "must name target: {err}");
+        assert!(err.contains("111111111111"), "must name allow list: {err}");
     }
 
     /// Regression for carina-rs/carina#2025: the VPC schema must carry the

--- a/carina-provider-awscc/src/provider/assume_role.rs
+++ b/carina-provider-awscc/src/provider/assume_role.rs
@@ -1,0 +1,313 @@
+//! Provider-level `assume_role` block: chain `sts:AssumeRole` on top of
+//! the ambient credential chain so cross-account workflows can be
+//! expressed in `.crn`.
+//!
+//! Mirrors the Terraform AWS provider's `assume_role` block. The MVP
+//! field set is `role_arn`, `session_name`, `external_id`, `duration`;
+//! Terraform's broader surface (`transitive_tag_keys`, `source_identity`,
+//! `policy`, `policy_arns`, `tags`) is deferred to follow-up issues.
+//!
+//! Sibling of the carina-provider-aws implementation; the two providers
+//! share the same WASM provider-host plumbing and the same SDK shape.
+
+use std::time::Duration;
+
+use carina_core::resource::{ConcreteValue, Value};
+
+/// Parsed, validated `assume_role` block.
+///
+/// `role_arn` is required; the optional fields are `None` when absent
+/// from the DSL.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AssumeRoleConfig {
+    pub role_arn: String,
+    pub session_name: Option<String>,
+    pub external_id: Option<String>,
+    pub duration: Option<Duration>,
+}
+
+/// Extract the 12-digit AWS account id from an IAM role ARN.
+///
+/// `arn:aws:iam::123456789012:role/example` → `Some("123456789012")`.
+/// Returns `None` for any ARN that does not match the IAM-role shape;
+/// callers should treat that as "cannot determine account, skip
+/// cross-account guard" rather than as a fatal error — schema-level
+/// ARN validation is the host's job, not this helper's.
+pub fn account_id_from_role_arn(arn: &str) -> Option<&str> {
+    let parts: Vec<&str> = arn.split(':').collect();
+    if parts.len() < 6 {
+        return None;
+    }
+    if parts[0] != "arn" || parts[2] != "iam" {
+        return None;
+    }
+    let account = parts[4];
+    if account.len() == 12 && account.chars().all(|c| c.is_ascii_digit()) {
+        Some(account)
+    } else {
+        None
+    }
+}
+
+/// Cross-account guardrail. Returns `Err` when `role_arn`'s account id
+/// is determinable and is **not** in `allowed_account_ids`.
+///
+/// No-op when:
+/// - `allowed_account_ids` is empty (guard not configured), or
+/// - the role ARN's account id cannot be extracted (treated as
+///   unknowable — fail open here, the STS call itself will surface the
+///   real error).
+pub fn check_cross_account(role_arn: &str, allowed_account_ids: &[String]) -> Result<(), String> {
+    if allowed_account_ids.is_empty() {
+        return Ok(());
+    }
+    let Some(target) = account_id_from_role_arn(role_arn) else {
+        return Ok(());
+    };
+    if allowed_account_ids.iter().any(|a| a == target) {
+        Ok(())
+    } else {
+        Err(format!(
+            "assume_role.role_arn '{role_arn}' targets account {target}, \
+             which is not in allowed_account_ids {allowed_account_ids:?}; \
+             refusing to configure provider with this cross-account role"
+        ))
+    }
+}
+
+/// Pull an `assume_role` Struct value out of provider config attrs.
+///
+/// Returns `Ok(None)` when the attribute is absent (assume_role is
+/// optional). Returns `Err` with a human-readable reason when the
+/// attribute is present but malformed (missing required field, wrong
+/// shape, unparseable duration, etc.).
+pub fn extract_assume_role(value: Option<&Value>) -> Result<Option<AssumeRoleConfig>, String> {
+    let map = match value {
+        None => return Ok(None),
+        Some(Value::Concrete(ConcreteValue::Map(m))) => m,
+        Some(_) => return Err("assume_role must be a block / map value".to_string()),
+    };
+
+    let role_arn = match map.get("role_arn") {
+        Some(Value::Concrete(ConcreteValue::String(s))) => s.clone(),
+        Some(_) => return Err("assume_role.role_arn must be a string".to_string()),
+        None => return Err("assume_role.role_arn is required".to_string()),
+    };
+
+    let session_name = match map.get("session_name") {
+        None => None,
+        Some(Value::Concrete(ConcreteValue::String(s))) => Some(s.clone()),
+        Some(_) => return Err("assume_role.session_name must be a string".to_string()),
+    };
+
+    let external_id = match map.get("external_id") {
+        None => None,
+        Some(Value::Concrete(ConcreteValue::String(s))) => Some(s.clone()),
+        Some(_) => return Err("assume_role.external_id must be a string".to_string()),
+    };
+
+    // `duration` is declared as `AttributeType::Duration` in the schema.
+    // The in-process path (lib.rs factory) delivers the literal value as
+    // `ConcreteValue::Duration`; the WASM/proto path (main.rs) currently
+    // delivers it as `ConcreteValue::Int(seconds)` because schema-aware
+    // inbound re-typing across the WIT boundary is the deferred
+    // follow-up flagged at `carina-plugin-host/src/wasm_convert.rs:60-76`.
+    // Accept both so provider behaves the same regardless of host path.
+    let duration = match map.get("duration") {
+        None => None,
+        Some(Value::Concrete(ConcreteValue::Duration(d))) => Some(*d),
+        Some(Value::Concrete(ConcreteValue::Int(secs))) if *secs >= 0 => {
+            Some(Duration::from_secs(*secs as u64))
+        }
+        Some(_) => {
+            return Err(
+                "assume_role.duration must be a Duration literal (e.g., 30min, 1h)".to_string(),
+            );
+        }
+    };
+
+    Ok(Some(AssumeRoleConfig {
+        role_arn,
+        session_name,
+        external_id,
+        duration,
+    }))
+}
+
+/// Layer an STS `AssumeRoleProvider` on top of the ambient base
+/// credential chain. The returned [`aws_config::SdkConfig`] uses the
+/// assumed-role credentials for every SDK call thereafter.
+pub async fn wrap_with_assume_role(
+    base: aws_config::SdkConfig,
+    ar: &AssumeRoleConfig,
+) -> aws_config::SdkConfig {
+    let mut builder =
+        aws_config::sts::AssumeRoleProvider::builder(ar.role_arn.clone()).configure(&base);
+    if let Some(name) = ar.session_name.as_deref() {
+        builder = builder.session_name(name);
+    }
+    if let Some(eid) = ar.external_id.as_deref() {
+        builder = builder.external_id(eid);
+    }
+    if let Some(dur) = ar.duration {
+        builder = builder.session_length(dur);
+    }
+    let provider = builder.build().await;
+    let shared = aws_credential_types::provider::SharedCredentialsProvider::new(provider);
+    base.into_builder().credentials_provider(shared).build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn val_str(s: &str) -> Value {
+        Value::Concrete(ConcreteValue::String(s.to_string()))
+    }
+
+    fn val_map(items: &[(&str, Value)]) -> Value {
+        let mut m = indexmap::IndexMap::new();
+        for (k, v) in items {
+            m.insert((*k).to_string(), v.clone());
+        }
+        Value::Concrete(ConcreteValue::Map(m))
+    }
+
+    fn val_duration(secs: u64) -> Value {
+        Value::Concrete(ConcreteValue::Duration(Duration::from_secs(secs)))
+    }
+
+    fn val_int(n: i64) -> Value {
+        Value::Concrete(ConcreteValue::Int(n))
+    }
+
+    #[test]
+    fn account_id_from_role_arn_extracts() {
+        assert_eq!(
+            account_id_from_role_arn("arn:aws:iam::412038850359:role/foo"),
+            Some("412038850359")
+        );
+    }
+
+    #[test]
+    fn account_id_from_role_arn_rejects_non_iam() {
+        assert_eq!(account_id_from_role_arn("arn:aws:s3:::my-bucket"), None);
+    }
+
+    #[test]
+    fn account_id_from_role_arn_rejects_non_12_digit() {
+        assert_eq!(account_id_from_role_arn("arn:aws:iam::abc:role/foo"), None);
+        assert_eq!(account_id_from_role_arn("arn:aws:iam::123:role/foo"), None);
+    }
+
+    #[test]
+    fn check_cross_account_no_allow_list_passes() {
+        assert!(check_cross_account("arn:aws:iam::412038850359:role/foo", &[]).is_ok());
+    }
+
+    #[test]
+    fn check_cross_account_target_in_allow_list_passes() {
+        let allowed = vec!["412038850359".to_string()];
+        assert!(check_cross_account("arn:aws:iam::412038850359:role/foo", &allowed).is_ok());
+    }
+
+    #[test]
+    fn check_cross_account_target_not_in_allow_list_fails() {
+        let allowed = vec!["111111111111".to_string()];
+        let err = check_cross_account("arn:aws:iam::412038850359:role/foo", &allowed)
+            .expect_err("should reject cross-account role");
+        assert!(err.contains("412038850359"));
+        assert!(err.contains("111111111111"));
+        assert!(err.contains("assume_role.role_arn"));
+    }
+
+    #[test]
+    fn check_cross_account_unparseable_arn_fails_open() {
+        let allowed = vec!["111111111111".to_string()];
+        assert!(check_cross_account("not-an-arn", &allowed).is_ok());
+    }
+
+    #[test]
+    fn extract_assume_role_absent_returns_none() {
+        let attrs: HashMap<String, Value> = HashMap::new();
+        assert_eq!(extract_assume_role(attrs.get("assume_role")).unwrap(), None);
+    }
+
+    #[test]
+    fn extract_assume_role_role_arn_only() {
+        let v = val_map(&[("role_arn", val_str("arn:aws:iam::412038850359:role/foo"))]);
+        let got = extract_assume_role(Some(&v)).unwrap().unwrap();
+        assert_eq!(got.role_arn, "arn:aws:iam::412038850359:role/foo");
+        assert_eq!(got.session_name, None);
+        assert_eq!(got.external_id, None);
+        assert_eq!(got.duration, None);
+    }
+
+    #[test]
+    fn extract_assume_role_all_fields_with_duration_literal() {
+        // In-process path: `duration = 30min` arrives as
+        // `ConcreteValue::Duration` (the parser's native Duration form).
+        let v = val_map(&[
+            ("role_arn", val_str("arn:aws:iam::412038850359:role/foo")),
+            ("session_name", val_str("carina")),
+            ("external_id", val_str("xid")),
+            ("duration", val_duration(1800)),
+        ]);
+        let got = extract_assume_role(Some(&v)).unwrap().unwrap();
+        assert_eq!(got.session_name.as_deref(), Some("carina"));
+        assert_eq!(got.external_id.as_deref(), Some("xid"));
+        assert_eq!(got.duration, Some(Duration::from_secs(1800)));
+    }
+
+    #[test]
+    fn extract_assume_role_duration_from_int_seconds() {
+        // WASM/proto path: until the schema-aware inbound re-typing
+        // follow-up lands (see carina-plugin-host wasm_convert.rs:60-76),
+        // a Duration-typed attribute crosses back as
+        // `ConcreteValue::Int(seconds)`. Provider must still accept it
+        // so behavior matches across in-process vs WASM hosting.
+        let v = val_map(&[
+            ("role_arn", val_str("arn:aws:iam::412038850359:role/foo")),
+            ("duration", val_int(3600)),
+        ]);
+        let got = extract_assume_role(Some(&v)).unwrap().unwrap();
+        assert_eq!(got.duration, Some(Duration::from_secs(3600)));
+    }
+
+    #[test]
+    fn extract_assume_role_missing_role_arn_fails() {
+        let v = val_map(&[("session_name", val_str("oops"))]);
+        let err = extract_assume_role(Some(&v)).unwrap_err();
+        assert!(err.contains("role_arn is required"));
+    }
+
+    #[test]
+    fn extract_assume_role_non_map_fails() {
+        let err = extract_assume_role(Some(&val_str("oops"))).unwrap_err();
+        assert!(err.contains("block / map"));
+    }
+
+    #[test]
+    fn extract_assume_role_string_duration_fails() {
+        // Old String-typed schema is gone; a string value at the
+        // duration slot is now a schema-level type error rather than
+        // a provider-side parsable shape. Surfaces a clear error.
+        let v = val_map(&[
+            ("role_arn", val_str("arn:aws:iam::412038850359:role/foo")),
+            ("duration", val_str("30m")),
+        ]);
+        let err = extract_assume_role(Some(&v)).unwrap_err();
+        assert!(err.contains("Duration literal"), "got: {err}");
+    }
+
+    #[test]
+    fn extract_assume_role_negative_int_duration_fails() {
+        let v = val_map(&[
+            ("role_arn", val_str("arn:aws:iam::412038850359:role/foo")),
+            ("duration", val_int(-1)),
+        ]);
+        let err = extract_assume_role(Some(&v)).unwrap_err();
+        assert!(err.contains("Duration literal"), "got: {err}");
+    }
+}

--- a/carina-provider-awscc/src/provider/mod.rs
+++ b/carina-provider-awscc/src/provider/mod.rs
@@ -16,6 +16,7 @@
 
 pub(crate) mod account_guard;
 mod arn_synthesis;
+pub mod assume_role;
 mod cloudcontrol;
 pub(crate) mod conversion;
 mod normalizer;
@@ -60,13 +61,15 @@ const DELETE_RETRY_MAX_DELAY_SECS: u64 = 120;
 
 /// Provider-level configuration that affects AwsccProvider construction.
 ///
-/// Currently carries the `allowed_account_ids` / `forbidden_account_ids`
-/// guard lists. Both empty means "no check", matching the
-/// pre-allowed-account-ids behavior.
+/// Carries the `allowed_account_ids` / `forbidden_account_ids` guard
+/// lists (both empty = "no check") and, when present, a parsed
+/// `assume_role` block that layers an STS `AssumeRoleProvider` on top
+/// of the ambient credential chain.
 #[derive(Debug, Default, Clone)]
 pub struct AwsccProviderConfig {
     pub allowed_account_ids: Vec<String>,
     pub forbidden_account_ids: Vec<String>,
+    pub assume_role: Option<assume_role::AssumeRoleConfig>,
 }
 
 /// AWS Cloud Control Provider
@@ -105,7 +108,7 @@ impl AwsccProvider {
     /// returned instance will surface that error before any
     /// CloudControl call.
     pub async fn new_with_config(region: &str, cfg: &AwsccProviderConfig) -> Self {
-        let config = Self::build_config(region).await;
+        let config = Self::build_config(region, cfg.assume_role.as_ref()).await;
 
         let init_error =
             if cfg.allowed_account_ids.is_empty() && cfg.forbidden_account_ids.is_empty() {
@@ -176,21 +179,35 @@ impl AwsccProvider {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
-    async fn build_config(region: &str) -> aws_config::SdkConfig {
-        aws_config::defaults(aws_config::BehaviorVersion::latest())
+    async fn build_config(
+        region: &str,
+        assume_role: Option<&assume_role::AssumeRoleConfig>,
+    ) -> aws_config::SdkConfig {
+        let base = aws_config::defaults(aws_config::BehaviorVersion::latest())
             .region(Region::new(region.to_string()))
             .load()
-            .await
+            .await;
+        match assume_role {
+            None => base,
+            Some(ar) => assume_role::wrap_with_assume_role(base, ar).await,
+        }
     }
 
     #[cfg(target_arch = "wasm32")]
-    async fn build_config(region: &str) -> aws_config::SdkConfig {
+    async fn build_config(
+        region: &str,
+        assume_role: Option<&assume_role::AssumeRoleConfig>,
+    ) -> aws_config::SdkConfig {
         use carina_plugin_sdk::wasi_http::WasiHttpClient;
-        aws_config::defaults(aws_config::BehaviorVersion::latest())
+        let base = aws_config::defaults(aws_config::BehaviorVersion::latest())
             .region(Region::new(region.to_string()))
             .http_client(WasiHttpClient::new())
             .load()
-            .await
+            .await;
+        match assume_role {
+            None => base,
+            Some(ar) => assume_role::wrap_with_assume_role(base, ar).await,
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Sibling of carina-rs/carina-provider-aws#343. Adds the same provider-level `assume_role` block to `provider awscc { ... }` so multi-account AWS workflows can be expressed via the awscc provider identically to the aws provider.

```crn
let management = provider awscc {
  region              = aws.Region.us_east_1
  assume_role = {
    role_arn     = 'arn:aws:iam::412038850359:role/cross-account-writer'
    session_name = 'carina-cross-account'
    external_id  = '...'
    duration     = 30min
  }
  allowed_account_ids = ['412038850359']
}
```

## What's included

- 4 MVP fields: `role_arn` (required), `session_name`, `external_id`, `duration` (all optional).
- `duration` typed as `AttributeType::Duration` (enabled by carina-rs/carina#3166 / PR 3168) so the DSL literal `30min` is accepted natively.
- `AssumeRoleProvider` layered on top of the ambient credential chain via `AwsccProviderConfig.assume_role` → `new_with_config` → `build_config` → `wrap_with_assume_role`.
- Cross-account validate guardrail.

## Sibling-provider duplication is intentional

Per the project rule that aws and awscc do not dedup across the provider boundary, this PR carries its own `provider/assume_role.rs` with behavior identical to the aws sibling. Each provider can evolve its assume_role surface independently.

## Test plan

- [x] 20+ new tests covering: cross-account guard accept/reject/no-guard, both Duration and Int duration value shapes, schema regression for Struct + Duration type.
- [x] `cargo nextest run --workspace` — 490 passed.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo test --workspace --doc` — clean.
- [x] `cargo fmt --check` — clean.
- [x] `bash scripts/check-carina-pin.sh` && `bash scripts/check-docs-drift.sh` — both pass.
- [x] 5-round self-review: all clean, HIGH confidence.

Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)