### PR TITLE
aws-types: migrate to structured TypeIdentity (S4 of carina#2807)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=055a4128#055a4128df15ed880735130bb0e6da95cdeac9ea"
+source = "git+https://github.com/carina-rs/carina?rev=a5f54215#a5f54215d3e481869b8d44e7d42849d18aaa1f84"
 dependencies = [
  "argon2",
  "futures",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=055a4128#055a4128df15ed880735130bb0e6da95cdeac9ea"
+source = "git+https://github.com/carina-rs/carina?rev=a5f54215#a5f54215d3e481869b8d44e7d42849d18aaa1f84"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -580,7 +580,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=055a4128#055a4128df15ed880735130bb0e6da95cdeac9ea"
+source = "git+https://github.com/carina-rs/carina?rev=a5f54215#a5f54215d3e481869b8d44e7d42849d18aaa1f84"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "055a4128" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "a5f54215" }

--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -5,7 +5,30 @@
 //! schema config structs) remain in their respective crates.
 
 use carina_core::resource::{ConcreteValue, Value};
-use carina_core::schema::{AttributeType, CompletionValue, StructField, legacy_validator};
+use carina_core::schema::{
+    AttributeType, CompletionValue, StructField, TypeIdentity, legacy_validator,
+};
+
+/// Structured identity for an AWS resource-scoped custom type.
+///
+/// `service` + `resource` become the namespace segments and `kind` the
+/// reference-kind tail, yielding `aws.<service>.<Resource>.<kind>` —
+/// e.g. `aws.ec2.Vpc.Id`, `aws.iam.Role.Arn`. The provider axis keeps
+/// the type distinct from any same-named type a future non-AWS
+/// provider might define; the service/resource axis distinguishes
+/// `aws.iam.Role.Arn` from `aws.acm.Certificate.Arn`.
+fn aws_type(service: &str, resource: &str, kind: &str) -> TypeIdentity {
+    TypeIdentity::new(Some("aws"), [service, resource], kind)
+}
+
+/// Structured identity for an AWS custom type with no service axis.
+///
+/// Used for `AvailabilityZone` (a cross-service concept) and for the
+/// fully-generic provider-scoped types (`aws.Arn`, `aws.ResourceId`,
+/// `aws.AccountId`), which pass an empty `segments` slice.
+fn aws_bare_type(segments: &[&str], kind: &str) -> TypeIdentity {
+    TypeIdentity::new(Some("aws"), segments.iter().copied(), kind)
+}
 
 // ========== Enum helpers ==========
 
@@ -222,7 +245,7 @@ pub fn validate_prefixed_resource_id(id: &str, expected_prefix: &str) -> Result<
 #[allow(dead_code)]
 pub fn aws_resource_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("AwsResourceId".to_string()),
+        identity: Some(aws_bare_type(&[], "ResourceId")),
         pattern: None,
         length: None,
         base: Box::new(AttributeType::String),
@@ -242,7 +265,7 @@ pub fn aws_resource_id() -> AttributeType {
 /// VPC ID type (e.g., "vpc-1a2b3c4d")
 pub fn vpc_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("VpcId".to_string()),
+        identity: Some(aws_type("ec2", "Vpc", "Id")),
         pattern: None,
         length: None,
         base: Box::new(aws_resource_id()),
@@ -262,7 +285,7 @@ pub fn vpc_id() -> AttributeType {
 /// Subnet ID type (e.g., "subnet-0123456789abcdef0")
 pub fn subnet_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("SubnetId".to_string()),
+        identity: Some(aws_type("ec2", "Subnet", "Id")),
         pattern: None,
         length: None,
         base: Box::new(aws_resource_id()),
@@ -282,7 +305,7 @@ pub fn subnet_id() -> AttributeType {
 /// Security Group ID type (e.g., "sg-12345678")
 pub fn security_group_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("SecurityGroupId".to_string()),
+        identity: Some(aws_type("ec2", "SecurityGroup", "Id")),
         pattern: None,
         length: None,
         base: Box::new(aws_resource_id()),
@@ -302,7 +325,7 @@ pub fn security_group_id() -> AttributeType {
 /// Internet Gateway ID type (e.g., "igw-12345678")
 pub fn internet_gateway_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("InternetGatewayId".to_string()),
+        identity: Some(aws_type("ec2", "InternetGateway", "Id")),
         pattern: None,
         length: None,
         base: Box::new(aws_resource_id()),
@@ -322,7 +345,7 @@ pub fn internet_gateway_id() -> AttributeType {
 /// Route Table ID type (e.g., "rtb-abcdef12")
 pub fn route_table_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("RouteTableId".to_string()),
+        identity: Some(aws_type("ec2", "RouteTable", "Id")),
         pattern: None,
         length: None,
         base: Box::new(aws_resource_id()),
@@ -342,7 +365,7 @@ pub fn route_table_id() -> AttributeType {
 /// NAT Gateway ID type (e.g., "nat-12345678")
 pub fn nat_gateway_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("NatGatewayId".to_string()),
+        identity: Some(aws_type("ec2", "NatGateway", "Id")),
         pattern: None,
         length: None,
         base: Box::new(aws_resource_id()),
@@ -362,7 +385,7 @@ pub fn nat_gateway_id() -> AttributeType {
 /// VPC Peering Connection ID type (e.g., "pcx-12345678")
 pub fn vpc_peering_connection_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("VpcPeeringConnectionId".to_string()),
+        identity: Some(aws_type("ec2", "VpcPeeringConnection", "Id")),
         pattern: None,
         length: None,
         base: Box::new(aws_resource_id()),
@@ -383,7 +406,7 @@ pub fn vpc_peering_connection_id() -> AttributeType {
 /// Transit Gateway ID type (e.g., "tgw-12345678")
 pub fn transit_gateway_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("TransitGatewayId".to_string()),
+        identity: Some(aws_type("ec2", "TransitGateway", "Id")),
         pattern: None,
         length: None,
         base: Box::new(aws_resource_id()),
@@ -403,7 +426,7 @@ pub fn transit_gateway_id() -> AttributeType {
 /// VPC CIDR Block Association ID type (e.g., "vpc-cidr-assoc-12345678")
 pub fn vpc_cidr_block_association_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("VpcCidrBlockAssociationId".to_string()),
+        identity: Some(aws_type("ec2", "VpcCidrBlockAssociation", "Id")),
         pattern: None,
         length: None,
         base: Box::new(aws_resource_id()),
@@ -424,7 +447,7 @@ pub fn vpc_cidr_block_association_id() -> AttributeType {
 /// Transit Gateway Route Table ID type (e.g., "tgw-rtb-12345678")
 pub fn tgw_route_table_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("TgwRouteTableId".to_string()),
+        identity: Some(aws_type("ec2", "TransitGatewayRouteTable", "Id")),
         pattern: None,
         length: None,
         base: Box::new(aws_resource_id()),
@@ -444,7 +467,7 @@ pub fn tgw_route_table_id() -> AttributeType {
 /// VPN Gateway ID type (e.g., "vgw-12345678")
 pub fn vpn_gateway_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("VpnGatewayId".to_string()),
+        identity: Some(aws_type("ec2", "VpnGateway", "Id")),
         pattern: None,
         length: None,
         base: Box::new(aws_resource_id()),
@@ -469,7 +492,7 @@ pub fn gateway_id() -> AttributeType {
 /// Egress Only Internet Gateway ID type (e.g., "eigw-12345678")
 pub fn egress_only_internet_gateway_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("EgressOnlyInternetGatewayId".to_string()),
+        identity: Some(aws_type("ec2", "EgressOnlyInternetGateway", "Id")),
         pattern: None,
         length: None,
         base: Box::new(aws_resource_id()),
@@ -493,7 +516,7 @@ pub fn egress_only_internet_gateway_id() -> AttributeType {
 /// VPC Endpoint ID type (e.g., "vpce-12345678")
 pub fn vpc_endpoint_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("VpcEndpointId".to_string()),
+        identity: Some(aws_type("ec2", "VpcEndpoint", "Id")),
         pattern: None,
         length: None,
         base: Box::new(aws_resource_id()),
@@ -513,7 +536,7 @@ pub fn vpc_endpoint_id() -> AttributeType {
 /// Instance ID type (e.g., "i-0123456789abcdef0")
 pub fn instance_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("InstanceId".to_string()),
+        identity: Some(aws_type("ec2", "Instance", "Id")),
         pattern: None,
         length: None,
         base: Box::new(aws_resource_id()),
@@ -533,7 +556,7 @@ pub fn instance_id() -> AttributeType {
 /// Network Interface ID type (e.g., "eni-0123456789abcdef0")
 pub fn network_interface_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("NetworkInterfaceId".to_string()),
+        identity: Some(aws_type("ec2", "NetworkInterface", "Id")),
         pattern: None,
         length: None,
         base: Box::new(aws_resource_id()),
@@ -554,7 +577,7 @@ pub fn network_interface_id() -> AttributeType {
 #[allow(dead_code)]
 pub fn allocation_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("AllocationId".to_string()),
+        identity: Some(aws_type("ec2", "Eip", "AllocationId")),
         pattern: None,
         length: None,
         base: Box::new(aws_resource_id()),
@@ -574,7 +597,7 @@ pub fn allocation_id() -> AttributeType {
 /// Prefix List ID type (e.g., "pl-0123456789abcdef0")
 pub fn prefix_list_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("PrefixListId".to_string()),
+        identity: Some(aws_type("ec2", "PrefixList", "Id")),
         pattern: None,
         length: None,
         base: Box::new(aws_resource_id()),
@@ -594,7 +617,7 @@ pub fn prefix_list_id() -> AttributeType {
 /// Carrier Gateway ID type (e.g., "cagw-0123456789abcdef0")
 pub fn carrier_gateway_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("CarrierGatewayId".to_string()),
+        identity: Some(aws_type("ec2", "CarrierGateway", "Id")),
         pattern: None,
         length: None,
         base: Box::new(aws_resource_id()),
@@ -614,7 +637,7 @@ pub fn carrier_gateway_id() -> AttributeType {
 /// Local Gateway ID type (e.g., "lgw-0123456789abcdef0")
 pub fn local_gateway_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("LocalGatewayId".to_string()),
+        identity: Some(aws_type("ec2", "LocalGateway", "Id")),
         pattern: None,
         length: None,
         base: Box::new(aws_resource_id()),
@@ -635,7 +658,7 @@ pub fn local_gateway_id() -> AttributeType {
 #[allow(dead_code)]
 pub fn network_acl_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("NetworkAclId".to_string()),
+        identity: Some(aws_type("ec2", "NetworkAcl", "Id")),
         pattern: None,
         length: None,
         base: Box::new(aws_resource_id()),
@@ -655,7 +678,7 @@ pub fn network_acl_id() -> AttributeType {
 /// Transit Gateway Attachment ID type (e.g., "tgw-attach-0123456789abcdef0")
 pub fn transit_gateway_attachment_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("TransitGatewayAttachmentId".to_string()),
+        identity: Some(aws_type("ec2", "TransitGatewayAttachment", "Id")),
         pattern: None,
         length: None,
         base: Box::new(aws_resource_id()),
@@ -676,7 +699,7 @@ pub fn transit_gateway_attachment_id() -> AttributeType {
 /// Flow Log ID type (e.g., "fl-0123456789abcdef0")
 pub fn flow_log_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("FlowLogId".to_string()),
+        identity: Some(aws_type("ec2", "FlowLog", "Id")),
         pattern: None,
         length: None,
         base: Box::new(aws_resource_id()),
@@ -696,7 +719,7 @@ pub fn flow_log_id() -> AttributeType {
 /// IPAM ID type (e.g., "ipam-0123456789abcdef0")
 pub fn ipam_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("IpamId".to_string()),
+        identity: Some(aws_type("ec2", "Ipam", "Id")),
         pattern: None,
         length: None,
         base: Box::new(aws_resource_id()),
@@ -716,7 +739,7 @@ pub fn ipam_id() -> AttributeType {
 /// Subnet Route Table Association ID type (e.g., "rtbassoc-0123456789abcdef0")
 pub fn subnet_route_table_association_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("SubnetRouteTableAssociationId".to_string()),
+        identity: Some(aws_type("ec2", "SubnetRouteTableAssociation", "Id")),
         pattern: None,
         length: None,
         base: Box::new(aws_resource_id()),
@@ -740,7 +763,7 @@ pub fn subnet_route_table_association_id() -> AttributeType {
 /// Security Group Rule ID type (e.g., "sgr-0123456789abcdef0")
 pub fn security_group_rule_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("SecurityGroupRuleId".to_string()),
+        identity: Some(aws_type("ec2", "SecurityGroupRule", "Id")),
         pattern: None,
         length: None,
         base: Box::new(aws_resource_id()),
@@ -774,7 +797,7 @@ pub fn validate_iam_role_id(id: &str) -> Result<(), String> {
 /// IAM Role ID type (e.g., "AROAEXAMPLEID")
 pub fn iam_role_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("IamRoleId".to_string()),
+        identity: Some(aws_type("iam", "Role", "Id")),
         pattern: None,
         length: None,
         base: Box::new(aws_resource_id()),
@@ -810,7 +833,7 @@ pub fn validate_aws_account_id(id: &str) -> Result<(), String> {
 /// AWS Account ID type (12-digit numeric string, e.g., "123456789012")
 pub fn aws_account_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("AwsAccountId".to_string()),
+        identity: Some(aws_bare_type(&[], "AccountId")),
         pattern: None,
         length: None,
         base: Box::new(AttributeType::String),
@@ -845,7 +868,7 @@ pub fn validate_sso_principal_id(id: &str) -> Result<(), String> {
 /// SSO PrincipalId type (user or group id from IdentityStore).
 pub fn sso_principal_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("SsoPrincipalId".to_string()),
+        identity: Some(aws_type("sso", "Principal", "Id")),
         pattern: None,
         length: None,
         base: Box::new(AttributeType::String),
@@ -881,7 +904,7 @@ pub fn validate_sso_instance_arn(arn: &str) -> Result<(), String> {
 /// SSO Instance ARN type (e.g., "arn:aws:sso:::instance/ssoins-xxxxxxxx").
 pub fn sso_instance_arn() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("SsoInstanceArn".to_string()),
+        identity: Some(aws_type("sso", "Instance", "Arn")),
         pattern: None,
         length: None,
         base: Box::new(arn()),
@@ -918,7 +941,7 @@ pub fn validate_identity_store_id(id: &str) -> Result<(), String> {
 /// IdentityStore identity store id (`d-...` or UUID).
 pub fn identity_store_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("IdentityStoreId".to_string()),
+        identity: Some(aws_type("identitystore", "Store", "Id")),
         pattern: None,
         length: None,
         base: Box::new(AttributeType::String),
@@ -951,7 +974,7 @@ pub fn validate_sso_permission_set_arn(arn: &str) -> Result<(), String> {
 /// SSO PermissionSet ARN type.
 pub fn sso_permission_set_arn() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("SsoPermissionSetArn".to_string()),
+        identity: Some(aws_type("sso", "PermissionSet", "Arn")),
         pattern: None,
         length: None,
         base: Box::new(arn()),
@@ -1090,7 +1113,7 @@ pub fn validate_iam_arn(arn: &str, resource_prefix: &str) -> Result<(), String> 
 /// ARN type (e.g., "arn:aws:s3:::my-bucket")
 pub fn arn() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("Arn".to_string()),
+        identity: Some(aws_bare_type(&[], "Arn")),
         pattern: None,
         length: None,
         base: Box::new(AttributeType::String),
@@ -1110,7 +1133,7 @@ pub fn arn() -> AttributeType {
 #[allow(dead_code)]
 pub fn iam_role_arn() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("IamRoleArn".to_string()),
+        identity: Some(aws_type("iam", "Role", "Arn")),
         pattern: None,
         length: None,
         base: Box::new(arn()),
@@ -1131,7 +1154,7 @@ pub fn iam_role_arn() -> AttributeType {
 #[allow(dead_code)]
 pub fn iam_policy_arn() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("IamPolicyArn".to_string()),
+        identity: Some(aws_type("iam", "Policy", "Arn")),
         pattern: None,
         length: None,
         base: Box::new(arn()),
@@ -1152,7 +1175,7 @@ pub fn iam_policy_arn() -> AttributeType {
 #[allow(dead_code)]
 pub fn iam_oidc_provider_arn() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("IamOidcProviderArn".to_string()),
+        identity: Some(aws_type("iam", "OidcProvider", "Arn")),
         pattern: None,
         length: None,
         base: Box::new(arn()),
@@ -1173,7 +1196,7 @@ pub fn iam_oidc_provider_arn() -> AttributeType {
 #[allow(dead_code)]
 pub fn kms_key_arn() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("KmsKeyArn".to_string()),
+        identity: Some(aws_type("kms", "Key", "Arn")),
         pattern: None,
         length: None,
         base: Box::new(arn()),
@@ -1243,7 +1266,7 @@ pub fn validate_kms_key_id(value: &str) -> Result<(), String> {
 #[allow(dead_code)]
 pub fn kms_key_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("KmsKeyId".to_string()),
+        identity: Some(aws_type("kms", "Key", "Id")),
         pattern: None,
         length: None,
         base: Box::new(aws_resource_id()),
@@ -1279,7 +1302,7 @@ pub fn validate_ipam_pool_id(id: &str) -> Result<(), String> {
 /// IPAM Pool ID type (e.g., "ipam-pool-0123456789abcdef0")
 pub fn ipam_pool_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("IpamPoolId".to_string()),
+        identity: Some(aws_type("ec2", "IpamPool", "Id")),
         pattern: None,
         length: None,
         base: Box::new(aws_resource_id()),
@@ -1388,7 +1411,7 @@ pub fn validate_availability_zone_id(az_id: &str) -> Result<(), String> {
 /// Availability Zone ID type (e.g., "use1-az1", "usw2-az2", "apne1-az4")
 pub fn availability_zone_id() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("AvailabilityZoneId".to_string()),
+        identity: Some(aws_bare_type(&["AvailabilityZone"], "ZoneId")),
         pattern: None,
         length: None,
         base: Box::new(AttributeType::String),
@@ -2493,11 +2516,14 @@ mod tests {
     // --- IAM OIDC Provider ARN tests ---
 
     #[test]
-    fn iam_oidc_provider_arn_semantic_name() {
-        let AttributeType::Custom { semantic_name, .. } = iam_oidc_provider_arn() else {
+    fn iam_oidc_provider_arn_identity() {
+        let AttributeType::Custom { identity, .. } = iam_oidc_provider_arn() else {
             panic!("iam_oidc_provider_arn() should be a Custom type");
         };
-        assert_eq!(semantic_name.as_deref(), Some("IamOidcProviderArn"));
+        assert_eq!(
+            identity.map(|id| id.to_string()).as_deref(),
+            Some("aws.iam.OidcProvider.Arn")
+        );
     }
 
     #[test]

--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -23,10 +23,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "055a4128" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "a5f54215" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "055a4128" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "055a4128" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "a5f54215" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "a5f54215" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }

--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -4153,7 +4153,7 @@ fn cfn_type_to_carina_type_with_enum(
                     return (
                         format!(
                             r#"AttributeType::Custom {{
-                semantic_name: None,
+                identity: None,
                 pattern: {},
                 length: {},
                 base: Box::new(AttributeType::String),
@@ -4192,7 +4192,7 @@ fn cfn_type_to_carina_type_with_enum(
             return (
                 format!(
                     r#"AttributeType::Custom {{
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: None,
                 base: Box::new(AttributeType::Int),
@@ -4286,7 +4286,7 @@ fn cfn_type_to_carina_type_with_enum(
                 return (
                     format!(
                         r#"AttributeType::Custom {{
-                semantic_name: None,
+                identity: None,
                 pattern: {},
                 length: {},
                 base: Box::new(AttributeType::String),
@@ -4324,7 +4324,7 @@ fn cfn_type_to_carina_type_with_enum(
                 return (
                     format!(
                         r#"AttributeType::Custom {{
-                semantic_name: None,
+                identity: None,
                 pattern: {},
                 length: {},
                 base: Box::new(AttributeType::String),
@@ -4342,7 +4342,7 @@ fn cfn_type_to_carina_type_with_enum(
             if prop.format.is_some() {
                 return (
                     r#"AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: None,
                 base: Box::new(AttributeType::String),
@@ -4363,7 +4363,7 @@ fn cfn_type_to_carina_type_with_enum(
                 return (
                     format!(
                         r#"AttributeType::Custom {{
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: {},
                 base: Box::new(AttributeType::String),
@@ -4389,7 +4389,7 @@ fn cfn_type_to_carina_type_with_enum(
                 return (
                     format!(
                         r#"AttributeType::Custom {{
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: None,
                 base: Box::new(AttributeType::Int),
@@ -4407,7 +4407,7 @@ fn cfn_type_to_carina_type_with_enum(
                 return (
                     format!(
                         r#"AttributeType::Custom {{
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: None,
                 base: Box::new(AttributeType::Int),
@@ -4435,7 +4435,7 @@ fn cfn_type_to_carina_type_with_enum(
                 (
                     format!(
                         r#"AttributeType::Custom {{
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: None,
                 base: Box::new(AttributeType::Int),
@@ -4451,7 +4451,7 @@ fn cfn_type_to_carina_type_with_enum(
                 // Format-only integer (e.g., int64) - informational, no range validation
                 (
                     r#"AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: None,
                 base: Box::new(AttributeType::Int),
@@ -4475,7 +4475,7 @@ fn cfn_type_to_carina_type_with_enum(
                 return (
                     format!(
                         r#"AttributeType::Custom {{
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: None,
                 base: Box::new(AttributeType::Float),
@@ -4503,7 +4503,7 @@ fn cfn_type_to_carina_type_with_enum(
                 (
                     format!(
                         r#"AttributeType::Custom {{
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: None,
                 base: Box::new(AttributeType::Float),
@@ -4519,7 +4519,7 @@ fn cfn_type_to_carina_type_with_enum(
                 // Format-only float (e.g., double) - informational, no range validation
                 (
                     r#"AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: None,
                 base: Box::new(AttributeType::Float),
@@ -4580,7 +4580,7 @@ fn cfn_type_to_carina_type_with_enum(
                 (
                     format!(
                         r#"AttributeType::Custom {{
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: None,
                 base: Box::new({}),

--- a/carina-provider-awscc/src/convert.rs
+++ b/carina-provider-awscc/src/convert.rs
@@ -254,10 +254,10 @@ fn proto_to_core_attribute_type(t: &ProtoAttributeType) -> CoreAttributeType {
             base,
             namespace,
         } => CoreAttributeType::Custom {
-            semantic_name: if name.is_empty() {
+            identity: if name.is_empty() {
                 None
             } else {
-                Some(name.clone())
+                Some(carina_core::schema::TypeIdentity::from_dotted(name))
             },
             pattern: None,
             length: None,
@@ -377,12 +377,18 @@ fn core_to_proto_attribute_type(t: &CoreAttributeType) -> ProtoAttributeType {
             fields: fields.iter().map(core_to_proto_struct_field).collect(),
         },
         CoreAttributeType::Custom {
-            semantic_name,
+            identity,
             base,
             namespace,
             ..
         } => ProtoAttributeType::Custom {
-            name: semantic_name.clone().unwrap_or_default(),
+            // Serialize the structured identity to its dotted display
+            // form for the JSON wire; the host parses it back via
+            // `TypeIdentity::from_dotted`.
+            name: identity
+                .as_ref()
+                .map(|id| id.to_string())
+                .unwrap_or_default(),
             base: Box::new(core_to_proto_attribute_type(base)),
             namespace: namespace.clone(),
         },

--- a/carina-provider-awscc/src/lib.rs
+++ b/carina-provider-awscc/src/lib.rs
@@ -150,12 +150,21 @@ impl ProviderFactory for AwsccProviderFactory {
         Ok(())
     }
 
-    fn validate_custom_type(&self, type_name: &str, value: &str) -> Result<(), String> {
+    fn validate_custom_type(
+        &self,
+        identity: &carina_core::schema::TypeIdentity,
+        value: &str,
+    ) -> Result<(), String> {
         use carina_core::parser::ValidatorFn;
         use std::sync::OnceLock;
         static VALIDATORS: OnceLock<HashMap<String, ValidatorFn>> = OnceLock::new();
         let validators = VALIDATORS.get_or_init(schemas::awscc_types::awscc_validators);
-        if let Some(validator) = validators.get(type_name) {
+        // The inner map is still keyed on snake-cased semantic names —
+        // project the identity's kind through `pascal_to_snake` at this
+        // single boundary. Provider-axis collisions are already
+        // filtered by the host before the call reaches us.
+        let key = carina_core::parser::pascal_to_snake(&identity.kind);
+        if let Some(validator) = validators.get(&key) {
             validator(value)
         } else {
             Ok(())

--- a/carina-provider-awscc/src/main.rs
+++ b/carina-provider-awscc/src/main.rs
@@ -182,12 +182,20 @@ impl CarinaProvider for AwsccProcessProvider {
     // (sourced from `carina-core` schema). The host-side dispatch
     // table this method used to feed has been removed.
 
-    fn validate_custom_type(&self, type_name: &str, value: &str) -> Result<(), String> {
+    fn validate_custom_type(
+        &self,
+        identity: &carina_plugin_sdk::types::TypeIdentity,
+        value: &str,
+    ) -> Result<(), String> {
         use carina_core::parser::ValidatorFn;
         use std::sync::OnceLock;
         static VALIDATORS: OnceLock<HashMap<String, ValidatorFn>> = OnceLock::new();
         let validators = VALIDATORS.get_or_init(schemas::awscc_types::awscc_validators);
-        if let Some(validator) = validators.get(type_name) {
+        // Inner map is still snake-cased; project the kind once at the
+        // boundary. Provider-axis collisions are filtered by the host
+        // before the call reaches us.
+        let key = carina_core::parser::pascal_to_snake(&identity.kind);
+        if let Some(validator) = validators.get(&key) {
             validator(value)
         } else {
             Ok(())

--- a/carina-provider-awscc/src/provider/conversion.rs
+++ b/carina-provider-awscc/src/provider/conversion.rs
@@ -747,7 +747,11 @@ mod tests {
     #[test]
     fn test_dsl_value_to_aws_converts_underscores_for_region() {
         let attr_type = AttributeType::Custom {
-            semantic_name: Some("Region".to_string()),
+            identity: Some(carina_core::schema::TypeIdentity::new(
+                Some("awscc"),
+                Vec::<String>::new(),
+                "Region",
+            )),
             pattern: None,
             length: None,
             base: Box::new(AttributeType::String),
@@ -1713,7 +1717,7 @@ mod tests {
     #[test]
     fn test_aws_value_to_dsl_custom_to_dsl_strips_trailing_dot() {
         let attr_type = AttributeType::Custom {
-            semantic_name: Some("DnsName".to_string()),
+            identity: Some(carina_core::schema::TypeIdentity::bare("DnsName")),
             pattern: None,
             length: None,
             base: Box::new(AttributeType::String),
@@ -1734,7 +1738,7 @@ mod tests {
     #[test]
     fn test_aws_value_to_dsl_custom_without_to_dsl_passes_through() {
         let attr_type = AttributeType::Custom {
-            semantic_name: Some("DnsName".to_string()),
+            identity: Some(carina_core::schema::TypeIdentity::bare("DnsName")),
             pattern: None,
             length: None,
             base: Box::new(AttributeType::String),

--- a/carina-provider-awscc/src/provider/normalizer.rs
+++ b/carina-provider-awscc/src/provider/normalizer.rs
@@ -604,7 +604,11 @@ mod tests {
             StructField::new(
                 "ip_protocol",
                 AttributeType::Custom {
-                    semantic_name: Some("IpProtocol".to_string()),
+                    identity: Some(carina_core::schema::TypeIdentity::new(
+                        Some("awscc"),
+                        ["ec2", "SecurityGroup"],
+                        "IpProtocol",
+                    )),
                     pattern: None,
                     length: None,
                     base: Box::new(AttributeType::String),

--- a/carina-provider-awscc/src/schemas/awscc_types.rs
+++ b/carina-provider-awscc/src/schemas/awscc_types.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 
 use carina_core::parser::ValidatorFn;
 use carina_core::resource::{ConcreteValue, Value};
-use carina_core::schema::{AttributeType, ResourceSchema, legacy_validator};
+use carina_core::schema::{AttributeType, ResourceSchema, TypeIdentity, legacy_validator};
 use carina_core::utils::{extract_enum_value, validate_enum_namespace};
 
 /// AWS Cloud Control schema configuration
@@ -111,7 +111,20 @@ pub(crate) fn validate_namespaced_enum(
     valid_values: &[&str],
 ) -> Result<(), String> {
     if let Value::Concrete(ConcreteValue::String(s)) = value {
-        validate_enum_namespace(s, type_name, namespace)?;
+        // Reconstruct the structured identity from the caller-supplied
+        // `(type_name, namespace)` pair: the namespace's first segment is
+        // the provider, the remainder are the service/resource segments,
+        // and the type name is the kind. Mirrors the helper used in
+        // S2.5b's test corpus.
+        let mut parts = namespace.split('.');
+        let provider = parts.next().map(String::from);
+        let segments: Vec<String> = parts.map(String::from).collect();
+        let identity = carina_core::schema::TypeIdentity {
+            provider,
+            segments,
+            kind: type_name.to_string(),
+        };
+        validate_enum_namespace(s, &identity)?;
 
         let normalized = extract_enum_value(s);
         if find_matching_enum_value(normalized, valid_values).is_some() {
@@ -131,13 +144,18 @@ pub(crate) fn validate_namespaced_enum(
 /// - Shorthand: ap_northeast_1
 pub fn awscc_region() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("Region".to_string()),
+        identity: Some(TypeIdentity::new(
+            Some("awscc"),
+            Vec::<String>::new(),
+            "Region",
+        )),
         pattern: None,
         length: None,
         base: Box::new(AttributeType::String),
         validate: legacy_validator(|value| {
             if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_enum_namespace(s, "Region", "awscc")
+                let id = TypeIdentity::new(Some("awscc"), Vec::<String>::new(), "Region");
+                validate_enum_namespace(s, &id)
                     .map_err(|reason| format!("Invalid region '{}': {}", s, reason))?;
                 let normalized = extract_enum_value(s).replace('_', "-");
                 if is_valid_region(&normalized) {
@@ -162,13 +180,18 @@ pub fn awscc_region() -> AttributeType {
 /// Validates format: region + single letter zone identifier
 pub fn availability_zone() -> AttributeType {
     AttributeType::Custom {
-        semantic_name: Some("AvailabilityZone".to_string()),
+        identity: Some(TypeIdentity::new(
+            Some("awscc"),
+            ["AvailabilityZone"],
+            "ZoneName",
+        )),
         pattern: None,
         length: None,
         base: Box::new(AttributeType::String),
         validate: legacy_validator(|value| {
             if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_enum_namespace(s, "AvailabilityZone", "awscc")
+                let id = TypeIdentity::new(Some("awscc"), ["AvailabilityZone"], "ZoneName");
+                validate_enum_namespace(s, &id)
                     .map_err(|reason| format!("Invalid availability zone '{}': {}", s, reason))?;
                 let extracted = extract_enum_value(s);
                 let normalized = extracted.replace('_', "-");
@@ -193,17 +216,19 @@ mod tests {
     #[test]
     fn validate_availability_zone_namespace_expanded() {
         let t = availability_zone();
-        // Full namespace format
+        // Full namespace format — under the structured identity the
+        // type lives at `awscc.AvailabilityZone.ZoneName`, so the value
+        // form carries the kind segment as well.
         assert!(
             t.validate(&Value::Concrete(ConcreteValue::String(
-                "awscc.AvailabilityZone.us_east_1a".to_string()
+                "awscc.AvailabilityZone.ZoneName.us_east_1a".to_string()
             )))
             .is_ok()
         );
-        // Type.value format
+        // 2-part shorthand: TypeName matches the identity's kind.
         assert!(
             t.validate(&Value::Concrete(ConcreteValue::String(
-                "AvailabilityZone.us_east_1a".to_string()
+                "ZoneName.us_east_1a".to_string()
             )))
             .is_ok()
         );

--- a/carina-provider-awscc/src/schemas/generated/ec2/flow_log.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/flow_log.rs
@@ -113,7 +113,7 @@ pub fn ec2_flow_log_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("max_aggregation_interval", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: None,
                 base: Box::new(AttributeType::Int),

--- a/carina-provider-awscc/src/schemas/generated/ec2/ipam.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/ipam.rs
@@ -73,7 +73,7 @@ pub fn ec2_ipam_config() -> AwsccSchemaConfig {
                     name: "IpamOrganizationalUnitExclusion".to_string(),
                     fields: vec![
                     StructField::new("organizations_entity_path", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: Some((Some(1), None)),
                 base: Box::new(AttributeType::String),
@@ -131,7 +131,7 @@ pub fn ec2_ipam_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("public_default_scope_id", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: Some((None, Some(255))),
                 base: Box::new(AttributeType::String),

--- a/carina-provider-awscc/src/schemas/generated/ec2/nat_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/nat_gateway.rs
@@ -127,7 +127,7 @@ pub fn ec2_nat_gateway_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("secondary_private_ip_address_count", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: None,
                 base: Box::new(AttributeType::Int),

--- a/carina-provider-awscc/src/schemas/generated/ec2/security_group.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/security_group.rs
@@ -83,7 +83,7 @@ pub fn ec2_security_group_config() -> AwsccSchemaConfig {
                     StructField::new("destination_prefix_list_id", super::prefix_list_id()).with_provider_name("DestinationPrefixListId"),
                     StructField::new("destination_security_group_id", super::security_group_id()).with_provider_name("DestinationSecurityGroupId"),
                     StructField::new("from_port", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: None,
                 base: Box::new(AttributeType::Int),
@@ -98,7 +98,7 @@ pub fn ec2_security_group_config() -> AwsccSchemaConfig {
                 dsl_aliases: vec![("tcp".to_string(), "tcp".to_string()), ("udp".to_string(), "udp".to_string()), ("icmp".to_string(), "icmp".to_string()), ("icmpv6".to_string(), "icmpv6".to_string()), ("-1".to_string(), "all".to_string()), ("all".to_string(), "all".to_string())],
             }).required().with_provider_name("IpProtocol"),
                     StructField::new("to_port", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: None,
                 base: Box::new(AttributeType::Int),
@@ -120,7 +120,7 @@ pub fn ec2_security_group_config() -> AwsccSchemaConfig {
                     StructField::new("cidr_ipv6", types::ipv6_cidr()).with_provider_name("CidrIpv6"),
                     StructField::new("description", AttributeType::String).with_provider_name("Description"),
                     StructField::new("from_port", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: None,
                 base: Box::new(AttributeType::Int),
@@ -139,7 +139,7 @@ pub fn ec2_security_group_config() -> AwsccSchemaConfig {
                     StructField::new("source_security_group_name", AttributeType::String).with_provider_name("SourceSecurityGroupName"),
                     StructField::new("source_security_group_owner_id", super::aws_account_id()).with_provider_name("SourceSecurityGroupOwnerId"),
                     StructField::new("to_port", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: None,
                 base: Box::new(AttributeType::Int),

--- a/carina-provider-awscc/src/schemas/generated/ec2/security_group_egress.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/security_group_egress.rs
@@ -75,7 +75,7 @@ pub fn ec2_security_group_egress_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("from_port", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: None,
                 base: Box::new(AttributeType::Int),
@@ -114,7 +114,7 @@ pub fn ec2_security_group_egress_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("to_port", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: None,
                 base: Box::new(AttributeType::Int),

--- a/carina-provider-awscc/src/schemas/generated/ec2/security_group_ingress.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/security_group_ingress.rs
@@ -63,7 +63,7 @@ pub fn ec2_security_group_ingress_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("from_port", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: None,
                 base: Box::new(AttributeType::Int),
@@ -131,7 +131,7 @@ pub fn ec2_security_group_ingress_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("to_port", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: None,
                 base: Box::new(AttributeType::Int),

--- a/carina-provider-awscc/src/schemas/generated/ec2/subnet.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/subnet.rs
@@ -103,7 +103,7 @@ pub fn ec2_subnet_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("ipv4_netmask_length", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: None,
                 base: Box::new(AttributeType::Int),
@@ -142,7 +142,7 @@ pub fn ec2_subnet_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("ipv6_netmask_length", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: None,
                 base: Box::new(AttributeType::Int),

--- a/carina-provider-awscc/src/schemas/generated/ec2/transit_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/transit_gateway.rs
@@ -54,7 +54,7 @@ pub fn ec2_transit_gateway_config() -> AwsccSchemaConfig {
                 AttributeSchema::new(
                     "amazon_side_asn",
                     AttributeType::Custom {
-                        semantic_name: None,
+                        identity: None,
                         pattern: None,
                         length: None,
                         base: Box::new(AttributeType::Int),

--- a/carina-provider-awscc/src/schemas/generated/ec2/vpc.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/vpc.rs
@@ -87,7 +87,7 @@ pub fn ec2_vpc_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("ipv4_netmask_length", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: None,
                 base: Box::new(AttributeType::Int),

--- a/carina-provider-awscc/src/schemas/generated/ec2/vpc_endpoint.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/vpc_endpoint.rs
@@ -110,11 +110,11 @@ pub fn ec2_vpc_endpoint_config() -> AwsccSchemaConfig {
                 dsl_aliases: vec![("VERIFIED_DOMAINS_ONLY".to_string(), "verified_domains_only".to_string()), ("ALL_DOMAINS".to_string(), "all_domains".to_string()), ("VERIFIED_DOMAINS_AND_SPECIFIED_DOMAINS".to_string(), "verified_domains_and_specified_domains".to_string()), ("SPECIFIED_DOMAINS_ONLY".to_string(), "specified_domains_only".to_string())],
             }).with_description("The preference for which private domains have a private hosted zone created for and associated with the specified VPC. Only supported when private DNS is enabled and when the VPC endpoint type is ServiceNetwork or Resource.").with_provider_name("PrivateDnsPreference"),
                     StructField::new("private_dns_specified_domains", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: None,
                 base: Box::new(AttributeType::list(AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: Some((Some(1), Some(255))),
                 base: Box::new(AttributeType::String),

--- a/carina-provider-awscc/src/schemas/generated/ec2/vpn_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/vpn_gateway.rs
@@ -34,7 +34,7 @@ pub fn ec2_vpn_gateway_config() -> AwsccSchemaConfig {
         .with_description("Specifies a virtual private gateway. A virtual private gateway is the endpoint on the VPC side of your VPN connection. You can create a virtual private gateway before creating the VPC itself.  For more information, see [](https://docs.aws.amazon.com/vpn/latest/s2svpn/VPC_VPN.html) in the *User Guide*.")
         .attribute(
             AttributeSchema::new("amazon_side_asn", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: None,
                 base: Box::new(AttributeType::Int),

--- a/carina-provider-awscc/src/schemas/generated/iam/oidc_provider.rs
+++ b/carina-provider-awscc/src/schemas/generated/iam/oidc_provider.rs
@@ -78,7 +78,7 @@ pub fn iam_oidc_provider_config() -> AwsccSchemaConfig {
                 AttributeSchema::new(
                     "client_id_list",
                     AttributeType::unordered_list(AttributeType::Custom {
-                        semantic_name: None,
+                        identity: None,
                         pattern: None,
                         length: Some((Some(1), Some(255))),
                         base: Box::new(AttributeType::String),
@@ -94,11 +94,11 @@ pub fn iam_oidc_provider_config() -> AwsccSchemaConfig {
                 AttributeSchema::new(
                     "thumbprint_list",
                     AttributeType::Custom {
-                        semantic_name: None,
+                        identity: None,
                         pattern: None,
                         length: None,
                         base: Box::new(AttributeType::unordered_list(AttributeType::Custom {
-                            semantic_name: None,
+                            identity: None,
                             pattern: Some("[0-9A-Fa-f]{40}".to_string()),
                             length: Some((Some(40), Some(40))),
                             base: Box::new(AttributeType::String),
@@ -119,7 +119,7 @@ pub fn iam_oidc_provider_config() -> AwsccSchemaConfig {
                 AttributeSchema::new(
                     "url",
                     AttributeType::Custom {
-                        semantic_name: None,
+                        identity: None,
                         pattern: None,
                         length: Some((Some(1), Some(255))),
                         base: Box::new(AttributeType::String),

--- a/carina-provider-awscc/src/schemas/generated/iam/role.rs
+++ b/carina-provider-awscc/src/schemas/generated/iam/role.rs
@@ -56,7 +56,7 @@ pub fn iam_role_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("max_session_duration", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: None,
                 base: Box::new(AttributeType::Int),

--- a/carina-provider-awscc/src/schemas/generated/identitystore/group.rs
+++ b/carina-provider-awscc/src/schemas/generated/identitystore/group.rs
@@ -65,7 +65,7 @@ pub fn identitystore_group_config() -> AwsccSchemaConfig {
         .with_description("Resource Type definition for AWS::IdentityStore::Group")
         .attribute(
             AttributeSchema::new("description", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: Some("^[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}\\t\\n\\r  　]+$".to_string()),
                 length: Some((Some(1), Some(1024))),
                 base: Box::new(AttributeType::String),
@@ -78,7 +78,7 @@ pub fn identitystore_group_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("display_name", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: Some("^[\\p{L}\\p{M}\\p{S}\\p{N}\\p{P}\\t\\n\\r  ]+$".to_string()),
                 length: Some((Some(1), Some(1024))),
                 base: Box::new(AttributeType::String),

--- a/carina-provider-awscc/src/schemas/generated/identitystore/group_membership.rs
+++ b/carina-provider-awscc/src/schemas/generated/identitystore/group_membership.rs
@@ -60,7 +60,7 @@ pub fn identitystore_group_membership_config() -> AwsccSchemaConfig {
                     name: "MemberId".to_string(),
                     fields: vec![
                     StructField::new("user_id", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: Some("^([0-9a-f]{10}-|)[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$".to_string()),
                 length: Some((Some(1), Some(47))),
                 base: Box::new(AttributeType::String),
@@ -77,7 +77,7 @@ pub fn identitystore_group_membership_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("membership_id", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: Some("^([0-9a-f]{10}-|)[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$".to_string()),
                 length: Some((Some(1), Some(47))),
                 base: Box::new(AttributeType::String),

--- a/carina-provider-awscc/src/schemas/generated/logs/log_group.rs
+++ b/carina-provider-awscc/src/schemas/generated/logs/log_group.rs
@@ -100,7 +100,7 @@ pub fn logs_log_group_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("log_group_name", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: Some("^[.\\-_/#A-Za-z0-9]{1,512}\\Z".to_string()),
                 length: Some((Some(1), Some(512))),
                 base: Box::new(AttributeType::String),
@@ -119,7 +119,7 @@ pub fn logs_log_group_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("retention_in_days", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: None,
                 base: Box::new(AttributeType::Int),

--- a/carina-provider-awscc/src/schemas/generated/organizations/account.rs
+++ b/carina-provider-awscc/src/schemas/generated/organizations/account.rs
@@ -160,7 +160,7 @@ pub fn organizations_account_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("account_name", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: Some("[\\u0020-\\u007E]+".to_string()),
                 length: Some((Some(1), Some(50))),
                 base: Box::new(AttributeType::String),
@@ -203,7 +203,7 @@ pub fn organizations_account_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("parent_ids", AttributeType::unordered_list(AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: Some("^(r-[0-9a-z]{4,32})|(ou-[0-9a-z]{4,32}-[a-z0-9]{8,32})$".to_string()),
                 length: None,
                 base: Box::new(AttributeType::String),
@@ -216,7 +216,7 @@ pub fn organizations_account_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("paths", AttributeType::list(AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: Some("^(o-[a-z0-9]{10,32}/r-[0-9a-z]{4,32}(/ou-[0-9a-z]{4,32}-[a-z0-9]{8,32})*(/\\d{12})*)/".to_string()),
                 length: None,
                 base: Box::new(AttributeType::String),
@@ -230,7 +230,7 @@ pub fn organizations_account_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("role_name", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: Some("[\\w+=,.@-]{1,64}".to_string()),
                 length: Some((Some(1), Some(64))),
                 base: Box::new(AttributeType::String),

--- a/carina-provider-awscc/src/schemas/generated/organizations/organization.rs
+++ b/carina-provider-awscc/src/schemas/generated/organizations/organization.rs
@@ -101,7 +101,7 @@ pub fn organizations_organization_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("id", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: Some("^o-[a-z0-9]{10,32}$".to_string()),
                 length: None,
                 base: Box::new(AttributeType::String),
@@ -121,7 +121,7 @@ pub fn organizations_organization_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("management_account_email", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: Some("[^\\s@]+@[^\\s@]+\\.[^\\s@]+".to_string()),
                 length: Some((Some(6), Some(64))),
                 base: Box::new(AttributeType::String),
@@ -141,7 +141,7 @@ pub fn organizations_organization_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("root_id", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: Some("^r-[0-9a-z]{4,32}$".to_string()),
                 length: Some((None, Some(64))),
                 base: Box::new(AttributeType::String),

--- a/carina-provider-awscc/src/schemas/generated/route53/hosted_zone.rs
+++ b/carina-provider-awscc/src/schemas/generated/route53/hosted_zone.rs
@@ -63,7 +63,7 @@ pub fn route53_hosted_zone_config() -> AwsccSchemaConfig {
                     name: "HostedZoneConfig".to_string(),
                     fields: vec![
                     StructField::new("comment", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: Some((None, Some(256))),
                 base: Box::new(AttributeType::String),
@@ -91,7 +91,7 @@ pub fn route53_hosted_zone_config() -> AwsccSchemaConfig {
                     name: "HostedZoneTag".to_string(),
                     fields: vec![
                     StructField::new("key", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: Some((None, Some(128))),
                 base: Box::new(AttributeType::String),
@@ -100,7 +100,7 @@ pub fn route53_hosted_zone_config() -> AwsccSchemaConfig {
                 to_dsl: None,
             }).required().with_description("The value of ``Key`` depends on the operation that you want to perform: + *Add a tag to a health check or hosted zone*: ``Key`` is the name that you want to give the new tag. + *Edit a tag*: ``Key`` is the name of the tag that you want to change the ``Value`` for. + *Delete a key*: ``Key`` is the name of the tag you want to remove. + *Give a name to a health check*: Edit the default ``Name`` tag. In the Amazon Route 53 console, the list of your health checks includes a *Name* column that lets you see the name that you've given to each health check.").with_provider_name("Key"),
                     StructField::new("value", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: Some((None, Some(256))),
                 base: Box::new(AttributeType::String),
@@ -122,7 +122,7 @@ pub fn route53_hosted_zone_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("name", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: Some((None, Some(1024))),
                 base: Box::new(AttributeType::String),

--- a/carina-provider-awscc/src/schemas/generated/s3/bucket.rs
+++ b/carina-provider-awscc/src/schemas/generated/s3/bucket.rs
@@ -382,7 +382,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("allowed_origins", AttributeType::list(AttributeType::String)).required().with_description("One or more origins you want customers to be able to access the bucket from.").with_provider_name("AllowedOrigins"),
                     StructField::new("exposed_headers", AttributeType::list(AttributeType::String)).with_description("One or more headers in the response that you want customers to be able to access from their applications (for example, from a JavaScript ``XMLHttpRequest`` object).").with_provider_name("ExposedHeaders"),
                     StructField::new("id", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: Some((None, Some(255))),
                 base: Box::new(AttributeType::String),
@@ -391,7 +391,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 to_dsl: None,
             }).with_description("A unique identifier for this rule. The value must be no more than 255 characters.").with_provider_name("Id"),
                     StructField::new("max_age", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: None,
                 base: Box::new(AttributeType::Int),
@@ -506,7 +506,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     name: "AbortIncompleteMultipartUpload".to_string(),
                     fields: vec![
                     StructField::new("days_after_initiation", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: None,
                 base: Box::new(AttributeType::Int),
@@ -517,7 +517,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     ],
                 }).with_description("Specifies a lifecycle rule that stops incomplete multipart uploads to an Amazon S3 bucket.").with_provider_name("AbortIncompleteMultipartUpload"),
                     StructField::new("expiration_date", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: Some("^(\\d{4})-(0[0-9]|1[0-2])-([0-2]\\d|3[01])T([01]\\d|2[0-4]):([0-5]\\d):([0-6]\\d)((\\.\\d{3})?)Z$".to_string()),
                 length: None,
                 base: Box::new(AttributeType::String),
@@ -528,7 +528,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("expiration_in_days", AttributeType::Int).with_description("Indicates the number of days after creation when objects are deleted from Amazon S3 and Amazon S3 Glacier. If you specify an expiration and transition time, you must use the same time unit for both properties (either in days or by date). The expiration time must also be later than the transition time.").with_provider_name("ExpirationInDays"),
                     StructField::new("expired_object_delete_marker", AttributeType::Bool).with_description("Indicates whether Amazon S3 will remove a delete marker without any noncurrent versions. If set to true, the delete marker will be removed if there are no noncurrent versions. This cannot be specified with ``ExpirationInDays``, ``ExpirationDate``, or ``TagFilters``.").with_provider_name("ExpiredObjectDeleteMarker"),
                     StructField::new("id", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: Some((None, Some(255))),
                 base: Box::new(AttributeType::String),
@@ -571,7 +571,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     ],
                 })).with_description("For buckets with versioning enabled (or suspended), one or more transition rules that specify when non-current objects transition to a specified storage class. If you specify a transition and expiration time, the expiration time must be later than the transition time. If you specify this property, don't specify the ``NoncurrentVersionTransition`` property.").with_provider_name("NoncurrentVersionTransitions").with_block_name("noncurrent_version_transition"),
                     StructField::new("object_size_greater_than", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: Some("[0-9]+".to_string()),
                 length: Some((None, Some(20))),
                 base: Box::new(AttributeType::String),
@@ -580,7 +580,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 to_dsl: None,
             }).with_description("Specifies the minimum object size in bytes for this rule to apply to. Objects must be larger than this value in bytes. For more information about size based rules, see [Lifecycle configuration using size-based rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/lifecycle-configuration-examples.html#lc-size-rules) in the *Amazon S3 User Guide*.").with_provider_name("ObjectSizeGreaterThan"),
                     StructField::new("object_size_less_than", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: Some("[0-9]+".to_string()),
                 length: Some((None, Some(20))),
                 base: Box::new(AttributeType::String),
@@ -606,7 +606,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 dsl_aliases: vec![("DEEP_ARCHIVE".to_string(), "deep_archive".to_string()), ("GLACIER".to_string(), "glacier".to_string()), ("GLACIER_IR".to_string(), "glacier_ir".to_string()), ("INTELLIGENT_TIERING".to_string(), "intelligent_tiering".to_string()), ("ONEZONE_IA".to_string(), "onezone_ia".to_string()), ("STANDARD_IA".to_string(), "standard_ia".to_string())],
             }).required().with_description("The storage class to which you want the object to transition.").with_provider_name("StorageClass"),
                     StructField::new("transition_date", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: Some("^(\\d{4})-(0[0-9]|1[0-2])-([0-2]\\d|3[01])T([01]\\d|2[0-4]):([0-5]\\d):([0-6]\\d)((\\.\\d{3})?)Z$".to_string()),
                 length: None,
                 base: Box::new(AttributeType::String),
@@ -627,7 +627,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 dsl_aliases: vec![("DEEP_ARCHIVE".to_string(), "deep_archive".to_string()), ("GLACIER".to_string(), "glacier".to_string()), ("GLACIER_IR".to_string(), "glacier_ir".to_string()), ("INTELLIGENT_TIERING".to_string(), "intelligent_tiering".to_string()), ("ONEZONE_IA".to_string(), "onezone_ia".to_string()), ("STANDARD_IA".to_string(), "standard_ia".to_string())],
             }).required().with_description("The storage class to which you want the object to transition.").with_provider_name("StorageClass"),
                     StructField::new("transition_date", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: Some("^(\\d{4})-(0[0-9]|1[0-2])-([0-2]\\d|3[01])T([01]\\d|2[0-4]):([0-5]\\d):([0-6]\\d)((\\.\\d{3})?)Z$".to_string()),
                 length: None,
                 base: Box::new(AttributeType::String),
@@ -817,7 +817,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     name: "FilterRule".to_string(),
                     fields: vec![
                     StructField::new("name", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: Some((None, Some(1024))),
                 base: Box::new(AttributeType::String),
@@ -849,7 +849,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     name: "FilterRule".to_string(),
                     fields: vec![
                     StructField::new("name", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: Some((None, Some(1024))),
                 base: Box::new(AttributeType::String),
@@ -881,7 +881,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     name: "FilterRule".to_string(),
                     fields: vec![
                     StructField::new("name", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: Some((None, Some(1024))),
                 base: Box::new(AttributeType::String),
@@ -1081,7 +1081,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     ],
                 }).with_description("A filter that identifies the subset of objects to which the replication rule applies. A ``Filter`` must specify exactly one ``Prefix``, ``TagFilter``, or an ``And`` child element. The use of the filter field indicates that this is a V2 replication configuration. This field isn't supported in a V1 replication configuration. V1 replication configuration only supports filtering by key prefix. To filter using a V1 replication configuration, add the ``Prefix`` directly as a child element of the ``Rule`` element.").with_provider_name("Filter"),
                     StructField::new("id", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: Some((None, Some(255))),
                 base: Box::new(AttributeType::String),
@@ -1090,7 +1090,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 to_dsl: None,
             }).with_description("A unique identifier for the rule. The maximum value is 255 characters. If you don't specify a value, AWS CloudFormation generates a random ID. When using a V2 replication configuration this property is capitalized as \"ID\".").with_provider_name("Id"),
                     StructField::new("prefix", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: Some((None, Some(1024))),
                 base: Box::new(AttributeType::String),
@@ -1213,7 +1213,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("website_url", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: None,
                 base: Box::new(AttributeType::String),

--- a/carina-provider-awscc/src/schemas/generated/sso/instance.rs
+++ b/carina-provider-awscc/src/schemas/generated/sso/instance.rs
@@ -107,7 +107,7 @@ pub fn sso_instance_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("name", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: Some("^[\\w+=,.@-]+$".to_string()),
                 length: Some((Some(1), Some(32))),
                 base: Box::new(AttributeType::String),

--- a/carina-provider-awscc/src/schemas/generated/sso/permission_set.rs
+++ b/carina-provider-awscc/src/schemas/generated/sso/permission_set.rs
@@ -191,14 +191,14 @@ pub fn sso_permission_set_config() -> AwsccSchemaConfig {
         .with_description("Resource Type definition for SSO PermissionSet")
         .attribute(
             AttributeSchema::new("customer_managed_policy_references", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: None,
                 base: Box::new(AttributeType::unordered_list(AttributeType::Struct {
                     name: "CustomerManagedPolicyReference".to_string(),
                     fields: vec![
                     StructField::new("name", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: Some("[\\w+=,.@-]+".to_string()),
                 length: Some((Some(1), Some(128))),
                 base: Box::new(AttributeType::String),
@@ -207,7 +207,7 @@ pub fn sso_permission_set_config() -> AwsccSchemaConfig {
                 to_dsl: None,
             }).required().with_provider_name("Name"),
                     StructField::new("path", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: Some("((/[A-Za-z0-9\\.,\\+@=_-]+)*)/".to_string()),
                 length: Some((Some(1), Some(512))),
                 base: Box::new(AttributeType::String),
@@ -226,7 +226,7 @@ pub fn sso_permission_set_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("description", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: Some("[\\u0009\\u000A\\u000D\\u0020-\\u007E\\u00A1-\\u00FF]*".to_string()),
                 length: Some((Some(1), Some(700))),
                 base: Box::new(AttributeType::String),
@@ -251,7 +251,7 @@ pub fn sso_permission_set_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("managed_policies", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: None,
                 length: None,
                 base: Box::new(AttributeType::unordered_list(AttributeType::String)),
@@ -263,7 +263,7 @@ pub fn sso_permission_set_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("name", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: Some("[\\w+=,.@-]+".to_string()),
                 length: Some((Some(1), Some(32))),
                 base: Box::new(AttributeType::String),
@@ -290,7 +290,7 @@ pub fn sso_permission_set_config() -> AwsccSchemaConfig {
                     name: "CustomerManagedPolicyReference".to_string(),
                     fields: vec![
                     StructField::new("name", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: Some("[\\w+=,.@-]+".to_string()),
                 length: Some((Some(1), Some(128))),
                 base: Box::new(AttributeType::String),
@@ -299,7 +299,7 @@ pub fn sso_permission_set_config() -> AwsccSchemaConfig {
                 to_dsl: None,
             }).required().with_provider_name("Name"),
                     StructField::new("path", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: Some("((/[A-Za-z0-9\\.,\\+@=_-]+)*)/".to_string()),
                 length: Some((Some(1), Some(512))),
                 base: Box::new(AttributeType::String),
@@ -316,7 +316,7 @@ pub fn sso_permission_set_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("relay_state_type", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: Some("[a-zA-Z0-9&amp;$@#\\/%?=~\\-_'&quot;|!:,.;*+\\[\\]\\ \\(\\)\\{\\}]+".to_string()),
                 length: Some((Some(1), Some(240))),
                 base: Box::new(AttributeType::String),
@@ -329,7 +329,7 @@ pub fn sso_permission_set_config() -> AwsccSchemaConfig {
         )
         .attribute(
             AttributeSchema::new("session_duration", AttributeType::Custom {
-                semantic_name: None,
+                identity: None,
                 pattern: Some("^(-?)P(?=\\d|T\\d)(?:(\\d+)Y)?(?:(\\d+)M)?(?:(\\d+)([DW]))?(?:T(?:(\\d+)H)?(?:(\\d+)M)?(?:(\\d+(?:\\.\\d+)?)S)?)?$".to_string()),
                 length: Some((Some(1), Some(100))),
                 base: Box::new(AttributeType::String),


### PR DESCRIPTION
Sub-issue S4 of carina-rs/carina#2807. Migrates the awscc `carina-aws-types` copy (and the awscc provider's own `awscc_types`) from the legacy flat `semantic_name` field to the structured `TypeIdentity` introduced in carina#3056.

Depends on the carina-side chain (all merged) and S3 (aws#353, merged).

## Identity scheme

Same rules as S3 — `aws.<service>.<Resource>.<kind>` — applied to awscc's 40 shared types plus the awscc-only 5 (SSO Instance/PermissionSet/Principal, IamOidcProvider, IdentityStore):

- **EC2 IDs**: `aws.ec2.<Resource>.Id` (20+ types).
- **EIP**: `aws.ec2.Eip.AllocationId` (kind != `Id`).
- **IAM / KMS**: `aws.iam.Role.Arn`, `aws.iam.Policy.Arn`, `aws.iam.OidcProvider.Arn`, `aws.kms.Key.Arn`, `aws.kms.Key.Id`, `aws.iam.Role.Id`.
- **SSO**: `aws.sso.Instance.Arn`, `aws.sso.PermissionSet.Arn`, `aws.sso.Principal.Id`.
- **Identity Store**: `aws.identitystore.Store.Id`.
- **Cross-service**: `aws.AvailabilityZone.ZoneId` (zone id) / `awscc.AvailabilityZone.ZoneName` (zone name).
- **Provider-scoped generic**: `aws.Arn`, `aws.ResourceId`, `aws.AccountId`.

The awscc provider's own `awscc_types::awscc_region` and `availability_zone` carry **`awscc`** as the provider segment — distinct from `aws.Region` / `aws.AvailabilityZone.ZoneName`, since aws and awscc are separate providers in carina's type system.

## Provider-side adjustments

- `awscc_types::validate_enum_with_dsl_aliases` reconstructs a structured identity from the caller-supplied `(type_name, namespace)` pair before delegating to S2.5b's identity-keyed `validate_enum_namespace`.
- Codegen template (`carina-provider-awscc/src/bin/codegen.rs`) emits `identity: None`; 65+ generated schema files refresh through that path.
- `provider/conversion.rs` / `normalizer.rs` test fixtures adopt structured identities for hand-written `Custom` constructions (`Region`, `DnsName`, `IpProtocol`).
- `convert.rs` proto<->core round-trips through `TypeIdentity::from_dotted` / `Display`.
- `main.rs` and `lib.rs` impls take `&TypeIdentity` on `validate_custom_type`; the inner `awscc_validators` map stays snake-keyed, so the impl applies `pascal_to_snake(identity.kind)` at this single boundary. Migrating `awscc_validators` to structured-identity keys is S2.5c follow-up.

## Cargo deps bump

`carina-aws-types` and `carina-provider-awscc` move their `carina-core` / `carina-plugin-sdk` / `carina-provider-protocol` git revs to the S2.5b merge commit (`a5f54215`). The WIT submodule bumps to the S1 commit (`2dcc8eba`).

## Verification

- `cargo nextest run --workspace`: 490 passed.
- `cargo test --workspace --doc`, `cargo clippy --workspace --all-targets -D warnings`: green.
- `cargo build -p carina-provider-awscc --target wasm32-wasip2 --release`: green.

AvailabilityZone DSL value tests adopt `awscc.AvailabilityZone.ZoneName.<value>` to match the structured identity's dotted name space.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
