### PR TITLE
Fix FlowLog resource_type shadowed by let vpc binding in acceptance fixtures

### DIFF
--- a/acceptance-tests/ec2_flow_log/cloudwatch.crn
+++ b/acceptance-tests/ec2_flow_log/cloudwatch.crn
@@ -35,7 +35,7 @@ let flow_log_role = awscc.iam.Role {
 
 awscc.ec2.FlowLog {
   resource_id                 = vpc.vpc_id
-  resource_type               = vpc
+  resource_type               = awscc.ec2.FlowLog.ResourceType.vpc
   traffic_type                = all
   log_destination_type        = cloud_watch_logs
   log_group_name              = log_group.log_group_name

--- a/acceptance-tests/ec2_flow_log/s3.crn
+++ b/acceptance-tests/ec2_flow_log/s3.crn
@@ -19,7 +19,7 @@ let bucket = awscc.s3.Bucket {
 
 awscc.ec2.FlowLog {
   resource_id          = vpc.vpc_id
-  resource_type        = vpc
+  resource_type        = awscc.ec2.FlowLog.ResourceType.vpc
   traffic_type         = all
   log_destination_type = s3
   log_destination      = bucket.arn


### PR DESCRIPTION
## Summary

- Fix `ec2_flow_log/cloudwatch.crn` and `ec2_flow_log/s3.crn` to use the fully-qualified enum identifier `awscc.ec2.FlowLog.ResourceType.vpc` for `resource_type`.

Both fixtures bind `let vpc = awscc.ec2.Vpc { ... }` and then wrote `resource_type = vpc`. The bare `vpc` identifier resolved to the resource binding (interpolated as `"${vpc}"`) instead of the `ResourceType` enum value, so `apply` failed with `'resource_type' (ResourceType) expects an enum identifier, got a string literal "${vpc}"`.

## Test plan

- [x] `carina validate` passes for both fixtures (failed before the fix)
- [ ] `acceptance-tests/run-tests.sh full` — `ec2_flow_log/cloudwatch` and `ec2_flow_log/s3` apply succeeds

Closes #216