### PR TITLE
Bump carina-core to 055a4128, adopt resource typestate split (carina#3181)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=5c661f78#5c661f781c46e25c4967cc941b365ec0af0d58a6"
+source = "git+https://github.com/carina-rs/carina?rev=055a4128#055a4128df15ed880735130bb0e6da95cdeac9ea"
 dependencies = [
  "argon2",
  "futures",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=5c661f78#5c661f781c46e25c4967cc941b365ec0af0d58a6"
+source = "git+https://github.com/carina-rs/carina?rev=055a4128#055a4128df15ed880735130bb0e6da95cdeac9ea"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -580,7 +580,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=5c661f78#5c661f781c46e25c4967cc941b365ec0af0d58a6"
+source = "git+https://github.com/carina-rs/carina?rev=055a4128#055a4128df15ed880735130bb0e6da95cdeac9ea"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "5c661f78" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "055a4128" }

--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -23,10 +23,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "5c661f78" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "055a4128" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "5c661f78" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "5c661f78" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "055a4128" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "055a4128" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }

--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -6583,7 +6583,7 @@ mod tests {
             handlers: BTreeMap::new(),
         };
         let enums = BTreeMap::new();
-        // Resource-scoped override takes precedence over schema enum values
+        // ManagedResource-scoped override takes precedence over schema enum values
         let result = type_display_string("RetentionInDays", &prop, &schema, &enums);
         assert_eq!(
             result,

--- a/carina-provider-awscc/src/convert.rs
+++ b/carina-provider-awscc/src/convert.rs
@@ -11,8 +11,9 @@ use carina_core::provider::{
     UpdatePatch as CoreUpdatePatch,
 };
 use carina_core::resource::{
-    ConcreteValue, DeferredValue, Directives as CoreDirectives, Resource as CoreResource,
-    ResourceId as CoreResourceId, State as CoreState, Value as CoreValue,
+    ConcreteValue, DataSource as CoreDataSource, DeferredValue, Directives as CoreDirectives,
+    ManagedResource as CoreResource, ResourceId as CoreResourceId, State as CoreState,
+    Value as CoreValue,
 };
 use carina_core::schema::{
     AttributeSchema as CoreAttributeSchema, AttributeType as CoreAttributeType,
@@ -189,6 +190,28 @@ pub fn proto_to_core_resource(r: &ProtoResource) -> CoreResource {
         provider_instance: None,
     };
     resource
+}
+
+/// Rebuild a [`CoreDataSource`] from the WIT `Resource` record carried
+/// over the plugin boundary. `Provider::read_data_source` consumes a
+/// `DataSource`, so a data-source read request maps to this typed
+/// projection (carina#3181).
+pub fn proto_to_core_data_source(r: &ProtoResource) -> CoreDataSource {
+    let mut data_source =
+        CoreDataSource::with_provider(&r.id.provider, &r.id.resource_type, &r.id.name, None);
+    data_source.attributes = r
+        .attributes
+        .iter()
+        .map(|(k, v)| (k.clone(), proto_to_core_value(v)))
+        .collect();
+    data_source.directives = CoreDirectives {
+        force_delete: r.directives.force_delete,
+        create_before_destroy: r.directives.create_before_destroy,
+        prevent_destroy: r.directives.prevent_destroy,
+        depends_on: Vec::new(),
+        provider_instance: None,
+    };
+    data_source
 }
 
 // -- AttributeType --

--- a/carina-provider-awscc/src/lib.rs
+++ b/carina-provider-awscc/src/lib.rs
@@ -24,7 +24,7 @@ use carina_core::provider::{
     ProviderNormalizer, ProviderResult, ReadRequest, SavedAttrs, UpdateRequest,
     merge_default_tags_for_provider,
 };
-use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, DataSource, ManagedResource, ResourceId, State, Value};
 use carina_core::schema::SchemaRegistry;
 
 use crate::provider::AwsccProviderConfig;
@@ -41,7 +41,7 @@ impl ProviderNormalizer for AwsccNormalizer {
     // resolution, state canonicalization, attr hydration, tag merge —
     // no I/O), so wrapping the existing sync logic in a ready future is
     // sufficient; no logic change.
-    fn normalize_desired<'a>(&'a self, resources: &'a mut [Resource]) -> BoxFuture<'a, ()> {
+    fn normalize_desired<'a>(&'a self, resources: &'a mut [ManagedResource]) -> BoxFuture<'a, ()> {
         Box::pin(async move {
             crate::provider::resolve_enum_identifiers_impl(resources);
         })
@@ -73,7 +73,7 @@ impl ProviderNormalizer for AwsccNormalizer {
 
     fn merge_default_tags<'a>(
         &'a self,
-        resources: &'a mut [Resource],
+        resources: &'a mut [ManagedResource],
         default_tags: &'a IndexMap<String, Value>,
         registry: &'a SchemaRegistry,
     ) -> BoxFuture<'a, ()> {
@@ -312,7 +312,7 @@ impl Provider for AwsccProvider {
         })
     }
 
-    fn read_data_source(&self, resource: &Resource) -> BoxFuture<'_, ProviderResult<State>> {
+    fn read_data_source(&self, resource: &DataSource) -> BoxFuture<'_, ProviderResult<State>> {
         if let Some(err) = self.init_error() {
             let err = err.to_string();
             let id = resource.id.clone();
@@ -662,7 +662,7 @@ mod tests {
         let schemas = build_schemas();
         let normalizer = AwsccNormalizer;
 
-        let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "test-vpc", None);
+        let mut resource = ManagedResource::with_provider("awscc", "ec2.Vpc", "test-vpc", None);
         resource.set_attr(
             "cidr_block".to_string(),
             Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
@@ -740,7 +740,7 @@ mod tests {
         let schemas = build_schemas();
         let normalizer = AwsccNormalizer;
 
-        let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "test-vpc", None);
+        let mut resource = ManagedResource::with_provider("awscc", "ec2.Vpc", "test-vpc", None);
         resource.set_attr(
             "cidr_block".to_string(),
             Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
@@ -789,7 +789,7 @@ mod tests {
         let schemas = build_schemas();
         let normalizer = AwsccNormalizer;
 
-        let mut resource = Resource::with_provider("awscc", "ec2.Route", "test-route", None);
+        let mut resource = ManagedResource::with_provider("awscc", "ec2.Route", "test-route", None);
         resource.set_attr(
             "route_table_id".to_string(),
             Value::Concrete(ConcreteValue::String("rtb-123".to_string())),
@@ -815,7 +815,7 @@ mod tests {
         let schemas = build_schemas();
         let normalizer = AwsccNormalizer;
 
-        let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "test-vpc", None);
+        let mut resource = ManagedResource::with_provider("awscc", "ec2.Vpc", "test-vpc", None);
         resource.set_attr(
             "cidr_block".to_string(),
             Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),

--- a/carina-provider-awscc/src/main.rs
+++ b/carina-provider-awscc/src/main.rs
@@ -214,10 +214,10 @@ impl CarinaProvider for AwsccProcessProvider {
         &self,
         resource: &proto::Resource,
     ) -> Result<proto::State, proto::ProviderError> {
-        let core_resource = convert::proto_to_core_resource(resource);
+        let core_data_source = convert::proto_to_core_data_source(resource);
         let result = self
             .runtime
-            .block_on(self.provider().read_data_source(&core_resource));
+            .block_on(self.provider().read_data_source(&core_data_source));
         match result {
             Ok(state) => Ok(convert::core_to_proto_state(&state)),
             Err(e) => Err(Self::convert_error(e)),

--- a/carina-provider-awscc/src/provider/cloudcontrol.rs
+++ b/carina-provider-awscc/src/provider/cloudcontrol.rs
@@ -359,11 +359,11 @@ impl AwsccProvider {
     /// Retryable error types:
     /// - `ThrottlingException`: Request rate exceeded (covers "Throttling", "Rate exceeded")
     /// - `ServiceInternalErrorException`: AWS internal server error
-    /// - `HandlerFailureException`: Resource handler failed (may be transient)
+    /// - `HandlerFailureException`: ManagedResource handler failed (may be transient)
     /// - `HandlerInternalFailureException`: Internal handler error
     /// - `NetworkFailureException`: Network connectivity issues
     /// - `ConcurrentOperationException`: Another operation is in progress
-    /// - `NotStabilizedException`: Resource not yet stabilized
+    /// - `NotStabilizedException`: ManagedResource not yet stabilized
     /// - `SdkError::TimeoutError`: Connection timeout
     /// - `SdkError::DispatchFailure`: HTTP dispatch failure
     pub(crate) fn is_retryable_sdk_error<E, R>(error: &SdkError<E, R>) -> bool

--- a/carina-provider-awscc/src/provider/conversion.rs
+++ b/carina-provider-awscc/src/provider/conversion.rs
@@ -665,7 +665,7 @@ mod tests {
         let attr_schema = config.schema.attributes.get("vpc_endpoint_type").unwrap();
 
         // 1. DSL side: resolve_enum_identifiers_impl converts bare `Gateway` ident
-        let mut resource = carina_core::resource::Resource::with_provider(
+        let mut resource = carina_core::resource::ManagedResource::with_provider(
             "awscc",
             "ec2.VpcEndpoint",
             "test",

--- a/carina-provider-awscc/src/provider/mod.rs
+++ b/carina-provider-awscc/src/provider/mod.rs
@@ -10,7 +10,7 @@
 //! - `normalizer` - Plan-time enum resolution and state hydration
 //! - `operations` - High-level resource operations (read, create, update, delete)
 //! - `s3` - S3-specific operations (empty bucket for force_delete)
-//! - `special_cases` - Resource-type-specific attribute handling
+//! - `special_cases` - ManagedResource-type-specific attribute handling
 //! - `tags` - Tag conversion between DSL and CloudFormation formats
 //! - `update` - Update patch building and resource property parsing
 

--- a/carina-provider-awscc/src/provider/normalizer.rs
+++ b/carina-provider-awscc/src/provider/normalizer.rs
@@ -6,7 +6,7 @@
 use indexmap::IndexMap;
 use std::collections::HashMap;
 
-use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
 use carina_core::schema::{AttributeType, StructField};
 
 /// Resolve enum identifiers in resources to their fully-qualified DSL format.
@@ -14,7 +14,7 @@ use carina_core::schema::{AttributeType, StructField};
 /// For each awscc resource, looks up the schema and resolves bare identifiers
 /// (e.g., `advanced`) or TypeName.value identifiers (e.g., `Tier.advanced`)
 /// into fully-qualified namespaced strings (e.g., `awscc.ec2.Ipam.Tier.advanced`).
-pub fn resolve_enum_identifiers_impl(resources: &mut [Resource]) {
+pub fn resolve_enum_identifiers_impl(resources: &mut [ManagedResource]) {
     for resource in resources.iter_mut() {
         // Only handle awscc resources
         if resource.id.provider != "awscc" {
@@ -274,7 +274,7 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_bare_ident() {
-        let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "test", None);
+        let mut resource = ManagedResource::with_provider("awscc", "ec2.Vpc", "test", None);
         resource.set_attr(
             "instance_tenancy".to_string(),
             Value::Concrete(ConcreteValue::String("dedicated".to_string())),
@@ -294,7 +294,7 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_typename_value() {
-        let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "test", None);
+        let mut resource = ManagedResource::with_provider("awscc", "ec2.Vpc", "test", None);
         resource.set_attr(
             "instance_tenancy".to_string(),
             Value::Concrete(ConcreteValue::String(
@@ -316,7 +316,7 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_skips_non_awscc() {
-        let mut resource = Resource::with_provider("aws", "s3.Bucket", "test", None);
+        let mut resource = ManagedResource::with_provider("aws", "s3.Bucket", "test", None);
         resource.set_attr(
             "instance_tenancy".to_string(),
             Value::Concrete(ConcreteValue::String("dedicated".to_string())),
@@ -364,7 +364,7 @@ mod tests {
                 ConcreteValue::Map(stmt),
             )])),
         );
-        let mut resource = Resource::with_provider("awscc", "iam.Role", "rd-role", None);
+        let mut resource = ManagedResource::with_provider("awscc", "iam.Role", "rd-role", None);
         resource.set_attr(
             "assume_role_policy_document".to_string(),
             Value::Concrete(ConcreteValue::Map(policy)),
@@ -396,7 +396,7 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_hyphen_to_underscore() {
-        let mut resource = Resource::with_provider("awscc", "ec2.FlowLog", "test", None);
+        let mut resource = ManagedResource::with_provider("awscc", "ec2.FlowLog", "test", None);
         resource.set_attr(
             "log_destination_type".to_string(),
             Value::Concrete(ConcreteValue::String("cloud_watch_logs".to_string())),
@@ -418,7 +418,7 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_hyphen_string_to_underscore() {
-        let mut resource = Resource::with_provider("awscc", "ec2.FlowLog", "test", None);
+        let mut resource = ManagedResource::with_provider("awscc", "ec2.FlowLog", "test", None);
         resource.set_attr(
             "log_destination_type".to_string(),
             Value::Concrete(ConcreteValue::String("cloud-watch-logs".to_string())),
@@ -555,7 +555,7 @@ mod tests {
     #[test]
     fn test_resolve_enum_identifiers_ip_protocol_all_alias() {
         let mut resource =
-            Resource::with_provider("awscc", "ec2.SecurityGroupEgress", "test", None);
+            ManagedResource::with_provider("awscc", "ec2.SecurityGroupEgress", "test", None);
         resource.set_attr(
             "ip_protocol".to_string(),
             Value::Concrete(ConcreteValue::String("all".to_string())),
@@ -578,7 +578,7 @@ mod tests {
     #[test]
     fn test_resolve_enum_identifiers_ip_protocol_tcp() {
         let mut resource =
-            Resource::with_provider("awscc", "ec2.SecurityGroupEgress", "test", None);
+            ManagedResource::with_provider("awscc", "ec2.SecurityGroupEgress", "test", None);
         resource.set_attr(
             "ip_protocol".to_string(),
             Value::Concrete(ConcreteValue::String("tcp".to_string())),
@@ -718,7 +718,8 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_impl_struct_field() {
-        let mut resource = Resource::with_provider("awscc", "ec2.SecurityGroup", "test-sg", None);
+        let mut resource =
+            ManagedResource::with_provider("awscc", "ec2.SecurityGroup", "test-sg", None);
         resource.set_attr(
             "group_description".to_string(),
             Value::Concrete(ConcreteValue::String("test".to_string())),

--- a/carina-provider-awscc/src/provider/operations.rs
+++ b/carina-provider-awscc/src/provider/operations.rs
@@ -7,7 +7,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult, UpdatePatch};
-use carina_core::resource::{ConcreteValue, Directives, Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Directives, ManagedResource, ResourceId, State, Value};
 use carina_core::schema::{AttributeSchema, AttributeType};
 use indexmap::IndexMap;
 use serde_json::json;
@@ -72,7 +72,7 @@ impl AwsccProvider {
     }
 
     /// Create a resource using its configuration
-    pub async fn create_resource(&self, resource: Resource) -> ProviderResult<State> {
+    pub async fn create_resource(&self, resource: ManagedResource) -> ProviderResult<State> {
         let config = get_schema_config(&resource.id.resource_type).ok_or_else(|| {
             ProviderError::internal(format!(
                 "Unknown resource type: {}",
@@ -199,7 +199,7 @@ impl AwsccProvider {
         // patch we just applied). This is the source of values to carry
         // forward for attributes CloudControl's read does not return —
         // same logic as `create_resource` but built without a `to:
-        // Resource` (which Level 3 deliberately does not pass through).
+        // ManagedResource` (which Level 3 deliberately does not pass through).
         let desired = post_update_attributes(from, patch);
         for dsl_name in config.schema.attributes.keys() {
             if !state.attributes.contains_key(dsl_name)
@@ -314,8 +314,8 @@ fn map_aws_props_to_attributes(
 ///
 /// Used by `update_resource` to know which attributes to carry forward
 /// when CloudControl's read response omits them. The map is the same
-/// logical shape as the old `to: Resource.attributes`, but built
-/// without exposing a full `Resource` to the update path.
+/// logical shape as the old `to: ManagedResource.attributes`, but built
+/// without exposing a full `ManagedResource` to the update path.
 fn post_update_attributes(
     from: &State,
     patch: &UpdatePatch,

--- a/carina-provider-awscc/src/provider/special_cases.rs
+++ b/carina-provider-awscc/src/provider/special_cases.rs
@@ -1,4 +1,4 @@
-//! Resource-type-specific special case handlers.
+//! ManagedResource-type-specific special case handlers.
 //!
 //! Some AWS resource types require non-standard attribute handling that falls
 //! outside the generic schema-driven mapping. This module centralizes those
@@ -7,7 +7,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{ConcreteValue, Resource, ResourceId, Value};
+use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, Value};
 use serde_json::json;
 
 use super::AwsccProvider;
@@ -59,7 +59,7 @@ impl AwsccProvider {
     /// Handle special attributes for create
     pub(crate) fn create_special_attributes(
         &self,
-        _resource: &Resource,
+        _resource: &ManagedResource,
         _desired_state: &mut serde_json::Map<String, serde_json::Value>,
     ) {
     }


### PR DESCRIPTION
## Summary

carina#3181 (PR carina-rs/carina#3200) deleted the `kind` discriminant from carina-core: the legacy `Resource` type was renamed `ManagedResource`, and a separate `DataSource` type now models `read`-keyword resources. `Provider::read_data_source` consequently takes `&DataSource`.

- Bump `carina-core` / `carina-plugin-sdk` / `carina-provider-protocol` pins from `5c661f78` to `055a4128`.
- Rename `carina_core::resource::Resource` → `ManagedResource` across the provider. The WIT-boundary `carina_provider_protocol::types::Resource` is a separate type and is left unchanged.
- `Provider::read_data_source` now takes `&DataSource`. Adds `convert::proto_to_core_data_source` to project the WIT `Resource` record into a core `DataSource`.

The pin bump also pulls in other unrelated carina-core commits since `5c661f78`; no provider behavior change beyond the typestate adoption.

## Test plan

- [x] `cargo test` — 196 passed
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo build -p carina-provider-awscc --target wasm32-wasip2 --release` — clean
- [x] `scripts/check-carina-pin.sh` — all 4 pins on 055a4128
- [x] `scripts/check-docs-drift.sh` — schemas and docs in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)