### PR TITLE
Fix effect field to use enum identifier in acceptance test fixtures

### DIFF
--- a/acceptance-tests/ec2_vpc_endpoint/gateway.crn
+++ b/acceptance-tests/ec2_vpc_endpoint/gateway.crn
@@ -23,7 +23,7 @@ awscc.ec2.VpcEndpoint {
   policy_document = {
     version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect    = 'Allow'
+      effect    = aws.iam.PolicyDocument.Effect.allow
       principal = '*'
       action    = 's3:GetObject'
       resource  = 'arn:aws:s3:::*'

--- a/acceptance-tests/iam_role/with_policy.crn
+++ b/acceptance-tests/iam_role/with_policy.crn
@@ -31,7 +31,7 @@ awscc.iam.Role {
     policy_document = {
       version = aws.iam.PolicyDocument.Version.2012_10_17
       statement {
-        effect   = 'Allow'
+        effect   = aws.iam.PolicyDocument.Effect.allow
         action   = 'logs:CreateLogGroup'
         resource = '*'
       }


### PR DESCRIPTION
## Summary

- Fix `ec2_vpc_endpoint/gateway.crn` and `iam_role/with_policy.crn` to use the enum identifier `aws.iam.PolicyDocument.Effect.allow` for the `effect` field instead of the string literal `'Allow'`.

The `effect` field is a typed enum (`aws.iam.PolicyDocument.Effect`); the string literal was rejected by the schema during `apply`. Both files already used the correct enum identifier form in their `assume_role_policy_document` blocks — this aligns the inline `policy_document` statements with that existing convention.

## Test plan

- [x] `carina validate` passes for both fixtures (failed before the fix)
- [ ] `acceptance-tests/run-tests.sh full` — `ec2_vpc_endpoint/gateway` and `iam_role/with_policy` apply succeeds

Closes #263