### PR TITLE
acceptance-tests: run `carina init` before `validate`

### DIFF
--- a/acceptance-tests/run-tests.sh
+++ b/acceptance-tests/run-tests.sh
@@ -993,6 +993,17 @@ for TEST_FILE in "${TESTS[@]}"; do
         cp "$INJECTED_FILE" "$VALIDATE_DIR/main.crn"
         rm -f "$INJECTED_FILE"
         TARGET_PATH="$VALIDATE_DIR"
+
+        # `carina validate` loads the provider WASM to do schema-driven
+        # validation, so the provider must be installed first. `carina init`
+        # on a file:// source does not require AWS credentials.
+        if ! INIT_OUTPUT=$("$CARINA_BIN" init "$VALIDATE_DIR" 2>&1); then
+            echo "FAIL (init)"
+            ERRORS+=("$REL_PATH: $INIT_OUTPUT")
+            FAILED=$((FAILED + 1))
+            rm -rf "$VALIDATE_DIR"
+            continue
+        fi
     fi
 
     RUN_PREFIX=""


### PR DESCRIPTION
## Summary

- Run `carina init` before `carina validate` in `acceptance-tests/run-tests.sh`.
- Was failing 100% of validate tests with `Provider 'awscc' not installed. Run carina init in <dir>` because `carina validate` loads the provider WASM for schema-driven validation, which requires the provider to be installed.
- `carina init` on a `file://` source needs no AWS credentials, so the documented "no AWS credentials needed" contract for `validate` is preserved.

## Test plan

- [x] `./acceptance-tests/run-tests.sh validate ec2_vpc/basic` → 1 passed, 0 failed
- [x] `./acceptance-tests/run-tests.sh validate` (all 54 test directories, 164 .crn files) → 54 passed, 0 failed

Closes #271
