### PR TITLE
deps: bump carina-core to 88cfdf60 + thread new error-detail fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=4cfff0e9#4cfff0e92ad8c94191748e4f15282f77dd623fcc"
+source = "git+https://github.com/carina-rs/carina?rev=88cfdf60#88cfdf60c8e168bb5cf9ac92924e03aeb5085234"
 dependencies = [
  "argon2",
  "futures",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=4cfff0e9#4cfff0e92ad8c94191748e4f15282f77dd623fcc"
+source = "git+https://github.com/carina-rs/carina?rev=88cfdf60#88cfdf60c8e168bb5cf9ac92924e03aeb5085234"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -580,7 +580,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=4cfff0e9#4cfff0e92ad8c94191748e4f15282f77dd623fcc"
+source = "git+https://github.com/carina-rs/carina?rev=88cfdf60#88cfdf60c8e168bb5cf9ac92924e03aeb5085234"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "4cfff0e9" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "88cfdf60" }

--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -23,10 +23,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "4cfff0e9" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "88cfdf60" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "4cfff0e9" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "4cfff0e9" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "88cfdf60" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "88cfdf60" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }

--- a/carina-provider-awscc/src/convert.rs
+++ b/carina-provider-awscc/src/convert.rs
@@ -521,12 +521,20 @@ pub fn core_to_proto_provider_error(e: CoreProviderError) -> ProtoProviderError 
     let cause = detail.cause.as_ref().map(|c| c.to_string());
     let provider_name = detail.provider_name.clone();
     let message = detail.message.clone();
+    let operation = detail.operation.clone();
+    let status = detail.status;
+    let code = detail.code.clone();
+    let request_id = detail.request_id.clone();
     ProtoProviderError {
         kind,
         message,
         resource_id,
         cause,
         provider_name,
+        operation,
+        status,
+        code,
+        request_id,
     }
 }
 


### PR DESCRIPTION
Cross-repo counterpart of carina-rs/carina-provider-aws#367 / #374:
bumps the carina-core pin past carina#3247 (structured AWS error
display) so awscc absorbs the new WIT `error-detail` shape and the
4 new optional fields on `ProviderError`
(`operation` / `status` / `code` / `request_id`).

Without this bump, awscc plugins built against the old carina-core
fail the WIT signature check at the host boundary when loaded by a
carina CLI built from current main — the `error-detail` record on
the host (4 new optional fields) no longer matches the plugin's
older shape.

## Changes

- `carina-aws-types` + `carina-provider-awscc` Cargo.toml: bump
  carina-core / carina-plugin-sdk / carina-provider-protocol rev
  `4cfff0e9` → `88cfdf60`.
- `carina-plugin-wit` submodule: `2dcc8eb` → `3695b68` (picks up
  carina-plugin-wit#18 — the 4 optional `error-detail` fields).
- `carina-provider-awscc/src/convert.rs`:
  `core_to_proto_provider_error` now forwards the 4 new fields
  from `ErrorDetail` to `proto::ProviderError`. Mirrors the same
  change the aws repo's `main.rs:56` made in aws#367.

awscc itself uses the AWS Cloud Control API path, so it has no
`sdk_error_message` call sites to sweep — the helper
`api_error_with_meta` stays in `carina-provider-aws` per the
provider-boundary no-dedup convention. This PR is the pure
cross-repo absorption: rev bump + WIT submodule + the convert
function update needed to satisfy the new compile-time signature.

## Verify

- `cargo nextest run --workspace --all-features` — 490 passed
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `cargo build -p carina-provider-awscc --target wasm32-wasip2 --release` — passed

Refs carina-rs/carina#3241
Refs carina-rs/carina#3242
