### PR TITLE
Bump carina pin to 83a9597b and absorb ManagedResource->Resource rename

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=88cfdf60#88cfdf60c8e168bb5cf9ac92924e03aeb5085234"
+source = "git+https://github.com/carina-rs/carina?rev=83a9597b6848a911da06eb2f19acfacab9a2813f#83a9597b6848a911da06eb2f19acfacab9a2813f"
 dependencies = [
  "argon2",
  "futures",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=88cfdf60#88cfdf60c8e168bb5cf9ac92924e03aeb5085234"
+source = "git+https://github.com/carina-rs/carina?rev=83a9597b6848a911da06eb2f19acfacab9a2813f#83a9597b6848a911da06eb2f19acfacab9a2813f"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -580,7 +580,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=88cfdf60#88cfdf60c8e168bb5cf9ac92924e03aeb5085234"
+source = "git+https://github.com/carina-rs/carina?rev=83a9597b6848a911da06eb2f19acfacab9a2813f#83a9597b6848a911da06eb2f19acfacab9a2813f"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "88cfdf60" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "83a9597b6848a911da06eb2f19acfacab9a2813f" }

--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -23,10 +23,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "88cfdf60" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "83a9597b6848a911da06eb2f19acfacab9a2813f" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "88cfdf60" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "88cfdf60" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "83a9597b6848a911da06eb2f19acfacab9a2813f" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "83a9597b6848a911da06eb2f19acfacab9a2813f" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }

--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -6577,7 +6577,7 @@ mod tests {
             handlers: BTreeMap::new(),
         };
         let enums = BTreeMap::new();
-        // ManagedResource-scoped override takes precedence over schema enum values
+        // Resource-scoped override takes precedence over schema enum values
         let result = type_display_string("RetentionInDays", &prop, &schema, &enums);
         assert_eq!(
             result,

--- a/carina-provider-awscc/src/convert.rs
+++ b/carina-provider-awscc/src/convert.rs
@@ -12,8 +12,7 @@ use carina_core::provider::{
 };
 use carina_core::resource::{
     ConcreteValue, DataSource as CoreDataSource, DeferredValue, Directives as CoreDirectives,
-    ManagedResource as CoreResource, ResourceId as CoreResourceId, State as CoreState,
-    Value as CoreValue,
+    Resource as CoreResource, ResourceId as CoreResourceId, State as CoreState, Value as CoreValue,
 };
 use carina_core::schema::{
     AttributeSchema as CoreAttributeSchema, AttributeType as CoreAttributeType,
@@ -326,7 +325,7 @@ pub fn proto_to_core_schema(s: &ProtoResourceSchema) -> CoreResourceSchema {
     use carina_core::schema::SchemaKind as CoreSchemaKind;
     use carina_provider_protocol::types::SchemaKind as ProtoSchemaKind;
     let kind = match s.kind {
-        ProtoSchemaKind::Managed => CoreSchemaKind::Managed,
+        ProtoSchemaKind::Managed => CoreSchemaKind::Resource,
         ProtoSchemaKind::DataSource => CoreSchemaKind::DataSource,
     };
     CoreResourceSchema {
@@ -451,7 +450,7 @@ pub fn core_to_proto_schema(s: &CoreResourceSchema) -> ProtoResourceSchema {
     use carina_core::schema::SchemaKind as CoreSchemaKind;
     use carina_provider_protocol::types::SchemaKind as ProtoSchemaKind;
     let kind = match s.kind {
-        CoreSchemaKind::Managed => ProtoSchemaKind::Managed,
+        CoreSchemaKind::Resource => ProtoSchemaKind::Managed,
         CoreSchemaKind::DataSource => ProtoSchemaKind::DataSource,
     };
     ProtoResourceSchema {

--- a/carina-provider-awscc/src/lib.rs
+++ b/carina-provider-awscc/src/lib.rs
@@ -24,7 +24,7 @@ use carina_core::provider::{
     ProviderNormalizer, ProviderResult, ReadRequest, SavedAttrs, UpdateRequest,
     merge_default_tags_for_provider,
 };
-use carina_core::resource::{ConcreteValue, DataSource, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, DataSource, Resource, ResourceId, State, Value};
 use carina_core::schema::SchemaRegistry;
 
 use crate::provider::AwsccProviderConfig;
@@ -41,7 +41,7 @@ impl ProviderNormalizer for AwsccNormalizer {
     // resolution, state canonicalization, attr hydration, tag merge —
     // no I/O), so wrapping the existing sync logic in a ready future is
     // sufficient; no logic change.
-    fn normalize_desired<'a>(&'a self, resources: &'a mut [ManagedResource]) -> BoxFuture<'a, ()> {
+    fn normalize_desired<'a>(&'a self, resources: &'a mut [Resource]) -> BoxFuture<'a, ()> {
         Box::pin(async move {
             crate::provider::resolve_enum_identifiers_impl(resources);
         })
@@ -73,7 +73,7 @@ impl ProviderNormalizer for AwsccNormalizer {
 
     fn merge_default_tags<'a>(
         &'a self,
-        resources: &'a mut [ManagedResource],
+        resources: &'a mut [Resource],
         default_tags: &'a IndexMap<String, Value>,
         registry: &'a SchemaRegistry,
     ) -> BoxFuture<'a, ()> {
@@ -674,7 +674,7 @@ mod tests {
         let schemas = build_schemas();
         let normalizer = AwsccNormalizer;
 
-        let mut resource = ManagedResource::with_provider("awscc", "ec2.Vpc", "test-vpc", None);
+        let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "test-vpc", None);
         resource.set_attr(
             "cidr_block".to_string(),
             Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
@@ -752,7 +752,7 @@ mod tests {
         let schemas = build_schemas();
         let normalizer = AwsccNormalizer;
 
-        let mut resource = ManagedResource::with_provider("awscc", "ec2.Vpc", "test-vpc", None);
+        let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "test-vpc", None);
         resource.set_attr(
             "cidr_block".to_string(),
             Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),
@@ -801,7 +801,7 @@ mod tests {
         let schemas = build_schemas();
         let normalizer = AwsccNormalizer;
 
-        let mut resource = ManagedResource::with_provider("awscc", "ec2.Route", "test-route", None);
+        let mut resource = Resource::with_provider("awscc", "ec2.Route", "test-route", None);
         resource.set_attr(
             "route_table_id".to_string(),
             Value::Concrete(ConcreteValue::String("rtb-123".to_string())),
@@ -827,7 +827,7 @@ mod tests {
         let schemas = build_schemas();
         let normalizer = AwsccNormalizer;
 
-        let mut resource = ManagedResource::with_provider("awscc", "ec2.Vpc", "test-vpc", None);
+        let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "test-vpc", None);
         resource.set_attr(
             "cidr_block".to_string(),
             Value::Concrete(ConcreteValue::String("10.0.0.0/16".to_string())),

--- a/carina-provider-awscc/src/provider/cloudcontrol.rs
+++ b/carina-provider-awscc/src/provider/cloudcontrol.rs
@@ -359,11 +359,11 @@ impl AwsccProvider {
     /// Retryable error types:
     /// - `ThrottlingException`: Request rate exceeded (covers "Throttling", "Rate exceeded")
     /// - `ServiceInternalErrorException`: AWS internal server error
-    /// - `HandlerFailureException`: ManagedResource handler failed (may be transient)
+    /// - `HandlerFailureException`: Resource handler failed (may be transient)
     /// - `HandlerInternalFailureException`: Internal handler error
     /// - `NetworkFailureException`: Network connectivity issues
     /// - `ConcurrentOperationException`: Another operation is in progress
-    /// - `NotStabilizedException`: ManagedResource not yet stabilized
+    /// - `NotStabilizedException`: Resource not yet stabilized
     /// - `SdkError::TimeoutError`: Connection timeout
     /// - `SdkError::DispatchFailure`: HTTP dispatch failure
     pub(crate) fn is_retryable_sdk_error<E, R>(error: &SdkError<E, R>) -> bool

--- a/carina-provider-awscc/src/provider/conversion.rs
+++ b/carina-provider-awscc/src/provider/conversion.rs
@@ -671,7 +671,7 @@ mod tests {
         let attr_schema = config.schema.attributes.get("vpc_endpoint_type").unwrap();
 
         // 1. DSL side: resolve_enum_identifiers_impl converts bare `Gateway` ident
-        let mut resource = carina_core::resource::ManagedResource::with_provider(
+        let mut resource = carina_core::resource::Resource::with_provider(
             "awscc",
             "ec2.VpcEndpoint",
             "test",

--- a/carina-provider-awscc/src/provider/mod.rs
+++ b/carina-provider-awscc/src/provider/mod.rs
@@ -10,7 +10,7 @@
 //! - `normalizer` - Plan-time enum resolution and state hydration
 //! - `operations` - High-level resource operations (read, create, update, delete)
 //! - `s3` - S3-specific operations (empty bucket for force_delete)
-//! - `special_cases` - ManagedResource-type-specific attribute handling
+//! - `special_cases` - Resource-type-specific attribute handling
 //! - `tags` - Tag conversion between DSL and CloudFormation formats
 //! - `update` - Update patch building and resource property parsing
 

--- a/carina-provider-awscc/src/provider/normalizer.rs
+++ b/carina-provider-awscc/src/provider/normalizer.rs
@@ -6,7 +6,7 @@
 use indexmap::IndexMap;
 use std::collections::HashMap;
 
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
 use carina_core::schema::{AttributeType, StructField};
 
 /// Resolve enum identifiers in resources to their fully-qualified DSL format.
@@ -14,7 +14,7 @@ use carina_core::schema::{AttributeType, StructField};
 /// For each awscc resource, looks up the schema and resolves bare identifiers
 /// (e.g., `advanced`) or TypeName.value identifiers (e.g., `Tier.advanced`)
 /// into fully-qualified namespaced strings (e.g., `awscc.ec2.Ipam.Tier.advanced`).
-pub fn resolve_enum_identifiers_impl(resources: &mut [ManagedResource]) {
+pub fn resolve_enum_identifiers_impl(resources: &mut [Resource]) {
     for resource in resources.iter_mut() {
         // Only handle awscc resources
         if resource.id.provider != "awscc" {
@@ -274,7 +274,7 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_bare_ident() {
-        let mut resource = ManagedResource::with_provider("awscc", "ec2.Vpc", "test", None);
+        let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "test", None);
         resource.set_attr(
             "instance_tenancy".to_string(),
             Value::Concrete(ConcreteValue::String("dedicated".to_string())),
@@ -294,7 +294,7 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_typename_value() {
-        let mut resource = ManagedResource::with_provider("awscc", "ec2.Vpc", "test", None);
+        let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "test", None);
         resource.set_attr(
             "instance_tenancy".to_string(),
             Value::Concrete(ConcreteValue::String(
@@ -316,7 +316,7 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_skips_non_awscc() {
-        let mut resource = ManagedResource::with_provider("aws", "s3.Bucket", "test", None);
+        let mut resource = Resource::with_provider("aws", "s3.Bucket", "test", None);
         resource.set_attr(
             "instance_tenancy".to_string(),
             Value::Concrete(ConcreteValue::String("dedicated".to_string())),
@@ -364,7 +364,7 @@ mod tests {
                 ConcreteValue::Map(stmt),
             )])),
         );
-        let mut resource = ManagedResource::with_provider("awscc", "iam.Role", "rd-role", None);
+        let mut resource = Resource::with_provider("awscc", "iam.Role", "rd-role", None);
         resource.set_attr(
             "assume_role_policy_document".to_string(),
             Value::Concrete(ConcreteValue::Map(policy)),
@@ -396,7 +396,7 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_hyphen_to_underscore() {
-        let mut resource = ManagedResource::with_provider("awscc", "ec2.FlowLog", "test", None);
+        let mut resource = Resource::with_provider("awscc", "ec2.FlowLog", "test", None);
         resource.set_attr(
             "log_destination_type".to_string(),
             Value::Concrete(ConcreteValue::String("cloud_watch_logs".to_string())),
@@ -418,7 +418,7 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_hyphen_string_to_underscore() {
-        let mut resource = ManagedResource::with_provider("awscc", "ec2.FlowLog", "test", None);
+        let mut resource = Resource::with_provider("awscc", "ec2.FlowLog", "test", None);
         resource.set_attr(
             "log_destination_type".to_string(),
             Value::Concrete(ConcreteValue::String("cloud-watch-logs".to_string())),
@@ -555,7 +555,7 @@ mod tests {
     #[test]
     fn test_resolve_enum_identifiers_ip_protocol_all_alias() {
         let mut resource =
-            ManagedResource::with_provider("awscc", "ec2.SecurityGroupEgress", "test", None);
+            Resource::with_provider("awscc", "ec2.SecurityGroupEgress", "test", None);
         resource.set_attr(
             "ip_protocol".to_string(),
             Value::Concrete(ConcreteValue::String("all".to_string())),
@@ -578,7 +578,7 @@ mod tests {
     #[test]
     fn test_resolve_enum_identifiers_ip_protocol_tcp() {
         let mut resource =
-            ManagedResource::with_provider("awscc", "ec2.SecurityGroupEgress", "test", None);
+            Resource::with_provider("awscc", "ec2.SecurityGroupEgress", "test", None);
         resource.set_attr(
             "ip_protocol".to_string(),
             Value::Concrete(ConcreteValue::String("tcp".to_string())),
@@ -719,8 +719,7 @@ mod tests {
 
     #[test]
     fn test_resolve_enum_identifiers_impl_struct_field() {
-        let mut resource =
-            ManagedResource::with_provider("awscc", "ec2.SecurityGroup", "test-sg", None);
+        let mut resource = Resource::with_provider("awscc", "ec2.SecurityGroup", "test-sg", None);
         resource.set_attr(
             "group_description".to_string(),
             Value::Concrete(ConcreteValue::String("test".to_string())),

--- a/carina-provider-awscc/src/provider/operations.rs
+++ b/carina-provider-awscc/src/provider/operations.rs
@@ -7,7 +7,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult, UpdatePatch};
-use carina_core::resource::{ConcreteValue, Directives, ManagedResource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, Directives, Resource, ResourceId, State, Value};
 use carina_core::schema::{AttributeSchema, AttributeType};
 use indexmap::IndexMap;
 use serde_json::json;
@@ -72,7 +72,7 @@ impl AwsccProvider {
     }
 
     /// Create a resource using its configuration
-    pub async fn create_resource(&self, resource: ManagedResource) -> ProviderResult<State> {
+    pub async fn create_resource(&self, resource: Resource) -> ProviderResult<State> {
         let config = get_schema_config(&resource.id.resource_type).ok_or_else(|| {
             ProviderError::internal(format!(
                 "Unknown resource type: {}",
@@ -199,7 +199,7 @@ impl AwsccProvider {
         // patch we just applied). This is the source of values to carry
         // forward for attributes CloudControl's read does not return —
         // same logic as `create_resource` but built without a `to:
-        // ManagedResource` (which Level 3 deliberately does not pass through).
+        // Resource` (which Level 3 deliberately does not pass through).
         let desired = post_update_attributes(from, patch);
         for dsl_name in config.schema.attributes.keys() {
             if !state.attributes.contains_key(dsl_name)
@@ -314,8 +314,8 @@ fn map_aws_props_to_attributes(
 ///
 /// Used by `update_resource` to know which attributes to carry forward
 /// when CloudControl's read response omits them. The map is the same
-/// logical shape as the old `to: ManagedResource.attributes`, but built
-/// without exposing a full `ManagedResource` to the update path.
+/// logical shape as the old `to: Resource.attributes`, but built
+/// without exposing a full `Resource` to the update path.
 fn post_update_attributes(
     from: &State,
     patch: &UpdatePatch,

--- a/carina-provider-awscc/src/provider/special_cases.rs
+++ b/carina-provider-awscc/src/provider/special_cases.rs
@@ -1,4 +1,4 @@
-//! ManagedResource-type-specific special case handlers.
+//! Resource-type-specific special case handlers.
 //!
 //! Some AWS resource types require non-standard attribute handling that falls
 //! outside the generic schema-driven mapping. This module centralizes those
@@ -7,7 +7,7 @@
 use std::collections::HashMap;
 
 use carina_core::provider::{ProviderError, ProviderResult};
-use carina_core::resource::{ConcreteValue, ManagedResource, ResourceId, Value};
+use carina_core::resource::{ConcreteValue, Resource, ResourceId, Value};
 use serde_json::json;
 
 use super::AwsccProvider;
@@ -59,7 +59,7 @@ impl AwsccProvider {
     /// Handle special attributes for create
     pub(crate) fn create_special_attributes(
         &self,
-        _resource: &ManagedResource,
+        _resource: &Resource,
         _desired_state: &mut serde_json::Map<String, serde_json::Value>,
     ) {
     }


### PR DESCRIPTION
## Summary

Catches `carina-core` / `carina-plugin-sdk` / `carina-provider-protocol` pins up to the latest carina main (`83a9597b`, post carina#3314 — the fix for the ~20s S3 socket-idle stall on body-less DELETE via the WASM provider). Absorbs the breaking change from carina#3288 across the provider source.

Sibling change to `carina-rs/carina-provider-aws#377` — same shape, smaller surface here because the awscc provider uses CFN-derived codegen.

## Changes

1. **Pins bumped** in `carina-aws-types/Cargo.toml` and `carina-provider-awscc/Cargo.toml`: `88cfdf60` -> `83a9597b6848a911da06eb2f19acfacab9a2813f`. `Cargo.lock` updated.
2. **`ManagedResource` -> `Resource`** rename applied across ~9 files. The wire-level `carina_provider_protocol::SchemaKind::Managed` variant is intentionally unchanged; only the carina-core-side rename is followed.
3. **`convert.rs`** `proto_to_core_schema` / `core_to_proto_schema` updated to translate `ProtoSchemaKind::Managed <-> CoreSchemaKind::Resource`.

## Verify

- [x] `cargo check` - clean
- [x] `cargo check --target wasm32-wasip2` - clean
- [x] `cargo nextest run` - 490/490 pass
- [x] `cargo clippy --all-targets -- -D warnings` - clean
- [x] `bash scripts/check-carina-pin.sh` - pin ancestry confirmed
- [x] `bash scripts/check-docs-drift.sh` - schemas/docs in sync (37 resources)
- [ ] Real-S3 acceptance smoke on the carina#3254-blocked suites — pending user run with `CARINA_WASI_HTTP_TRACE=1`.

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)
