### PR TITLE
Fix multi-step destroy: rename cleanup() to destroy_work_dir() across 4 scripts (closes #276)

### DIFF
--- a/acceptance-tests/attribute_removal/run.sh
+++ b/acceptance-tests/attribute_removal/run.sh
@@ -95,9 +95,12 @@ run_plan_verify() {
     return 0
 }
 
-# Cleanup helper: try to destroy with both step configs, then retry
+# destroy_work_dir: try to destroy with both step configs, then retry
 # Returns 0 if at least one destroy succeeded, 1 if ALL failed
-cleanup() {
+# (Named distinctly from `cleanup` so the EXIT trap in _helpers.sh keeps using
+# its own cleanup() — overriding it would call this with no args at exit and
+# emit "No .crn files found in .".)
+destroy_work_dir() {
     local work_dir="$1"
     local step2="$2"
     local step1="$3"
@@ -157,7 +160,7 @@ run_test() {
 
     # Step 1: Apply initial config (with policy_document)
     if ! run_step "$work_dir" "step1: apply initial (with attribute)" "apply" "$step1" "--auto-approve"; then
-        cleanup "$work_dir" "$step2" "$step1"
+        destroy_work_dir "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
         rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
@@ -166,7 +169,7 @@ run_test() {
 
     # Step 1b: Plan-verify initial state
     if ! run_plan_verify "$work_dir" "step1: plan-verify initial" "$step1"; then
-        cleanup "$work_dir" "$step2" "$step1"
+        destroy_work_dir "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
         rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
@@ -175,7 +178,7 @@ run_test() {
 
     # Step 2: Apply modified config (attribute removed)
     if ! run_step "$work_dir" "step2: apply attribute removal" "apply" "$step2" "--auto-approve"; then
-        cleanup "$work_dir" "$step2" "$step1"
+        destroy_work_dir "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
         rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
@@ -184,15 +187,15 @@ run_test() {
 
     # Step 3: Plan-verify after attribute removal (must be idempotent)
     if ! run_plan_verify "$work_dir" "step3: plan-verify after attribute removal" "$step2"; then
-        cleanup "$work_dir" "$step2" "$step1"
+        destroy_work_dir "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
         rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
 
-    # Step 4: Destroy (use cleanup to try both configs and retry)
-    if ! cleanup "$work_dir" "$step2" "$step1"; then
+    # Step 4: Destroy (use destroy_work_dir to try both configs and retry)
+    if ! destroy_work_dir "$work_dir" "$step2" "$step1"; then
         echo "  WARNING: All destroy attempts failed. Preserving work dir for debugging:"
         echo "    $work_dir"
         TOTAL_FAILED=$((TOTAL_FAILED + 1))

--- a/acceptance-tests/create_before_destroy/run.sh
+++ b/acceptance-tests/create_before_destroy/run.sh
@@ -302,7 +302,7 @@ run_test() {
     fi
 
     # Step 4: Destroy
-    if ! cleanup "$work_dir"; then
+    if ! destroy_work_dir "$work_dir"; then
         echo "  WARNING: All destroy attempts failed. Preserving work dir for debugging:"
         echo "    $work_dir"
         TOTAL_FAILED=$((TOTAL_FAILED + 1))

--- a/acceptance-tests/in_place_update/run.sh
+++ b/acceptance-tests/in_place_update/run.sh
@@ -165,9 +165,12 @@ run_plan_verify() {
     return 0
 }
 
-# Cleanup helper: try to destroy with both step configs, then retry
+# destroy_work_dir: try to destroy with both step configs, then retry
 # Returns 0 if at least one destroy succeeded, 1 if ALL failed
-cleanup() {
+# (Named distinctly from `cleanup` so the EXIT trap in _helpers.sh keeps using
+# its own cleanup() — overriding it would call this with no args at exit and
+# emit "No .crn files found in .".)
+destroy_work_dir() {
     local work_dir="$1"
     local step2="$2"
     local step1="$3"
@@ -227,7 +230,7 @@ run_test() {
 
     # Step 1: Apply initial config
     if ! run_step "$work_dir" "step1: apply initial" "apply" "$step1" "--auto-approve"; then
-        cleanup "$work_dir" "$step2" "$step1"
+        destroy_work_dir "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
         rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
@@ -236,7 +239,7 @@ run_test() {
 
     # Step 1b: Plan-verify initial state
     if ! run_plan_verify "$work_dir" "step1: plan-verify initial" "$step1"; then
-        cleanup "$work_dir" "$step2" "$step1"
+        destroy_work_dir "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
         rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
@@ -249,7 +252,7 @@ run_test() {
 
     # Step 2: Apply modified config (in-place update)
     if ! run_step "$work_dir" "step2: apply in-place update" "apply" "$step2" "--auto-approve"; then
-        cleanup "$work_dir" "$step2" "$step1"
+        destroy_work_dir "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
         rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
@@ -262,7 +265,7 @@ run_test() {
 
     # Assert identifiers preserved (in-place update should NOT replace any resource)
     if ! assert_identifiers "assert: identifiers preserved after update" "$ids_after_step1" "$ids_after_step2" "equal"; then
-        cleanup "$work_dir" "$step2" "$step1"
+        destroy_work_dir "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
         rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
@@ -271,15 +274,15 @@ run_test() {
 
     # Step 3: Plan-verify after update
     if ! run_plan_verify "$work_dir" "step3: plan-verify after update" "$step2"; then
-        cleanup "$work_dir" "$step2" "$step1"
+        destroy_work_dir "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
         rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
 
-    # Step 4: Destroy (use cleanup to try both configs and retry)
-    if ! cleanup "$work_dir" "$step2" "$step1"; then
+    # Step 4: Destroy (use destroy_work_dir to try both configs and retry)
+    if ! destroy_work_dir "$work_dir" "$step2" "$step1"; then
         echo "  WARNING: All destroy attempts failed. Preserving work dir for debugging:"
         echo "    $work_dir"
         TOTAL_FAILED=$((TOTAL_FAILED + 1))

--- a/acceptance-tests/simhash_update/run.sh
+++ b/acceptance-tests/simhash_update/run.sh
@@ -151,9 +151,12 @@ run_plan_verify() {
     return 0
 }
 
-# Cleanup helper: try to destroy with both step configs, then retry
+# destroy_work_dir: try to destroy with both step configs, then retry
 # Returns 0 if at least one destroy succeeded, 1 if ALL failed
-cleanup() {
+# (Named distinctly from `cleanup` so the EXIT trap in _helpers.sh keeps using
+# its own cleanup() — overriding it would call this with no args at exit and
+# emit "No .crn files found in .".)
+destroy_work_dir() {
     local work_dir="$1"
     local step2="$2"
     local step1="$3"
@@ -213,7 +216,7 @@ run_test() {
 
     # Step 1: Apply initial config
     if ! run_step "$work_dir" "step1: apply initial" "apply" "$step1" "--auto-approve"; then
-        cleanup "$work_dir" "$step2" "$step1"
+        destroy_work_dir "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
         rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
@@ -222,7 +225,7 @@ run_test() {
 
     # Step 1b: Plan-verify initial state
     if ! run_plan_verify "$work_dir" "step1: plan-verify initial" "$step1"; then
-        cleanup "$work_dir" "$step2" "$step1"
+        destroy_work_dir "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
         rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
@@ -235,7 +238,7 @@ run_test() {
 
     # Step 2: Apply modified config (SimHash reconciliation should match)
     if ! run_step "$work_dir" "step2: apply update (simhash reconcile)" "apply" "$step2" "--auto-approve"; then
-        cleanup "$work_dir" "$step2" "$step1"
+        destroy_work_dir "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
         rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
@@ -248,7 +251,7 @@ run_test() {
 
     # Assert identifiers preserved (simhash update should NOT replace the resource)
     if ! assert_identifiers "assert: identifiers preserved after update" "$ids_after_step1" "$ids_after_step2" "equal"; then
-        cleanup "$work_dir" "$step2" "$step1"
+        destroy_work_dir "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
         rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
@@ -257,15 +260,15 @@ run_test() {
 
     # Step 3: Plan-verify after update
     if ! run_plan_verify "$work_dir" "step3: plan-verify after update" "$step2"; then
-        cleanup "$work_dir" "$step2" "$step1"
+        destroy_work_dir "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
         rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
 
-    # Step 4: Destroy (use cleanup to try both configs and retry)
-    if ! cleanup "$work_dir" "$step2" "$step1"; then
+    # Step 4: Destroy (use destroy_work_dir to try both configs and retry)
+    if ! destroy_work_dir "$work_dir" "$step2" "$step1"; then
         echo "  WARNING: All destroy attempts failed. Preserving work dir for debugging:"
         echo "    $work_dir"
         TOTAL_FAILED=$((TOTAL_FAILED + 1))


### PR DESCRIPTION
## Summary

Root-cause fix for #276. The tag_deletion rename in this repo (matching `carina-provider-aws`'s 2c48af0) already moved the per-test destroy helper from `cleanup()` to `destroy_work_dir()` so the EXIT-trap-bound `_helpers.sh:cleanup()` would not be shadowed by a local override. It missed:

- One happy-path call site in `create_before_destroy/run.sh` (Step 4 destroy), with the symptom that 15/15 tests reported pass but per-test VPC/TGW resources leaked into the account.
- Three sibling scripts that still defined a local `cleanup()` shadowing the helper: `in_place_update/run.sh`, `simhash_update/run.sh`, `attribute_removal/run.sh`.

When the helper version runs (either by shadowing failing at EXIT or by the missed call site routing there), it ignores its argument, runs `carina destroy` **without** `with_account_creds` (no AWS auth), discards stderr, returns 0 unconditionally, and removes `carina.state.json`. Every test then "passes" while leaving resources alive.

## Fix

Same rename pattern as 2c48af0: redefine the local helper as `destroy_work_dir()` with the "Named distinctly from `cleanup`..." doc-comment, and route every call site to it.

| Script | Def | Calls renamed |
|--------|-----|--------------|
| `create_before_destroy/run.sh` | already renamed | 1 missed call site → `destroy_work_dir` |
| `in_place_update/run.sh` | `cleanup()` → `destroy_work_dir()` | 6 |
| `simhash_update/run.sh` | `cleanup()` → `destroy_work_dir()` | 6 (`cleanup_single` left alone) |
| `attribute_removal/run.sh` | `cleanup()` → `destroy_work_dir()` | 5 |

## Verification

Local end-to-end run on `carina-test-000`:

```
env AWS_PROFILE=carina-test-000 AWSCC_PROVIDER_BIN=... \
    ./acceptance-tests/create_before_destroy/run.sh
...
Total: 15 passed, 0 failed
```

Each test's destroy phase emits `Destroy complete! N resources destroyed.` Post-run `aws ec2 describe-vpcs --filters Name=isDefault,Values=false` and `describe-transit-gateways` (active) both return empty.

The sibling fix in `carina-rs/carina-provider-aws#380` (closes carina-rs/carina-provider-aws#379) lands the same rename in the aws repo.

## Test plan

- [x] `create_before_destroy/run.sh` completes 15/15 tests with `Destroy complete!` per test and 0 leaked VPC/TGW
- [x] `bash -n` syntax-check on all four touched scripts
- [x] Pre-existing `shellcheck` warnings unchanged (no new findings introduced by the rename)
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)