### PR TITLE
deps: bump carina rev to f8dafdc5 (wasi_http chunked write_body)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=83a9597b6848a911da06eb2f19acfacab9a2813f#83a9597b6848a911da06eb2f19acfacab9a2813f"
+source = "git+https://github.com/carina-rs/carina?rev=f8dafdc50d87760a47b6b52728bbf8b1d23aa55a#f8dafdc50d87760a47b6b52728bbf8b1d23aa55a"
 dependencies = [
  "argon2",
  "futures",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=83a9597b6848a911da06eb2f19acfacab9a2813f#83a9597b6848a911da06eb2f19acfacab9a2813f"
+source = "git+https://github.com/carina-rs/carina?rev=f8dafdc50d87760a47b6b52728bbf8b1d23aa55a#f8dafdc50d87760a47b6b52728bbf8b1d23aa55a"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -580,7 +580,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=83a9597b6848a911da06eb2f19acfacab9a2813f#83a9597b6848a911da06eb2f19acfacab9a2813f"
+source = "git+https://github.com/carina-rs/carina?rev=f8dafdc50d87760a47b6b52728bbf8b1d23aa55a#f8dafdc50d87760a47b6b52728bbf8b1d23aa55a"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "83a9597b6848a911da06eb2f19acfacab9a2813f" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "f8dafdc50d87760a47b6b52728bbf8b1d23aa55a" }

--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -23,10 +23,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "83a9597b6848a911da06eb2f19acfacab9a2813f" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "f8dafdc50d87760a47b6b52728bbf8b1d23aa55a" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "83a9597b6848a911da06eb2f19acfacab9a2813f" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "83a9597b6848a911da06eb2f19acfacab9a2813f" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "f8dafdc50d87760a47b6b52728bbf8b1d23aa55a" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "f8dafdc50d87760a47b6b52728bbf8b1d23aa55a" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }


### PR DESCRIPTION
## Summary

- Bumps carina-core / carina-plugin-sdk / carina-provider-protocol from `83a9597b` to `f8dafdc5`.
- The single upstream change in that window is carina-rs/carina#3319: `wasi_http::write_body` now splits SDK-buffered bodies into ≤4096-byte chunks before each `blocking_write_and_flush` call, restoring the wasi:io WIT contract the host enforces via `StreamError::trap`. Without this, a >4096-byte request body — the size produced by a routine CloudControl `UpdateResource` against `awscc.iam.RolePolicy` — trapped this provider's WASM instance and cascaded into `cannot enter component instance` on the post-apply refresh (the carina-rs/carina#3318 reproducer).
- This rev bump is what makes the upstream fix reach the awscc artifact. No source changes follow from it.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo nextest run --workspace` — 490 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] Real-AWS acceptance run against `carina-rs/infra@0fae933, envs/registry/dev/infra-deploy/` (driven by user) — apply should succeed where the same shape trapped at `[0.0s]` before.

Refs carina-rs/carina#3318.