### PR TITLE
deps: bump carina rev to 63e88c37 (wasi_http handle-before-write)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=f8dafdc50d87760a47b6b52728bbf8b1d23aa55a#f8dafdc50d87760a47b6b52728bbf8b1d23aa55a"
+source = "git+https://github.com/carina-rs/carina?rev=63e88c37b54fe41b7c52dede4bd8ebd6e5f04341#63e88c37b54fe41b7c52dede4bd8ebd6e5f04341"
 dependencies = [
  "argon2",
  "futures",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=f8dafdc50d87760a47b6b52728bbf8b1d23aa55a#f8dafdc50d87760a47b6b52728bbf8b1d23aa55a"
+source = "git+https://github.com/carina-rs/carina?rev=63e88c37b54fe41b7c52dede4bd8ebd6e5f04341#63e88c37b54fe41b7c52dede4bd8ebd6e5f04341"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -580,7 +580,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=f8dafdc50d87760a47b6b52728bbf8b1d23aa55a#f8dafdc50d87760a47b6b52728bbf8b1d23aa55a"
+source = "git+https://github.com/carina-rs/carina?rev=63e88c37b54fe41b7c52dede4bd8ebd6e5f04341#63e88c37b54fe41b7c52dede4bd8ebd6e5f04341"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "f8dafdc50d87760a47b6b52728bbf8b1d23aa55a" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "63e88c37b54fe41b7c52dede4bd8ebd6e5f04341" }

--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -23,10 +23,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "f8dafdc50d87760a47b6b52728bbf8b1d23aa55a" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "63e88c37b54fe41b7c52dede4bd8ebd6e5f04341" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "f8dafdc50d87760a47b6b52728bbf8b1d23aa55a" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "f8dafdc50d87760a47b6b52728bbf8b1d23aa55a" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "63e88c37b54fe41b7c52dede4bd8ebd6e5f04341" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "63e88c37b54fe41b7c52dede4bd8ebd6e5f04341" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }


### PR DESCRIPTION
## Summary

- Bumps carina-core / carina-plugin-sdk / carina-provider-protocol from `f8dafdc5` to `63e88c37`.
- The single upstream change in that window is carina-rs/carina#3321: `wasi_http::make_request` now calls `outgoing_handler::handle` **before** shipping the body, so the hyper consumer is live by the time `blocking_write_and_flush` starts filling the host-side mpsc channel. Without it, multi-chunk bodies (any request body >4096 bytes after carina-rs/carina#3318) blocked forever on the trailing `write_ready().await`, surfacing as the 20-minute `WASM plugin operation 'update' exceeded 1200s` hard-timeout that the awscc `iam.RolePolicy` `UpdateResource` reproducer in carina-rs/carina#3320 hit.
- This rev bump is what makes the upstream fix reach the awscc artifact. No source changes follow from it.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo nextest run --workspace` — 490 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] Real-AWS acceptance run against `carina-rs/infra@0fae933, envs/registry/dev/infra-deploy/` (driven by user) — apply should now succeed instead of hanging for 20 min on the `awscc.iam.RolePolicy` update.

Refs carina-rs/carina#3320.