### PR TITLE
feat(wafv2): add AWS::WAFv2::WebACL via cyclic-schema Ref codegen (closes #196, #197)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=63e88c37b54fe41b7c52dede4bd8ebd6e5f04341#63e88c37b54fe41b7c52dede4bd8ebd6e5f04341"
+source = "git+https://github.com/carina-rs/carina?rev=8003d7eb2c9cb03784b08422b2586970f6c33978#8003d7eb2c9cb03784b08422b2586970f6c33978"
 dependencies = [
  "argon2",
  "futures",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=63e88c37b54fe41b7c52dede4bd8ebd6e5f04341#63e88c37b54fe41b7c52dede4bd8ebd6e5f04341"
+source = "git+https://github.com/carina-rs/carina?rev=8003d7eb2c9cb03784b08422b2586970f6c33978#8003d7eb2c9cb03784b08422b2586970f6c33978"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -580,7 +580,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=63e88c37b54fe41b7c52dede4bd8ebd6e5f04341#63e88c37b54fe41b7c52dede4bd8ebd6e5f04341"
+source = "git+https://github.com/carina-rs/carina?rev=8003d7eb2c9cb03784b08422b2586970f6c33978#8003d7eb2c9cb03784b08422b2586970f6c33978"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "63e88c37b54fe41b7c52dede4bd8ebd6e5f04341" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "8003d7eb2c9cb03784b08422b2586970f6c33978" }

--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -23,10 +23,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "63e88c37b54fe41b7c52dede4bd8ebd6e5f04341" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "8003d7eb2c9cb03784b08422b2586970f6c33978" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "63e88c37b54fe41b7c52dede4bd8ebd6e5f04341" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "63e88c37b54fe41b7c52dede4bd8ebd6e5f04341" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "8003d7eb2c9cb03784b08422b2586970f6c33978" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "8003d7eb2c9cb03784b08422b2586970f6c33978" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }

--- a/carina-provider-awscc/scripts/generate-schemas.sh
+++ b/carina-provider-awscc/scripts/generate-schemas.sh
@@ -77,6 +77,7 @@ RESOURCE_TYPES=(
     "AWS::Route53::HostedZone"
     "AWS::CloudFront::Distribution"
     "AWS::CloudFront::OriginAccessControl"
+    "AWS::WAFv2::WebACL"
 )
 
 echo "Generating awscc provider schemas..."

--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -17,9 +17,137 @@ use clap::Parser;
 use heck::{ToPascalCase, ToSnakeCase};
 use regex::Regex;
 use serde::Deserialize;
+use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::io::{self, Read};
 use std::sync::LazyLock;
+
+// carina#3340: in-progress recursion guard for cyclic CFN $ref
+// definitions (WAFv2 `WebACL.Statement` → `AndStatement` → `List<Statement>`).
+// When `generate_struct_type` is asked to expand a definition whose name
+// is already on the stack, it emits `AttributeType::Ref(name)` and
+// records the def's body into [`STRUCT_DEFS_OUT`] for later emission
+// into `ResourceSchema.defs`. The set is per-resource — cleared at the
+// top of each resource generation pass.
+/// `(pattern, min, max)` triples accumulated by the recursion guard.
+type PatternWithLength = (String, Option<u64>, Option<u64>);
+/// `(min, max, is_float)` tuple keyed by prop name for int / float
+/// range validators accumulated by the recursion guard.
+type RangeValidator = (Option<i64>, Option<i64>, bool);
+
+// `HashSet::new()` is not `const fn`, so clippy's
+// `missing_const_for_thread_local` suggestion is rejected for the
+// HashSet-typed cells by rustc. The BTree-typed cells can use `const`
+// init, but mixing styles inside one `thread_local!` block makes the
+// allow attribute awkward; suppressing the lint for the whole block
+// keeps the source consistent. (carina#3340.)
+thread_local! {
+    #[allow(clippy::missing_const_for_thread_local)]
+    static IN_PROGRESS_DEFS: RefCell<HashSet<String>> = RefCell::new(HashSet::new());
+    /// Collected `(def_name, AttributeType-rendered Rust code)` for the
+    /// resource currently being generated. Populated by the recursion
+    /// guard in `cfn_type_to_carina_type_with_enum`; consumed by the
+    /// resource emitter to populate `ResourceSchema.defs`.
+    #[allow(clippy::missing_const_for_thread_local)]
+    static EMITTED_DEFS: RefCell<BTreeMap<String, String>> = RefCell::new(BTreeMap::new());
+    /// Patterns discovered during recursive expansion of CFN `$ref`
+    /// struct definitions. The original pre-scan walks only the
+    /// top-level properties + definitions one hop deep; once the
+    /// recursion guard lets `generate_struct_type` walk N levels deep
+    /// into a cyclic struct, the patterns inside those nested levels
+    /// must still be emitted as `fn` definitions or the generated
+    /// file will reference undefined symbols. Populated by
+    /// `cfn_type_to_carina_type_with_enum` at every pattern emission
+    /// site; the resource emitter drains this into the same
+    /// `pattern_with_lengths` set used by the existing pre-scan
+    /// emitter (carina#3340).
+    #[allow(clippy::missing_const_for_thread_local)]
+    static EMITTED_PATTERNS_WITH_LENGTHS: RefCell<BTreeSet<PatternWithLength>> =
+        RefCell::new(BTreeSet::new());
+    #[allow(clippy::missing_const_for_thread_local)]
+    static EMITTED_STANDALONE_PATTERNS: RefCell<HashSet<String>> = RefCell::new(HashSet::new());
+    /// `(prop_name -> (min, max, is_float))` for integer/number range
+    /// validators referenced by the recursive cycle expansion. Same
+    /// rationale as `EMITTED_PATTERNS_WITH_LENGTHS`: the existing
+    /// `ranged_ints` / `ranged_floats` pre-scan walks only one hop
+    /// into definitions; nested cyclic fields can reference
+    /// `validate_<snake>_range` fns the pre-scan never collected.
+    #[allow(clippy::missing_const_for_thread_local)]
+    static EMITTED_RANGE_VALIDATORS: RefCell<BTreeMap<String, RangeValidator>> =
+        RefCell::new(BTreeMap::new());
+    /// `prop_name -> integer enum values`, same rationale as
+    /// `EMITTED_RANGE_VALIDATORS` (carina#3340).
+    #[allow(clippy::missing_const_for_thread_local)]
+    static EMITTED_INT_ENUMS: RefCell<BTreeMap<String, Vec<i64>>> =
+        RefCell::new(BTreeMap::new());
+}
+
+/// Reset the per-resource recursion guard state. Called at the start
+/// of every resource generation so a cycle detected for resource A
+/// does not leak into resource B.
+fn reset_recursion_guard() {
+    IN_PROGRESS_DEFS.with(|s| s.borrow_mut().clear());
+    EMITTED_DEFS.with(|s| s.borrow_mut().clear());
+    EMITTED_PATTERNS_WITH_LENGTHS.with(|s| s.borrow_mut().clear());
+    EMITTED_STANDALONE_PATTERNS.with(|s| s.borrow_mut().clear());
+    EMITTED_RANGE_VALIDATORS.with(|s| s.borrow_mut().clear());
+    EMITTED_INT_ENUMS.with(|s| s.borrow_mut().clear());
+}
+
+/// Take the defs collected during the current resource pass and
+/// return them as a sorted `BTreeMap`. Empty for non-cyclic resources.
+fn take_emitted_defs() -> BTreeMap<String, String> {
+    EMITTED_DEFS.with(|s| std::mem::take(&mut *s.borrow_mut()))
+}
+
+/// Record a pattern+length validator emission so the function-emitter
+/// can produce its matching `fn` definition. Called from every
+/// emission site in `cfn_type_to_carina_type_with_enum` that
+/// references a `validate_string_pattern_<hash>_len_<min>_<max>`
+/// symbol. The pre-scan over `definitions` already collects most
+/// patterns; this set is the cycle-recursion safety net that catches
+/// patterns nested deeper than the pre-scan walks (carina#3340).
+fn record_pattern_with_length(pattern: &str, min: Option<u64>, max: Option<u64>) {
+    EMITTED_PATTERNS_WITH_LENGTHS.with(|s| {
+        s.borrow_mut().insert((pattern.to_string(), min, max));
+    });
+}
+
+fn record_standalone_pattern(pattern: &str) {
+    EMITTED_STANDALONE_PATTERNS.with(|s| {
+        s.borrow_mut().insert(pattern.to_string());
+    });
+}
+
+fn take_emitted_patterns_with_lengths() -> BTreeSet<(String, Option<u64>, Option<u64>)> {
+    EMITTED_PATTERNS_WITH_LENGTHS.with(|s| std::mem::take(&mut *s.borrow_mut()))
+}
+
+fn take_emitted_standalone_patterns() -> HashSet<String> {
+    EMITTED_STANDALONE_PATTERNS.with(|s| std::mem::take(&mut *s.borrow_mut()))
+}
+
+fn record_range_validator(prop_name: &str, min: Option<i64>, max: Option<i64>, is_float: bool) {
+    EMITTED_RANGE_VALIDATORS.with(|s| {
+        s.borrow_mut()
+            .insert(prop_name.to_string(), (min, max, is_float));
+    });
+}
+
+fn take_emitted_range_validators() -> BTreeMap<String, (Option<i64>, Option<i64>, bool)> {
+    EMITTED_RANGE_VALIDATORS.with(|s| std::mem::take(&mut *s.borrow_mut()))
+}
+
+fn record_int_enum(prop_name: &str, values: &[i64]) {
+    EMITTED_INT_ENUMS.with(|s| {
+        s.borrow_mut()
+            .insert(prop_name.to_string(), values.to_vec());
+    });
+}
+
+fn take_emitted_int_enums() -> BTreeMap<String, Vec<i64>> {
+    EMITTED_INT_ENUMS.with(|s| std::mem::take(&mut *s.borrow_mut()))
+}
 
 /// Exit status used when a schema is deliberately skipped (NON_PROVISIONABLE).
 /// The generate-schemas.sh / generate-docs.sh wrappers branch on this to
@@ -1346,6 +1474,12 @@ fn detect_exclusive_fields(schema: &CfnSchema, type_name: &str) -> Vec<Vec<Strin
 }
 
 fn generate_schema_code(schema: &CfnSchema, type_name: &str) -> Result<String> {
+    // carina#3340: clear per-resource codegen state at function entry
+    // (cyclic-$ref guard + emitted-pattern accumulators) so prior
+    // resources don't leak entries into this resource's pre-scan or
+    // post-emit validator-fn generation.
+    reset_recursion_guard();
+
     let mut code = String::new();
 
     // Parse type name: AWS::EC2::VPC -> (ec2, vpc)
@@ -2304,8 +2438,190 @@ pub fn {}() -> AwsccSchemaConfig {{
         );
     }
 
+    // carina#3340: drain any cyclic-struct definitions that the
+    // `$ref` recursion guard accumulated during attribute emission
+    // and attach them to the schema via `.with_def(...)`. Non-cyclic
+    // resources contribute nothing here; the map is empty and no
+    // calls are emitted. The Rust string in `def_body` is already a
+    // valid `AttributeType` expression (the same string the inline
+    // attribute emitter would have produced).
+    let defs = take_emitted_defs();
+    for (def_name, def_body) in &defs {
+        body.push_str(&format!(
+            "        .with_def(\"{}\", {})\n",
+            def_name, def_body
+        ));
+    }
+
     // Close the schema (ResourceSchema) and the AwsccSchemaConfig struct
     body.push_str("    }\n}\n");
+
+    // carina#3340: emit validator fns for patterns that the cycle
+    // expansion in `cfn_type_to_carina_type_with_enum` referenced
+    // but the original `pattern_with_lengths` pre-scan didn't see.
+    // The pre-scan walks top-level properties + each definition one
+    // hop deep; with the recursion guard, `generate_struct_type` can
+    // recurse arbitrarily many hops into cyclic CFN structures
+    // (WAFv2 `WebACL.Statement` → `AndStatement` → ...) and emit
+    // pattern validators that the pre-scan would never have visited.
+    // Each emission site records its (pattern, min, max) into
+    // `EMITTED_PATTERNS_WITH_LENGTHS`; here we drain that set,
+    // subtract anything the pre-scan already emitted, and append the
+    // remaining `fn` definitions. Rust allows fn definitions in any
+    // order, so appending after the schema body works.
+    let extra_pwl = take_emitted_patterns_with_lengths();
+    let extra_standalone = take_emitted_standalone_patterns();
+    let already_pwl: HashSet<(String, Option<u64>, Option<u64>)> =
+        pattern_with_lengths.iter().cloned().collect();
+    for (pattern, min, max) in &extra_pwl {
+        if already_pwl.contains(&(pattern.clone(), *min, *max)) {
+            continue;
+        }
+        let fn_name = pattern_and_length_fn_name(pattern, *min, *max);
+        let rust_pattern = rust_compatible_pattern(pattern);
+        let escaped_for_rust = rust_pattern.replace('\\', "\\\\").replace('"', "\\\"");
+        let escaped_for_msg = escaped_for_rust.replace('{', "{{").replace('}', "}}");
+        let (len_condition, range_display) = string_length_condition_and_display(*min, *max);
+        body.push_str(&format!(
+            r#"
+#[allow(dead_code)]
+fn {fn_name}(value: &Value) -> Result<(), String> {{
+    if let Value::Concrete(ConcreteValue::String(s)) = value {{
+        static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {{
+            Regex::new("{escaped_for_rust}").expect("invalid pattern regex")
+        }});
+        if !RE.is_match(s) {{
+            return Err(format!("Value '{{}}' does not match pattern {escaped_for_msg}", s));
+        }}
+        let len = s.chars().count();
+        if {len_condition} {{
+            return Err(format!("String length {{}} is out of range {range_display}", len));
+        }}
+        Ok(())
+    }} else {{
+        Err("Expected string".to_string())
+    }}
+}}
+"#
+        ));
+    }
+    // Same shape for int / float range validators referenced by
+    // cyclic nested struct fields (carina#3340).
+    let extra_ranges = take_emitted_range_validators();
+    for (prop_name, (min, max, is_float)) in &extra_ranges {
+        // Skip if pre-scan already emitted via ranged_ints / ranged_floats.
+        if ranged_ints.contains_key(prop_name) || ranged_floats.contains_key(prop_name) {
+            continue;
+        }
+        let fn_name = format!("validate_{}_range", prop_name.to_snake_case());
+        if *is_float {
+            let (condition, range_display) = float_range_condition_and_display(*min, *max);
+            body.push_str(&format!(
+                r#"
+#[allow(dead_code)]
+fn {}(value: &Value) -> Result<(), String> {{
+    let n = match value {{
+        Value::Concrete(ConcreteValue::Int(i)) => *i as f64,
+        Value::Concrete(ConcreteValue::Float(f)) => *f,
+        _ => return Err("Expected number".to_string()),
+    }};
+    if {} {{
+        Err(format!("Value {{}} is out of range {}", n))
+    }} else {{
+        Ok(())
+    }}
+}}
+"#,
+                fn_name, condition, range_display
+            ));
+        } else {
+            let (condition, range_display) = int_range_condition_and_display(*min, *max);
+            body.push_str(&format!(
+                r#"
+#[allow(dead_code)]
+fn {}(value: &Value) -> Result<(), String> {{
+    if let Value::Concrete(ConcreteValue::Int(n)) = value {{
+        if {} {{
+            Err(format!("Value {{}} is out of range {}", n))
+        }} else {{
+            Ok(())
+        }}
+    }} else {{
+        Err("Expected integer".to_string())
+    }}
+}}
+"#,
+                fn_name, condition, range_display
+            ));
+        }
+    }
+
+    // Same shape for integer enum validators referenced from cyclic
+    // nested fields (carina#3340).
+    let extra_int_enums = take_emitted_int_enums();
+    for (prop_name, values) in &extra_int_enums {
+        if int_enums.contains_key(prop_name) {
+            continue;
+        }
+        let fn_name = format!("validate_{}_int_enum", prop_name.to_snake_case());
+        let const_name = format!("VALID_{}_VALUES", prop_name.to_snake_case().to_uppercase());
+        let values_str = values
+            .iter()
+            .map(|v| v.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        body.push_str(&format!(
+            r#"
+#[allow(dead_code)]
+const {}: &[i64] = &[{}];
+
+#[allow(dead_code)]
+fn {}(value: &Value) -> Result<(), String> {{
+    if let Value::Concrete(ConcreteValue::Int(n)) = value {{
+        if {}.contains(n) {{
+            Ok(())
+        }} else {{
+            Err(format!("Value {{}} is not a valid value", n))
+        }}
+    }} else {{
+        Err("Expected integer".to_string())
+    }}
+}}
+"#,
+            const_name, values_str, fn_name, const_name
+        ));
+    }
+
+    // And the standalone (no-length) patterns recorded by the
+    // recursion guard. Skip any the pre-scan already emitted.
+    for pattern in &extra_standalone {
+        if patterns_used_standalone.contains(pattern) || patterns.values().any(|p| p == pattern) {
+            continue;
+        }
+        let fn_name = pattern_fn_name(pattern);
+        let rust_pattern = rust_compatible_pattern(pattern);
+        let escaped_for_rust = rust_pattern.replace('\\', "\\\\").replace('"', "\\\"");
+        let escaped_for_msg = escaped_for_rust.replace('{', "{{").replace('}', "}}");
+        body.push_str(&format!(
+            r#"
+#[allow(dead_code)]
+fn {fn_name}(value: &Value) -> Result<(), String> {{
+    if let Value::Concrete(ConcreteValue::String(s)) = value {{
+        static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {{
+            Regex::new("{escaped_for_rust}").expect("invalid pattern regex")
+        }});
+        if RE.is_match(s) {{
+            Ok(())
+        }} else {{
+            Err(format!("Value '{{}}' does not match pattern {escaped_for_msg}", s))
+        }}
+    }} else {{
+        Err("Expected string".to_string())
+    }}
+}}
+"#
+        ));
+    }
 
     // Generate enum_valid_values() function that exposes VALID_* constants
     body.push_str(&format!(
@@ -2953,8 +3269,11 @@ fn list_items_condition_and_display(min: Option<i64>, max: Option<i64>) -> (Stri
 
 fn float_range_condition_and_display(min: Option<i64>, max: Option<i64>) -> (String, String) {
     match (min, max) {
+        // Clippy 1.95 flags `n < x || n > y` as `manual_range_contains`;
+        // emit the `!RangeInclusive::contains` form directly so generated
+        // files stay `-D warnings` clean (carina#3340 post-emit drain).
         (Some(min), Some(max)) => (
-            format!("n < {}.0 || n > {}.0", min, max),
+            format!("!({}.0..={}.0).contains(&n)", min, max),
             format!("{}..={}", min, max),
         ),
         (Some(min), None) => (format!("n < {}.0", min), format!("{}..", min)),
@@ -4065,16 +4384,58 @@ fn cfn_type_to_carina_type_with_enum(
         if ref_path.contains("/Tag") {
             return ("tags_type()".to_string(), None);
         }
+        // carina#3340: cycle guard + reuse-via-Ref. Two cases emit
+        // `AttributeType::Ref(<name>)` instead of recursing into the
+        // resolved body:
+        //   1. The def name is already on the expansion stack — a
+        //      true cycle that would otherwise recurse infinitely.
+        //   2. The def has already been emitted once during this
+        //      resource's generation pass. Inlining the body again
+        //      at every reuse site (WAFv2 `Statement` is referenced
+        //      from 6 parent fields and itself contains thousands
+        //      of nested struct/list nodes) explodes both the
+        //      generated source size AND the runtime stack at
+        //      `ResourceSchema::new()` construction. The factored
+        //      shape is also the design `defs` exists for —
+        //      sharing a single canonical instance via `Ref`.
+        // Either way, the body is in `EMITTED_DEFS` and the host
+        // resolves the `Ref` at walk-time.
+        if let Some(def_name) = ref_def_name(ref_path) {
+            let already_known = IN_PROGRESS_DEFS.with(|s| s.borrow().contains(def_name))
+                || EMITTED_DEFS.with(|s| s.borrow().contains_key(def_name));
+            if already_known {
+                return (
+                    format!("AttributeType::Ref(\"{}\".to_string())", def_name),
+                    None,
+                );
+            }
+        }
         // Try to resolve the $ref to a definition and generate Struct type
         if let Some(def) = resolve_ref(schema, ref_path) {
             if let Some(props) = &def.properties
                 && !props.is_empty()
             {
                 let def_name = ref_def_name(ref_path).unwrap_or(prop_name);
-                return (
-                    generate_struct_type(def_name, props, &def.required, schema, namespace, enums),
-                    None,
-                );
+                // Push onto the expansion stack so a nested re-entry
+                // emits a Ref instead of recursing infinitely. The
+                // body is generated under this guard, then popped.
+                IN_PROGRESS_DEFS.with(|s| {
+                    s.borrow_mut().insert(def_name.to_string());
+                });
+                let body =
+                    generate_struct_type(def_name, props, &def.required, schema, namespace, enums);
+                IN_PROGRESS_DEFS.with(|s| {
+                    s.borrow_mut().remove(def_name);
+                });
+                // Record the def's body so the resource emitter can
+                // populate `ResourceSchema.defs` with it (only useful
+                // when this def is actually cycle-target; storing
+                // unconditionally is fine because non-cycle defs are
+                // never referenced via `Ref(_)`).
+                EMITTED_DEFS.with(|s| {
+                    s.borrow_mut().insert(def_name.to_string(), body.clone());
+                });
+                return (body, None);
             }
             // Handle oneOf: merge all variant properties into a single struct
             if !def.one_of.is_empty() {
@@ -4089,17 +4450,26 @@ fn cfn_type_to_carina_type_with_enum(
                 }
                 if !merged_props.is_empty() {
                     let def_name = ref_def_name(ref_path).unwrap_or(prop_name);
-                    return (
-                        generate_struct_type(
-                            def_name,
-                            &merged_props,
-                            &[], // no required fields - variants are mutually exclusive
-                            schema,
-                            namespace,
-                            enums,
-                        ),
-                        None,
+                    // Same cycle-guarded shape as the `properties`
+                    // branch above (carina#3340).
+                    IN_PROGRESS_DEFS.with(|s| {
+                        s.borrow_mut().insert(def_name.to_string());
+                    });
+                    let body = generate_struct_type(
+                        def_name,
+                        &merged_props,
+                        &[], // no required fields - variants are mutually exclusive
+                        schema,
+                        namespace,
+                        enums,
                     );
+                    IN_PROGRESS_DEFS.with(|s| {
+                        s.borrow_mut().remove(def_name);
+                    });
+                    EMITTED_DEFS.with(|s| {
+                        s.borrow_mut().insert(def_name.to_string(), body.clone());
+                    });
+                    return (body, None);
                 }
             }
             // Handle enum-only $ref definitions (no properties, just enum values)
@@ -4152,8 +4522,10 @@ fn cfn_type_to_carina_type_with_enum(
                     let effective_min = def.min_length.filter(|&m| m > 0);
                     let has_length = effective_min.is_some() || def.max_length.is_some();
                     let validate_fn = if has_length {
+                        record_pattern_with_length(pattern, effective_min, def.max_length);
                         pattern_and_length_fn_name(pattern, effective_min, def.max_length)
                     } else {
+                        record_standalone_pattern(pattern);
                         pattern_fn_name(pattern)
                     };
                     let pattern_expr = emit_pattern_option(Some(pattern));
@@ -4194,6 +4566,7 @@ fn cfn_type_to_carina_type_with_enum(
                     _ => None,
                 })
                 .collect();
+            record_int_enum(prop_name, &values);
             let _ = values;
             let validate_fn = format!("validate_{}_int_enum", prop_name.to_snake_case());
             return (
@@ -4283,8 +4656,10 @@ fn cfn_type_to_carina_type_with_enum(
                 && is_numeric_string_pattern(pattern)
             {
                 let validate_fn = if has_length {
+                    record_pattern_with_length(pattern, effective_min, prop.max_length);
                     pattern_and_length_fn_name(pattern, effective_min, prop.max_length)
                 } else {
+                    record_standalone_pattern(pattern);
                     pattern_fn_name(pattern)
                 };
                 let pattern_expr = emit_pattern_option(Some(pattern));
@@ -4320,8 +4695,10 @@ fn cfn_type_to_carina_type_with_enum(
             // Check for regex pattern constraint
             if let Some(pattern) = &prop.pattern {
                 let validate_fn = if has_length {
+                    record_pattern_with_length(pattern, effective_min, prop.max_length);
                     pattern_and_length_fn_name(pattern, effective_min, prop.max_length)
                 } else {
+                    record_standalone_pattern(pattern);
                     pattern_fn_name(pattern)
                 };
                 let pattern_expr = emit_pattern_option(Some(pattern));
@@ -4386,8 +4763,9 @@ fn cfn_type_to_carina_type_with_enum(
             // Check resource-scoped overrides first
             let res_override =
                 resource_type_overrides().get(&(schema.type_name.as_str(), prop_name));
-            if let Some(TypeOverride::IntRange(_min, _max)) = res_override {
+            if let Some(TypeOverride::IntRange(min, max)) = res_override {
                 let validate_fn = format!("validate_{}_range", prop_name.to_snake_case());
+                record_range_validator(prop_name, Some(*min), Some(*max), false);
                 return (
                     format!(
                         r#"AttributeType::Custom {{
@@ -4403,7 +4781,8 @@ fn cfn_type_to_carina_type_with_enum(
                     None,
                 );
             }
-            if let Some(TypeOverride::IntEnum(_values)) = res_override {
+            if let Some(TypeOverride::IntEnum(values)) = res_override {
+                record_int_enum(prop_name, values);
                 let validate_fn = format!("validate_{}_int_enum", prop_name.to_snake_case());
                 return (
                     format!(
@@ -4429,9 +4808,10 @@ fn cfn_type_to_carina_type_with_enum(
                         .get(prop_name)
                         .map(|&(min, max)| (Some(min), Some(max)))
                 };
-            if range.is_some() {
+            if let Some((min, max)) = range {
                 // Generate a ranged int type with validation
                 let validate_fn = format!("validate_{}_range", prop_name.to_snake_case());
+                record_range_validator(prop_name, min, max, false);
                 (
                     format!(
                         r#"AttributeType::Custom {{
@@ -4468,8 +4848,9 @@ fn cfn_type_to_carina_type_with_enum(
             // Check resource-scoped overrides first
             let res_override =
                 resource_type_overrides().get(&(schema.type_name.as_str(), prop_name));
-            if let Some(TypeOverride::IntRange(_min, _max)) = res_override {
+            if let Some(TypeOverride::IntRange(min, max)) = res_override {
                 let validate_fn = format!("validate_{}_range", prop_name.to_snake_case());
+                record_range_validator(prop_name, Some(*min), Some(*max), true);
                 return (
                     format!(
                         r#"AttributeType::Custom {{
@@ -4494,9 +4875,10 @@ fn cfn_type_to_carina_type_with_enum(
                         .get(prop_name)
                         .map(|&(min, max)| (Some(min), Some(max)))
                 };
-            if range.is_some() {
+            if let Some((min, max)) = range {
                 // Generate a ranged float type with validation
                 let validate_fn = format!("validate_{}_range", prop_name.to_snake_case());
+                record_range_validator(prop_name, min, max, true);
                 (
                     format!(
                         r#"AttributeType::Custom {{

--- a/carina-provider-awscc/src/convert.rs
+++ b/carina-provider-awscc/src/convert.rs
@@ -280,6 +280,11 @@ fn proto_to_core_attribute_type(t: &ProtoAttributeType) -> CoreAttributeType {
             validate: noop_validator(),
             to_dsl: None,
         },
+        // Cyclic CFN struct reference (carina#3340). The host's
+        // structural counterpart is `AttributeType::Ref`; the matching
+        // `ResourceSchema.defs` map is converted alongside in
+        // `proto_to_core_schema` so resolution at walk-sites succeeds.
+        ProtoAttributeType::Ref { name } => CoreAttributeType::Ref(name.clone()),
     }
 }
 
@@ -351,6 +356,12 @@ pub fn proto_to_core_schema(s: &ProtoResourceSchema) -> CoreResourceSchema {
         exclusive_required: s.exclusive_required.clone(),
         default_wait_timeout: None,
         default_wait_interval: None,
+        // Cyclic CFN struct definitions reachable via Ref (carina#3340).
+        defs: s
+            .defs
+            .iter()
+            .map(|(k, v)| (k.clone(), proto_to_core_attribute_type(v)))
+            .collect(),
     }
 }
 
@@ -415,6 +426,9 @@ fn core_to_proto_attribute_type(t: &CoreAttributeType) -> ProtoAttributeType {
         CoreAttributeType::Union(members) => ProtoAttributeType::Union {
             members: members.iter().map(core_to_proto_attribute_type).collect(),
         },
+        // Cyclic CFN struct reference (carina#3340). Passes through
+        // unchanged so the host can reconstruct the structural Ref.
+        CoreAttributeType::Ref(name) => ProtoAttributeType::Ref { name: name.clone() },
     }
 }
 
@@ -474,6 +488,12 @@ pub fn core_to_proto_schema(s: &CoreResourceSchema) -> ProtoResourceSchema {
         }),
         validators: vec![],
         exclusive_required: s.exclusive_required.clone(),
+        // Cyclic CFN struct definitions reachable via Ref (carina#3340).
+        defs: s
+            .defs
+            .iter()
+            .map(|(k, v)| (k.clone(), core_to_proto_attribute_type(v)))
+            .collect(),
     }
 }
 

--- a/carina-provider-awscc/src/lib.rs
+++ b/carina-provider-awscc/src/lib.rs
@@ -629,27 +629,45 @@ mod tests {
 
         // Recursively collect the `ordered` flag of every List whose
         // owning struct field is named allowed_methods/cached_methods.
-        fn collect(at: &AttributeType, field: Option<&str>, out: &mut Vec<(String, bool)>) {
+        // carina#3340: the walker resolves `AttributeType::Ref` against
+        // `schema.defs` so cycle-broken / shared struct subtrees stay
+        // reachable. A `seen` set guards against infinite recursion on
+        // genuine cycles.
+        fn collect(
+            at: &AttributeType,
+            field: Option<&str>,
+            defs: &std::collections::BTreeMap<String, AttributeType>,
+            seen: &mut std::collections::HashSet<String>,
+            out: &mut Vec<(String, bool)>,
+        ) {
             match at {
                 AttributeType::List { inner, ordered } => {
                     if matches!(field, Some("allowed_methods" | "cached_methods")) {
                         out.push((field.unwrap().to_string(), *ordered));
                     }
-                    collect(inner, None, out);
+                    collect(inner, None, defs, seen, out);
                 }
                 AttributeType::Struct { fields, .. } => {
                     for f in fields {
-                        collect(&f.field_type, Some(f.name.as_str()), out);
+                        collect(&f.field_type, Some(f.name.as_str()), defs, seen, out);
                     }
                 }
-                AttributeType::Map { value, .. } => collect(value, None, out),
+                AttributeType::Map { value, .. } => collect(value, None, defs, seen, out),
+                AttributeType::Ref(name) => {
+                    if seen.insert(name.clone())
+                        && let Some(target) = defs.get(name)
+                    {
+                        collect(target, field, defs, seen, out);
+                    }
+                }
                 _ => {}
             }
         }
 
         let mut found = Vec::new();
         for attr in schema.attributes.values() {
-            collect(&attr.attr_type, None, &mut found);
+            let mut seen = std::collections::HashSet::new();
+            collect(&attr.attr_type, None, &schema.defs, &mut seen, &mut found);
         }
 
         assert!(

--- a/carina-provider-awscc/src/provider/conversion.rs
+++ b/carina-provider-awscc/src/provider/conversion.rs
@@ -13,13 +13,40 @@ use serde_json::json;
 use crate::schemas::generated::canonicalize_enum_value;
 use carina_core::utils::{convert_enum_value, extract_enum_value_with_values};
 
-/// Convert AWS value to DSL value
+/// Convert AWS value to DSL value (no cyclic-struct defs).
+/// Used by tests; production callers should prefer
+/// [`aws_value_to_dsl_with_defs`].
+#[allow(dead_code)]
 pub(crate) fn aws_value_to_dsl(
     dsl_name: &str,
     value: &serde_json::Value,
     attr_type: &AttributeType,
     resource_type: &str,
 ) -> Option<Value> {
+    aws_value_to_dsl_with_defs(
+        dsl_name,
+        value,
+        attr_type,
+        resource_type,
+        carina_core::schema::empty_defs(),
+    )
+}
+
+/// carina#3340: schema-aware variant that takes the enclosing
+/// [`ResourceSchema::defs`] map so `AttributeType::Ref` chains can be
+/// resolved during the value-tree walk. Callers that hold a resource
+/// schema should prefer this entry point; the 4-arg shim above uses
+/// an empty def map and will panic if a `Ref` is reached.
+pub(crate) fn aws_value_to_dsl_with_defs(
+    dsl_name: &str,
+    value: &serde_json::Value,
+    attr_type: &AttributeType,
+    resource_type: &str,
+    defs: &std::collections::BTreeMap<String, AttributeType>,
+) -> Option<Value> {
+    // Resolve any top-level `Ref` chain so the subsequent shape
+    // checks see the actual Struct/List/Map/... underneath.
+    let attr_type = attr_type.resolve_refs(defs);
     // This feeds the read/import path, whose result is written to
     // state. State must hold the provider-side (API) value, NOT a
     // fully-qualified DSL string: carina-core's state-lift reconciles
@@ -52,7 +79,7 @@ pub(crate) fn aws_value_to_dsl(
             .iter()
             .enumerate()
             .filter_map(|(i, item)| {
-                let result = aws_value_to_dsl(dsl_name, item, inner, resource_type);
+                let result = aws_value_to_dsl_with_defs(dsl_name, item, inner, resource_type, defs);
                 if result.is_none() {
                     log::warn!(
                         "aws_value_to_dsl: dropping unconvertible array item at index {} for attribute '{}' in resource '{}': {:?}",
@@ -68,7 +95,9 @@ pub(crate) fn aws_value_to_dsl(
     // For Union types, try each member type and use the first that produces a type-aware result
     if let AttributeType::Union(members) = attr_type {
         for member in members {
-            if let Some(result) = aws_value_to_dsl(dsl_name, value, member, resource_type) {
+            if let Some(result) =
+                aws_value_to_dsl_with_defs(dsl_name, value, member, resource_type, defs)
+            {
                 return Some(result);
             }
         }
@@ -84,8 +113,13 @@ pub(crate) fn aws_value_to_dsl(
             .filter_map(|field| {
                 let provider_key = field.provider_name.as_deref().unwrap_or(&field.name);
                 let json_val = obj.get(provider_key)?;
-                let dsl_val =
-                    aws_value_to_dsl(&field.name, json_val, &field.field_type, resource_type);
+                let dsl_val = aws_value_to_dsl_with_defs(
+                    &field.name,
+                    json_val,
+                    &field.field_type,
+                    resource_type,
+                    defs,
+                );
                 dsl_val.map(|v| (field.name.clone(), v))
             })
             .collect();
@@ -103,7 +137,7 @@ pub(crate) fn aws_value_to_dsl(
         let map: IndexMap<String, Value> = obj
             .iter()
             .filter_map(|(k, v)| {
-                let result = aws_value_to_dsl(dsl_name, v, inner, resource_type);
+                let result = aws_value_to_dsl_with_defs(dsl_name, v, inner, resource_type, defs);
                 if result.is_none() {
                     log::warn!(
                         "aws_value_to_dsl: dropping unconvertible map entry '{}' for attribute '{}' in resource '{}': {:?}",
@@ -192,12 +226,32 @@ pub(crate) fn json_to_value(value: &serde_json::Value) -> Option<Value> {
 }
 
 /// Convert DSL value to AWS JSON value
+#[allow(dead_code)]
 pub(crate) fn dsl_value_to_aws(
     value: &Value,
     attr_type: &AttributeType,
     resource_type: &str,
     attr_name: &str,
 ) -> Option<serde_json::Value> {
+    dsl_value_to_aws_with_defs(
+        value,
+        attr_type,
+        resource_type,
+        attr_name,
+        carina_core::schema::empty_defs(),
+    )
+}
+
+/// carina#3340: schema-aware variant — see [`aws_value_to_dsl_with_defs`]
+/// for the rationale. Same `Ref` chains, same `&defs` parameter.
+pub(crate) fn dsl_value_to_aws_with_defs(
+    value: &Value,
+    attr_type: &AttributeType,
+    resource_type: &str,
+    attr_name: &str,
+    defs: &std::collections::BTreeMap<String, AttributeType>,
+) -> Option<serde_json::Value> {
+    let attr_type = attr_type.resolve_refs(defs);
     // For schema-level string enums, convert namespaced DSL values back to provider values.
     if attr_type.namespaced_enum_parts().is_some() {
         match value {
@@ -239,7 +293,7 @@ pub(crate) fn dsl_value_to_aws(
             .iter()
             .enumerate()
             .filter_map(|(i, item)| {
-                let result = dsl_value_to_aws(item, inner, resource_type, attr_name);
+                let result = dsl_value_to_aws_with_defs(item, inner, resource_type, attr_name, defs);
                 if result.is_none() {
                     log::warn!(
                         "dsl_value_to_aws: dropping unconvertible list item at index {} for attribute '{}' in resource '{}': {:?}",
@@ -253,7 +307,9 @@ pub(crate) fn dsl_value_to_aws(
     } else if let AttributeType::Union(members) = attr_type {
         // Try each member type; use the first that produces a type-aware result
         for member in members {
-            if let Some(result) = dsl_value_to_aws(value, member, resource_type, attr_name) {
+            if let Some(result) =
+                dsl_value_to_aws_with_defs(value, member, resource_type, attr_name, defs)
+            {
                 return Some(result);
             }
         }
@@ -271,8 +327,13 @@ pub(crate) fn dsl_value_to_aws(
                     .as_deref()
                     .unwrap_or(&field.name)
                     .to_string();
-                let json_val =
-                    dsl_value_to_aws(dsl_val, &field.field_type, resource_type, &field.name);
+                let json_val = dsl_value_to_aws_with_defs(
+                    dsl_val,
+                    &field.field_type,
+                    resource_type,
+                    &field.name,
+                    defs,
+                );
                 json_val.map(|v| (provider_key, v))
             })
             .collect();
@@ -292,8 +353,13 @@ pub(crate) fn dsl_value_to_aws(
                     .as_deref()
                     .unwrap_or(&field.name)
                     .to_string();
-                let json_val =
-                    dsl_value_to_aws(dsl_val, &field.field_type, resource_type, &field.name);
+                let json_val = dsl_value_to_aws_with_defs(
+                    dsl_val,
+                    &field.field_type,
+                    resource_type,
+                    &field.name,
+                    defs,
+                );
                 json_val.map(|v| (provider_key, v))
             })
             .collect();
@@ -307,7 +373,7 @@ pub(crate) fn dsl_value_to_aws(
         let obj: serde_json::Map<String, serde_json::Value> = map
             .iter()
             .filter_map(|(k, v)| {
-                let result = dsl_value_to_aws(v, inner, resource_type, attr_name);
+                let result = dsl_value_to_aws_with_defs(v, inner, resource_type, attr_name, defs);
                 if result.is_none() {
                     log::warn!(
                         "dsl_value_to_aws: dropping unconvertible map entry '{}' for attribute '{}' in resource '{}': {:?}",
@@ -450,11 +516,12 @@ mod tests {
             "PriceClass": "PriceClass_200"
         });
 
-        let dsl = aws_value_to_dsl(
+        let dsl = aws_value_to_dsl_with_defs(
             "distribution_config",
             &aws_json,
             &attr_schema.attr_type,
             "cloudfront.Distribution",
+            &config.schema.defs,
         )
         .expect("aws_value_to_dsl should succeed for distribution_config");
 
@@ -484,8 +551,12 @@ mod tests {
         // carina-core's state-lift reduces the persisted API values to
         // the canonical short identifiers the differ reconciles against
         // the parsed-desired side — closing the awscc#254 spurious diff.
-        let lifted = carina_core::utils::lift_string_enum_leaves(&dsl, &attr_schema.attr_type)
-            .expect("API-canonical distribution_config must lift");
+        let lifted = carina_core::utils::lift_string_enum_leaves_with_defs(
+            &dsl,
+            &attr_schema.attr_type,
+            &config.schema.defs,
+        )
+        .expect("API-canonical distribution_config must lift");
         let Value::Concrete(ConcreteValue::Map(lifted_top)) = &lifted else {
             panic!("expected lifted distribution_config to be a Map, got {lifted:?}");
         };
@@ -1560,11 +1631,12 @@ mod tests {
         });
 
         // Read path: convert AWS JSON to DSL value
-        let dsl_value = aws_value_to_dsl(
+        let dsl_value = aws_value_to_dsl_with_defs(
             "lifecycle_configuration",
             &aws_json,
             &attr_schema.attr_type,
             "s3.Bucket",
+            &config.schema.defs,
         )
         .expect("aws_value_to_dsl should succeed for lifecycle_configuration");
 
@@ -1633,11 +1705,12 @@ mod tests {
         }
 
         // Write path: convert DSL value back to AWS JSON
-        let written_json = dsl_value_to_aws(
+        let written_json = dsl_value_to_aws_with_defs(
             &dsl_value,
             &attr_schema.attr_type,
             "s3.Bucket",
             "lifecycle_configuration",
+            &config.schema.defs,
         )
         .expect("dsl_value_to_aws should succeed");
 
@@ -1662,17 +1735,23 @@ mod tests {
             .attributes
             .get("ownership_controls")
             .expect("s3.Bucket has ownership_controls");
-        let AttributeType::Struct { fields, .. } = &ownership_controls.attr_type else {
+        // carina#3340: reuse-via-Ref may produce `AttributeType::Ref`
+        // at this position; resolve through `schema.defs` so the test
+        // still sees the underlying Struct.
+        let defs = &config.schema.defs;
+        let oc_resolved = ownership_controls.attr_type.resolve_refs(defs);
+        let AttributeType::Struct { fields, .. } = oc_resolved else {
             panic!("ownership_controls is a Struct");
         };
         let rules = fields.iter().find(|f| f.name == "rules").unwrap();
         let AttributeType::List { inner, .. } = &rules.field_type else {
             panic!("rules is a List");
         };
+        let inner_resolved = inner.as_ref().resolve_refs(defs);
         let AttributeType::Struct {
             fields: rule_fields,
             ..
-        } = inner.as_ref()
+        } = inner_resolved
         else {
             panic!("rules.inner is a Struct");
         };

--- a/carina-provider-awscc/src/provider/operations.rs
+++ b/carina-provider-awscc/src/provider/operations.rs
@@ -12,7 +12,7 @@ use carina_core::schema::{AttributeSchema, AttributeType};
 use indexmap::IndexMap;
 use serde_json::json;
 
-use super::conversion::{aws_value_to_dsl, dsl_value_to_aws};
+use super::conversion::{aws_value_to_dsl_with_defs, dsl_value_to_aws_with_defs};
 use super::update::build_update_patches;
 use super::{AwsccProvider, get_schema_config};
 
@@ -44,8 +44,12 @@ impl AwsccProvider {
             None => return Ok(State::not_found(id)),
         };
 
-        let mut attributes =
-            map_aws_props_to_attributes(&props, &config.schema.attributes, resource_type);
+        let mut attributes = map_aws_props_to_attributes(
+            &props,
+            &config.schema.attributes,
+            resource_type,
+            &config.schema.defs,
+        );
 
         // Handle tags
         if config.has_tags
@@ -92,11 +96,12 @@ impl AwsccProvider {
             if let Some(aws_name) = &attr_schema.provider_name
                 && let Some(value) = resource.get_attr(dsl_name.as_str())
             {
-                let aws_value = dsl_value_to_aws(
+                let aws_value = dsl_value_to_aws_with_defs(
                     value,
                     &attr_schema.attr_type,
                     &resource.id.resource_type,
                     dsl_name,
+                    &config.schema.defs,
                 );
                 if let Some(v) = aws_value {
                     desired_state.insert(aws_name.to_string(), v);
@@ -267,6 +272,7 @@ fn map_aws_props_to_attributes(
     props: &serde_json::Value,
     schema_attributes: &HashMap<String, AttributeSchema>,
     resource_type: &str,
+    defs: &std::collections::BTreeMap<String, AttributeType>,
 ) -> HashMap<String, Value> {
     let mut attributes = HashMap::new();
 
@@ -279,9 +285,13 @@ fn map_aws_props_to_attributes(
         };
         match props.get(aws_name.as_str()) {
             Some(value) => {
-                if let Some(v) =
-                    aws_value_to_dsl(dsl_name, value, &attr_schema.attr_type, resource_type)
-                {
+                if let Some(v) = aws_value_to_dsl_with_defs(
+                    dsl_name,
+                    value,
+                    &attr_schema.attr_type,
+                    resource_type,
+                    defs,
+                ) {
                     attributes.insert(dsl_name.clone(), v);
                 }
             }
@@ -373,7 +383,12 @@ mod tests {
         )]);
         let props = json!({});
 
-        let result = map_aws_props_to_attributes(&props, &attrs, "iam.Role");
+        let result = map_aws_props_to_attributes(
+            &props,
+            &attrs,
+            "iam.Role",
+            carina_core::schema::empty_defs(),
+        );
 
         assert_eq!(
             result.get("managed_policy_arns"),
@@ -393,7 +408,12 @@ mod tests {
         )]);
         let props = json!({});
 
-        let result = map_aws_props_to_attributes(&props, &attrs, "some.Resource");
+        let result = map_aws_props_to_attributes(
+            &props,
+            &attrs,
+            "some.Resource",
+            carina_core::schema::empty_defs(),
+        );
 
         assert_eq!(
             result.get("metadata"),
@@ -416,7 +436,12 @@ mod tests {
         )]);
         let props = json!({});
 
-        let result = map_aws_props_to_attributes(&props, &attrs, "some.Resource");
+        let result = map_aws_props_to_attributes(
+            &props,
+            &attrs,
+            "some.Resource",
+            carina_core::schema::empty_defs(),
+        );
 
         assert!(
             !result.contains_key("required_list"),
@@ -437,7 +462,12 @@ mod tests {
         )]);
         let props = json!({});
 
-        let result = map_aws_props_to_attributes(&props, &attrs, "some.Resource");
+        let result = map_aws_props_to_attributes(
+            &props,
+            &attrs,
+            "some.Resource",
+            carina_core::schema::empty_defs(),
+        );
 
         assert!(
             !result.contains_key("description"),
@@ -458,7 +488,12 @@ mod tests {
             "ManagedPolicyArns": ["arn:aws:iam::aws:policy/ReadOnlyAccess"]
         });
 
-        let result = map_aws_props_to_attributes(&props, &attrs, "iam.Role");
+        let result = map_aws_props_to_attributes(
+            &props,
+            &attrs,
+            "iam.Role",
+            carina_core::schema::empty_defs(),
+        );
 
         assert_eq!(
             result.get("managed_policy_arns"),
@@ -481,7 +516,12 @@ mod tests {
         )]);
         let props = json!({});
 
-        let result = map_aws_props_to_attributes(&props, &attrs, "some.Resource");
+        let result = map_aws_props_to_attributes(
+            &props,
+            &attrs,
+            "some.Resource",
+            carina_core::schema::empty_defs(),
+        );
 
         assert!(
             !result.contains_key("tags"),

--- a/carina-provider-awscc/src/provider/update.rs
+++ b/carina-provider-awscc/src/provider/update.rs
@@ -12,7 +12,7 @@ use carina_core::provider::{PatchOp, PatchOpKind, ProviderError, ProviderResult,
 use carina_core::resource::{ConcreteValue, Value};
 use serde_json::json;
 
-use super::conversion::dsl_value_to_aws;
+use super::conversion::dsl_value_to_aws_with_defs;
 use crate::schemas::generated::AwsccSchemaConfig;
 
 /// Parse a JSON string from CloudControl API response into a `serde_json::Value`.
@@ -84,9 +84,13 @@ pub(crate) fn build_update_patches(
 
         match (op.kind, &op.value) {
             (PatchOpKind::Add | PatchOpKind::Replace, Some(value)) => {
-                if let Some(aws_value) =
-                    dsl_value_to_aws(value, &attr_schema.attr_type, resource_type, &op.key)
-                {
+                if let Some(aws_value) = dsl_value_to_aws_with_defs(
+                    value,
+                    &attr_schema.attr_type,
+                    resource_type,
+                    &op.key,
+                    &config.schema.defs,
+                ) {
                     patch_ops.push(json!({
                         "op": "add",
                         "path": format!("/{}", aws_name),

--- a/carina-provider-awscc/src/schemas/generated/cloudfront/distribution.rs
+++ b/carina-provider-awscc/src/schemas/generated/cloudfront/distribution.rs
@@ -98,7 +98,162 @@ pub fn cloudfront_distribution_config() -> AwsccSchemaConfig {
         schema: ResourceSchema::new("cloudfront.Distribution")
         .with_description("A distribution tells CloudFront where you want content to be delivered from, and the details about how to track and manage content delivery.")
         .attribute(
-            AttributeSchema::new("distribution_config", AttributeType::Struct {
+            AttributeSchema::new("distribution_config", AttributeType::Ref("DistributionConfig".to_string()))
+                .required()
+                .with_description("The distribution's configuration.")
+                .with_provider_name("DistributionConfig"),
+        )
+        .attribute(
+            AttributeSchema::new("domain_name", AttributeType::String)
+                .read_only()
+                .deferred_populate()
+                .with_description(" (read-only)")
+                .with_provider_name("DomainName"),
+        )
+        .attribute(
+            AttributeSchema::new("id", AttributeType::String)
+                .read_only()
+                .with_description(" (read-only)")
+                .with_provider_name("Id"),
+        )
+        .attribute(
+            AttributeSchema::new("tags", tags_type())
+                .with_description("A complex type that contains zero or more ``Tag`` elements.")
+                .with_provider_name("Tags"),
+        )
+        .attribute(
+            AttributeSchema::new("arn", super::arn())
+                .read_only()
+                .with_description("The ARN of the CloudFront distribution. Synthesized by the provider from the distribution id; CloudFront's CloudFormation type does not expose ARN through the Cloud Control API. (read-only)"),
+        )
+        .with_validator(|attrs| {
+            let mut errors = Vec::new();
+            if let Err(mut e) = validate_tags_map(attrs) {
+                errors.append(&mut e);
+            }
+            if errors.is_empty() { Ok(()) } else { Err(errors) }
+        })
+        .with_def("CacheTagConfig", AttributeType::Struct {
+                    name: "CacheTagConfig".to_string(),
+                    fields: vec![
+                    StructField::new("header_name", AttributeType::String).required().with_description("The name of the HTTP header that your origin includes in responses. CloudFront uses this header to extract cache tags. The header value must contain comma-separated tag values (for example, ``product:electronics, category:tv, brand:example``).").with_provider_name("HeaderName")
+                    ],
+                })
+        .with_def("ConnectionFunctionAssociation", AttributeType::Struct {
+                    name: "ConnectionFunctionAssociation".to_string(),
+                    fields: vec![
+                    StructField::new("id", AttributeType::String).required().with_description("The association's ID.").with_provider_name("Id")
+                    ],
+                })
+        .with_def("Cookies", AttributeType::Struct {
+                    name: "Cookies".to_string(),
+                    fields: vec![
+                    StructField::new("forward", AttributeType::StringEnum {
+                name: "Forward".to_string(),
+                values: vec!["all".to_string(), "none".to_string(), "whitelist".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("Forward", Some("awscc.cloudfront.Distribution"))),
+                dsl_aliases: vec![("all".to_string(), "all".to_string()), ("none".to_string(), "none".to_string()), ("whitelist".to_string(), "whitelist".to_string())],
+            }).required().with_description("This field is deprecated. We recommend that you use a cache policy or an origin request policy instead of this field. If you want to include cookies in the cache key, use a cache policy. For more information, see [Creating cache policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy) in the *Amazon CloudFront Developer Guide*. If you want to send cookies to the origin but not include them in the cache key, use origin request policy. For more information, see [Creating origin request policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-origin-requests.html#origin-request-create-origin-request-policy) in the *Amazon CloudFront Developer Guide*. Specifies which cookies to forward to the origin for this cache behavior: all, none, or the list of cookies specified in the ``WhitelistedNames`` complex type. Amazon S3 doesn't process cookies. When the cache behavior is forwarding requests to an Amazon S3 origin, specify none for the ``Forward`` element.").with_provider_name("Forward"),
+                    StructField::new("whitelisted_names", AttributeType::list(AttributeType::String)).with_description("This field is deprecated. We recommend that you use a cache policy or an origin request policy instead of this field. If you want to include cookies in the cache key, use a cache policy. For more information, see [Creating cache policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy) in the *Amazon CloudFront Developer Guide*. If you want to send cookies to the origin but not include them in the cache key, use an origin request policy. For more information, see [Creating origin request policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-origin-requests.html#origin-request-create-origin-request-policy) in the *Amazon CloudFront Developer Guide*. Required if you specify ``whitelist`` for the value of ``Forward``. A complex type that specifies how many different cookies you want CloudFront to forward to the origin for this cache behavior and, if you want to forward selected cookies, the names of those cookies. If you specify ``all`` or ``none`` for the value of ``Forward``, omit ``WhitelistedNames``. If you change the value of ``Forward`` from ``whitelist`` to ``all`` or ``none`` and you don't delete the ``WhitelistedNames`` element and its child elements, CloudFront deletes them automatically. For the current limit on the number of cookie names that you can whitelist for each cache behavior, see [CloudFront Limits](https://docs.aws.amazon.com/general/latest/gr/xrefaws_service_limits.html#limits_cloudfront) in the *General Reference*.").with_provider_name("WhitelistedNames")
+                    ],
+                })
+        .with_def("CustomOriginConfig", AttributeType::Struct {
+                    name: "CustomOriginConfig".to_string(),
+                    fields: vec![
+                    StructField::new("http_port", AttributeType::Int).with_description("The HTTP port that CloudFront uses to connect to the origin. Specify the HTTP port that the origin listens on.").with_provider_name("HTTPPort"),
+                    StructField::new("https_port", AttributeType::Int).with_description("The HTTPS port that CloudFront uses to connect to the origin. Specify the HTTPS port that the origin listens on.").with_provider_name("HTTPSPort"),
+                    StructField::new("ip_address_type", AttributeType::StringEnum {
+                name: "IpAddressType".to_string(),
+                values: vec!["ipv4".to_string(), "ipv6".to_string(), "dualstack".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("IpAddressType", Some("awscc.cloudfront.Distribution"))),
+                dsl_aliases: vec![("ipv4".to_string(), "ipv4".to_string()), ("ipv6".to_string(), "ipv6".to_string()), ("dualstack".to_string(), "dualstack".to_string())],
+            }).with_description("Specifies which IP protocol CloudFront uses when connecting to your origin. If your origin uses both IPv4 and IPv6 protocols, you can choose ``dualstack`` to help optimize reliability.").with_provider_name("IpAddressType"),
+                    StructField::new("origin_keepalive_timeout", AttributeType::Int).with_description("Specifies how long, in seconds, CloudFront persists its connection to the origin. The minimum timeout is 1 second, the maximum is 120 seconds, and the default (if you don't specify otherwise) is 5 seconds. For more information, see [Keep-alive timeout (custom origins only)](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/DownloadDistValuesOrigin.html#DownloadDistValuesOriginKeepaliveTimeout) in the *Amazon CloudFront Developer Guide*.").with_provider_name("OriginKeepaliveTimeout"),
+                    StructField::new("origin_mtls_config", AttributeType::Struct {
+                    name: "OriginMtlsConfig".to_string(),
+                    fields: vec![
+                    StructField::new("client_certificate_arn", super::arn()).required().with_description("The Amazon Resource Name (ARN) of the client certificate stored in AWS Certificate Manager (ACM) that CloudFront uses to authenticate with your origin using Mutual TLS.").with_provider_name("ClientCertificateArn")
+                    ],
+                }).with_description("Configures mutual TLS authentication between CloudFront and your origin server.").with_provider_name("OriginMtlsConfig"),
+                    StructField::new("origin_protocol_policy", AttributeType::StringEnum {
+                name: "OriginProtocolPolicy".to_string(),
+                values: vec!["http-only".to_string(), "match-viewer".to_string(), "https-only".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("OriginProtocolPolicy", Some("awscc.cloudfront.Distribution"))),
+                dsl_aliases: vec![("http-only".to_string(), "http_only".to_string()), ("match-viewer".to_string(), "match_viewer".to_string()), ("https-only".to_string(), "https_only".to_string())],
+            }).required().with_description("Specifies the protocol (HTTP or HTTPS) that CloudFront uses to connect to the origin. Valid values are: + ``http-only`` – CloudFront always uses HTTP to connect to the origin. + ``match-viewer`` – CloudFront connects to the origin using the same protocol that the viewer used to connect to CloudFront. + ``https-only`` – CloudFront always uses HTTPS to connect to the origin.").with_provider_name("OriginProtocolPolicy"),
+                    StructField::new("origin_read_timeout", AttributeType::Int).with_description("Specifies how long, in seconds, CloudFront waits for a response from the origin. This is also known as the *origin response timeout*. The minimum timeout is 1 second, the maximum is 120 seconds, and the default (if you don't specify otherwise) is 30 seconds. For more information, see [Response timeout](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/DownloadDistValuesOrigin.html#DownloadDistValuesOriginResponseTimeout) in the *Amazon CloudFront Developer Guide*.").with_provider_name("OriginReadTimeout"),
+                    StructField::new("origin_ssl_protocols", AttributeType::list(AttributeType::StringEnum {
+                name: "OriginSslProtocols".to_string(),
+                values: vec!["SSLv3".to_string(), "TLSv1".to_string(), "TLSv1.1".to_string(), "TLSv1.2".to_string(), "sslv3".to_string(), "tlsv1".to_string(), "tlsv1_1".to_string(), "tlsv1_2".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("OriginSslProtocols", Some("awscc.cloudfront.Distribution"))),
+                dsl_aliases: vec![("SSLv3".to_string(), "sslv3".to_string()), ("TLSv1".to_string(), "tlsv1".to_string()), ("TLSv1.1".to_string(), "tlsv1_1".to_string()), ("TLSv1.2".to_string(), "tlsv1_2".to_string()), ("sslv3".to_string(), "sslv3".to_string()), ("tlsv1".to_string(), "tlsv1".to_string()), ("tlsv1_1".to_string(), "tlsv1_1".to_string()), ("tlsv1_2".to_string(), "tlsv1_2".to_string())],
+            })).with_description("Specifies the minimum SSL/TLS protocol that CloudFront uses when connecting to your origin over HTTPS. Valid values include ``SSLv3``, ``TLSv1``, ``TLSv1.1``, and ``TLSv1.2``. For more information, see [Minimum Origin SSL Protocol](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/DownloadDistValuesOrigin.html#DownloadDistValuesOriginSSLProtocols) in the *Amazon CloudFront Developer Guide*.").with_provider_name("OriginSSLProtocols")
+                    ],
+                })
+        .with_def("DefaultCacheBehavior", AttributeType::Struct {
+                    name: "DefaultCacheBehavior".to_string(),
+                    fields: vec![
+                    StructField::new("allowed_methods", AttributeType::unordered_list(AttributeType::StringEnum {
+                name: "AllowedMethods".to_string(),
+                values: vec!["GET".to_string(), "HEAD".to_string(), "OPTIONS".to_string(), "PUT".to_string(), "PATCH".to_string(), "POST".to_string(), "DELETE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("AllowedMethods", Some("awscc.cloudfront.Distribution"))),
+                dsl_aliases: vec![("GET".to_string(), "get".to_string()), ("HEAD".to_string(), "head".to_string()), ("OPTIONS".to_string(), "options".to_string()), ("PUT".to_string(), "put".to_string()), ("PATCH".to_string(), "patch".to_string()), ("POST".to_string(), "post".to_string()), ("DELETE".to_string(), "delete".to_string())],
+            })).with_description("A complex type that controls which HTTP methods CloudFront processes and forwards to your Amazon S3 bucket or your custom origin. There are three choices: + CloudFront forwards only ``GET`` and ``HEAD`` requests. + CloudFront forwards only ``GET``, ``HEAD``, and ``OPTIONS`` requests. + CloudFront forwards ``GET, HEAD, OPTIONS, PUT, PATCH, POST``, and ``DELETE`` requests. If you pick the third choice, you may need to restrict access to your Amazon S3 bucket or to your custom origin so users can't perform operations that you don't want them to. For example, you might not want users to have permissions to delete objects from your origin.").with_provider_name("AllowedMethods"),
+                    StructField::new("cache_policy_id", AttributeType::String).with_description("The unique identifier of the cache policy that is attached to the default cache behavior. For more information, see [Creating cache policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy) or [Using the managed cache policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html) in the *Amazon CloudFront Developer Guide*. A ``DefaultCacheBehavior`` must include either a ``CachePolicyId`` or ``ForwardedValues``. We recommend that you use a ``CachePolicyId``.").with_provider_name("CachePolicyId"),
+                    StructField::new("cached_methods", AttributeType::unordered_list(AttributeType::StringEnum {
+                name: "CachedMethods".to_string(),
+                values: vec!["GET".to_string(), "HEAD".to_string(), "OPTIONS".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("CachedMethods", Some("awscc.cloudfront.Distribution"))),
+                dsl_aliases: vec![("GET".to_string(), "get".to_string()), ("HEAD".to_string(), "head".to_string()), ("OPTIONS".to_string(), "options".to_string())],
+            })).with_description("A complex type that controls whether CloudFront caches the response to requests using the specified HTTP methods. There are two choices: + CloudFront caches responses to ``GET`` and ``HEAD`` requests. + CloudFront caches responses to ``GET``, ``HEAD``, and ``OPTIONS`` requests. If you pick the second choice for your Amazon S3 Origin, you may need to forward Access-Control-Request-Method, Access-Control-Request-Headers, and Origin headers for the responses to be cached correctly.").with_provider_name("CachedMethods"),
+                    StructField::new("compress", AttributeType::Bool).with_description("Whether you want CloudFront to automatically compress certain files for this cache behavior. If so, specify ``true``; if not, specify ``false``. For more information, see [Serving Compressed Files](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/ServingCompressedFiles.html) in the *Amazon CloudFront Developer Guide*.").with_provider_name("Compress"),
+                    StructField::new("default_ttl", AttributeType::Float).with_description("This field only supports standard distributions. You can't specify this field for multi-tenant distributions. For more information, see [Unsupported features for SaaS Manager for Amazon CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-config-options.html#unsupported-saas) in the *Amazon CloudFront Developer Guide*. This field is deprecated. We recommend that you use the ``DefaultTTL`` field in a cache policy instead of this field. For more information, see [Creating cache policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy) or [Using the managed cache policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html) in the *Amazon CloudFront Developer Guide*. The default amount of time that you want objects to stay in CloudFront caches before CloudFront forwards another request to your origin to determine whether the object has been updated. The value that you specify applies only when your origin does not add HTTP headers such as ``Cache-Control max-age``, ``Cache-Control s-maxage``, and ``Expires`` to objects. For more information, see [Managing How Long Content Stays in an Edge Cache (Expiration)](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html) in the *Amazon CloudFront Developer Guide*.").with_provider_name("DefaultTTL"),
+                    StructField::new("field_level_encryption_id", AttributeType::String).with_description("The value of ``ID`` for the field-level encryption configuration that you want CloudFront to use for encrypting specific fields of data for the default cache behavior.").with_provider_name("FieldLevelEncryptionId"),
+                    StructField::new("forwarded_values", AttributeType::Ref("ForwardedValues".to_string())).with_description("This field is deprecated. We recommend that you use a cache policy or an origin request policy instead of this field. For more information, see [Working with policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/working-with-policies.html) in the *Amazon CloudFront Developer Guide*. If you want to include values in the cache key, use a cache policy. For more information, see [Creating cache policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy) or [Using the managed cache policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html) in the *Amazon CloudFront Developer Guide*. If you want to send values to the origin but not include them in the cache key, use an origin request policy. For more information, see [Creating origin request policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-origin-requests.html#origin-request-create-origin-request-policy) or [Using the managed origin request policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-origin-request-policies.html) in the *Amazon CloudFront Developer Guide*. A ``DefaultCacheBehavior`` must include either a ``CachePolicyId`` or ``ForwardedValues``. We recommend that you use a ``CachePolicyId``. A complex type that specifies how CloudFront handles query strings, cookies, and HTTP headers.").with_provider_name("ForwardedValues"),
+                    StructField::new("function_associations", AttributeType::list(AttributeType::Struct {
+                    name: "FunctionAssociation".to_string(),
+                    fields: vec![
+                    StructField::new("event_type", AttributeType::StringEnum {
+                name: "EventType".to_string(),
+                values: vec!["viewer-request".to_string(), "viewer-response".to_string(), "origin-request".to_string(), "origin-response".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("EventType", Some("awscc.cloudfront.Distribution"))),
+                dsl_aliases: vec![("viewer-request".to_string(), "viewer_request".to_string()), ("viewer-response".to_string(), "viewer_response".to_string()), ("origin-request".to_string(), "origin_request".to_string()), ("origin-response".to_string(), "origin_response".to_string())],
+            }).with_description("The event type of the function, either ``viewer-request`` or ``viewer-response``. You cannot use origin-facing event types (``origin-request`` and ``origin-response``) with a CloudFront function.").with_provider_name("EventType"),
+                    StructField::new("function_arn", super::arn()).with_description("The Amazon Resource Name (ARN) of the function.").with_provider_name("FunctionARN")
+                    ],
+                })).with_description("A list of CloudFront functions that are associated with this cache behavior. Your functions must be published to the ``LIVE`` stage to associate them with a cache behavior.").with_provider_name("FunctionAssociations").with_block_name("function_association"),
+                    StructField::new("grpc_config", AttributeType::Ref("GrpcConfig".to_string())).with_description("The gRPC configuration for your cache behavior.").with_provider_name("GrpcConfig"),
+                    StructField::new("lambda_function_associations", AttributeType::list(AttributeType::Struct {
+                    name: "LambdaFunctionAssociation".to_string(),
+                    fields: vec![
+                    StructField::new("event_type", AttributeType::StringEnum {
+                name: "EventType".to_string(),
+                values: vec!["viewer-request".to_string(), "origin-request".to_string(), "origin-response".to_string(), "viewer-response".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("EventType", Some("awscc.cloudfront.Distribution"))),
+                dsl_aliases: vec![("viewer-request".to_string(), "viewer_request".to_string()), ("origin-request".to_string(), "origin_request".to_string()), ("origin-response".to_string(), "origin_response".to_string()), ("viewer-response".to_string(), "viewer_response".to_string())],
+            }).with_description("Specifies the event type that triggers a Lambda@Edge function invocation. You can specify the following values: + ``viewer-request``: The function executes when CloudFront receives a request from a viewer and before it checks to see whether the requested object is in the edge cache. + ``origin-request``: The function executes only when CloudFront sends a request to your origin. When the requested object is in the edge cache, the function doesn't execute. + ``origin-response``: The function executes after CloudFront receives a response from the origin and before it caches the object in the response. When the requested object is in the edge cache, the function doesn't execute. + ``viewer-response``: The function executes before CloudFront returns the requested object to the viewer. The function executes regardless of whether the object was already in the edge cache. If the origin returns an HTTP status code other than HTTP 200 (OK), the function doesn't execute.").with_provider_name("EventType"),
+                    StructField::new("include_body", AttributeType::Bool).with_description("A flag that allows a Lambda@Edge function to have read access to the body content. For more information, see [Accessing the Request Body by Choosing the Include Body Option](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-include-body-access.html) in the Amazon CloudFront Developer Guide.").with_provider_name("IncludeBody"),
+                    StructField::new("lambda_function_arn", super::arn()).with_description("The ARN of the Lambda@Edge function. You must specify the ARN of a function version; you can't specify an alias or $LATEST.").with_provider_name("LambdaFunctionARN")
+                    ],
+                })).with_description("A complex type that contains zero or more Lambda@Edge function associations for a cache behavior.").with_provider_name("LambdaFunctionAssociations").with_block_name("lambda_function_association"),
+                    StructField::new("max_ttl", AttributeType::Float).with_description("This field only supports standard distributions. You can't specify this field for multi-tenant distributions. For more information, see [Unsupported features for SaaS Manager for Amazon CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-config-options.html#unsupported-saas) in the *Amazon CloudFront Developer Guide*. This field is deprecated. We recommend that you use the ``MaxTTL`` field in a cache policy instead of this field. For more information, see [Creating cache policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy) or [Using the managed cache policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html) in the *Amazon CloudFront Developer Guide*. The maximum amount of time that you want objects to stay in CloudFront caches before CloudFront forwards another request to your origin to determine whether the object has been updated. The value that you specify applies only when your origin adds HTTP headers such as ``Cache-Control max-age``, ``Cache-Control s-maxage``, and ``Expires`` to objects. For more information, see [Managing How Long Content Stays in an Edge Cache (Expiration)](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html) in the *Amazon CloudFront Developer Guide*.").with_provider_name("MaxTTL"),
+                    StructField::new("min_ttl", AttributeType::Float).with_description("This field only supports standard distributions. You can't specify this field for multi-tenant distributions. For more information, see [Unsupported features for SaaS Manager for Amazon CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-config-options.html#unsupported-saas) in the *Amazon CloudFront Developer Guide*. This field is deprecated. We recommend that you use the ``MinTTL`` field in a cache policy instead of this field. For more information, see [Creating cache policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy) or [Using the managed cache policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html) in the *Amazon CloudFront Developer Guide*. The minimum amount of time that you want objects to stay in CloudFront caches before CloudFront forwards another request to your origin to determine whether the object has been updated. For more information, see [Managing How Long Content Stays in an Edge Cache (Expiration)](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html) in the *Amazon CloudFront Developer Guide*. You must specify ``0`` for ``MinTTL`` if you configure CloudFront to forward all headers to your origin (under ``Headers``, if you specify ``1`` for ``Quantity`` and ``*`` for ``Name``).").with_provider_name("MinTTL"),
+                    StructField::new("origin_request_policy_id", AttributeType::String).with_description("The unique identifier of the origin request policy that is attached to the default cache behavior. For more information, see [Creating origin request policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-origin-requests.html#origin-request-create-origin-request-policy) or [Using the managed origin request policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-origin-request-policies.html) in the *Amazon CloudFront Developer Guide*.").with_provider_name("OriginRequestPolicyId"),
+                    StructField::new("realtime_log_config_arn", super::arn()).with_description("The Amazon Resource Name (ARN) of the real-time log configuration that is attached to this cache behavior. For more information, see [Real-time logs](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/real-time-logs.html) in the *Amazon CloudFront Developer Guide*.").with_provider_name("RealtimeLogConfigArn"),
+                    StructField::new("response_headers_policy_id", AttributeType::String).with_description("The identifier for a response headers policy.").with_provider_name("ResponseHeadersPolicyId"),
+                    StructField::new("smooth_streaming", AttributeType::Bool).with_description("This field only supports standard distributions. You can't specify this field for multi-tenant distributions. For more information, see [Unsupported features for SaaS Manager for Amazon CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-config-options.html#unsupported-saas) in the *Amazon CloudFront Developer Guide*. Indicates whether you want to distribute media files in the Microsoft Smooth Streaming format using the origin that is associated with this cache behavior. If so, specify ``true``; if not, specify ``false``. If you specify ``true`` for ``SmoothStreaming``, you can still distribute other content using this cache behavior if the content matches the value of ``PathPattern``.").with_provider_name("SmoothStreaming"),
+                    StructField::new("target_origin_id", AttributeType::String).required().with_description("The value of ``ID`` for the origin that you want CloudFront to route requests to when they use the default cache behavior.").with_provider_name("TargetOriginId"),
+                    StructField::new("trusted_key_groups", AttributeType::list(AttributeType::String)).with_description("A list of key groups that CloudFront can use to validate signed URLs or signed cookies. When a cache behavior contains trusted key groups, CloudFront requires signed URLs or signed cookies for all requests that match the cache behavior. The URLs or cookies must be signed with a private key whose corresponding public key is in the key group. The signed URL or cookie contains information about which public key CloudFront should use to verify the signature. For more information, see [Serving private content](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/PrivateContent.html) in the *Amazon CloudFront Developer Guide*.").with_provider_name("TrustedKeyGroups"),
+                    StructField::new("trusted_signers", AttributeType::list(AttributeType::String)).with_description("We recommend using ``TrustedKeyGroups`` instead of ``TrustedSigners``. This field only supports standard distributions. You can't specify this field for multi-tenant distributions. For more information, see [Unsupported features for SaaS Manager for Amazon CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-config-options.html#unsupported-saas) in the *Amazon CloudFront Developer Guide*. A list of AWS-account IDs whose public keys CloudFront can use to validate signed URLs or signed cookies. When a cache behavior contains trusted signers, CloudFront requires signed URLs or signed cookies for all requests that match the cache behavior. The URLs or cookies must be signed with the private key of a CloudFront key pair in a trusted signer's AWS-account. The signed URL or cookie contains information about which public key CloudFront should use to verify the signature. For more information, see [Serving private content](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/PrivateContent.html) in the *Amazon CloudFront Developer Guide*.").with_provider_name("TrustedSigners"),
+                    StructField::new("viewer_protocol_policy", AttributeType::StringEnum {
+                name: "ViewerProtocolPolicy".to_string(),
+                values: vec!["allow-all".to_string(), "redirect-to-https".to_string(), "https-only".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("ViewerProtocolPolicy", Some("awscc.cloudfront.Distribution"))),
+                dsl_aliases: vec![("allow-all".to_string(), "allow_all".to_string()), ("redirect-to-https".to_string(), "redirect_to_https".to_string()), ("https-only".to_string(), "https_only".to_string())],
+            }).required().with_description("The protocol that viewers can use to access the files in the origin specified by ``TargetOriginId`` when a request matches the path pattern in ``PathPattern``. You can specify the following options: + ``allow-all``: Viewers can use HTTP or HTTPS. + ``redirect-to-https``: If a viewer submits an HTTP request, CloudFront returns an HTTP status code of 301 (Moved Permanently) to the viewer along with the HTTPS URL. The viewer then resubmits the request using the new URL. + ``https-only``: If a viewer sends an HTTP request, CloudFront returns an HTTP status code of 403 (Forbidden). For more information about requiring the HTTPS protocol, see [Requiring HTTPS Between Viewers and CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-https-viewers-to-cloudfront.html) in the *Amazon CloudFront Developer Guide*. The only way to guarantee that viewers retrieve an object that was fetched from the origin using HTTPS is never to use any other protocol to fetch the object. If you have recently changed from HTTP to HTTPS, we recommend that you clear your objects' cache because cached objects are protocol agnostic. That means that an edge location will return an object from the cache regardless of whether the current request protocol matches the protocol used previously. For more information, see [Managing Cache Expiration](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html) in the *Amazon CloudFront Developer Guide*.").with_provider_name("ViewerProtocolPolicy")
+                    ],
+                })
+        .with_def("DistributionConfig", AttributeType::Struct {
                     name: "DistributionConfig".to_string(),
                     fields: vec![
                     StructField::new("aliases", AttributeType::list(AttributeType::String)).with_description("This field only supports standard distributions. You can't specify this field for multi-tenant distributions. For more information, see [Unsupported features for SaaS Manager for Amazon CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-config-options.html#unsupported-saas) in the *Amazon CloudFront Developer Guide*. A complex type that contains information about CNAMEs (alternate domain names), if any, for this distribution.").with_provider_name("Aliases"),
@@ -147,9 +302,9 @@ pub fn cloudfront_distribution_config() -> AwsccSchemaConfig {
                     name: "FunctionAssociation".to_string(),
                     fields: vec![
                     StructField::new("event_type", AttributeType::StringEnum {
-                name: "FunctionAssociationEventType".to_string(),
+                name: "EventType".to_string(),
                 values: vec!["viewer-request".to_string(), "viewer-response".to_string(), "origin-request".to_string(), "origin-response".to_string()],
-                identity: Some(carina_core::schema::string_enum_identity("FunctionAssociationEventType", Some("awscc.cloudfront.Distribution"))),
+                identity: Some(carina_core::schema::string_enum_identity("EventType", Some("awscc.cloudfront.Distribution"))),
                 dsl_aliases: vec![("viewer-request".to_string(), "viewer_request".to_string()), ("viewer-response".to_string(), "viewer_response".to_string()), ("origin-request".to_string(), "origin_request".to_string()), ("origin-response".to_string(), "origin_response".to_string())],
             }).with_description("The event type of the function, either ``viewer-request`` or ``viewer-response``. You cannot use origin-facing event types (``origin-request`` and ``origin-response``) with a CloudFront function.").with_provider_name("EventType"),
                     StructField::new("function_arn", super::arn()).with_description("The Amazon Resource Name (ARN) of the function.").with_provider_name("FunctionARN")
@@ -165,9 +320,9 @@ pub fn cloudfront_distribution_config() -> AwsccSchemaConfig {
                     name: "LambdaFunctionAssociation".to_string(),
                     fields: vec![
                     StructField::new("event_type", AttributeType::StringEnum {
-                name: "LambdaFunctionAssociationEventType".to_string(),
+                name: "EventType".to_string(),
                 values: vec!["viewer-request".to_string(), "origin-request".to_string(), "origin-response".to_string(), "viewer-response".to_string()],
-                identity: Some(carina_core::schema::string_enum_identity("LambdaFunctionAssociationEventType", Some("awscc.cloudfront.Distribution"))),
+                identity: Some(carina_core::schema::string_enum_identity("EventType", Some("awscc.cloudfront.Distribution"))),
                 dsl_aliases: vec![("viewer-request".to_string(), "viewer_request".to_string()), ("origin-request".to_string(), "origin_request".to_string()), ("origin-response".to_string(), "origin_response".to_string()), ("viewer-response".to_string(), "viewer_response".to_string())],
             }).with_description("Specifies the event type that triggers a Lambda@Edge function invocation. You can specify the following values: + ``viewer-request``: The function executes when CloudFront receives a request from a viewer and before it checks to see whether the requested object is in the edge cache. + ``origin-request``: The function executes only when CloudFront sends a request to your origin. When the requested object is in the edge cache, the function doesn't execute. + ``origin-response``: The function executes after CloudFront receives a response from the origin and before it caches the object in the response. When the requested object is in the edge cache, the function doesn't execute. + ``viewer-response``: The function executes before CloudFront returns the requested object to the viewer. The function executes regardless of whether the object was already in the edge cache. If the origin returns an HTTP status code other than HTTP 200 (OK), the function doesn't execute.").with_provider_name("EventType"),
                     StructField::new("include_body", AttributeType::Bool).with_description("A flag that allows a Lambda@Edge function to have read access to the body content. For more information, see [Accessing the Request Body by Choosing the Include Body Option](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-include-body-access.html) in the Amazon CloudFront Developer Guide.").with_provider_name("IncludeBody"),
@@ -228,9 +383,9 @@ pub fn cloudfront_distribution_config() -> AwsccSchemaConfig {
                     StructField::new("http_port", AttributeType::Int).with_description("The HTTP port that CF uses to connect to the origin. Specify the HTTP port that the origin listens on.").with_provider_name("HTTPPort"),
                     StructField::new("https_port", AttributeType::Int).with_description("The HTTPS port that CF uses to connect to the origin. Specify the HTTPS port that the origin listens on.").with_provider_name("HTTPSPort"),
                     StructField::new("origin_protocol_policy", AttributeType::StringEnum {
-                name: "LegacyCustomOriginOriginProtocolPolicy".to_string(),
+                name: "OriginProtocolPolicy".to_string(),
                 values: vec!["http-only".to_string(), "https-only".to_string(), "match-viewer".to_string()],
-                identity: Some(carina_core::schema::string_enum_identity("LegacyCustomOriginOriginProtocolPolicy", Some("awscc.cloudfront.Distribution"))),
+                identity: Some(carina_core::schema::string_enum_identity("OriginProtocolPolicy", Some("awscc.cloudfront.Distribution"))),
                 dsl_aliases: vec![("http-only".to_string(), "http_only".to_string()), ("https-only".to_string(), "https_only".to_string()), ("match-viewer".to_string(), "match_viewer".to_string())],
             }).required().with_description("Specifies the protocol (HTTP or HTTPS) that CF uses to connect to the origin.").with_provider_name("OriginProtocolPolicy"),
                     StructField::new("origin_ssl_protocols", AttributeType::list(AttributeType::StringEnum {
@@ -260,51 +415,27 @@ pub fn cloudfront_distribution_config() -> AwsccSchemaConfig {
                     StructField::new("compress", AttributeType::Bool).with_description("Whether you want CloudFront to automatically compress certain files for this cache behavior. If so, specify ``true``; if not, specify ``false``. For more information, see [Serving Compressed Files](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/ServingCompressedFiles.html) in the *Amazon CloudFront Developer Guide*.").with_provider_name("Compress"),
                     StructField::new("default_ttl", AttributeType::Float).with_description("This field only supports standard distributions. You can't specify this field for multi-tenant distributions. For more information, see [Unsupported features for SaaS Manager for Amazon CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-config-options.html#unsupported-saas) in the *Amazon CloudFront Developer Guide*. This field is deprecated. We recommend that you use the ``DefaultTTL`` field in a cache policy instead of this field. For more information, see [Creating cache policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy) or [Using the managed cache policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html) in the *Amazon CloudFront Developer Guide*. The default amount of time that you want objects to stay in CloudFront caches before CloudFront forwards another request to your origin to determine whether the object has been updated. The value that you specify applies only when your origin does not add HTTP headers such as ``Cache-Control max-age``, ``Cache-Control s-maxage``, and ``Expires`` to objects. For more information, see [Managing How Long Content Stays in an Edge Cache (Expiration)](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Expiration.html) in the *Amazon CloudFront Developer Guide*.").with_provider_name("DefaultTTL"),
                     StructField::new("field_level_encryption_id", AttributeType::String).with_description("The value of ``ID`` for the field-level encryption configuration that you want CloudFront to use for encrypting specific fields of data for the default cache behavior.").with_provider_name("FieldLevelEncryptionId"),
-                    StructField::new("forwarded_values", AttributeType::Struct {
-                    name: "ForwardedValues".to_string(),
-                    fields: vec![
-                    StructField::new("cookies", AttributeType::Struct {
-                    name: "Cookies".to_string(),
-                    fields: vec![
-                    StructField::new("forward", AttributeType::StringEnum {
-                name: "Forward".to_string(),
-                values: vec!["all".to_string(), "none".to_string(), "whitelist".to_string()],
-                identity: Some(carina_core::schema::string_enum_identity("Forward", Some("awscc.cloudfront.Distribution"))),
-                dsl_aliases: vec![("all".to_string(), "all".to_string()), ("none".to_string(), "none".to_string()), ("whitelist".to_string(), "whitelist".to_string())],
-            }).required().with_description("This field is deprecated. We recommend that you use a cache policy or an origin request policy instead of this field. If you want to include cookies in the cache key, use a cache policy. For more information, see [Creating cache policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy) in the *Amazon CloudFront Developer Guide*. If you want to send cookies to the origin but not include them in the cache key, use origin request policy. For more information, see [Creating origin request policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-origin-requests.html#origin-request-create-origin-request-policy) in the *Amazon CloudFront Developer Guide*. Specifies which cookies to forward to the origin for this cache behavior: all, none, or the list of cookies specified in the ``WhitelistedNames`` complex type. Amazon S3 doesn't process cookies. When the cache behavior is forwarding requests to an Amazon S3 origin, specify none for the ``Forward`` element.").with_provider_name("Forward"),
-                    StructField::new("whitelisted_names", AttributeType::list(AttributeType::String)).with_description("This field is deprecated. We recommend that you use a cache policy or an origin request policy instead of this field. If you want to include cookies in the cache key, use a cache policy. For more information, see [Creating cache policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy) in the *Amazon CloudFront Developer Guide*. If you want to send cookies to the origin but not include them in the cache key, use an origin request policy. For more information, see [Creating origin request policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-origin-requests.html#origin-request-create-origin-request-policy) in the *Amazon CloudFront Developer Guide*. Required if you specify ``whitelist`` for the value of ``Forward``. A complex type that specifies how many different cookies you want CloudFront to forward to the origin for this cache behavior and, if you want to forward selected cookies, the names of those cookies. If you specify ``all`` or ``none`` for the value of ``Forward``, omit ``WhitelistedNames``. If you change the value of ``Forward`` from ``whitelist`` to ``all`` or ``none`` and you don't delete the ``WhitelistedNames`` element and its child elements, CloudFront deletes them automatically. For the current limit on the number of cookie names that you can whitelist for each cache behavior, see [CloudFront Limits](https://docs.aws.amazon.com/general/latest/gr/xrefaws_service_limits.html#limits_cloudfront) in the *General Reference*.").with_provider_name("WhitelistedNames")
-                    ],
-                }).with_description("This field is deprecated. We recommend that you use a cache policy or an origin request policy instead of this field. If you want to include cookies in the cache key, use a cache policy. For more information, see [Creating cache policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy) in the *Amazon CloudFront Developer Guide*. If you want to send cookies to the origin but not include them in the cache key, use an origin request policy. For more information, see [Creating origin request policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-origin-requests.html#origin-request-create-origin-request-policy) in the *Amazon CloudFront Developer Guide*. A complex type that specifies whether you want CloudFront to forward cookies to the origin and, if so, which ones. For more information about forwarding cookies to the origin, see [How CloudFront Forwards, Caches, and Logs Cookies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Cookies.html) in the *Amazon CloudFront Developer Guide*.").with_provider_name("Cookies"),
-                    StructField::new("headers", AttributeType::list(AttributeType::String)).with_description("This field is deprecated. We recommend that you use a cache policy or an origin request policy instead of this field. If you want to include headers in the cache key, use a cache policy. For more information, see [Creating cache policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy) in the *Amazon CloudFront Developer Guide*. If you want to send headers to the origin but not include them in the cache key, use an origin request policy. For more information, see [Creating origin request policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-origin-requests.html#origin-request-create-origin-request-policy) in the *Amazon CloudFront Developer Guide*. A complex type that specifies the ``Headers``, if any, that you want CloudFront to forward to the origin for this cache behavior (whitelisted headers). For the headers that you specify, CloudFront also caches separate versions of a specified object that is based on the header values in viewer requests. For more information, see [Caching Content Based on Request Headers](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/header-caching.html) in the *Amazon CloudFront Developer Guide*.").with_provider_name("Headers"),
-                    StructField::new("query_string", AttributeType::Bool).required().with_description("This field is deprecated. We recommend that you use a cache policy or an origin request policy instead of this field. If you want to include query strings in the cache key, use a cache policy. For more information, see [Creating cache policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy) in the *Amazon CloudFront Developer Guide*. If you want to send query strings to the origin but not include them in the cache key, use an origin request policy. For more information, see [Creating origin request policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-origin-requests.html#origin-request-create-origin-request-policy) in the *Amazon CloudFront Developer Guide*. Indicates whether you want CloudFront to forward query strings to the origin that is associated with this cache behavior and cache based on the query string parameters. CloudFront behavior depends on the value of ``QueryString`` and on the values that you specify for ``QueryStringCacheKeys``, if any: If you specify true for ``QueryString`` and you don't specify any values for ``QueryStringCacheKeys``, CloudFront forwards all query string parameters to the origin and caches based on all query string parameters. Depending on how many query string parameters and values you have, this can adversely affect performance because CloudFront must forward more requests to the origin. If you specify true for ``QueryString`` and you specify one or more values for ``QueryStringCacheKeys``, CloudFront forwards all query string parameters to the origin, but it only caches based on the query string parameters that you specify. If you specify false for ``QueryString``, CloudFront doesn't forward any query string parameters to the origin, and doesn't cache based on query string parameters. For more information, see [Configuring CloudFront to Cache Based on Query String Parameters](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/QueryStringParameters.html) in the *Amazon CloudFront Developer Guide*.").with_provider_name("QueryString"),
-                    StructField::new("query_string_cache_keys", AttributeType::list(AttributeType::String)).with_description("This field is deprecated. We recommend that you use a cache policy or an origin request policy instead of this field. If you want to include query strings in the cache key, use a cache policy. For more information, see [Creating cache policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy) in the *Amazon CloudFront Developer Guide*. If you want to send query strings to the origin but not include them in the cache key, use an origin request policy. For more information, see [Creating origin request policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-origin-requests.html#origin-request-create-origin-request-policy) in the *Amazon CloudFront Developer Guide*. A complex type that contains information about the query string parameters that you want CloudFront to use for caching for this cache behavior.").with_provider_name("QueryStringCacheKeys")
-                    ],
-                }).with_description("This field is deprecated. We recommend that you use a cache policy or an origin request policy instead of this field. For more information, see [Working with policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/working-with-policies.html) in the *Amazon CloudFront Developer Guide*. If you want to include values in the cache key, use a cache policy. For more information, see [Creating cache policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy) or [Using the managed cache policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html) in the *Amazon CloudFront Developer Guide*. If you want to send values to the origin but not include them in the cache key, use an origin request policy. For more information, see [Creating origin request policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-origin-requests.html#origin-request-create-origin-request-policy) or [Using the managed origin request policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-origin-request-policies.html) in the *Amazon CloudFront Developer Guide*. A ``DefaultCacheBehavior`` must include either a ``CachePolicyId`` or ``ForwardedValues``. We recommend that you use a ``CachePolicyId``. A complex type that specifies how CloudFront handles query strings, cookies, and HTTP headers.").with_provider_name("ForwardedValues"),
+                    StructField::new("forwarded_values", AttributeType::Ref("ForwardedValues".to_string())).with_description("This field is deprecated. We recommend that you use a cache policy or an origin request policy instead of this field. For more information, see [Working with policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/working-with-policies.html) in the *Amazon CloudFront Developer Guide*. If you want to include values in the cache key, use a cache policy. For more information, see [Creating cache policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy) or [Using the managed cache policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html) in the *Amazon CloudFront Developer Guide*. If you want to send values to the origin but not include them in the cache key, use an origin request policy. For more information, see [Creating origin request policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-origin-requests.html#origin-request-create-origin-request-policy) or [Using the managed origin request policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-origin-request-policies.html) in the *Amazon CloudFront Developer Guide*. A ``DefaultCacheBehavior`` must include either a ``CachePolicyId`` or ``ForwardedValues``. We recommend that you use a ``CachePolicyId``. A complex type that specifies how CloudFront handles query strings, cookies, and HTTP headers.").with_provider_name("ForwardedValues"),
                     StructField::new("function_associations", AttributeType::list(AttributeType::Struct {
                     name: "FunctionAssociation".to_string(),
                     fields: vec![
                     StructField::new("event_type", AttributeType::StringEnum {
-                name: "FunctionAssociationEventType".to_string(),
+                name: "EventType".to_string(),
                 values: vec!["viewer-request".to_string(), "viewer-response".to_string(), "origin-request".to_string(), "origin-response".to_string()],
-                identity: Some(carina_core::schema::string_enum_identity("FunctionAssociationEventType", Some("awscc.cloudfront.Distribution"))),
+                identity: Some(carina_core::schema::string_enum_identity("EventType", Some("awscc.cloudfront.Distribution"))),
                 dsl_aliases: vec![("viewer-request".to_string(), "viewer_request".to_string()), ("viewer-response".to_string(), "viewer_response".to_string()), ("origin-request".to_string(), "origin_request".to_string()), ("origin-response".to_string(), "origin_response".to_string())],
             }).with_description("The event type of the function, either ``viewer-request`` or ``viewer-response``. You cannot use origin-facing event types (``origin-request`` and ``origin-response``) with a CloudFront function.").with_provider_name("EventType"),
                     StructField::new("function_arn", super::arn()).with_description("The Amazon Resource Name (ARN) of the function.").with_provider_name("FunctionARN")
                     ],
                 })).with_description("A list of CloudFront functions that are associated with this cache behavior. Your functions must be published to the ``LIVE`` stage to associate them with a cache behavior.").with_provider_name("FunctionAssociations").with_block_name("function_association"),
-                    StructField::new("grpc_config", AttributeType::Struct {
-                    name: "GrpcConfig".to_string(),
-                    fields: vec![
-                    StructField::new("enabled", AttributeType::Bool).required().with_description("Enables your CloudFront distribution to receive gRPC requests and to proxy them directly to your origins.").with_provider_name("Enabled")
-                    ],
-                }).with_description("The gRPC configuration for your cache behavior.").with_provider_name("GrpcConfig"),
+                    StructField::new("grpc_config", AttributeType::Ref("GrpcConfig".to_string())).with_description("The gRPC configuration for your cache behavior.").with_provider_name("GrpcConfig"),
                     StructField::new("lambda_function_associations", AttributeType::list(AttributeType::Struct {
                     name: "LambdaFunctionAssociation".to_string(),
                     fields: vec![
                     StructField::new("event_type", AttributeType::StringEnum {
-                name: "LambdaFunctionAssociationEventType".to_string(),
+                name: "EventType".to_string(),
                 values: vec!["viewer-request".to_string(), "origin-request".to_string(), "origin-response".to_string(), "viewer-response".to_string()],
-                identity: Some(carina_core::schema::string_enum_identity("LambdaFunctionAssociationEventType", Some("awscc.cloudfront.Distribution"))),
+                identity: Some(carina_core::schema::string_enum_identity("EventType", Some("awscc.cloudfront.Distribution"))),
                 dsl_aliases: vec![("viewer-request".to_string(), "viewer_request".to_string()), ("origin-request".to_string(), "origin_request".to_string()), ("origin-response".to_string(), "origin_response".to_string()), ("viewer-response".to_string(), "viewer_response".to_string())],
             }).with_description("Specifies the event type that triggers a Lambda@Edge function invocation. You can specify the following values: + ``viewer-request``: The function executes when CloudFront receives a request from a viewer and before it checks to see whether the requested object is in the edge cache. + ``origin-request``: The function executes only when CloudFront sends a request to your origin. When the requested object is in the edge cache, the function doesn't execute. + ``origin-response``: The function executes after CloudFront receives a response from the origin and before it caches the object in the response. When the requested object is in the edge cache, the function doesn't execute. + ``viewer-response``: The function executes before CloudFront returns the requested object to the viewer. The function executes regardless of whether the object was already in the edge cache. If the origin returns an HTTP status code other than HTTP 200 (OK), the function doesn't execute.").with_provider_name("EventType"),
                     StructField::new("include_body", AttributeType::Bool).with_description("A flag that allows a Lambda@Edge function to have read access to the body content. For more information, see [Accessing the Request Body by Choosing the Include Body Option](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-include-body-access.html) in the Amazon CloudFront Developer Guide.").with_provider_name("IncludeBody"),
@@ -411,9 +542,9 @@ pub fn cloudfront_distribution_config() -> AwsccSchemaConfig {
                     ],
                 }).with_description("Configures mutual TLS authentication between CloudFront and your origin server.").with_provider_name("OriginMtlsConfig"),
                     StructField::new("origin_protocol_policy", AttributeType::StringEnum {
-                name: "CustomOriginConfigOriginProtocolPolicy".to_string(),
+                name: "OriginProtocolPolicy".to_string(),
                 values: vec!["http-only".to_string(), "match-viewer".to_string(), "https-only".to_string()],
-                identity: Some(carina_core::schema::string_enum_identity("CustomOriginConfigOriginProtocolPolicy", Some("awscc.cloudfront.Distribution"))),
+                identity: Some(carina_core::schema::string_enum_identity("OriginProtocolPolicy", Some("awscc.cloudfront.Distribution"))),
                 dsl_aliases: vec![("http-only".to_string(), "http_only".to_string()), ("match-viewer".to_string(), "match_viewer".to_string()), ("https-only".to_string(), "https_only".to_string())],
             }).required().with_description("Specifies the protocol (HTTP or HTTPS) that CloudFront uses to connect to the origin. Valid values are: + ``http-only`` – CloudFront always uses HTTP to connect to the origin. + ``match-viewer`` – CloudFront connects to the origin using the same protocol that the viewer used to connect to CloudFront. + ``https-only`` – CloudFront always uses HTTPS to connect to the origin.").with_provider_name("OriginProtocolPolicy"),
                     StructField::new("origin_read_timeout", AttributeType::Int).with_description("Specifies how long, in seconds, CloudFront waits for a response from the origin. This is also known as the *origin response timeout*. The minimum timeout is 1 second, the maximum is 120 seconds, and the default (if you don't specify otherwise) is 30 seconds. For more information, see [Response timeout](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/DownloadDistValuesOrigin.html#DownloadDistValuesOriginResponseTimeout) in the *Amazon CloudFront Developer Guide*.").with_provider_name("OriginReadTimeout"),
@@ -559,41 +690,245 @@ pub fn cloudfront_distribution_config() -> AwsccSchemaConfig {
                     StructField::new("web_acl_id", AttributeType::String).with_description("Multi-tenant distributions only support WAF V2 web ACLs. A unique identifier that specifies the WAF web ACL, if any, to associate with this distribution. To specify a web ACL created using the latest version of WAF, use the ACL ARN, for example ``arn:aws:wafv2:us-east-1:123456789012:global/webacl/ExampleWebACL/a1b2c3d4-5678-90ab-cdef-EXAMPLE11111``. To specify a web ACL created using WAF Classic, use the ACL ID, for example ``a1b2c3d4-5678-90ab-cdef-EXAMPLE11111``. WAF is a web application firewall that lets you monitor the HTTP and HTTPS requests that are forwarded to CloudFront, and lets you control access to your content. Based on conditions that you specify, such as the IP addresses that requests originate from or the values of query strings, CloudFront responds to requests either with the requested content or with an HTTP 403 status code (Forbidden). You can also configure CloudFront to return a custom error page when a request is blocked. For more information about WAF, see the [Developer Guide](https://docs.aws.amazon.com/waf/latest/developerguide/what-is-aws-waf.html).").with_provider_name("WebACLId")
                     ],
                 })
-                .required()
-                .with_description("The distribution's configuration.")
-                .with_provider_name("DistributionConfig")
-                .with_block_name("distribution_config"),
-        )
-        .attribute(
-            AttributeSchema::new("domain_name", AttributeType::String)
-                .read_only()
-                .deferred_populate()
-                .with_description(" (read-only)")
-                .with_provider_name("DomainName"),
-        )
-        .attribute(
-            AttributeSchema::new("id", AttributeType::String)
-                .read_only()
-                .with_description(" (read-only)")
-                .with_provider_name("Id"),
-        )
-        .attribute(
-            AttributeSchema::new("tags", tags_type())
-                .with_description("A complex type that contains zero or more ``Tag`` elements.")
-                .with_provider_name("Tags"),
-        )
-        .attribute(
-            AttributeSchema::new("arn", super::arn())
-                .read_only()
-                .with_description("The ARN of the CloudFront distribution. Synthesized by the provider from the distribution id; CloudFront's CloudFormation type does not expose ARN through the Cloud Control API. (read-only)"),
-        )
-        .with_validator(|attrs| {
-            let mut errors = Vec::new();
-            if let Err(mut e) = validate_tags_map(attrs) {
-                errors.append(&mut e);
-            }
-            if errors.is_empty() { Ok(()) } else { Err(errors) }
-        })
+        .with_def("ForwardedValues", AttributeType::Struct {
+                    name: "ForwardedValues".to_string(),
+                    fields: vec![
+                    StructField::new("cookies", AttributeType::Struct {
+                    name: "Cookies".to_string(),
+                    fields: vec![
+                    StructField::new("forward", AttributeType::StringEnum {
+                name: "Forward".to_string(),
+                values: vec!["all".to_string(), "none".to_string(), "whitelist".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("Forward", Some("awscc.cloudfront.Distribution"))),
+                dsl_aliases: vec![("all".to_string(), "all".to_string()), ("none".to_string(), "none".to_string()), ("whitelist".to_string(), "whitelist".to_string())],
+            }).required().with_description("This field is deprecated. We recommend that you use a cache policy or an origin request policy instead of this field. If you want to include cookies in the cache key, use a cache policy. For more information, see [Creating cache policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy) in the *Amazon CloudFront Developer Guide*. If you want to send cookies to the origin but not include them in the cache key, use origin request policy. For more information, see [Creating origin request policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-origin-requests.html#origin-request-create-origin-request-policy) in the *Amazon CloudFront Developer Guide*. Specifies which cookies to forward to the origin for this cache behavior: all, none, or the list of cookies specified in the ``WhitelistedNames`` complex type. Amazon S3 doesn't process cookies. When the cache behavior is forwarding requests to an Amazon S3 origin, specify none for the ``Forward`` element.").with_provider_name("Forward"),
+                    StructField::new("whitelisted_names", AttributeType::list(AttributeType::String)).with_description("This field is deprecated. We recommend that you use a cache policy or an origin request policy instead of this field. If you want to include cookies in the cache key, use a cache policy. For more information, see [Creating cache policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy) in the *Amazon CloudFront Developer Guide*. If you want to send cookies to the origin but not include them in the cache key, use an origin request policy. For more information, see [Creating origin request policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-origin-requests.html#origin-request-create-origin-request-policy) in the *Amazon CloudFront Developer Guide*. Required if you specify ``whitelist`` for the value of ``Forward``. A complex type that specifies how many different cookies you want CloudFront to forward to the origin for this cache behavior and, if you want to forward selected cookies, the names of those cookies. If you specify ``all`` or ``none`` for the value of ``Forward``, omit ``WhitelistedNames``. If you change the value of ``Forward`` from ``whitelist`` to ``all`` or ``none`` and you don't delete the ``WhitelistedNames`` element and its child elements, CloudFront deletes them automatically. For the current limit on the number of cookie names that you can whitelist for each cache behavior, see [CloudFront Limits](https://docs.aws.amazon.com/general/latest/gr/xrefaws_service_limits.html#limits_cloudfront) in the *General Reference*.").with_provider_name("WhitelistedNames")
+                    ],
+                }).with_description("This field is deprecated. We recommend that you use a cache policy or an origin request policy instead of this field. If you want to include cookies in the cache key, use a cache policy. For more information, see [Creating cache policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy) in the *Amazon CloudFront Developer Guide*. If you want to send cookies to the origin but not include them in the cache key, use an origin request policy. For more information, see [Creating origin request policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-origin-requests.html#origin-request-create-origin-request-policy) in the *Amazon CloudFront Developer Guide*. A complex type that specifies whether you want CloudFront to forward cookies to the origin and, if so, which ones. For more information about forwarding cookies to the origin, see [How CloudFront Forwards, Caches, and Logs Cookies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/Cookies.html) in the *Amazon CloudFront Developer Guide*.").with_provider_name("Cookies"),
+                    StructField::new("headers", AttributeType::list(AttributeType::String)).with_description("This field is deprecated. We recommend that you use a cache policy or an origin request policy instead of this field. If you want to include headers in the cache key, use a cache policy. For more information, see [Creating cache policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy) in the *Amazon CloudFront Developer Guide*. If you want to send headers to the origin but not include them in the cache key, use an origin request policy. For more information, see [Creating origin request policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-origin-requests.html#origin-request-create-origin-request-policy) in the *Amazon CloudFront Developer Guide*. A complex type that specifies the ``Headers``, if any, that you want CloudFront to forward to the origin for this cache behavior (whitelisted headers). For the headers that you specify, CloudFront also caches separate versions of a specified object that is based on the header values in viewer requests. For more information, see [Caching Content Based on Request Headers](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/header-caching.html) in the *Amazon CloudFront Developer Guide*.").with_provider_name("Headers"),
+                    StructField::new("query_string", AttributeType::Bool).required().with_description("This field is deprecated. We recommend that you use a cache policy or an origin request policy instead of this field. If you want to include query strings in the cache key, use a cache policy. For more information, see [Creating cache policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy) in the *Amazon CloudFront Developer Guide*. If you want to send query strings to the origin but not include them in the cache key, use an origin request policy. For more information, see [Creating origin request policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-origin-requests.html#origin-request-create-origin-request-policy) in the *Amazon CloudFront Developer Guide*. Indicates whether you want CloudFront to forward query strings to the origin that is associated with this cache behavior and cache based on the query string parameters. CloudFront behavior depends on the value of ``QueryString`` and on the values that you specify for ``QueryStringCacheKeys``, if any: If you specify true for ``QueryString`` and you don't specify any values for ``QueryStringCacheKeys``, CloudFront forwards all query string parameters to the origin and caches based on all query string parameters. Depending on how many query string parameters and values you have, this can adversely affect performance because CloudFront must forward more requests to the origin. If you specify true for ``QueryString`` and you specify one or more values for ``QueryStringCacheKeys``, CloudFront forwards all query string parameters to the origin, but it only caches based on the query string parameters that you specify. If you specify false for ``QueryString``, CloudFront doesn't forward any query string parameters to the origin, and doesn't cache based on query string parameters. For more information, see [Configuring CloudFront to Cache Based on Query String Parameters](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/QueryStringParameters.html) in the *Amazon CloudFront Developer Guide*.").with_provider_name("QueryString"),
+                    StructField::new("query_string_cache_keys", AttributeType::list(AttributeType::String)).with_description("This field is deprecated. We recommend that you use a cache policy or an origin request policy instead of this field. If you want to include query strings in the cache key, use a cache policy. For more information, see [Creating cache policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy) in the *Amazon CloudFront Developer Guide*. If you want to send query strings to the origin but not include them in the cache key, use an origin request policy. For more information, see [Creating origin request policies](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-origin-requests.html#origin-request-create-origin-request-policy) in the *Amazon CloudFront Developer Guide*. A complex type that contains information about the query string parameters that you want CloudFront to use for caching for this cache behavior.").with_provider_name("QueryStringCacheKeys")
+                    ],
+                })
+        .with_def("GeoRestriction", AttributeType::Struct {
+                    name: "GeoRestriction".to_string(),
+                    fields: vec![
+                    StructField::new("locations", AttributeType::list(AttributeType::String)).with_description("A complex type that contains a ``Location`` element for each country in which you want CloudFront either to distribute your content (``whitelist``) or not distribute your content (``blacklist``). The ``Location`` element is a two-letter, uppercase country code for a country that you want to include in your ``blacklist`` or ``whitelist``. Include one ``Location`` element for each country. CloudFront and ``MaxMind`` both use ``ISO 3166`` country codes. For the current list of countries and the corresponding codes, see ``ISO 3166-1-alpha-2`` code on the *International Organization for Standardization* website. You can also refer to the country list on the CloudFront console, which includes both country names and codes.").with_provider_name("Locations"),
+                    StructField::new("restriction_type", AttributeType::StringEnum {
+                name: "RestrictionType".to_string(),
+                values: vec!["none".to_string(), "blacklist".to_string(), "whitelist".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("RestrictionType", Some("awscc.cloudfront.Distribution"))),
+                dsl_aliases: vec![("none".to_string(), "none".to_string()), ("blacklist".to_string(), "blacklist".to_string()), ("whitelist".to_string(), "whitelist".to_string())],
+            }).required().with_description("The method that you want to use to restrict distribution of your content by country: + ``none``: No geo restriction is enabled, meaning access to content is not restricted by client geo location. + ``blacklist``: The ``Location`` elements specify the countries in which you don't want CloudFront to distribute your content. + ``whitelist``: The ``Location`` elements specify the countries in which you want CloudFront to distribute your content.").with_provider_name("RestrictionType")
+                    ],
+                })
+        .with_def("GrpcConfig", AttributeType::Struct {
+                    name: "GrpcConfig".to_string(),
+                    fields: vec![
+                    StructField::new("enabled", AttributeType::Bool).required().with_description("Enables your CloudFront distribution to receive gRPC requests and to proxy them directly to your origins.").with_provider_name("Enabled")
+                    ],
+                })
+        .with_def("LegacyCustomOrigin", AttributeType::Struct {
+                    name: "LegacyCustomOrigin".to_string(),
+                    fields: vec![
+                    StructField::new("dns_name", AttributeType::String).required().with_description("The domain name assigned to your CF distribution.").with_provider_name("DNSName"),
+                    StructField::new("http_port", AttributeType::Int).with_description("The HTTP port that CF uses to connect to the origin. Specify the HTTP port that the origin listens on.").with_provider_name("HTTPPort"),
+                    StructField::new("https_port", AttributeType::Int).with_description("The HTTPS port that CF uses to connect to the origin. Specify the HTTPS port that the origin listens on.").with_provider_name("HTTPSPort"),
+                    StructField::new("origin_protocol_policy", AttributeType::StringEnum {
+                name: "OriginProtocolPolicy".to_string(),
+                values: vec!["http-only".to_string(), "https-only".to_string(), "match-viewer".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("OriginProtocolPolicy", Some("awscc.cloudfront.Distribution"))),
+                dsl_aliases: vec![("http-only".to_string(), "http_only".to_string()), ("https-only".to_string(), "https_only".to_string()), ("match-viewer".to_string(), "match_viewer".to_string())],
+            }).required().with_description("Specifies the protocol (HTTP or HTTPS) that CF uses to connect to the origin.").with_provider_name("OriginProtocolPolicy"),
+                    StructField::new("origin_ssl_protocols", AttributeType::list(AttributeType::StringEnum {
+                name: "OriginSslProtocols".to_string(),
+                values: vec!["SSLv3".to_string(), "TLSv1".to_string(), "TLSv1.1".to_string(), "TLSv1.2".to_string(), "sslv3".to_string(), "tlsv1".to_string(), "tlsv1_1".to_string(), "tlsv1_2".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("OriginSslProtocols", Some("awscc.cloudfront.Distribution"))),
+                dsl_aliases: vec![("SSLv3".to_string(), "sslv3".to_string()), ("TLSv1".to_string(), "tlsv1".to_string()), ("TLSv1.1".to_string(), "tlsv1_1".to_string()), ("TLSv1.2".to_string(), "tlsv1_2".to_string()), ("sslv3".to_string(), "sslv3".to_string()), ("tlsv1".to_string(), "tlsv1".to_string()), ("tlsv1_1".to_string(), "tlsv1_1".to_string()), ("tlsv1_2".to_string(), "tlsv1_2".to_string())],
+            })).required().with_description("The minimum SSL/TLS protocol version that CF uses when communicating with your origin server over HTTPs. For more information, see [Minimum Origin SSL Protocol](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html#DownloadDistValuesOriginSSLProtocols) in the *Developer Guide*.").with_provider_name("OriginSSLProtocols")
+                    ],
+                })
+        .with_def("LegacyS3Origin", AttributeType::Struct {
+                    name: "LegacyS3Origin".to_string(),
+                    fields: vec![
+                    StructField::new("dns_name", AttributeType::String).required().with_description("The domain name assigned to your CF distribution.").with_provider_name("DNSName"),
+                    StructField::new("origin_access_identity", AttributeType::String).with_description("The CF origin access identity to associate with the distribution. Use an origin access identity to configure the distribution so that end users can only access objects in an S3 through CF. This property is legacy. We recommend that you use [OriginAccessControl](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudfront-originaccesscontrol.html) instead.").with_provider_name("OriginAccessIdentity")
+                    ],
+                })
+        .with_def("Logging", AttributeType::Struct {
+                    name: "Logging".to_string(),
+                    fields: vec![
+                    StructField::new("bucket", AttributeType::String).with_description("The Amazon S3 bucket to store the access logs in, for example, ``amzn-s3-demo-bucket.s3.amazonaws.com``.").with_provider_name("Bucket"),
+                    StructField::new("include_cookies", AttributeType::Bool).with_description("Specifies whether you want CloudFront to include cookies in access logs, specify ``true`` for ``IncludeCookies``. If you choose to include cookies in logs, CloudFront logs all cookies regardless of how you configure the cache behaviors for this distribution. If you don't want to include cookies when you create a distribution or if you want to disable include cookies for an existing distribution, specify ``false`` for ``IncludeCookies``.").with_provider_name("IncludeCookies"),
+                    StructField::new("prefix", AttributeType::String).with_description("An optional string that you want CloudFront to prefix to the access log ``filenames`` for this distribution, for example, ``myprefix/``. If you want to enable logging, but you don't want to specify a prefix, you still must include an empty ``Prefix`` element in the ``Logging`` element.").with_provider_name("Prefix")
+                    ],
+                })
+        .with_def("OriginGroupFailoverCriteria", AttributeType::Struct {
+                    name: "OriginGroupFailoverCriteria".to_string(),
+                    fields: vec![
+                    StructField::new("status_codes", AttributeType::Struct {
+                    name: "StatusCodes".to_string(),
+                    fields: vec![
+                    StructField::new("items", AttributeType::list(AttributeType::Int)).required().with_description("The items (status codes) for an origin group.").with_provider_name("Items"),
+                    StructField::new("quantity", AttributeType::Int).required().with_description("The number of status codes.").with_provider_name("Quantity")
+                    ],
+                }).required().with_description("The status codes that, when returned from the primary origin, will trigger CloudFront to failover to the second origin.").with_provider_name("StatusCodes")
+                    ],
+                })
+        .with_def("OriginGroupMembers", AttributeType::Struct {
+                    name: "OriginGroupMembers".to_string(),
+                    fields: vec![
+                    StructField::new("items", AttributeType::list(AttributeType::Struct {
+                    name: "OriginGroupMember".to_string(),
+                    fields: vec![
+                    StructField::new("origin_id", AttributeType::String).required().with_description("The ID for an origin in an origin group.").with_provider_name("OriginId")
+                    ],
+                })).required().with_description("Items (origins) in an origin group.").with_provider_name("Items").with_block_name("item"),
+                    StructField::new("quantity", AttributeType::Int).required().with_description("The number of origins in an origin group.").with_provider_name("Quantity")
+                    ],
+                })
+        .with_def("OriginGroups", AttributeType::Struct {
+                    name: "OriginGroups".to_string(),
+                    fields: vec![
+                    StructField::new("items", AttributeType::list(AttributeType::Struct {
+                    name: "OriginGroup".to_string(),
+                    fields: vec![
+                    StructField::new("failover_criteria", AttributeType::Struct {
+                    name: "OriginGroupFailoverCriteria".to_string(),
+                    fields: vec![
+                    StructField::new("status_codes", AttributeType::Struct {
+                    name: "StatusCodes".to_string(),
+                    fields: vec![
+                    StructField::new("items", AttributeType::list(AttributeType::Int)).required().with_description("The items (status codes) for an origin group.").with_provider_name("Items"),
+                    StructField::new("quantity", AttributeType::Int).required().with_description("The number of status codes.").with_provider_name("Quantity")
+                    ],
+                }).required().with_description("The status codes that, when returned from the primary origin, will trigger CloudFront to failover to the second origin.").with_provider_name("StatusCodes")
+                    ],
+                }).required().with_description("A complex type that contains information about the failover criteria for an origin group.").with_provider_name("FailoverCriteria"),
+                    StructField::new("id", AttributeType::String).required().with_description("The origin group's ID.").with_provider_name("Id"),
+                    StructField::new("members", AttributeType::Struct {
+                    name: "OriginGroupMembers".to_string(),
+                    fields: vec![
+                    StructField::new("items", AttributeType::list(AttributeType::Struct {
+                    name: "OriginGroupMember".to_string(),
+                    fields: vec![
+                    StructField::new("origin_id", AttributeType::String).required().with_description("The ID for an origin in an origin group.").with_provider_name("OriginId")
+                    ],
+                })).required().with_description("Items (origins) in an origin group.").with_provider_name("Items").with_block_name("item"),
+                    StructField::new("quantity", AttributeType::Int).required().with_description("The number of origins in an origin group.").with_provider_name("Quantity")
+                    ],
+                }).required().with_description("A complex type that contains information about the origins in an origin group.").with_provider_name("Members").with_block_name("member"),
+                    StructField::new("selection_criteria", AttributeType::StringEnum {
+                name: "OriginGroupSelectionCriteria".to_string(),
+                values: vec!["default".to_string(), "media-quality-based".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("OriginGroupSelectionCriteria", Some("awscc.cloudfront.Distribution"))),
+                dsl_aliases: vec![("default".to_string(), "default".to_string()), ("media-quality-based".to_string(), "media_quality_based".to_string())],
+            }).with_description("The selection criteria for the origin group. For more information, see [Create an origin group](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/high_availability_origin_failover.html#concept_origin_groups.creating) in the *Amazon CloudFront Developer Guide*.").with_provider_name("SelectionCriteria")
+                    ],
+                })).with_description("The items (origin groups) in a distribution.").with_provider_name("Items").with_block_name("item"),
+                    StructField::new("quantity", AttributeType::Int).required().with_description("The number of origin groups.").with_provider_name("Quantity")
+                    ],
+                })
+        .with_def("OriginMtlsConfig", AttributeType::Struct {
+                    name: "OriginMtlsConfig".to_string(),
+                    fields: vec![
+                    StructField::new("client_certificate_arn", super::arn()).required().with_description("The Amazon Resource Name (ARN) of the client certificate stored in AWS Certificate Manager (ACM) that CloudFront uses to authenticate with your origin using Mutual TLS.").with_provider_name("ClientCertificateArn")
+                    ],
+                })
+        .with_def("OriginShield", AttributeType::Struct {
+                    name: "OriginShield".to_string(),
+                    fields: vec![
+                    StructField::new("enabled", AttributeType::Bool).with_description("A flag that specifies whether Origin Shield is enabled. When it's enabled, CloudFront routes all requests through Origin Shield, which can help protect your origin. When it's disabled, CloudFront might send requests directly to your origin from multiple edge locations or regional edge caches.").with_provider_name("Enabled"),
+                    StructField::new("origin_shield_region", super::awscc_region()).with_description("The AWS-Region for Origin Shield. Specify the AWS-Region that has the lowest latency to your origin. To specify a region, use the region code, not the region name. For example, specify the US East (Ohio) region as ``us-east-2``. When you enable CloudFront Origin Shield, you must specify the AWS-Region for Origin Shield. For the list of AWS-Regions that you can specify, and for help choosing the best Region for your origin, see [Choosing the for Origin Shield](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/origin-shield.html#choose-origin-shield-region) in the *Amazon CloudFront Developer Guide*.").with_provider_name("OriginShieldRegion")
+                    ],
+                })
+        .with_def("Restrictions", AttributeType::Struct {
+                    name: "Restrictions".to_string(),
+                    fields: vec![
+                    StructField::new("geo_restriction", AttributeType::Struct {
+                    name: "GeoRestriction".to_string(),
+                    fields: vec![
+                    StructField::new("locations", AttributeType::list(AttributeType::String)).with_description("A complex type that contains a ``Location`` element for each country in which you want CloudFront either to distribute your content (``whitelist``) or not distribute your content (``blacklist``). The ``Location`` element is a two-letter, uppercase country code for a country that you want to include in your ``blacklist`` or ``whitelist``. Include one ``Location`` element for each country. CloudFront and ``MaxMind`` both use ``ISO 3166`` country codes. For the current list of countries and the corresponding codes, see ``ISO 3166-1-alpha-2`` code on the *International Organization for Standardization* website. You can also refer to the country list on the CloudFront console, which includes both country names and codes.").with_provider_name("Locations"),
+                    StructField::new("restriction_type", AttributeType::StringEnum {
+                name: "RestrictionType".to_string(),
+                values: vec!["none".to_string(), "blacklist".to_string(), "whitelist".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("RestrictionType", Some("awscc.cloudfront.Distribution"))),
+                dsl_aliases: vec![("none".to_string(), "none".to_string()), ("blacklist".to_string(), "blacklist".to_string()), ("whitelist".to_string(), "whitelist".to_string())],
+            }).required().with_description("The method that you want to use to restrict distribution of your content by country: + ``none``: No geo restriction is enabled, meaning access to content is not restricted by client geo location. + ``blacklist``: The ``Location`` elements specify the countries in which you don't want CloudFront to distribute your content. + ``whitelist``: The ``Location`` elements specify the countries in which you want CloudFront to distribute your content.").with_provider_name("RestrictionType")
+                    ],
+                }).required().with_description("A complex type that controls the countries in which your content is distributed. CF determines the location of your users using ``MaxMind`` GeoIP databases. To disable geo restriction, remove the [Restrictions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-distributionconfig.html#cfn-cloudfront-distribution-distributionconfig-restrictions) property from your stack template.").with_provider_name("GeoRestriction")
+                    ],
+                })
+        .with_def("S3OriginConfig", AttributeType::Struct {
+                    name: "S3OriginConfig".to_string(),
+                    fields: vec![
+                    StructField::new("origin_access_identity", AttributeType::String).with_description("If you're using origin access control (OAC) instead of origin access identity, specify an empty ``OriginAccessIdentity`` element. For more information, see [Restricting access to an](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-origin.html) in the *Amazon CloudFront Developer Guide*. The CloudFront origin access identity to associate with the origin. Use an origin access identity to configure the origin so that viewers can *only* access objects in an Amazon S3 bucket through CloudFront. The format of the value is: ``origin-access-identity/cloudfront/ID-of-origin-access-identity`` The ``ID-of-origin-access-identity`` is the value that CloudFront returned in the ``ID`` element when you created the origin access identity. If you want viewers to be able to access objects using either the CloudFront URL or the Amazon S3 URL, specify an empty ``OriginAccessIdentity`` element. To delete the origin access identity from an existing distribution, update the distribution configuration and include an empty ``OriginAccessIdentity`` element. To replace the origin access identity, update the distribution configuration and specify the new origin access identity. For more information about the origin access identity, see [Serving Private Content through CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/PrivateContent.html) in the *Amazon CloudFront Developer Guide*.").with_provider_name("OriginAccessIdentity"),
+                    StructField::new("origin_read_timeout", AttributeType::Int).with_description("Specifies how long, in seconds, CloudFront waits for a response from the origin. This is also known as the *origin response timeout*. The minimum timeout is 1 second, the maximum is 120 seconds, and the default (if you don't specify otherwise) is 30 seconds. For more information, see [Response timeout](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/DownloadDistValuesOrigin.html#DownloadDistValuesOriginResponseTimeout) in the *Amazon CloudFront Developer Guide*.").with_provider_name("OriginReadTimeout")
+                    ],
+                })
+        .with_def("StatusCodes", AttributeType::Struct {
+                    name: "StatusCodes".to_string(),
+                    fields: vec![
+                    StructField::new("items", AttributeType::list(AttributeType::Int)).required().with_description("The items (status codes) for an origin group.").with_provider_name("Items"),
+                    StructField::new("quantity", AttributeType::Int).required().with_description("The number of status codes.").with_provider_name("Quantity")
+                    ],
+                })
+        .with_def("TrustStoreConfig", AttributeType::Struct {
+                    name: "TrustStoreConfig".to_string(),
+                    fields: vec![
+                    StructField::new("advertise_trust_store_ca_names", AttributeType::Bool).with_description("The configuration to use to advertise trust store CA names.").with_provider_name("AdvertiseTrustStoreCaNames"),
+                    StructField::new("ignore_certificate_expiry", AttributeType::Bool).with_description("The configuration to use to ignore certificate expiration.").with_provider_name("IgnoreCertificateExpiry"),
+                    StructField::new("trust_store_id", AttributeType::String).required().with_description("The trust store ID.").with_provider_name("TrustStoreId")
+                    ],
+                })
+        .with_def("ViewerCertificate", AttributeType::Struct {
+                    name: "ViewerCertificate".to_string(),
+                    fields: vec![
+                    StructField::new("acm_certificate_arn", super::arn()).with_description("In CloudFormation, this field name is ``AcmCertificateArn``. Note the different capitalization. If the distribution uses ``Aliases`` (alternate domain names or CNAMEs) and the SSL/TLS certificate is stored in [(ACM)](https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html), provide the Amazon Resource Name (ARN) of the ACM certificate. CloudFront only supports ACM certificates in the US East (N. Virginia) Region (``us-east-1``). If you specify an ACM certificate ARN, you must also specify values for ``MinimumProtocolVersion`` and ``SSLSupportMethod``. (In CloudFormation, the field name is ``SslSupportMethod``. Note the different capitalization.)").with_provider_name("AcmCertificateArn"),
+                    StructField::new("cloud_front_default_certificate", AttributeType::Bool).with_description("If the distribution uses the CloudFront domain name such as ``d111111abcdef8.cloudfront.net``, set this field to ``true``. If the distribution uses ``Aliases`` (alternate domain names or CNAMEs), omit this field and specify values for the following fields: + ``AcmCertificateArn`` or ``IamCertificateId`` (specify a value for one, not both) + ``MinimumProtocolVersion`` + ``SslSupportMethod``").with_provider_name("CloudFrontDefaultCertificate"),
+                    StructField::new("iam_certificate_id", AttributeType::String).with_description("This field only supports standard distributions. You can't specify this field for multi-tenant distributions. For more information, see [Unsupported features for SaaS Manager for Amazon CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-config-options.html#unsupported-saas) in the *Amazon CloudFront Developer Guide*. In CloudFormation, this field name is ``IamCertificateId``. Note the different capitalization. If the distribution uses ``Aliases`` (alternate domain names or CNAMEs) and the SSL/TLS certificate is stored in [(IAM)](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html), provide the ID of the IAM certificate. If you specify an IAM certificate ID, you must also specify values for ``MinimumProtocolVersion`` and ``SSLSupportMethod``. (In CloudFormation, the field name is ``SslSupportMethod``. Note the different capitalization.)").with_provider_name("IamCertificateId"),
+                    StructField::new("minimum_protocol_version", AttributeType::StringEnum {
+                name: "MinimumProtocolVersion".to_string(),
+                values: vec!["SSLv3".to_string(), "TLSv1".to_string(), "TLSv1_2016".to_string(), "TLSv1.1_2016".to_string(), "TLSv1.2_2018".to_string(), "TLSv1.2_2019".to_string(), "TLSv1.2_2021".to_string(), "sslv3".to_string(), "tlsv1".to_string(), "tlsv1_2016".to_string(), "tlsv1_1_2016".to_string(), "tlsv1_2_2018".to_string(), "tlsv1_2_2019".to_string(), "tlsv1_2_2021".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("MinimumProtocolVersion", Some("awscc.cloudfront.Distribution"))),
+                dsl_aliases: vec![("SSLv3".to_string(), "sslv3".to_string()), ("TLSv1".to_string(), "tlsv1".to_string()), ("TLSv1_2016".to_string(), "tlsv1_2016".to_string()), ("TLSv1.1_2016".to_string(), "tlsv1_1_2016".to_string()), ("TLSv1.2_2018".to_string(), "tlsv1_2_2018".to_string()), ("TLSv1.2_2019".to_string(), "tlsv1_2_2019".to_string()), ("TLSv1.2_2021".to_string(), "tlsv1_2_2021".to_string()), ("sslv3".to_string(), "sslv3".to_string()), ("tlsv1".to_string(), "tlsv1".to_string()), ("tlsv1_2016".to_string(), "tlsv1_2016".to_string()), ("tlsv1_1_2016".to_string(), "tlsv1_1_2016".to_string()), ("tlsv1_2_2018".to_string(), "tlsv1_2_2018".to_string()), ("tlsv1_2_2019".to_string(), "tlsv1_2_2019".to_string()), ("tlsv1_2_2021".to_string(), "tlsv1_2_2021".to_string())],
+            }).with_description("If the distribution uses ``Aliases`` (alternate domain names or CNAMEs), specify the security policy that you want CloudFront to use for HTTPS connections with viewers. The security policy determines two settings: + The minimum SSL/TLS protocol that CloudFront can use to communicate with viewers. + The ciphers that CloudFront can use to encrypt the content that it returns to viewers. For more information, see [Security Policy](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html#DownloadDistValues-security-policy) and [Supported Protocols and Ciphers Between Viewers and CloudFront](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/secure-connections-supported-viewer-protocols-ciphers.html#secure-connections-supported-ciphers) in the *Amazon CloudFront Developer Guide*. On the CloudFront console, this setting is called *Security Policy*. When you're using SNI only (you set ``SSLSupportMethod`` to ``sni-only``), you must specify ``TLSv1`` or higher. (In CloudFormation, the field name is ``SslSupportMethod``. Note the different capitalization.) If the distribution uses the CloudFront domain name such as ``d111111abcdef8.cloudfront.net`` (you set ``CloudFrontDefaultCertificate`` to ``true``), CloudFront automatically sets the security policy to ``TLSv1`` regardless of the value that you set here.").with_provider_name("MinimumProtocolVersion"),
+                    StructField::new("ssl_support_method", AttributeType::StringEnum {
+                name: "SslSupportMethod".to_string(),
+                values: vec!["sni-only".to_string(), "vip".to_string(), "static-ip".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("SslSupportMethod", Some("awscc.cloudfront.Distribution"))),
+                dsl_aliases: vec![("sni-only".to_string(), "sni_only".to_string()), ("vip".to_string(), "vip".to_string()), ("static-ip".to_string(), "static_ip".to_string())],
+            }).with_description("In CloudFormation, this field name is ``SslSupportMethod``. Note the different capitalization. If the distribution uses ``Aliases`` (alternate domain names or CNAMEs), specify which viewers the distribution accepts HTTPS connections from. + ``sni-only`` – The distribution accepts HTTPS connections from only viewers that support [server name indication (SNI)](https://docs.aws.amazon.com/https://en.wikipedia.org/wiki/Server_Name_Indication). This is recommended. Most browsers and clients support SNI. + ``vip`` – The distribution accepts HTTPS connections from all viewers including those that don't support SNI. This is not recommended, and results in additional monthly charges from CloudFront. + ``static-ip`` - Do not specify this value unless your distribution has been enabled for this feature by the CloudFront team. If you have a use case that requires static IP addresses for a distribution, contact CloudFront through the [Center](https://docs.aws.amazon.com/support/home). If the distribution uses the CloudFront domain name such as ``d111111abcdef8.cloudfront.net``, don't set a value for this field.").with_provider_name("SslSupportMethod")
+                    ],
+                })
+        .with_def("ViewerMtlsConfig", AttributeType::Struct {
+                    name: "ViewerMtlsConfig".to_string(),
+                    fields: vec![
+                    StructField::new("mode", AttributeType::StringEnum {
+                name: "ViewerMtlsMode".to_string(),
+                values: vec!["required".to_string(), "optional".to_string(), "passthrough".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("ViewerMtlsMode", Some("awscc.cloudfront.Distribution"))),
+                dsl_aliases: vec![("required".to_string(), "required".to_string()), ("optional".to_string(), "optional".to_string()), ("passthrough".to_string(), "passthrough".to_string())],
+            }).with_description("The viewer mTLS mode.").with_provider_name("Mode"),
+                    StructField::new("trust_store_config", AttributeType::Struct {
+                    name: "TrustStoreConfig".to_string(),
+                    fields: vec![
+                    StructField::new("advertise_trust_store_ca_names", AttributeType::Bool).with_description("The configuration to use to advertise trust store CA names.").with_provider_name("AdvertiseTrustStoreCaNames"),
+                    StructField::new("ignore_certificate_expiry", AttributeType::Bool).with_description("The configuration to use to ignore certificate expiration.").with_provider_name("IgnoreCertificateExpiry"),
+                    StructField::new("trust_store_id", AttributeType::String).required().with_description("The trust store ID.").with_provider_name("TrustStoreId")
+                    ],
+                }).with_description("The trust store configuration associated with the viewer mTLS configuration.").with_provider_name("TrustStoreConfig")
+                    ],
+                })
+        .with_def("VpcOriginConfig", AttributeType::Struct {
+                    name: "VpcOriginConfig".to_string(),
+                    fields: vec![
+                    StructField::new("origin_keepalive_timeout", AttributeType::Int).with_description("Specifies how long, in seconds, CloudFront persists its connection to the origin. The minimum timeout is 1 second, the maximum is 120 seconds, and the default (if you don't specify otherwise) is 5 seconds. For more information, see [Keep-alive timeout (custom origins only)](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/DownloadDistValuesOrigin.html#DownloadDistValuesOriginKeepaliveTimeout) in the *Amazon CloudFront Developer Guide*.").with_provider_name("OriginKeepaliveTimeout"),
+                    StructField::new("origin_read_timeout", AttributeType::Int).with_description("Specifies how long, in seconds, CloudFront waits for a response from the origin. This is also known as the *origin response timeout*. The minimum timeout is 1 second, the maximum is 120 seconds, and the default (if you don't specify otherwise) is 30 seconds. For more information, see [Response timeout](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/DownloadDistValuesOrigin.html#DownloadDistValuesOriginResponseTimeout) in the *Amazon CloudFront Developer Guide*.").with_provider_name("OriginReadTimeout"),
+                    StructField::new("owner_account_id", super::aws_account_id()).with_description("The account ID of the AWS-account that owns the VPC origin.").with_provider_name("OwnerAccountId"),
+                    StructField::new("vpc_origin_id", AttributeType::String).required().with_description("The VPC origin ID.").with_provider_name("VpcOriginId")
+                    ],
+                })
     }
 }
 

--- a/carina-provider-awscc/src/schemas/generated/cloudfront/origin_access_control.rs
+++ b/carina-provider-awscc/src/schemas/generated/cloudfront/origin_access_control.rs
@@ -30,7 +30,12 @@ pub fn cloudfront_origin_access_control_config() -> AwsccSchemaConfig {
                 .with_provider_name("Id"),
         )
         .attribute(
-            AttributeSchema::new("origin_access_control_config", AttributeType::Struct {
+            AttributeSchema::new("origin_access_control_config", AttributeType::Ref("OriginAccessControlConfig".to_string()))
+                .required()
+                .with_description("The origin access control.")
+                .with_provider_name("OriginAccessControlConfig"),
+        )
+        .with_def("OriginAccessControlConfig", AttributeType::Struct {
                     name: "OriginAccessControlConfig".to_string(),
                     fields: vec![
                     StructField::new("description", AttributeType::String).with_description("A description of the origin access control.").with_provider_name("Description"),
@@ -55,10 +60,6 @@ pub fn cloudfront_origin_access_control_config() -> AwsccSchemaConfig {
             }).required().with_description("The signing protocol of the origin access control, which determines how CloudFront signs (authenticates) requests. The only valid value is ``sigv4``.").with_provider_name("SigningProtocol")
                     ],
                 })
-                .required()
-                .with_description("The origin access control.")
-                .with_provider_name("OriginAccessControlConfig"),
-        )
     }
 }
 

--- a/carina-provider-awscc/src/schemas/generated/ec2/ipam_pool.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/ipam_pool.rs
@@ -177,15 +177,7 @@ pub fn ec2_ipam_pool_config() -> AwsccSchemaConfig {
                 .with_provider_name("SourceIpamPoolId"),
         )
         .attribute(
-            AttributeSchema::new("source_resource", AttributeType::Struct {
-                    name: "SourceResource".to_string(),
-                    fields: vec![
-                    StructField::new("resource_id", AttributeType::String).required().with_provider_name("ResourceId"),
-                    StructField::new("resource_owner", AttributeType::String).required().with_provider_name("ResourceOwner"),
-                    StructField::new("resource_region", super::awscc_region()).required().with_provider_name("ResourceRegion"),
-                    StructField::new("resource_type", AttributeType::String).required().with_provider_name("ResourceType")
-                    ],
-                })
+            AttributeSchema::new("source_resource", AttributeType::Ref("SourceResource".to_string()))
                 .create_only()
                 .with_provider_name("SourceResource"),
         )
@@ -224,6 +216,15 @@ pub fn ec2_ipam_pool_config() -> AwsccSchemaConfig {
             }
             if errors.is_empty() { Ok(()) } else { Err(errors) }
         })
+        .with_def("SourceResource", AttributeType::Struct {
+                    name: "SourceResource".to_string(),
+                    fields: vec![
+                    StructField::new("resource_id", AttributeType::String).required().with_provider_name("ResourceId"),
+                    StructField::new("resource_owner", AttributeType::String).required().with_provider_name("ResourceOwner"),
+                    StructField::new("resource_region", super::awscc_region()).required().with_provider_name("ResourceRegion"),
+                    StructField::new("resource_type", AttributeType::String).required().with_provider_name("ResourceType")
+                    ],
+                })
     }
 }
 

--- a/carina-provider-awscc/src/schemas/generated/ec2/vpc_endpoint.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/vpc_endpoint.rs
@@ -88,44 +88,7 @@ pub fn ec2_vpc_endpoint_config() -> AwsccSchemaConfig {
                 .with_provider_name("DnsEntries"),
         )
         .attribute(
-            AttributeSchema::new("dns_options", AttributeType::Struct {
-                    name: "DnsOptionsSpecification".to_string(),
-                    fields: vec![
-                    StructField::new("dns_record_ip_type", AttributeType::StringEnum {
-                name: "DnsRecordIpType".to_string(),
-                values: vec!["ipv4".to_string(), "ipv6".to_string(), "dualstack".to_string(), "service-defined".to_string(), "not-specified".to_string()],
-                identity: Some(carina_core::schema::string_enum_identity("DnsRecordIpType", Some("awscc.ec2.VpcEndpoint"))),
-                dsl_aliases: vec![("ipv4".to_string(), "ipv4".to_string()), ("ipv6".to_string(), "ipv6".to_string()), ("dualstack".to_string(), "dualstack".to_string()), ("service-defined".to_string(), "service_defined".to_string()), ("not-specified".to_string(), "not_specified".to_string())],
-            }).with_description("The DNS records created for the endpoint.").with_provider_name("DnsRecordIpType"),
-                    StructField::new("private_dns_only_for_inbound_resolver_endpoint", AttributeType::StringEnum {
-                name: "PrivateDnsOnlyForInboundResolverEndpoint".to_string(),
-                values: vec!["OnlyInboundResolver".to_string(), "AllResolvers".to_string(), "NotSpecified".to_string()],
-                identity: Some(carina_core::schema::string_enum_identity("PrivateDnsOnlyForInboundResolverEndpoint", Some("awscc.ec2.VpcEndpoint"))),
-                dsl_aliases: vec![("OnlyInboundResolver".to_string(), "only_inbound_resolver".to_string()), ("AllResolvers".to_string(), "all_resolvers".to_string()), ("NotSpecified".to_string(), "not_specified".to_string())],
-            }).with_description("Indicates whether to enable private DNS only for inbound endpoints. This option is available only for services that support both gateway and interface endpoints. It routes traffic that originates from the VPC to the gateway endpoint and traffic that originates from on-premises to the interface endpoint.").with_provider_name("PrivateDnsOnlyForInboundResolverEndpoint"),
-                    StructField::new("private_dns_preference", AttributeType::StringEnum {
-                name: "PrivateDnsPreference".to_string(),
-                values: vec!["VERIFIED_DOMAINS_ONLY".to_string(), "ALL_DOMAINS".to_string(), "VERIFIED_DOMAINS_AND_SPECIFIED_DOMAINS".to_string(), "SPECIFIED_DOMAINS_ONLY".to_string()],
-                identity: Some(carina_core::schema::string_enum_identity("PrivateDnsPreference", Some("awscc.ec2.VpcEndpoint"))),
-                dsl_aliases: vec![("VERIFIED_DOMAINS_ONLY".to_string(), "verified_domains_only".to_string()), ("ALL_DOMAINS".to_string(), "all_domains".to_string()), ("VERIFIED_DOMAINS_AND_SPECIFIED_DOMAINS".to_string(), "verified_domains_and_specified_domains".to_string()), ("SPECIFIED_DOMAINS_ONLY".to_string(), "specified_domains_only".to_string())],
-            }).with_description("The preference for which private domains have a private hosted zone created for and associated with the specified VPC. Only supported when private DNS is enabled and when the VPC endpoint type is ServiceNetwork or Resource.").with_provider_name("PrivateDnsPreference"),
-                    StructField::new("private_dns_specified_domains", AttributeType::Custom {
-                identity: None,
-                pattern: None,
-                length: None,
-                base: Box::new(AttributeType::list(AttributeType::Custom {
-                identity: None,
-                pattern: None,
-                length: Some((Some(1), Some(255))),
-                base: Box::new(AttributeType::String),
-                validate: legacy_validator(validate_string_length_1_255),
-                to_dsl: None,
-            })),
-                validate: legacy_validator(validate_list_items_1_10),
-                to_dsl: None,
-            }).with_description("Indicates which of the private domains to create private hosted zones for and associate with the specified VPC. Only supported when private DNS is enabled and the private DNS preference is ``VERIFIED_DOMAINS_AND_SPECIFIED_DOMAINS`` or ``SPECIFIED_DOMAINS_ONLY``.").with_provider_name("PrivateDnsSpecifiedDomains")
-                    ],
-                })
+            AttributeSchema::new("dns_options", AttributeType::Ref("DnsOptionsSpecification".to_string()))
                 .create_only()
                 .with_description("Describes the DNS options for an endpoint.")
                 .with_provider_name("DnsOptions"),
@@ -231,6 +194,44 @@ pub fn ec2_vpc_endpoint_config() -> AwsccSchemaConfig {
             }
             if errors.is_empty() { Ok(()) } else { Err(errors) }
         })
+        .with_def("DnsOptionsSpecification", AttributeType::Struct {
+                    name: "DnsOptionsSpecification".to_string(),
+                    fields: vec![
+                    StructField::new("dns_record_ip_type", AttributeType::StringEnum {
+                name: "DnsRecordIpType".to_string(),
+                values: vec!["ipv4".to_string(), "ipv6".to_string(), "dualstack".to_string(), "service-defined".to_string(), "not-specified".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("DnsRecordIpType", Some("awscc.ec2.VpcEndpoint"))),
+                dsl_aliases: vec![("ipv4".to_string(), "ipv4".to_string()), ("ipv6".to_string(), "ipv6".to_string()), ("dualstack".to_string(), "dualstack".to_string()), ("service-defined".to_string(), "service_defined".to_string()), ("not-specified".to_string(), "not_specified".to_string())],
+            }).with_description("The DNS records created for the endpoint.").with_provider_name("DnsRecordIpType"),
+                    StructField::new("private_dns_only_for_inbound_resolver_endpoint", AttributeType::StringEnum {
+                name: "PrivateDnsOnlyForInboundResolverEndpoint".to_string(),
+                values: vec!["OnlyInboundResolver".to_string(), "AllResolvers".to_string(), "NotSpecified".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("PrivateDnsOnlyForInboundResolverEndpoint", Some("awscc.ec2.VpcEndpoint"))),
+                dsl_aliases: vec![("OnlyInboundResolver".to_string(), "only_inbound_resolver".to_string()), ("AllResolvers".to_string(), "all_resolvers".to_string()), ("NotSpecified".to_string(), "not_specified".to_string())],
+            }).with_description("Indicates whether to enable private DNS only for inbound endpoints. This option is available only for services that support both gateway and interface endpoints. It routes traffic that originates from the VPC to the gateway endpoint and traffic that originates from on-premises to the interface endpoint.").with_provider_name("PrivateDnsOnlyForInboundResolverEndpoint"),
+                    StructField::new("private_dns_preference", AttributeType::StringEnum {
+                name: "PrivateDnsPreference".to_string(),
+                values: vec!["VERIFIED_DOMAINS_ONLY".to_string(), "ALL_DOMAINS".to_string(), "VERIFIED_DOMAINS_AND_SPECIFIED_DOMAINS".to_string(), "SPECIFIED_DOMAINS_ONLY".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("PrivateDnsPreference", Some("awscc.ec2.VpcEndpoint"))),
+                dsl_aliases: vec![("VERIFIED_DOMAINS_ONLY".to_string(), "verified_domains_only".to_string()), ("ALL_DOMAINS".to_string(), "all_domains".to_string()), ("VERIFIED_DOMAINS_AND_SPECIFIED_DOMAINS".to_string(), "verified_domains_and_specified_domains".to_string()), ("SPECIFIED_DOMAINS_ONLY".to_string(), "specified_domains_only".to_string())],
+            }).with_description("The preference for which private domains have a private hosted zone created for and associated with the specified VPC. Only supported when private DNS is enabled and when the VPC endpoint type is ServiceNetwork or Resource.").with_provider_name("PrivateDnsPreference"),
+                    StructField::new("private_dns_specified_domains", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: Some((Some(1), Some(255))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_length_1_255),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_10),
+                to_dsl: None,
+            }).with_description("Indicates which of the private domains to create private hosted zones for and associate with the specified VPC. Only supported when private DNS is enabled and the private DNS preference is ``VERIFIED_DOMAINS_AND_SPECIFIED_DOMAINS`` or ``SPECIFIED_DOMAINS_ONLY``.").with_provider_name("PrivateDnsSpecifiedDomains")
+                    ],
+                })
     }
 }
 

--- a/carina-provider-awscc/src/schemas/generated/identitystore/group_membership.rs
+++ b/carina-provider-awscc/src/schemas/generated/identitystore/group_membership.rs
@@ -56,19 +56,7 @@ pub fn identitystore_group_membership_config() -> AwsccSchemaConfig {
                 .with_provider_name("IdentityStoreId"),
         )
         .attribute(
-            AttributeSchema::new("member_id", AttributeType::Struct {
-                    name: "MemberId".to_string(),
-                    fields: vec![
-                    StructField::new("user_id", AttributeType::Custom {
-                identity: None,
-                pattern: Some("^([0-9a-f]{10}-|)[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$".to_string()),
-                length: Some((Some(1), Some(47))),
-                base: Box::new(AttributeType::String),
-                validate: legacy_validator(validate_string_pattern_2a77a2e32f71b5f3_len_1_47),
-                to_dsl: None,
-            }).required().with_description("The identifier for a user in the identity store.").with_provider_name("UserId")
-                    ],
-                })
+            AttributeSchema::new("member_id", AttributeType::Ref("MemberId".to_string()))
                 .required()
                 .create_only()
                 .with_description("An object containing the identifier of a group member.")
@@ -87,6 +75,19 @@ pub fn identitystore_group_membership_config() -> AwsccSchemaConfig {
                 .with_description("The identifier for a GroupMembership in the identity store. (read-only)")
                 .with_provider_name("MembershipId"),
         )
+        .with_def("MemberId", AttributeType::Struct {
+                    name: "MemberId".to_string(),
+                    fields: vec![
+                    StructField::new("user_id", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^([0-9a-f]{10}-|)[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$".to_string()),
+                length: Some((Some(1), Some(47))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_2a77a2e32f71b5f3_len_1_47),
+                to_dsl: None,
+            }).required().with_description("The identifier for a user in the identity store.").with_provider_name("UserId")
+                    ],
+                })
     }
 }
 

--- a/carina-provider-awscc/src/schemas/generated/mod.rs
+++ b/carina-provider-awscc/src/schemas/generated/mod.rs
@@ -19,6 +19,7 @@ pub mod organizations;
 pub mod route53;
 pub mod s3;
 pub mod sso;
+pub mod wafv2;
 
 /// Cached schema configs, initialized once on first access.
 static SCHEMA_CONFIGS: LazyLock<Vec<AwsccSchemaConfig>> = LazyLock::new(build_configs);
@@ -75,6 +76,7 @@ static ENUM_VALID_VALUES: LazyLock<
         route53::hosted_zone::enum_valid_values(),
         cloudfront::distribution::enum_valid_values(),
         cloudfront::origin_access_control::enum_valid_values(),
+        wafv2::web_acl::enum_valid_values(),
     ];
     let mut map: HashMap<&str, HashMap<&str, &[&str]>> = HashMap::new();
     for (rt, attrs) in modules {
@@ -126,6 +128,7 @@ fn build_configs() -> Vec<AwsccSchemaConfig> {
         route53::hosted_zone::route53_hosted_zone_config(),
         cloudfront::distribution::cloudfront_distribution_config(),
         cloudfront::origin_access_control::cloudfront_origin_access_control_config(),
+        wafv2::web_acl::wafv2_web_acl_config(),
     ]
 }
 

--- a/carina-provider-awscc/src/schemas/generated/route53/hosted_zone.rs
+++ b/carina-provider-awscc/src/schemas/generated/route53/hosted_zone.rs
@@ -59,29 +59,12 @@ pub fn route53_hosted_zone_config() -> AwsccSchemaConfig {
         schema: ResourceSchema::new("route53.HostedZone")
         .with_description("Creates a new public or private hosted zone. You create records in a public hosted zone to define how you want to route traffic on the internet for a domain, such as example.com, and its subdomains (apex.example.com, acme.example.com). You create records in a private hosted zone to define how you want to route traffic for a domain and its subdomains within one or more Amazon Virtual Private Clouds (Amazon VPCs).    You can't convert a public hosted zone to a private hosted zone or vice versa. Instead, you must create a new hosted zone with the same name and create new resource record sets.   For more information about charges for hosted zones, see [Amazon Route 53 Pricing](https://docs.aws.amazon.com/route53/pricing/).  Note the following:   +  You can't create a hosted zone for a top-level domain (TLD) such as .com.   +  If your domain is registered with a registrar other than Route 53, you must update the name servers with your registrar to make Route 53 the DNS service for the domain. For more information, see [Migrating DNS Service for an Existing Domain to Amazon Route 53](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/MigratingDNS.html) in the *Amazon Route 53 Developer Guide*.      When you submit a ``CreateHostedZone`` request, the initial status of the hosted zone is ``PENDING``. For public hosted zones, this means that the NS and SOA records are not yet available on all Route 53 DNS servers. When the NS and SOA records are available, the status of the zone changes to ``INSYNC``.  The ``CreateHostedZone`` request requires the caller to have an ``ec2:DescribeVpcs`` permission.   When creating private hosted zones, the Amazon VPC must belong to the same partition where the hosted zone is created. A partition is a group of AWS-Regions. Each AWS-account is scoped to one partition.  The following are the supported partitions:   +  ``aws`` - AWS-Regions   +  ``aws-cn`` - China Regions   +  ``aws-us-gov`` - govcloud-us-region     For more information, see [Access Management](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) in the *General Reference*.")
         .attribute(
-            AttributeSchema::new("hosted_zone_config", AttributeType::Struct {
-                    name: "HostedZoneConfig".to_string(),
-                    fields: vec![
-                    StructField::new("comment", AttributeType::Custom {
-                identity: None,
-                pattern: None,
-                length: Some((None, Some(256))),
-                base: Box::new(AttributeType::String),
-                validate: legacy_validator(validate_string_length_max_256),
-                to_dsl: None,
-            }).with_description("Any comments that you want to include about the hosted zone.").with_provider_name("Comment")
-                    ],
-                })
+            AttributeSchema::new("hosted_zone_config", AttributeType::Ref("HostedZoneConfig".to_string()))
                 .with_description("A complex type that contains an optional comment. If you don't want to specify a comment, omit the ``HostedZoneConfig`` and ``Comment`` elements.")
                 .with_provider_name("HostedZoneConfig"),
         )
         .attribute(
-            AttributeSchema::new("hosted_zone_features", AttributeType::Struct {
-                    name: "HostedZoneFeatures".to_string(),
-                    fields: vec![
-                    StructField::new("enable_accelerated_recovery", AttributeType::Bool).with_description("").with_provider_name("EnableAcceleratedRecovery")
-                    ],
-                })
+            AttributeSchema::new("hosted_zone_features", AttributeType::Ref("HostedZoneFeatures".to_string()))
                 .with_description("The features configuration for the hosted zone, including accelerated recovery settings and status information.")
                 .with_provider_name("HostedZoneFeatures"),
         )
@@ -137,12 +120,7 @@ pub fn route53_hosted_zone_config() -> AwsccSchemaConfig {
                 .with_provider_name("NameServers"),
         )
         .attribute(
-            AttributeSchema::new("query_logging_config", AttributeType::Struct {
-                    name: "QueryLoggingConfig".to_string(),
-                    fields: vec![
-                    StructField::new("cloud_watch_logs_log_group_arn", super::arn()).required().with_description("The Amazon Resource Name (ARN) of the CloudWatch Logs log group that Amazon Route 53 is publishing logs to.").with_provider_name("CloudWatchLogsLogGroupArn")
-                    ],
-                })
+            AttributeSchema::new("query_logging_config", AttributeType::Ref("QueryLoggingConfig".to_string()))
                 .with_description("Creates a configuration for DNS query logging. After you create a query logging configuration, Amazon Route 53 begins to publish log data to an Amazon CloudWatch Logs log group. DNS query logs contain information about the queries that Route 53 receives for a specified public hosted zone, such as the following: + Route 53 edge location that responded to the DNS query + Domain or subdomain that was requested + DNS record type, such as A or AAAA + DNS response code, such as ``NoError`` or ``ServFail`` + Log Group and Resource Policy Before you create a query logging configuration, perform the following operations. If you create a query logging configuration using the Route 53 console, Route 53 performs these operations automatically. Create a CloudWatch Logs log group, and make note of the ARN, which you specify when you create a query logging configuration. Note the following: You must create the log group in the us-east-1 region. You must use the same to create the log group and the hosted zone that you want to configure query logging for. When you create log groups for query logging, we recommend that you use a consistent prefix, for example: /aws/route53/hosted zone name In the next step, you'll create a resource policy, which controls access to one or more log groups and the associated resources, such as Route 53 hosted zones. There's a limit on the number of resource policies that you can create, so we recommend that you use a consistent prefix so you can use the same resource policy for all the log groups that you create for query logging. Create a CloudWatch Logs resource policy, and give it the permissions that Route 53 needs to create log streams and to send query logs to log streams. You must create the CloudWatch Logs resource policy in the us-east-1 region. For the value of Resource, specify the ARN for the log group that you created in the previous step. To use the same resource policy for all the CloudWatch Logs log groups that you created for query logging configurations, replace the hosted zone name with *, for example: arn:aws:logs:us-east-1:123412341234:log-group:/aws/route53/* To avoid the confused deputy problem, a security issue where an entity without a permission for an action can coerce a more-privileged entity to perform it, you can optionally limit the permissions that a service has to a resource in a resource-based policy by supplying the following values: For aws:SourceArn, supply the hosted zone ARN used in creating the query logging configuration. For example, aws:SourceArn: arn:aws:route53:::hostedzone/hosted zone ID. For aws:SourceAccount, supply the account ID for the account that creates the query logging configuration. For example, aws:SourceAccount:111111111111. For more information, see The confused deputy problem in the IAM User Guide. You can't use the CloudWatch console to create or edit a resource policy. You must use the CloudWatch API, one of the SDKs, or the . + Log Streams and Edge Locations When Route 53 finishes creating the configuration for DNS query logging, it does the following: Creates a log stream for an edge location the first time that the edge location responds to DNS queries for the specified hosted zone. That log stream is used to log all queries that Route 53 responds to for that edge location. Begins to send query logs to the applicable log stream. The name of each log stream is in the following format: hosted zone ID/edge location code The edge location code is a three-letter code and an arbitrarily assigned number, for example, DFW3. The three-letter code typically corresponds with the International Air Transport Association airport code for an airport near the edge location. (These abbreviations might change in the future.) For a list of edge locations, see \"The Route 53 Global Network\" on the Route 53 Product Details page. + Queries That Are Logged Query logs contain only the queries that DNS resolvers forward to Route 53. If a DNS resolver has already cached the response to a query (such as the IP address for a load balancer for example.com), the resolver will continue to return the cached response. It doesn't forward another query to Route 53 until the TTL for the corresponding resource record set expires. Depending on how many DNS queries are submitted for a resource record set, and depending on the TTL for that resource record set, query logs might contain information about only one query out of every several thousand queries that are submitted to DNS. For more information about how DNS works, see Routing Internet Traffic to Your Website or Web Application in the Amazon Route 53 Developer Guide. + Log File Format For a list of the values in each query log and the format of each value, see Logging DNS Queries in the Amazon Route 53 Developer Guide. + Pricing For information about charges for query logs, see Amazon CloudWatch Pricing. + How to Stop Logging If you want Route 53 to stop sending query logs to CloudWatch Logs, delete the query logging configuration. For more information, see DeleteQueryLoggingConfig.")
                 .with_provider_name("QueryLoggingConfig"),
         )
@@ -165,6 +143,31 @@ pub fn route53_hosted_zone_config() -> AwsccSchemaConfig {
             }
             if errors.is_empty() { Ok(()) } else { Err(errors) }
         })
+        .with_def("HostedZoneConfig", AttributeType::Struct {
+                    name: "HostedZoneConfig".to_string(),
+                    fields: vec![
+                    StructField::new("comment", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: Some((None, Some(256))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_length_max_256),
+                to_dsl: None,
+            }).with_description("Any comments that you want to include about the hosted zone.").with_provider_name("Comment")
+                    ],
+                })
+        .with_def("HostedZoneFeatures", AttributeType::Struct {
+                    name: "HostedZoneFeatures".to_string(),
+                    fields: vec![
+                    StructField::new("enable_accelerated_recovery", AttributeType::Bool).with_description("").with_provider_name("EnableAcceleratedRecovery")
+                    ],
+                })
+        .with_def("QueryLoggingConfig", AttributeType::Struct {
+                    name: "QueryLoggingConfig".to_string(),
+                    fields: vec![
+                    StructField::new("cloud_watch_logs_log_group_arn", super::arn()).required().with_description("The Amazon Resource Name (ARN) of the CloudWatch Logs log group that Amazon Route 53 is publishing logs to.").with_provider_name("CloudWatchLogsLogGroupArn")
+                    ],
+                })
     }
 }
 

--- a/carina-provider-awscc/src/schemas/generated/s3/bucket.rs
+++ b/carina-provider-awscc/src/schemas/generated/s3/bucket.rs
@@ -246,17 +246,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 .with_provider_name("AbacStatus"),
         )
         .attribute(
-            AttributeSchema::new("accelerate_configuration", AttributeType::Struct {
-                    name: "AccelerateConfiguration".to_string(),
-                    fields: vec![
-                    StructField::new("acceleration_status", AttributeType::StringEnum {
-                name: "AccelerationStatus".to_string(),
-                values: vec!["Enabled".to_string(), "Suspended".to_string()],
-                identity: Some(carina_core::schema::string_enum_identity("AccelerationStatus", Some("awscc.s3.Bucket"))),
-                dsl_aliases: vec![("Enabled".to_string(), "enabled".to_string()), ("Suspended".to_string(), "suspended".to_string())],
-            }).required().with_description("Specifies the transfer acceleration status of the bucket.").with_provider_name("AccelerationStatus")
-                    ],
-                })
+            AttributeSchema::new("accelerate_configuration", AttributeType::Ref("AccelerateConfiguration".to_string()))
                 .with_description("Configures the transfer acceleration state for an Amazon S3 bucket. For more information, see [Amazon S3 Transfer Acceleration](https://docs.aws.amazon.com/AmazonS3/latest/dev/transfer-acceleration.html) in the *Amazon S3 User Guide*.")
                 .with_provider_name("AccelerateConfiguration"),
         )
@@ -277,36 +267,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     fields: vec![
                     StructField::new("id", AttributeType::String).required().with_description("The ID that identifies the analytics configuration.").with_provider_name("Id"),
                     StructField::new("prefix", AttributeType::String).with_description("The prefix that an object must have to be included in the analytics results.").with_provider_name("Prefix"),
-                    StructField::new("storage_class_analysis", AttributeType::Struct {
-                    name: "StorageClassAnalysis".to_string(),
-                    fields: vec![
-                    StructField::new("data_export", AttributeType::Struct {
-                    name: "DataExport".to_string(),
-                    fields: vec![
-                    StructField::new("destination", AttributeType::Struct {
-                    name: "Destination".to_string(),
-                    fields: vec![
-                    StructField::new("bucket_account_id", super::aws_account_id()).with_description("The account ID that owns the destination S3 bucket. If no account ID is provided, the owner is not validated before exporting data. Although this value is optional, we strongly recommend that you set it to help prevent problems if the destination bucket ownership changes.").with_provider_name("BucketAccountId"),
-                    StructField::new("bucket_arn", super::arn()).required().with_description("The Amazon Resource Name (ARN) of the bucket to which data is exported.").with_provider_name("BucketArn"),
-                    StructField::new("format", AttributeType::StringEnum {
-                name: "Format".to_string(),
-                values: vec!["CSV".to_string(), "ORC".to_string(), "Parquet".to_string()],
-                identity: Some(carina_core::schema::string_enum_identity("Format", Some("awscc.s3.Bucket"))),
-                dsl_aliases: vec![("CSV".to_string(), "csv".to_string()), ("ORC".to_string(), "orc".to_string()), ("Parquet".to_string(), "parquet".to_string())],
-            }).required().with_description("Specifies the file format used when exporting data to Amazon S3. *Allowed values*: ``CSV`` | ``ORC`` | ``Parquet``").with_provider_name("Format"),
-                    StructField::new("prefix", AttributeType::String).with_description("The prefix to use when exporting data. The prefix is prepended to all results.").with_provider_name("Prefix")
-                    ],
-                }).required().with_description("The place to store the data for an analysis.").with_provider_name("Destination"),
-                    StructField::new("output_schema_version", AttributeType::StringEnum {
-                name: "OutputSchemaVersion".to_string(),
-                values: vec!["V_1".to_string()],
-                identity: Some(carina_core::schema::string_enum_identity("OutputSchemaVersion", Some("awscc.s3.Bucket"))),
-                dsl_aliases: vec![("V_1".to_string(), "v_1".to_string())],
-            }).required().with_description("The version of the output schema to use when exporting data. Must be ``V_1``.").with_provider_name("OutputSchemaVersion")
-                    ],
-                }).with_description("Specifies how data related to the storage class analysis for an Amazon S3 bucket should be exported.").with_provider_name("DataExport")
-                    ],
-                }).required().with_description("Contains data related to access patterns to be collected and made available to analyze the tradeoffs between different storage classes.").with_provider_name("StorageClassAnalysis"),
+                    StructField::new("storage_class_analysis", AttributeType::Ref("StorageClassAnalysis".to_string())).required().with_description("Contains data related to access patterns to be collected and made available to analyze the tradeoffs between different storage classes.").with_provider_name("StorageClassAnalysis"),
                     StructField::new("tag_filters", AttributeType::list(tags_type())).with_description("The tags to use when evaluating an analytics filter. The analytics only includes objects that meet the filter's criteria. If no filter is specified, all of the contents of the bucket are included in the analysis.").with_provider_name("TagFilters")
                     ],
                 }))
@@ -321,43 +282,9 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 .with_provider_name("Arn"),
         )
         .attribute(
-            AttributeSchema::new("bucket_encryption", AttributeType::Struct {
-                    name: "BucketEncryption".to_string(),
-                    fields: vec![
-                    StructField::new("server_side_encryption_configuration", AttributeType::list(AttributeType::Struct {
-                    name: "ServerSideEncryptionRule".to_string(),
-                    fields: vec![
-                    StructField::new("blocked_encryption_types", AttributeType::Struct {
-                    name: "BlockedEncryptionTypes".to_string(),
-                    fields: vec![
-                    StructField::new("encryption_type", AttributeType::list(AttributeType::StringEnum {
-                name: "EncryptionType".to_string(),
-                values: vec!["NONE".to_string(), "SSE-C".to_string()],
-                identity: Some(carina_core::schema::string_enum_identity("EncryptionType", Some("awscc.s3.Bucket"))),
-                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("SSE-C".to_string(), "sse_c".to_string())],
-            })).with_description("The object encryption type that you want to block or unblock for an Amazon S3 general purpose bucket. Currently, this parameter only supports blocking or unblocking server side encryption with customer-provided keys (SSE-C). For more information about SSE-C, see [Using server-side encryption with customer-provided keys (SSE-C)](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerSideEncryptionCustomerKeys.html).").with_provider_name("EncryptionType")
-                    ],
-                }).with_description("A bucket-level setting for Amazon S3 general purpose buckets used to prevent the upload of new objects encrypted with the specified server-side encryption type. For example, blocking an encryption type will block ``PutObject``, ``CopyObject``, ``PostObject``, multipart upload, and replication requests to the bucket for objects with the specified encryption type. However, you can continue to read and list any pre-existing objects already encrypted with the specified encryption type. For more information, see [Blocking or unblocking SSE-C for a general purpose bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/blocking-unblocking-s3-c-encryption-gpb.html). Currently, this parameter only supports blocking or unblocking server-side encryption with customer-provided keys (SSE-C). For more information about SSE-C, see [Using server-side encryption with customer-provided keys (SSE-C)](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerSideEncryptionCustomerKeys.html).").with_provider_name("BlockedEncryptionTypes"),
-                    StructField::new("bucket_key_enabled", AttributeType::Bool).with_description("Specifies whether Amazon S3 should use an S3 Bucket Key with server-side encryption using KMS (SSE-KMS) for new objects in the bucket. Existing objects are not affected. Setting the ``BucketKeyEnabled`` element to ``true`` causes Amazon S3 to use an S3 Bucket Key. By default, S3 Bucket Key is not enabled. For more information, see [Amazon S3 Bucket Keys](https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html) in the *Amazon S3 User Guide*.").with_provider_name("BucketKeyEnabled"),
-                    StructField::new("server_side_encryption_by_default", AttributeType::Struct {
-                    name: "ServerSideEncryptionByDefault".to_string(),
-                    fields: vec![
-                    StructField::new("kms_master_key_id", super::kms_key_id()).with_description("AWS Key Management Service (KMS) customer managed key ID to use for the default encryption. + *General purpose buckets* - This parameter is allowed if and only if ``SSEAlgorithm`` is set to ``aws:kms`` or ``aws:kms:dsse``. + *Directory buckets* - This parameter is allowed if and only if ``SSEAlgorithm`` is set to ``aws:kms``. You can specify the key ID, key alias, or the Amazon Resource Name (ARN) of the KMS key. + Key ID: ``1234abcd-12ab-34cd-56ef-1234567890ab`` + Key ARN: ``arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab`` + Key Alias: ``alias/alias-name`` If you are using encryption with cross-account or AWS service operations, you must use a fully qualified KMS key ARN. For more information, see [Using encryption for cross-account operations](https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html#bucket-encryption-update-bucket-policy). + *General purpose buckets* - If you're specifying a customer managed KMS key, we recommend using a fully qualified KMS key ARN. If you use a KMS key alias instead, then KMS resolves the key within the requester?s account. This behavior can result in data that's encrypted with a KMS key that belongs to the requester, and not the bucket owner. Also, if you use a key ID, you can run into a LogDestination undeliverable error when creating a VPC flow log. + *Directory buckets* - When you specify an [customer managed key](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk) for encryption in your directory bucket, only use the key ID or key ARN. The key alias format of the KMS key isn't supported. Amazon S3 only supports symmetric encryption KMS keys. For more information, see [Asymmetric keys in KMS](https://docs.aws.amazon.com//kms/latest/developerguide/symmetric-asymmetric.html) in the *Key Management Service Developer Guide*.").with_provider_name("KMSMasterKeyID"),
-                    StructField::new("sse_algorithm", AttributeType::StringEnum {
-                name: "ServerSideEncryptionByDefaultSseAlgorithm".to_string(),
-                values: vec!["aws:kms".to_string(), "AES256".to_string(), "aws:kms:dsse".to_string()],
-                identity: Some(carina_core::schema::string_enum_identity("ServerSideEncryptionByDefaultSseAlgorithm", Some("awscc.s3.Bucket"))),
-                dsl_aliases: vec![("aws:kms".to_string(), "aws_kms".to_string()), ("AES256".to_string(), "aes256".to_string()), ("aws:kms:dsse".to_string(), "aws_kms_dsse".to_string())],
-            }).required().with_description("Server-side encryption algorithm to use for the default encryption. For directory buckets, there are only two supported values for server-side encryption: ``AES256`` and ``aws:kms``.").with_provider_name("SSEAlgorithm")
-                    ],
-                }).with_description("Specifies the default server-side encryption to apply to new objects in the bucket. If a PUT Object request doesn't specify any server-side encryption, this default encryption will be applied.").with_provider_name("ServerSideEncryptionByDefault")
-                    ],
-                })).required().with_description("Specifies the default server-side-encryption configuration.").with_provider_name("ServerSideEncryptionConfiguration").with_block_name("server_side_encryption_configuration")
-                    ],
-                })
+            AttributeSchema::new("bucket_encryption", AttributeType::Ref("BucketEncryption".to_string()))
                 .with_description("Specifies default encryption for a bucket using server-side encryption with Amazon S3-managed keys (SSE-S3), AWS KMS-managed keys (SSE-KMS), or dual-layer server-side encryption with KMS-managed keys (DSSE-KMS). For information about the Amazon S3 default encryption feature, see [Amazon S3 Default Encryption for S3 Buckets](https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html) in the *Amazon S3 User Guide*.")
-                .with_provider_name("BucketEncryption")
-                .with_block_name("bucket_encryption"),
+                .with_provider_name("BucketEncryption"),
         )
         .attribute(
             AttributeSchema::new("bucket_name", AttributeType::String)
@@ -366,44 +293,9 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 .with_provider_name("BucketName"),
         )
         .attribute(
-            AttributeSchema::new("cors_configuration", AttributeType::Struct {
-                    name: "CorsConfiguration".to_string(),
-                    fields: vec![
-                    StructField::new("cors_rules", AttributeType::list(AttributeType::Struct {
-                    name: "CorsRule".to_string(),
-                    fields: vec![
-                    StructField::new("allowed_headers", AttributeType::list(AttributeType::String)).with_description("Headers that are specified in the ``Access-Control-Request-Headers`` header. These headers are allowed in a preflight OPTIONS request. In response to any preflight OPTIONS request, Amazon S3 returns any requested headers that are allowed.").with_provider_name("AllowedHeaders"),
-                    StructField::new("allowed_methods", AttributeType::list(AttributeType::StringEnum {
-                name: "AllowedMethods".to_string(),
-                values: vec!["GET".to_string(), "PUT".to_string(), "HEAD".to_string(), "POST".to_string(), "DELETE".to_string()],
-                identity: Some(carina_core::schema::string_enum_identity("AllowedMethods", Some("awscc.s3.Bucket"))),
-                dsl_aliases: vec![("GET".to_string(), "get".to_string()), ("PUT".to_string(), "put".to_string()), ("HEAD".to_string(), "head".to_string()), ("POST".to_string(), "post".to_string()), ("DELETE".to_string(), "delete".to_string())],
-            })).required().with_description("An HTTP method that you allow the origin to run. *Allowed values*: ``GET`` | ``PUT`` | ``HEAD`` | ``POST`` | ``DELETE``").with_provider_name("AllowedMethods"),
-                    StructField::new("allowed_origins", AttributeType::list(AttributeType::String)).required().with_description("One or more origins you want customers to be able to access the bucket from.").with_provider_name("AllowedOrigins"),
-                    StructField::new("exposed_headers", AttributeType::list(AttributeType::String)).with_description("One or more headers in the response that you want customers to be able to access from their applications (for example, from a JavaScript ``XMLHttpRequest`` object).").with_provider_name("ExposedHeaders"),
-                    StructField::new("id", AttributeType::Custom {
-                identity: None,
-                pattern: None,
-                length: Some((None, Some(255))),
-                base: Box::new(AttributeType::String),
-                validate: legacy_validator(validate_string_length_max_255),
-                to_dsl: None,
-            }).with_description("A unique identifier for this rule. The value must be no more than 255 characters.").with_provider_name("Id"),
-                    StructField::new("max_age", AttributeType::Custom {
-                identity: None,
-                pattern: None,
-                length: None,
-                base: Box::new(AttributeType::Int),
-                validate: legacy_validator(validate_max_age_range),
-                to_dsl: None,
-            }).with_description("The time in seconds that your browser is to cache the preflight response for the specified resource.").with_provider_name("MaxAge")
-                    ],
-                })).required().with_description("A set of origins and methods (cross-origin access that you want to allow). You can add up to 100 rules to the configuration.").with_provider_name("CorsRules").with_block_name("cors_rule")
-                    ],
-                })
+            AttributeSchema::new("cors_configuration", AttributeType::Ref("CorsConfiguration".to_string()))
                 .with_description("Describes the cross-origin access configuration for objects in an Amazon S3 bucket. For more information, see [Enabling Cross-Origin Resource Sharing](https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html) in the *Amazon S3 User Guide*.")
-                .with_provider_name("CorsConfiguration")
-                .with_block_name("cors_configuration"),
+                .with_provider_name("CorsConfiguration"),
         )
         .attribute(
             AttributeSchema::new("domain_name", AttributeType::String)
@@ -452,20 +344,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
             AttributeSchema::new("inventory_configurations", AttributeType::list(AttributeType::Struct {
                     name: "InventoryConfiguration".to_string(),
                     fields: vec![
-                    StructField::new("destination", AttributeType::Struct {
-                    name: "Destination".to_string(),
-                    fields: vec![
-                    StructField::new("bucket_account_id", super::aws_account_id()).with_description("The account ID that owns the destination S3 bucket. If no account ID is provided, the owner is not validated before exporting data. Although this value is optional, we strongly recommend that you set it to help prevent problems if the destination bucket ownership changes.").with_provider_name("BucketAccountId"),
-                    StructField::new("bucket_arn", super::arn()).required().with_description("The Amazon Resource Name (ARN) of the bucket to which data is exported.").with_provider_name("BucketArn"),
-                    StructField::new("format", AttributeType::StringEnum {
-                name: "Format".to_string(),
-                values: vec!["CSV".to_string(), "ORC".to_string(), "Parquet".to_string()],
-                identity: Some(carina_core::schema::string_enum_identity("Format", Some("awscc.s3.Bucket"))),
-                dsl_aliases: vec![("CSV".to_string(), "csv".to_string()), ("ORC".to_string(), "orc".to_string()), ("Parquet".to_string(), "parquet".to_string())],
-            }).required().with_description("Specifies the file format used when exporting data to Amazon S3. *Allowed values*: ``CSV`` | ``ORC`` | ``Parquet``").with_provider_name("Format"),
-                    StructField::new("prefix", AttributeType::String).with_description("The prefix to use when exporting data. The prefix is prepended to all results.").with_provider_name("Prefix")
-                    ],
-                }).required().with_description("Contains information about where to publish the inventory results.").with_provider_name("Destination"),
+                    StructField::new("destination", AttributeType::Ref("Destination".to_string())).required().with_description("Contains information about where to publish the inventory results.").with_provider_name("Destination"),
                     StructField::new("enabled", AttributeType::Bool).required().with_description("Specifies whether the inventory is enabled or disabled. If set to ``True``, an inventory list is generated. If set to ``False``, no inventory list is generated.").with_provider_name("Enabled"),
                     StructField::new("id", AttributeType::String).required().with_description("The ID used to identify the inventory configuration.").with_provider_name("Id"),
                     StructField::new("included_object_versions", AttributeType::StringEnum {
@@ -494,7 +373,347 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 .with_block_name("inventory_configuration"),
         )
         .attribute(
-            AttributeSchema::new("lifecycle_configuration", AttributeType::Struct {
+            AttributeSchema::new("lifecycle_configuration", AttributeType::Ref("LifecycleConfiguration".to_string()))
+                .with_description("Specifies the lifecycle configuration for objects in an Amazon S3 bucket. For more information, see [Object Lifecycle Management](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) in the *Amazon S3 User Guide*.")
+                .with_provider_name("LifecycleConfiguration"),
+        )
+        .attribute(
+            AttributeSchema::new("logging_configuration", AttributeType::Ref("LoggingConfiguration".to_string()))
+                .with_description("Settings that define where logs are stored.")
+                .with_provider_name("LoggingConfiguration"),
+        )
+        .attribute(
+            AttributeSchema::new("metadata_configuration", AttributeType::Ref("MetadataConfiguration".to_string()))
+                .with_description("The S3 Metadata configuration for a general purpose bucket.")
+                .with_provider_name("MetadataConfiguration"),
+        )
+        .attribute(
+            AttributeSchema::new("metadata_table_configuration", AttributeType::Ref("MetadataTableConfiguration".to_string()))
+                .with_description("The metadata table configuration of an S3 general purpose bucket.")
+                .with_provider_name("MetadataTableConfiguration"),
+        )
+        .attribute(
+            AttributeSchema::new("metrics_configurations", AttributeType::list(AttributeType::Struct {
+                    name: "MetricsConfiguration".to_string(),
+                    fields: vec![
+                    StructField::new("access_point_arn", super::arn()).with_description("The access point that was used while performing operations on the object. The metrics configuration only includes objects that meet the filter's criteria.").with_provider_name("AccessPointArn"),
+                    StructField::new("id", AttributeType::String).required().with_description("The ID used to identify the metrics configuration. This can be any value you choose that helps you identify your metrics configuration.").with_provider_name("Id"),
+                    StructField::new("prefix", AttributeType::String).with_description("The prefix that an object must have to be included in the metrics results.").with_provider_name("Prefix"),
+                    StructField::new("tag_filters", AttributeType::list(tags_type())).with_description("Specifies a list of tag filters to use as a metrics configuration filter. The metrics configuration includes only objects that meet the filter's criteria.").with_provider_name("TagFilters")
+                    ],
+                }))
+                .with_description("Specifies a metrics configuration for the CloudWatch request metrics (specified by the metrics configuration ID) from an Amazon S3 bucket. If you're updating an existing metrics configuration, note that this is a full replacement of the existing metrics configuration. If you don't include the elements you want to keep, they are erased. For more information, see [PutBucketMetricsConfiguration](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTMetricConfiguration.html).")
+                .with_provider_name("MetricsConfigurations")
+                .with_block_name("metrics_configuration"),
+        )
+        .attribute(
+            AttributeSchema::new("notification_configuration", AttributeType::Ref("NotificationConfiguration".to_string()))
+                .with_description("Configuration that defines how Amazon S3 handles bucket notifications.")
+                .with_provider_name("NotificationConfiguration"),
+        )
+        .attribute(
+            AttributeSchema::new("object_lock_configuration", AttributeType::Ref("ObjectLockConfiguration".to_string()))
+                .with_description("This operation is not supported for directory buckets. Places an Object Lock configuration on the specified bucket. The rule specified in the Object Lock configuration will be applied by default to every new object placed in the specified bucket. For more information, see [Locking Objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html). + The ``DefaultRetention`` settings require both a mode and a period. + The ``DefaultRetention`` period can be either ``Days`` or ``Years`` but you must select one. You cannot specify ``Days`` and ``Years`` at the same time. + You can enable Object Lock for new or existing buckets. For more information, see [Configuring Object Lock](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock-configure.html). You must URL encode any signed header values that contain spaces. For example, if your header value is ``my file.txt``, containing two spaces after ``my``, you must URL encode this value to ``my%20%20file.txt``.")
+                .with_provider_name("ObjectLockConfiguration"),
+        )
+        .attribute(
+            AttributeSchema::new("object_lock_enabled", AttributeType::Bool)
+                .with_description("Indicates whether this bucket has an Object Lock configuration enabled. Enable ``ObjectLockEnabled`` when you apply ``ObjectLockConfiguration`` to a bucket.")
+                .with_provider_name("ObjectLockEnabled"),
+        )
+        .attribute(
+            AttributeSchema::new("ownership_controls", AttributeType::Ref("OwnershipControls".to_string()))
+                .with_description("Configuration that defines how Amazon S3 handles Object Ownership rules.")
+                .with_provider_name("OwnershipControls"),
+        )
+        .attribute(
+            AttributeSchema::new("public_access_block_configuration", AttributeType::Ref("PublicAccessBlockConfiguration".to_string()))
+                .with_description("Configuration that defines how Amazon S3 handles public access.")
+                .with_provider_name("PublicAccessBlockConfiguration"),
+        )
+        .attribute(
+            AttributeSchema::new("regional_domain_name", AttributeType::String)
+                .read_only()
+                .with_description(" (read-only)")
+                .with_provider_name("RegionalDomainName"),
+        )
+        .attribute(
+            AttributeSchema::new("replication_configuration", AttributeType::Ref("ReplicationConfiguration".to_string()))
+                .with_description("Configuration for replicating objects in an S3 bucket. To enable replication, you must also enable versioning by using the ``VersioningConfiguration`` property. Amazon S3 can store replicated objects in a single destination bucket or multiple destination buckets. The destination bucket or buckets must already exist.")
+                .with_provider_name("ReplicationConfiguration"),
+        )
+        .attribute(
+            AttributeSchema::new("tags", tags_type())
+                .with_description("An arbitrary set of tags (key-value pairs) for this S3 bucket.")
+                .with_provider_name("Tags"),
+        )
+        .attribute(
+            AttributeSchema::new("versioning_configuration", AttributeType::Ref("VersioningConfiguration".to_string()))
+                .with_description("Enables multiple versions of all objects in this bucket. You might enable versioning to prevent objects from being deleted or overwritten by mistake or to archive objects so that you can retrieve previous versions of them. When you enable versioning on a bucket for the first time, it might take a short amount of time for the change to be fully propagated. We recommend that you wait for 15 minutes after enabling versioning before issuing write operations (``PUT`` or ``DELETE``) on objects in the bucket.")
+                .with_provider_name("VersioningConfiguration"),
+        )
+        .attribute(
+            AttributeSchema::new("website_configuration", AttributeType::Ref("WebsiteConfiguration".to_string()))
+                .with_description("Information used to configure the bucket as a static website. For more information, see [Hosting Websites on Amazon S3](https://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteHosting.html).")
+                .with_provider_name("WebsiteConfiguration"),
+        )
+        .attribute(
+            AttributeSchema::new("website_url", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: noop_validator(),
+                to_dsl: None,
+            })
+                .read_only()
+                .with_description(" (read-only)")
+                .with_provider_name("WebsiteURL"),
+        )
+        .with_name_attribute("bucket_name")
+        .with_validator(|attrs| {
+            let mut errors = Vec::new();
+            if let Err(mut e) = validate_tags_map(attrs) {
+                errors.append(&mut e);
+            }
+            if errors.is_empty() { Ok(()) } else { Err(errors) }
+        })
+        .with_def("AbortIncompleteMultipartUpload", AttributeType::Struct {
+                    name: "AbortIncompleteMultipartUpload".to_string(),
+                    fields: vec![
+                    StructField::new("days_after_initiation", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::Int),
+                validate: legacy_validator(validate_days_after_initiation_range),
+                to_dsl: None,
+            }).required().with_description("Specifies the number of days after which Amazon S3 stops an incomplete multipart upload.").with_provider_name("DaysAfterInitiation")
+                    ],
+                })
+        .with_def("AccelerateConfiguration", AttributeType::Struct {
+                    name: "AccelerateConfiguration".to_string(),
+                    fields: vec![
+                    StructField::new("acceleration_status", AttributeType::StringEnum {
+                name: "AccelerationStatus".to_string(),
+                values: vec!["Enabled".to_string(), "Suspended".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("AccelerationStatus", Some("awscc.s3.Bucket"))),
+                dsl_aliases: vec![("Enabled".to_string(), "enabled".to_string()), ("Suspended".to_string(), "suspended".to_string())],
+            }).required().with_description("Specifies the transfer acceleration status of the bucket.").with_provider_name("AccelerationStatus")
+                    ],
+                })
+        .with_def("AccessControlTranslation", AttributeType::Struct {
+                    name: "AccessControlTranslation".to_string(),
+                    fields: vec![
+                    StructField::new("owner", AttributeType::StringEnum {
+                name: "Owner".to_string(),
+                values: vec!["Destination".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("Owner", Some("awscc.s3.Bucket"))),
+                dsl_aliases: vec![("Destination".to_string(), "destination".to_string())],
+            }).required().with_description("Specifies the replica ownership. For default and valid values, see [PUT bucket replication](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTreplication.html) in the *Amazon S3 API Reference*.").with_provider_name("Owner")
+                    ],
+                })
+        .with_def("BlockedEncryptionTypes", AttributeType::Struct {
+                    name: "BlockedEncryptionTypes".to_string(),
+                    fields: vec![
+                    StructField::new("encryption_type", AttributeType::list(AttributeType::StringEnum {
+                name: "EncryptionType".to_string(),
+                values: vec!["NONE".to_string(), "SSE-C".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("EncryptionType", Some("awscc.s3.Bucket"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("SSE-C".to_string(), "sse_c".to_string())],
+            })).with_description("The object encryption type that you want to block or unblock for an Amazon S3 general purpose bucket. Currently, this parameter only supports blocking or unblocking server side encryption with customer-provided keys (SSE-C). For more information about SSE-C, see [Using server-side encryption with customer-provided keys (SSE-C)](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerSideEncryptionCustomerKeys.html).").with_provider_name("EncryptionType")
+                    ],
+                })
+        .with_def("BucketEncryption", AttributeType::Struct {
+                    name: "BucketEncryption".to_string(),
+                    fields: vec![
+                    StructField::new("server_side_encryption_configuration", AttributeType::list(AttributeType::Struct {
+                    name: "ServerSideEncryptionRule".to_string(),
+                    fields: vec![
+                    StructField::new("blocked_encryption_types", AttributeType::Struct {
+                    name: "BlockedEncryptionTypes".to_string(),
+                    fields: vec![
+                    StructField::new("encryption_type", AttributeType::list(AttributeType::StringEnum {
+                name: "EncryptionType".to_string(),
+                values: vec!["NONE".to_string(), "SSE-C".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("EncryptionType", Some("awscc.s3.Bucket"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("SSE-C".to_string(), "sse_c".to_string())],
+            })).with_description("The object encryption type that you want to block or unblock for an Amazon S3 general purpose bucket. Currently, this parameter only supports blocking or unblocking server side encryption with customer-provided keys (SSE-C). For more information about SSE-C, see [Using server-side encryption with customer-provided keys (SSE-C)](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerSideEncryptionCustomerKeys.html).").with_provider_name("EncryptionType")
+                    ],
+                }).with_description("A bucket-level setting for Amazon S3 general purpose buckets used to prevent the upload of new objects encrypted with the specified server-side encryption type. For example, blocking an encryption type will block ``PutObject``, ``CopyObject``, ``PostObject``, multipart upload, and replication requests to the bucket for objects with the specified encryption type. However, you can continue to read and list any pre-existing objects already encrypted with the specified encryption type. For more information, see [Blocking or unblocking SSE-C for a general purpose bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/blocking-unblocking-s3-c-encryption-gpb.html). Currently, this parameter only supports blocking or unblocking server-side encryption with customer-provided keys (SSE-C). For more information about SSE-C, see [Using server-side encryption with customer-provided keys (SSE-C)](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerSideEncryptionCustomerKeys.html).").with_provider_name("BlockedEncryptionTypes"),
+                    StructField::new("bucket_key_enabled", AttributeType::Bool).with_description("Specifies whether Amazon S3 should use an S3 Bucket Key with server-side encryption using KMS (SSE-KMS) for new objects in the bucket. Existing objects are not affected. Setting the ``BucketKeyEnabled`` element to ``true`` causes Amazon S3 to use an S3 Bucket Key. By default, S3 Bucket Key is not enabled. For more information, see [Amazon S3 Bucket Keys](https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-key.html) in the *Amazon S3 User Guide*.").with_provider_name("BucketKeyEnabled"),
+                    StructField::new("server_side_encryption_by_default", AttributeType::Struct {
+                    name: "ServerSideEncryptionByDefault".to_string(),
+                    fields: vec![
+                    StructField::new("kms_master_key_id", super::kms_key_id()).with_description("AWS Key Management Service (KMS) customer managed key ID to use for the default encryption. + *General purpose buckets* - This parameter is allowed if and only if ``SSEAlgorithm`` is set to ``aws:kms`` or ``aws:kms:dsse``. + *Directory buckets* - This parameter is allowed if and only if ``SSEAlgorithm`` is set to ``aws:kms``. You can specify the key ID, key alias, or the Amazon Resource Name (ARN) of the KMS key. + Key ID: ``1234abcd-12ab-34cd-56ef-1234567890ab`` + Key ARN: ``arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab`` + Key Alias: ``alias/alias-name`` If you are using encryption with cross-account or AWS service operations, you must use a fully qualified KMS key ARN. For more information, see [Using encryption for cross-account operations](https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html#bucket-encryption-update-bucket-policy). + *General purpose buckets* - If you're specifying a customer managed KMS key, we recommend using a fully qualified KMS key ARN. If you use a KMS key alias instead, then KMS resolves the key within the requester?s account. This behavior can result in data that's encrypted with a KMS key that belongs to the requester, and not the bucket owner. Also, if you use a key ID, you can run into a LogDestination undeliverable error when creating a VPC flow log. + *Directory buckets* - When you specify an [customer managed key](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk) for encryption in your directory bucket, only use the key ID or key ARN. The key alias format of the KMS key isn't supported. Amazon S3 only supports symmetric encryption KMS keys. For more information, see [Asymmetric keys in KMS](https://docs.aws.amazon.com//kms/latest/developerguide/symmetric-asymmetric.html) in the *Key Management Service Developer Guide*.").with_provider_name("KMSMasterKeyID"),
+                    StructField::new("sse_algorithm", AttributeType::StringEnum {
+                name: "SseAlgorithm".to_string(),
+                values: vec!["aws:kms".to_string(), "AES256".to_string(), "aws:kms:dsse".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("SseAlgorithm", Some("awscc.s3.Bucket"))),
+                dsl_aliases: vec![("aws:kms".to_string(), "aws_kms".to_string()), ("AES256".to_string(), "aes256".to_string()), ("aws:kms:dsse".to_string(), "aws_kms_dsse".to_string())],
+            }).required().with_description("Server-side encryption algorithm to use for the default encryption. For directory buckets, there are only two supported values for server-side encryption: ``AES256`` and ``aws:kms``.").with_provider_name("SSEAlgorithm")
+                    ],
+                }).with_description("Specifies the default server-side encryption to apply to new objects in the bucket. If a PUT Object request doesn't specify any server-side encryption, this default encryption will be applied.").with_provider_name("ServerSideEncryptionByDefault")
+                    ],
+                })).required().with_description("Specifies the default server-side-encryption configuration.").with_provider_name("ServerSideEncryptionConfiguration").with_block_name("server_side_encryption_configuration")
+                    ],
+                })
+        .with_def("CorsConfiguration", AttributeType::Struct {
+                    name: "CorsConfiguration".to_string(),
+                    fields: vec![
+                    StructField::new("cors_rules", AttributeType::list(AttributeType::Struct {
+                    name: "CorsRule".to_string(),
+                    fields: vec![
+                    StructField::new("allowed_headers", AttributeType::list(AttributeType::String)).with_description("Headers that are specified in the ``Access-Control-Request-Headers`` header. These headers are allowed in a preflight OPTIONS request. In response to any preflight OPTIONS request, Amazon S3 returns any requested headers that are allowed.").with_provider_name("AllowedHeaders"),
+                    StructField::new("allowed_methods", AttributeType::list(AttributeType::StringEnum {
+                name: "AllowedMethods".to_string(),
+                values: vec!["GET".to_string(), "PUT".to_string(), "HEAD".to_string(), "POST".to_string(), "DELETE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("AllowedMethods", Some("awscc.s3.Bucket"))),
+                dsl_aliases: vec![("GET".to_string(), "get".to_string()), ("PUT".to_string(), "put".to_string()), ("HEAD".to_string(), "head".to_string()), ("POST".to_string(), "post".to_string()), ("DELETE".to_string(), "delete".to_string())],
+            })).required().with_description("An HTTP method that you allow the origin to run. *Allowed values*: ``GET`` | ``PUT`` | ``HEAD`` | ``POST`` | ``DELETE``").with_provider_name("AllowedMethods"),
+                    StructField::new("allowed_origins", AttributeType::list(AttributeType::String)).required().with_description("One or more origins you want customers to be able to access the bucket from.").with_provider_name("AllowedOrigins"),
+                    StructField::new("exposed_headers", AttributeType::list(AttributeType::String)).with_description("One or more headers in the response that you want customers to be able to access from their applications (for example, from a JavaScript ``XMLHttpRequest`` object).").with_provider_name("ExposedHeaders"),
+                    StructField::new("id", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: Some((None, Some(255))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_length_max_255),
+                to_dsl: None,
+            }).with_description("A unique identifier for this rule. The value must be no more than 255 characters.").with_provider_name("Id"),
+                    StructField::new("max_age", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::Int),
+                validate: legacy_validator(validate_max_age_range),
+                to_dsl: None,
+            }).with_description("The time in seconds that your browser is to cache the preflight response for the specified resource.").with_provider_name("MaxAge")
+                    ],
+                })).required().with_description("A set of origins and methods (cross-origin access that you want to allow). You can add up to 100 rules to the configuration.").with_provider_name("CorsRules").with_block_name("cors_rule")
+                    ],
+                })
+        .with_def("DataExport", AttributeType::Struct {
+                    name: "DataExport".to_string(),
+                    fields: vec![
+                    StructField::new("destination", AttributeType::Struct {
+                    name: "Destination".to_string(),
+                    fields: vec![
+                    StructField::new("bucket_account_id", super::aws_account_id()).with_description("The account ID that owns the destination S3 bucket. If no account ID is provided, the owner is not validated before exporting data. Although this value is optional, we strongly recommend that you set it to help prevent problems if the destination bucket ownership changes.").with_provider_name("BucketAccountId"),
+                    StructField::new("bucket_arn", super::arn()).required().with_description("The Amazon Resource Name (ARN) of the bucket to which data is exported.").with_provider_name("BucketArn"),
+                    StructField::new("format", AttributeType::StringEnum {
+                name: "Format".to_string(),
+                values: vec!["CSV".to_string(), "ORC".to_string(), "Parquet".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("Format", Some("awscc.s3.Bucket"))),
+                dsl_aliases: vec![("CSV".to_string(), "csv".to_string()), ("ORC".to_string(), "orc".to_string()), ("Parquet".to_string(), "parquet".to_string())],
+            }).required().with_description("Specifies the file format used when exporting data to Amazon S3. *Allowed values*: ``CSV`` | ``ORC`` | ``Parquet``").with_provider_name("Format"),
+                    StructField::new("prefix", AttributeType::String).with_description("The prefix to use when exporting data. The prefix is prepended to all results.").with_provider_name("Prefix")
+                    ],
+                }).required().with_description("The place to store the data for an analysis.").with_provider_name("Destination"),
+                    StructField::new("output_schema_version", AttributeType::StringEnum {
+                name: "OutputSchemaVersion".to_string(),
+                values: vec!["V_1".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("OutputSchemaVersion", Some("awscc.s3.Bucket"))),
+                dsl_aliases: vec![("V_1".to_string(), "v_1".to_string())],
+            }).required().with_description("The version of the output schema to use when exporting data. Must be ``V_1``.").with_provider_name("OutputSchemaVersion")
+                    ],
+                })
+        .with_def("DefaultRetention", AttributeType::Struct {
+                    name: "DefaultRetention".to_string(),
+                    fields: vec![
+                    StructField::new("days", AttributeType::Int).with_description("The number of days that you want to specify for the default retention period. If Object Lock is turned on, you must specify ``Mode`` and specify either ``Days`` or ``Years``.").with_provider_name("Days"),
+                    StructField::new("mode", AttributeType::StringEnum {
+                name: "Mode".to_string(),
+                values: vec!["COMPLIANCE".to_string(), "GOVERNANCE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("Mode", Some("awscc.s3.Bucket"))),
+                dsl_aliases: vec![("COMPLIANCE".to_string(), "compliance".to_string()), ("GOVERNANCE".to_string(), "governance".to_string())],
+            }).with_description("The default Object Lock retention mode you want to apply to new objects placed in the specified bucket. If Object Lock is turned on, you must specify ``Mode`` and specify either ``Days`` or ``Years``.").with_provider_name("Mode"),
+                    StructField::new("years", AttributeType::Int).with_description("The number of years that you want to specify for the default retention period. If Object Lock is turned on, you must specify ``Mode`` and specify either ``Days`` or ``Years``.").with_provider_name("Years")
+                    ],
+                })
+        .with_def("DeleteMarkerReplication", AttributeType::Struct {
+                    name: "DeleteMarkerReplication".to_string(),
+                    fields: vec![
+                    StructField::new("status", AttributeType::StringEnum {
+                name: "Status".to_string(),
+                values: vec!["Disabled".to_string(), "Enabled".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("Status", Some("awscc.s3.Bucket"))),
+                dsl_aliases: vec![("Disabled".to_string(), "disabled".to_string()), ("Enabled".to_string(), "enabled".to_string())],
+            }).with_description("Indicates whether to replicate delete markers.").with_provider_name("Status")
+                    ],
+                })
+        .with_def("Destination", AttributeType::Struct {
+                    name: "Destination".to_string(),
+                    fields: vec![
+                    StructField::new("bucket_account_id", super::aws_account_id()).with_description("The account ID that owns the destination S3 bucket. If no account ID is provided, the owner is not validated before exporting data. Although this value is optional, we strongly recommend that you set it to help prevent problems if the destination bucket ownership changes.").with_provider_name("BucketAccountId"),
+                    StructField::new("bucket_arn", super::arn()).required().with_description("The Amazon Resource Name (ARN) of the bucket to which data is exported.").with_provider_name("BucketArn"),
+                    StructField::new("format", AttributeType::StringEnum {
+                name: "Format".to_string(),
+                values: vec!["CSV".to_string(), "ORC".to_string(), "Parquet".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("Format", Some("awscc.s3.Bucket"))),
+                dsl_aliases: vec![("CSV".to_string(), "csv".to_string()), ("ORC".to_string(), "orc".to_string()), ("Parquet".to_string(), "parquet".to_string())],
+            }).required().with_description("Specifies the file format used when exporting data to Amazon S3. *Allowed values*: ``CSV`` | ``ORC`` | ``Parquet``").with_provider_name("Format"),
+                    StructField::new("prefix", AttributeType::String).with_description("The prefix to use when exporting data. The prefix is prepended to all results.").with_provider_name("Prefix")
+                    ],
+                })
+        .with_def("EncryptionConfiguration", AttributeType::Struct {
+                    name: "EncryptionConfiguration".to_string(),
+                    fields: vec![
+                    StructField::new("replica_kms_key_id", super::kms_key_id()).required().with_description("Specifies the ID (Key ARN or Alias ARN) of the customer managed AWS KMS key stored in AWS Key Management Service (KMS) for the destination bucket. Amazon S3 uses this key to encrypt replica objects. Amazon S3 only supports symmetric encryption KMS keys. For more information, see [Asymmetric keys in KMS](https://docs.aws.amazon.com//kms/latest/developerguide/symmetric-asymmetric.html) in the *Key Management Service Developer Guide*.").with_provider_name("ReplicaKmsKeyID")
+                    ],
+                })
+        .with_def("EventBridgeConfiguration", AttributeType::Struct {
+                    name: "EventBridgeConfiguration".to_string(),
+                    fields: vec![
+                    StructField::new("event_bridge_enabled", AttributeType::Bool).required().with_description("Enables delivery of events to Amazon EventBridge.").with_provider_name("EventBridgeEnabled")
+                    ],
+                })
+        .with_def("InventoryTableConfiguration", AttributeType::Struct {
+                    name: "InventoryTableConfiguration".to_string(),
+                    fields: vec![
+                    StructField::new("configuration_state", AttributeType::StringEnum {
+                name: "ConfigurationState".to_string(),
+                values: vec!["ENABLED".to_string(), "DISABLED".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("ConfigurationState", Some("awscc.s3.Bucket"))),
+                dsl_aliases: vec![("ENABLED".to_string(), "enabled".to_string()), ("DISABLED".to_string(), "disabled".to_string())],
+            }).required().with_description("The configuration state of the inventory table, indicating whether the inventory table is enabled or disabled.").with_provider_name("ConfigurationState"),
+                    StructField::new("encryption_configuration", AttributeType::Struct {
+                    name: "MetadataTableEncryptionConfiguration".to_string(),
+                    fields: vec![
+                    StructField::new("kms_key_arn", super::kms_key_arn()).with_description("If server-side encryption with KMSlong (KMS) keys (SSE-KMS) is specified, you must also specify the KMS key Amazon Resource Name (ARN). You must specify a customer-managed KMS key that's located in the same Region as the general purpose bucket that corresponds to the metadata table configuration.").with_provider_name("KmsKeyArn"),
+                    StructField::new("sse_algorithm", AttributeType::StringEnum {
+                name: "SseAlgorithm".to_string(),
+                values: vec!["aws:kms".to_string(), "AES256".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("SseAlgorithm", Some("awscc.s3.Bucket"))),
+                dsl_aliases: vec![("aws:kms".to_string(), "aws_kms".to_string()), ("AES256".to_string(), "aes256".to_string())],
+            }).required().with_description("The encryption type specified for a metadata table. To specify server-side encryption with KMSlong (KMS) keys (SSE-KMS), use the ``aws:kms`` value. To specify server-side encryption with Amazon S3 managed keys (SSE-S3), use the ``AES256`` value.").with_provider_name("SseAlgorithm")
+                    ],
+                }).with_description("The encryption configuration for the inventory table.").with_provider_name("EncryptionConfiguration"),
+                    StructField::new("table_arn", super::arn()).with_description("The Amazon Resource Name (ARN) for the inventory table.").with_provider_name("TableArn"),
+                    StructField::new("table_name", AttributeType::String).with_description("The name of the inventory table.").with_provider_name("TableName")
+                    ],
+                })
+        .with_def("JournalTableConfiguration", AttributeType::Struct {
+                    name: "JournalTableConfiguration".to_string(),
+                    fields: vec![
+                    StructField::new("encryption_configuration", AttributeType::Ref("MetadataTableEncryptionConfiguration".to_string())).with_description("The encryption configuration for the journal table.").with_provider_name("EncryptionConfiguration"),
+                    StructField::new("record_expiration", AttributeType::Struct {
+                    name: "RecordExpiration".to_string(),
+                    fields: vec![
+                    StructField::new("days", AttributeType::Int).with_description("If you enable journal table record expiration, you can set the number of days to retain your journal table records. Journal table records must be retained for a minimum of 7 days. To set this value, specify any whole number from ``7`` to ``2147483647``. For example, to retain your journal table records for one year, set this value to ``365``.").with_provider_name("Days"),
+                    StructField::new("expiration", AttributeType::StringEnum {
+                name: "Expiration".to_string(),
+                values: vec!["ENABLED".to_string(), "DISABLED".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("Expiration", Some("awscc.s3.Bucket"))),
+                dsl_aliases: vec![("ENABLED".to_string(), "enabled".to_string()), ("DISABLED".to_string(), "disabled".to_string())],
+            }).required().with_description("Specifies whether journal table record expiration is enabled or disabled.").with_provider_name("Expiration")
+                    ],
+                }).required().with_description("The journal table record expiration settings for the journal table.").with_provider_name("RecordExpiration"),
+                    StructField::new("table_arn", super::arn()).with_description("The Amazon Resource Name (ARN) for the journal table.").with_provider_name("TableArn"),
+                    StructField::new("table_name", AttributeType::String).with_description("The name of the journal table.").with_provider_name("TableName")
+                    ],
+                })
+        .with_def("LifecycleConfiguration", AttributeType::Struct {
                     name: "LifecycleConfiguration".to_string(),
                     fields: vec![
                     StructField::new("rules", AttributeType::list(AttributeType::Struct {
@@ -544,9 +763,9 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     fields: vec![
                     StructField::new("newer_noncurrent_versions", AttributeType::Int).with_description("Specifies how many noncurrent versions S3 will retain. If there are this many more recent noncurrent versions, S3 will take the associated action. For more information about noncurrent versions, see [Lifecycle configuration elements](https://docs.aws.amazon.com/AmazonS3/latest/userguide/intro-lifecycle-rules.html) in the *Amazon S3 User Guide*.").with_provider_name("NewerNoncurrentVersions"),
                     StructField::new("storage_class", AttributeType::StringEnum {
-                name: "NoncurrentVersionTransitionStorageClass".to_string(),
+                name: "StorageClass".to_string(),
                 values: vec!["DEEP_ARCHIVE".to_string(), "GLACIER".to_string(), "GLACIER_IR".to_string(), "INTELLIGENT_TIERING".to_string(), "ONEZONE_IA".to_string(), "STANDARD_IA".to_string()],
-                identity: Some(carina_core::schema::string_enum_identity("NoncurrentVersionTransitionStorageClass", Some("awscc.s3.Bucket"))),
+                identity: Some(carina_core::schema::string_enum_identity("StorageClass", Some("awscc.s3.Bucket"))),
                 dsl_aliases: vec![("DEEP_ARCHIVE".to_string(), "deep_archive".to_string()), ("GLACIER".to_string(), "glacier".to_string()), ("GLACIER_IR".to_string(), "glacier_ir".to_string()), ("INTELLIGENT_TIERING".to_string(), "intelligent_tiering".to_string()), ("ONEZONE_IA".to_string(), "onezone_ia".to_string()), ("STANDARD_IA".to_string(), "standard_ia".to_string())],
             }).required().with_description("The class of storage used to store the object.").with_provider_name("StorageClass"),
                     StructField::new("transition_in_days", AttributeType::Int).required().with_description("Specifies the number of days an object is noncurrent before Amazon S3 can perform the associated action. For information about the noncurrent days calculations, see [How Amazon S3 Calculates How Long an Object Has Been Noncurrent](https://docs.aws.amazon.com/AmazonS3/latest/dev/intro-lifecycle-rules.html#non-current-days-calculations) in the *Amazon S3 User Guide*.").with_provider_name("TransitionInDays")
@@ -557,9 +776,9 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     fields: vec![
                     StructField::new("newer_noncurrent_versions", AttributeType::Int).with_description("Specifies how many noncurrent versions S3 will retain. If there are this many more recent noncurrent versions, S3 will take the associated action. For more information about noncurrent versions, see [Lifecycle configuration elements](https://docs.aws.amazon.com/AmazonS3/latest/userguide/intro-lifecycle-rules.html) in the *Amazon S3 User Guide*.").with_provider_name("NewerNoncurrentVersions"),
                     StructField::new("storage_class", AttributeType::StringEnum {
-                name: "NoncurrentVersionTransitionStorageClass".to_string(),
+                name: "StorageClass".to_string(),
                 values: vec!["DEEP_ARCHIVE".to_string(), "GLACIER".to_string(), "GLACIER_IR".to_string(), "INTELLIGENT_TIERING".to_string(), "ONEZONE_IA".to_string(), "STANDARD_IA".to_string()],
-                identity: Some(carina_core::schema::string_enum_identity("NoncurrentVersionTransitionStorageClass", Some("awscc.s3.Bucket"))),
+                identity: Some(carina_core::schema::string_enum_identity("StorageClass", Some("awscc.s3.Bucket"))),
                 dsl_aliases: vec![("DEEP_ARCHIVE".to_string(), "deep_archive".to_string()), ("GLACIER".to_string(), "glacier".to_string()), ("GLACIER_IR".to_string(), "glacier_ir".to_string()), ("INTELLIGENT_TIERING".to_string(), "intelligent_tiering".to_string()), ("ONEZONE_IA".to_string(), "onezone_ia".to_string()), ("STANDARD_IA".to_string(), "standard_ia".to_string())],
             }).required().with_description("The class of storage used to store the object.").with_provider_name("StorageClass"),
                     StructField::new("transition_in_days", AttributeType::Int).required().with_description("Specifies the number of days an object is noncurrent before Amazon S3 can perform the associated action. For information about the noncurrent days calculations, see [How Amazon S3 Calculates How Long an Object Has Been Noncurrent](https://docs.aws.amazon.com/AmazonS3/latest/dev/intro-lifecycle-rules.html#non-current-days-calculations) in the *Amazon S3 User Guide*.").with_provider_name("TransitionInDays")
@@ -583,9 +802,9 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
             }).with_description("Specifies the maximum object size in bytes for this rule to apply to. Objects must be smaller than this value in bytes. For more information about sized based rules, see [Lifecycle configuration using size-based rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/lifecycle-configuration-examples.html#lc-size-rules) in the *Amazon S3 User Guide*.").with_provider_name("ObjectSizeLessThan"),
                     StructField::new("prefix", AttributeType::String).with_description("Object key prefix that identifies one or more objects to which this rule applies. Replacement must be made for object keys containing special characters (such as carriage returns) when using XML requests. For more information, see [XML related object key constraints](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints).").with_provider_name("Prefix"),
                     StructField::new("status", AttributeType::StringEnum {
-                name: "RuleStatus".to_string(),
+                name: "Status".to_string(),
                 values: vec!["Enabled".to_string(), "Disabled".to_string()],
-                identity: Some(carina_core::schema::string_enum_identity("RuleStatus", Some("awscc.s3.Bucket"))),
+                identity: Some(carina_core::schema::string_enum_identity("Status", Some("awscc.s3.Bucket"))),
                 dsl_aliases: vec![("Enabled".to_string(), "enabled".to_string()), ("Disabled".to_string(), "disabled".to_string())],
             }).required().with_description("If ``Enabled``, the rule is currently being applied. If ``Disabled``, the rule is not currently being applied.").with_provider_name("Status"),
                     StructField::new("tag_filters", AttributeType::list(tags_type())).with_description("Tags to use to identify a subset of objects to which the lifecycle rule applies.").with_provider_name("TagFilters"),
@@ -593,9 +812,9 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     name: "Transition".to_string(),
                     fields: vec![
                     StructField::new("storage_class", AttributeType::StringEnum {
-                name: "TransitionStorageClass".to_string(),
+                name: "StorageClass".to_string(),
                 values: vec!["DEEP_ARCHIVE".to_string(), "GLACIER".to_string(), "GLACIER_IR".to_string(), "INTELLIGENT_TIERING".to_string(), "ONEZONE_IA".to_string(), "STANDARD_IA".to_string()],
-                identity: Some(carina_core::schema::string_enum_identity("TransitionStorageClass", Some("awscc.s3.Bucket"))),
+                identity: Some(carina_core::schema::string_enum_identity("StorageClass", Some("awscc.s3.Bucket"))),
                 dsl_aliases: vec![("DEEP_ARCHIVE".to_string(), "deep_archive".to_string()), ("GLACIER".to_string(), "glacier".to_string()), ("GLACIER_IR".to_string(), "glacier_ir".to_string()), ("INTELLIGENT_TIERING".to_string(), "intelligent_tiering".to_string()), ("ONEZONE_IA".to_string(), "onezone_ia".to_string()), ("STANDARD_IA".to_string(), "standard_ia".to_string())],
             }).required().with_description("The storage class to which you want the object to transition.").with_provider_name("StorageClass"),
                     StructField::new("transition_date", AttributeType::Custom {
@@ -613,9 +832,9 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     name: "Transition".to_string(),
                     fields: vec![
                     StructField::new("storage_class", AttributeType::StringEnum {
-                name: "TransitionStorageClass".to_string(),
+                name: "StorageClass".to_string(),
                 values: vec!["DEEP_ARCHIVE".to_string(), "GLACIER".to_string(), "GLACIER_IR".to_string(), "INTELLIGENT_TIERING".to_string(), "ONEZONE_IA".to_string(), "STANDARD_IA".to_string()],
-                identity: Some(carina_core::schema::string_enum_identity("TransitionStorageClass", Some("awscc.s3.Bucket"))),
+                identity: Some(carina_core::schema::string_enum_identity("StorageClass", Some("awscc.s3.Bucket"))),
                 dsl_aliases: vec![("DEEP_ARCHIVE".to_string(), "deep_archive".to_string()), ("GLACIER".to_string(), "glacier".to_string()), ("GLACIER_IR".to_string(), "glacier_ir".to_string()), ("INTELLIGENT_TIERING".to_string(), "intelligent_tiering".to_string()), ("ONEZONE_IA".to_string(), "onezone_ia".to_string()), ("STANDARD_IA".to_string(), "standard_ia".to_string())],
             }).required().with_description("The storage class to which you want the object to transition.").with_provider_name("StorageClass"),
                     StructField::new("transition_date", AttributeType::Custom {
@@ -639,12 +858,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
             }).with_description("Indicates which default minimum object size behavior is applied to the lifecycle configuration. This parameter applies to general purpose buckets only. It isn't supported for directory bucket lifecycle configurations. + ``all_storage_classes_128K`` - Objects smaller than 128 KB will not transition to any storage class by default. + ``varies_by_storage_class`` - Objects smaller than 128 KB will transition to Glacier Flexible Retrieval or Glacier Deep Archive storage classes. By default, all other storage classes will prevent transitions smaller than 128 KB. To customize the minimum object size for any transition you can add a filter that specifies a custom ``ObjectSizeGreaterThan`` or ``ObjectSizeLessThan`` in the body of your transition rule. Custom filters always take precedence over the default transition behavior.").with_provider_name("TransitionDefaultMinimumObjectSize")
                     ],
                 })
-                .with_description("Specifies the lifecycle configuration for objects in an Amazon S3 bucket. For more information, see [Object Lifecycle Management](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html) in the *Amazon S3 User Guide*.")
-                .with_provider_name("LifecycleConfiguration")
-                .with_block_name("lifecycle_configuration"),
-        )
-        .attribute(
-            AttributeSchema::new("logging_configuration", AttributeType::Struct {
+        .with_def("LoggingConfiguration", AttributeType::Struct {
                     name: "LoggingConfiguration".to_string(),
                     fields: vec![
                     StructField::new("destination_bucket_name", AttributeType::String).with_description("The name of the bucket where Amazon S3 should store server access log files. You can store log files in any bucket that you own. By default, logs are stored in the bucket where the ``LoggingConfiguration`` property is defined.").with_provider_name("DestinationBucketName"),
@@ -671,11 +885,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 }).with_description("Amazon S3 key format for log objects. Only one format, either PartitionedPrefix or SimplePrefix, is allowed.").with_provider_name("TargetObjectKeyFormat")
                     ],
                 })
-                .with_description("Settings that define where logs are stored.")
-                .with_provider_name("LoggingConfiguration"),
-        )
-        .attribute(
-            AttributeSchema::new("metadata_configuration", AttributeType::Struct {
+        .with_def("MetadataConfiguration", AttributeType::Struct {
                     name: "MetadataConfiguration".to_string(),
                     fields: vec![
                     StructField::new("destination", AttributeType::Struct {
@@ -705,9 +915,9 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     fields: vec![
                     StructField::new("kms_key_arn", super::kms_key_arn()).with_description("If server-side encryption with KMSlong (KMS) keys (SSE-KMS) is specified, you must also specify the KMS key Amazon Resource Name (ARN). You must specify a customer-managed KMS key that's located in the same Region as the general purpose bucket that corresponds to the metadata table configuration.").with_provider_name("KmsKeyArn"),
                     StructField::new("sse_algorithm", AttributeType::StringEnum {
-                name: "MetadataTableEncryptionConfigurationSseAlgorithm".to_string(),
+                name: "SseAlgorithm".to_string(),
                 values: vec!["aws:kms".to_string(), "AES256".to_string()],
-                identity: Some(carina_core::schema::string_enum_identity("MetadataTableEncryptionConfigurationSseAlgorithm", Some("awscc.s3.Bucket"))),
+                identity: Some(carina_core::schema::string_enum_identity("SseAlgorithm", Some("awscc.s3.Bucket"))),
                 dsl_aliases: vec![("aws:kms".to_string(), "aws_kms".to_string()), ("AES256".to_string(), "aes256".to_string())],
             }).required().with_description("The encryption type specified for a metadata table. To specify server-side encryption with KMSlong (KMS) keys (SSE-KMS), use the ``aws:kms`` value. To specify server-side encryption with Amazon S3 managed keys (SSE-S3), use the ``AES256`` value.").with_provider_name("SseAlgorithm")
                     ],
@@ -719,18 +929,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("journal_table_configuration", AttributeType::Struct {
                     name: "JournalTableConfiguration".to_string(),
                     fields: vec![
-                    StructField::new("encryption_configuration", AttributeType::Struct {
-                    name: "MetadataTableEncryptionConfiguration".to_string(),
-                    fields: vec![
-                    StructField::new("kms_key_arn", super::kms_key_arn()).with_description("If server-side encryption with KMSlong (KMS) keys (SSE-KMS) is specified, you must also specify the KMS key Amazon Resource Name (ARN). You must specify a customer-managed KMS key that's located in the same Region as the general purpose bucket that corresponds to the metadata table configuration.").with_provider_name("KmsKeyArn"),
-                    StructField::new("sse_algorithm", AttributeType::StringEnum {
-                name: "MetadataTableEncryptionConfigurationSseAlgorithm".to_string(),
-                values: vec!["aws:kms".to_string(), "AES256".to_string()],
-                identity: Some(carina_core::schema::string_enum_identity("MetadataTableEncryptionConfigurationSseAlgorithm", Some("awscc.s3.Bucket"))),
-                dsl_aliases: vec![("aws:kms".to_string(), "aws_kms".to_string()), ("AES256".to_string(), "aes256".to_string())],
-            }).required().with_description("The encryption type specified for a metadata table. To specify server-side encryption with KMSlong (KMS) keys (SSE-KMS), use the ``aws:kms`` value. To specify server-side encryption with Amazon S3 managed keys (SSE-S3), use the ``AES256`` value.").with_provider_name("SseAlgorithm")
-                    ],
-                }).with_description("The encryption configuration for the journal table.").with_provider_name("EncryptionConfiguration"),
+                    StructField::new("encryption_configuration", AttributeType::Ref("MetadataTableEncryptionConfiguration".to_string())).with_description("The encryption configuration for the journal table.").with_provider_name("EncryptionConfiguration"),
                     StructField::new("record_expiration", AttributeType::Struct {
                     name: "RecordExpiration".to_string(),
                     fields: vec![
@@ -749,11 +948,20 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 }).required().with_description("The journal table configuration for a metadata configuration.").with_provider_name("JournalTableConfiguration")
                     ],
                 })
-                .with_description("The S3 Metadata configuration for a general purpose bucket.")
-                .with_provider_name("MetadataConfiguration"),
-        )
-        .attribute(
-            AttributeSchema::new("metadata_table_configuration", AttributeType::Struct {
+        .with_def("MetadataDestination", AttributeType::Struct {
+                    name: "MetadataDestination".to_string(),
+                    fields: vec![
+                    StructField::new("table_bucket_arn", super::arn()).with_description("The Amazon Resource Name (ARN) of the table bucket where the metadata configuration is stored.").with_provider_name("TableBucketArn"),
+                    StructField::new("table_bucket_type", AttributeType::StringEnum {
+                name: "TableBucketType".to_string(),
+                values: vec!["aws".to_string(), "customer".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TableBucketType", Some("awscc.s3.Bucket"))),
+                dsl_aliases: vec![("aws".to_string(), "aws".to_string()), ("customer".to_string(), "customer".to_string())],
+            }).required().with_description("The type of the table bucket where the metadata configuration is stored. The ``aws`` value indicates an AWS managed table bucket, and the ``customer`` value indicates a customer-managed table bucket. V2 metadata configurations are stored in AWS managed table buckets, and V1 metadata configurations are stored in customer-managed table buckets.").with_provider_name("TableBucketType"),
+                    StructField::new("table_namespace", AttributeType::String).with_description("The namespace in the table bucket where the metadata tables for a metadata configuration are stored.").with_provider_name("TableNamespace")
+                    ],
+                })
+        .with_def("MetadataTableConfiguration", AttributeType::Struct {
                     name: "MetadataTableConfiguration".to_string(),
                     fields: vec![
                     StructField::new("s3_tables_destination", AttributeType::Struct {
@@ -767,25 +975,56 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 }).required().with_description("The destination information for the metadata table configuration. The destination table bucket must be in the same Region and AWS-account as the general purpose bucket. The specified metadata table name must be unique within the ``aws_s3_metadata`` namespace in the destination table bucket.").with_provider_name("S3TablesDestination")
                     ],
                 })
-                .with_description("The metadata table configuration of an S3 general purpose bucket.")
-                .with_provider_name("MetadataTableConfiguration"),
-        )
-        .attribute(
-            AttributeSchema::new("metrics_configurations", AttributeType::list(AttributeType::Struct {
-                    name: "MetricsConfiguration".to_string(),
+        .with_def("MetadataTableEncryptionConfiguration", AttributeType::Struct {
+                    name: "MetadataTableEncryptionConfiguration".to_string(),
                     fields: vec![
-                    StructField::new("access_point_arn", super::arn()).with_description("The access point that was used while performing operations on the object. The metrics configuration only includes objects that meet the filter's criteria.").with_provider_name("AccessPointArn"),
-                    StructField::new("id", AttributeType::String).required().with_description("The ID used to identify the metrics configuration. This can be any value you choose that helps you identify your metrics configuration.").with_provider_name("Id"),
-                    StructField::new("prefix", AttributeType::String).with_description("The prefix that an object must have to be included in the metrics results.").with_provider_name("Prefix"),
-                    StructField::new("tag_filters", AttributeType::list(tags_type())).with_description("Specifies a list of tag filters to use as a metrics configuration filter. The metrics configuration includes only objects that meet the filter's criteria.").with_provider_name("TagFilters")
+                    StructField::new("kms_key_arn", super::kms_key_arn()).with_description("If server-side encryption with KMSlong (KMS) keys (SSE-KMS) is specified, you must also specify the KMS key Amazon Resource Name (ARN). You must specify a customer-managed KMS key that's located in the same Region as the general purpose bucket that corresponds to the metadata table configuration.").with_provider_name("KmsKeyArn"),
+                    StructField::new("sse_algorithm", AttributeType::StringEnum {
+                name: "SseAlgorithm".to_string(),
+                values: vec!["aws:kms".to_string(), "AES256".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("SseAlgorithm", Some("awscc.s3.Bucket"))),
+                dsl_aliases: vec![("aws:kms".to_string(), "aws_kms".to_string()), ("AES256".to_string(), "aes256".to_string())],
+            }).required().with_description("The encryption type specified for a metadata table. To specify server-side encryption with KMSlong (KMS) keys (SSE-KMS), use the ``aws:kms`` value. To specify server-side encryption with Amazon S3 managed keys (SSE-S3), use the ``AES256`` value.").with_provider_name("SseAlgorithm")
                     ],
-                }))
-                .with_description("Specifies a metrics configuration for the CloudWatch request metrics (specified by the metrics configuration ID) from an Amazon S3 bucket. If you're updating an existing metrics configuration, note that this is a full replacement of the existing metrics configuration. If you don't include the elements you want to keep, they are erased. For more information, see [PutBucketMetricsConfiguration](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTMetricConfiguration.html).")
-                .with_provider_name("MetricsConfigurations")
-                .with_block_name("metrics_configuration"),
-        )
-        .attribute(
-            AttributeSchema::new("notification_configuration", AttributeType::Struct {
+                })
+        .with_def("Metrics", AttributeType::Struct {
+                    name: "Metrics".to_string(),
+                    fields: vec![
+                    StructField::new("event_threshold", AttributeType::Struct {
+                    name: "ReplicationTimeValue".to_string(),
+                    fields: vec![
+                    StructField::new("minutes", AttributeType::Int).required().with_description("Contains an integer specifying time in minutes. Valid value: 15").with_provider_name("Minutes")
+                    ],
+                }).with_description("A container specifying the time threshold for emitting the ``s3:Replication:OperationMissedThreshold`` event.").with_provider_name("EventThreshold"),
+                    StructField::new("status", AttributeType::StringEnum {
+                name: "Status".to_string(),
+                values: vec!["Disabled".to_string(), "Enabled".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("Status", Some("awscc.s3.Bucket"))),
+                dsl_aliases: vec![("Disabled".to_string(), "disabled".to_string()), ("Enabled".to_string(), "enabled".to_string())],
+            }).required().with_description("Specifies whether the replication metrics are enabled.").with_provider_name("Status")
+                    ],
+                })
+        .with_def("NoncurrentVersionExpiration", AttributeType::Struct {
+                    name: "NoncurrentVersionExpiration".to_string(),
+                    fields: vec![
+                    StructField::new("newer_noncurrent_versions", AttributeType::Int).with_description("Specifies how many noncurrent versions S3 will retain. If there are this many more recent noncurrent versions, S3 will take the associated action. For more information about noncurrent versions, see [Lifecycle configuration elements](https://docs.aws.amazon.com/AmazonS3/latest/userguide/intro-lifecycle-rules.html) in the *Amazon S3 User Guide*.").with_provider_name("NewerNoncurrentVersions"),
+                    StructField::new("noncurrent_days", AttributeType::Int).required().with_description("Specifies the number of days an object is noncurrent before S3 can perform the associated action. For information about the noncurrent days calculations, see [How Amazon S3 Calculates When an Object Became Noncurrent](https://docs.aws.amazon.com/AmazonS3/latest/dev/intro-lifecycle-rules.html#non-current-days-calculations) in the *Amazon S3 User Guide*.").with_provider_name("NoncurrentDays")
+                    ],
+                })
+        .with_def("NoncurrentVersionTransition", AttributeType::Struct {
+                    name: "NoncurrentVersionTransition".to_string(),
+                    fields: vec![
+                    StructField::new("newer_noncurrent_versions", AttributeType::Int).with_description("Specifies how many noncurrent versions S3 will retain. If there are this many more recent noncurrent versions, S3 will take the associated action. For more information about noncurrent versions, see [Lifecycle configuration elements](https://docs.aws.amazon.com/AmazonS3/latest/userguide/intro-lifecycle-rules.html) in the *Amazon S3 User Guide*.").with_provider_name("NewerNoncurrentVersions"),
+                    StructField::new("storage_class", AttributeType::StringEnum {
+                name: "StorageClass".to_string(),
+                values: vec!["DEEP_ARCHIVE".to_string(), "GLACIER".to_string(), "GLACIER_IR".to_string(), "INTELLIGENT_TIERING".to_string(), "ONEZONE_IA".to_string(), "STANDARD_IA".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("StorageClass", Some("awscc.s3.Bucket"))),
+                dsl_aliases: vec![("DEEP_ARCHIVE".to_string(), "deep_archive".to_string()), ("GLACIER".to_string(), "glacier".to_string()), ("GLACIER_IR".to_string(), "glacier_ir".to_string()), ("INTELLIGENT_TIERING".to_string(), "intelligent_tiering".to_string()), ("ONEZONE_IA".to_string(), "onezone_ia".to_string()), ("STANDARD_IA".to_string(), "standard_ia".to_string())],
+            }).required().with_description("The class of storage used to store the object.").with_provider_name("StorageClass"),
+                    StructField::new("transition_in_days", AttributeType::Int).required().with_description("Specifies the number of days an object is noncurrent before Amazon S3 can perform the associated action. For information about the noncurrent days calculations, see [How Amazon S3 Calculates How Long an Object Has Been Noncurrent](https://docs.aws.amazon.com/AmazonS3/latest/dev/intro-lifecycle-rules.html#non-current-days-calculations) in the *Amazon S3 User Guide*.").with_provider_name("TransitionInDays")
+                    ],
+                })
+        .with_def("NotificationConfiguration", AttributeType::Struct {
                     name: "NotificationConfiguration".to_string(),
                     fields: vec![
                     StructField::new("event_bridge_configuration", AttributeType::Struct {
@@ -829,30 +1068,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     name: "QueueConfiguration".to_string(),
                     fields: vec![
                     StructField::new("event", AttributeType::String).required().with_description("The Amazon S3 bucket event about which you want to publish messages to Amazon SQS. For more information, see [Supported Event Types](https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html) in the *Amazon S3 User Guide*.").with_provider_name("Event"),
-                    StructField::new("filter", AttributeType::Struct {
-                    name: "NotificationFilter".to_string(),
-                    fields: vec![
-                    StructField::new("s3_key", AttributeType::Struct {
-                    name: "S3KeyFilter".to_string(),
-                    fields: vec![
-                    StructField::new("rules", AttributeType::unordered_list(AttributeType::Struct {
-                    name: "FilterRule".to_string(),
-                    fields: vec![
-                    StructField::new("name", AttributeType::Custom {
-                identity: None,
-                pattern: None,
-                length: Some((None, Some(1024))),
-                base: Box::new(AttributeType::String),
-                validate: legacy_validator(validate_string_length_max_1024),
-                to_dsl: None,
-            }).required().with_description("The object key name prefix or suffix identifying one or more objects to which the filtering rule applies. The maximum length is 1,024 characters. Overlapping prefixes and suffixes are not supported. For more information, see [Configuring Event Notifications](https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html) in the *Amazon S3 User Guide*.").with_provider_name("Name"),
-                    StructField::new("value", AttributeType::String).required().with_description("The value that the filter searches for in object key names.").with_provider_name("Value")
-                    ],
-                })).required().with_description("A list of containers for the key-value pair that defines the criteria for the filter rule.").with_provider_name("Rules").with_block_name("rule")
-                    ],
-                }).required().with_description("A container for object key name prefix and suffix filtering rules.").with_provider_name("S3Key").with_block_name("s3_key")
-                    ],
-                }).with_description("The filtering rules that determine which objects trigger notifications. For example, you can create a filter so that Amazon S3 sends notifications only when image files with a ``.jpg`` extension are added to the bucket. For more information, see [Configuring event notifications using object key name filtering](https://docs.aws.amazon.com/AmazonS3/latest/user-guide/notification-how-to-filtering.html) in the *Amazon S3 User Guide*.").with_provider_name("Filter").with_block_name("filter"),
+                    StructField::new("filter", AttributeType::Ref("NotificationFilter".to_string())).with_description("The filtering rules that determine which objects trigger notifications. For example, you can create a filter so that Amazon S3 sends notifications only when image files with a ``.jpg`` extension are added to the bucket. For more information, see [Configuring event notifications using object key name filtering](https://docs.aws.amazon.com/AmazonS3/latest/user-guide/notification-how-to-filtering.html) in the *Amazon S3 User Guide*.").with_provider_name("Filter"),
                     StructField::new("queue", super::arn()).required().with_description("The Amazon Resource Name (ARN) of the Amazon SQS queue to which Amazon S3 publishes a message when it detects events of the specified type. FIFO queues are not allowed when enabling an SQS queue as the event notification destination.").with_provider_name("Queue")
                     ],
                 })).with_description("The Amazon Simple Queue Service queues to publish messages to and the events for which to publish messages.").with_provider_name("QueueConfigurations").with_block_name("queue_configuration"),
@@ -860,7 +1076,13 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     name: "TopicConfiguration".to_string(),
                     fields: vec![
                     StructField::new("event", AttributeType::String).required().with_description("The Amazon S3 bucket event about which to send notifications. For more information, see [Supported Event Types](https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html) in the *Amazon S3 User Guide*.").with_provider_name("Event"),
-                    StructField::new("filter", AttributeType::Struct {
+                    StructField::new("filter", AttributeType::Ref("NotificationFilter".to_string())).with_description("The filtering rules that determine for which objects to send notifications. For example, you can create a filter so that Amazon S3 sends notifications only when image files with a ``.jpg`` extension are added to the bucket.").with_provider_name("Filter"),
+                    StructField::new("topic", super::arn()).required().with_description("The Amazon Resource Name (ARN) of the Amazon SNS topic to which Amazon S3 publishes a message when it detects events of the specified type.").with_provider_name("Topic")
+                    ],
+                })).with_description("The topic to which notifications are sent and the events for which notifications are generated.").with_provider_name("TopicConfigurations").with_block_name("topic_configuration")
+                    ],
+                })
+        .with_def("NotificationFilter", AttributeType::Struct {
                     name: "NotificationFilter".to_string(),
                     fields: vec![
                     StructField::new("s3_key", AttributeType::Struct {
@@ -883,18 +1105,8 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     ],
                 }).required().with_description("A container for object key name prefix and suffix filtering rules.").with_provider_name("S3Key").with_block_name("s3_key")
                     ],
-                }).with_description("The filtering rules that determine for which objects to send notifications. For example, you can create a filter so that Amazon S3 sends notifications only when image files with a ``.jpg`` extension are added to the bucket.").with_provider_name("Filter").with_block_name("filter"),
-                    StructField::new("topic", super::arn()).required().with_description("The Amazon Resource Name (ARN) of the Amazon SNS topic to which Amazon S3 publishes a message when it detects events of the specified type.").with_provider_name("Topic")
-                    ],
-                })).with_description("The topic to which notifications are sent and the events for which notifications are generated.").with_provider_name("TopicConfigurations").with_block_name("topic_configuration")
-                    ],
                 })
-                .with_description("Configuration that defines how Amazon S3 handles bucket notifications.")
-                .with_provider_name("NotificationConfiguration")
-                .with_block_name("notification_configuration"),
-        )
-        .attribute(
-            AttributeSchema::new("object_lock_configuration", AttributeType::Struct {
+        .with_def("ObjectLockConfiguration", AttributeType::Struct {
                     name: "ObjectLockConfiguration".to_string(),
                     fields: vec![
                     StructField::new("object_lock_enabled", AttributeType::StringEnum {
@@ -923,16 +1135,25 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 }).with_description("Specifies the Object Lock rule for the specified object. Enable this rule when you apply ``ObjectLockConfiguration`` to a bucket. If Object Lock is turned on, bucket settings require both ``Mode`` and a period of either ``Days`` or ``Years``. You cannot specify ``Days`` and ``Years`` at the same time. For more information, see [ObjectLockRule](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-objectlockrule.html) and [DefaultRetention](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-defaultretention.html).").with_provider_name("Rule")
                     ],
                 })
-                .with_description("This operation is not supported for directory buckets. Places an Object Lock configuration on the specified bucket. The rule specified in the Object Lock configuration will be applied by default to every new object placed in the specified bucket. For more information, see [Locking Objects](https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html). + The ``DefaultRetention`` settings require both a mode and a period. + The ``DefaultRetention`` period can be either ``Days`` or ``Years`` but you must select one. You cannot specify ``Days`` and ``Years`` at the same time. + You can enable Object Lock for new or existing buckets. For more information, see [Configuring Object Lock](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock-configure.html). You must URL encode any signed header values that contain spaces. For example, if your header value is ``my file.txt``, containing two spaces after ``my``, you must URL encode this value to ``my%20%20file.txt``.")
-                .with_provider_name("ObjectLockConfiguration"),
-        )
-        .attribute(
-            AttributeSchema::new("object_lock_enabled", AttributeType::Bool)
-                .with_description("Indicates whether this bucket has an Object Lock configuration enabled. Enable ``ObjectLockEnabled`` when you apply ``ObjectLockConfiguration`` to a bucket.")
-                .with_provider_name("ObjectLockEnabled"),
-        )
-        .attribute(
-            AttributeSchema::new("ownership_controls", AttributeType::Struct {
+        .with_def("ObjectLockRule", AttributeType::Struct {
+                    name: "ObjectLockRule".to_string(),
+                    fields: vec![
+                    StructField::new("default_retention", AttributeType::Struct {
+                    name: "DefaultRetention".to_string(),
+                    fields: vec![
+                    StructField::new("days", AttributeType::Int).with_description("The number of days that you want to specify for the default retention period. If Object Lock is turned on, you must specify ``Mode`` and specify either ``Days`` or ``Years``.").with_provider_name("Days"),
+                    StructField::new("mode", AttributeType::StringEnum {
+                name: "Mode".to_string(),
+                values: vec!["COMPLIANCE".to_string(), "GOVERNANCE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("Mode", Some("awscc.s3.Bucket"))),
+                dsl_aliases: vec![("COMPLIANCE".to_string(), "compliance".to_string()), ("GOVERNANCE".to_string(), "governance".to_string())],
+            }).with_description("The default Object Lock retention mode you want to apply to new objects placed in the specified bucket. If Object Lock is turned on, you must specify ``Mode`` and specify either ``Days`` or ``Years``.").with_provider_name("Mode"),
+                    StructField::new("years", AttributeType::Int).with_description("The number of years that you want to specify for the default retention period. If Object Lock is turned on, you must specify ``Mode`` and specify either ``Days`` or ``Years``.").with_provider_name("Years")
+                    ],
+                }).with_description("The default Object Lock retention mode and period that you want to apply to new objects placed in the specified bucket. If Object Lock is turned on, bucket settings require both ``Mode`` and a period of either ``Days`` or ``Years``. You cannot specify ``Days`` and ``Years`` at the same time. For more information about allowable values for mode and period, see [DefaultRetention](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-defaultretention.html).").with_provider_name("DefaultRetention")
+                    ],
+                })
+        .with_def("OwnershipControls", AttributeType::Struct {
                     name: "OwnershipControls".to_string(),
                     fields: vec![
                     StructField::new("rules", AttributeType::list(AttributeType::Struct {
@@ -948,12 +1169,18 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 })).required().with_description("Specifies the container element for Object Ownership rules.").with_provider_name("Rules").with_block_name("rule")
                     ],
                 })
-                .with_description("Configuration that defines how Amazon S3 handles Object Ownership rules.")
-                .with_provider_name("OwnershipControls")
-                .with_block_name("ownership_control"),
-        )
-        .attribute(
-            AttributeSchema::new("public_access_block_configuration", AttributeType::Struct {
+        .with_def("PartitionedPrefix", AttributeType::Struct {
+                    name: "PartitionedPrefix".to_string(),
+                    fields: vec![
+                    StructField::new("partition_date_source", AttributeType::StringEnum {
+                name: "PartitionDateSource".to_string(),
+                values: vec!["EventTime".to_string(), "DeliveryTime".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("PartitionDateSource", Some("awscc.s3.Bucket"))),
+                dsl_aliases: vec![("EventTime".to_string(), "event_time".to_string()), ("DeliveryTime".to_string(), "delivery_time".to_string())],
+            }).with_description("Specifies the partition date source for the partitioned prefix. ``PartitionDateSource`` can be ``EventTime`` or ``DeliveryTime``. For ``DeliveryTime``, the time in the log file names corresponds to the delivery time for the log files. For ``EventTime``, The logs delivered are for a specific day only. The year, month, and day correspond to the day on which the event occurred, and the hour, minutes and seconds are set to 00 in the key.").with_provider_name("PartitionDateSource")
+                    ],
+                })
+        .with_def("PublicAccessBlockConfiguration", AttributeType::Struct {
                     name: "PublicAccessBlockConfiguration".to_string(),
                     fields: vec![
                     StructField::new("block_public_acls", AttributeType::Bool).with_description("Specifies whether Amazon S3 should block public access control lists (ACLs) for this bucket and objects in this bucket. Setting this element to ``TRUE`` causes the following behavior: + PUT Bucket ACL and PUT Object ACL calls fail if the specified ACL is public. + PUT Object calls fail if the request includes a public ACL. + PUT Bucket calls fail if the request includes a public ACL. Enabling this setting doesn't affect existing policies or ACLs.").with_provider_name("BlockPublicAcls"),
@@ -962,17 +1189,57 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     StructField::new("restrict_public_buckets", AttributeType::Bool).with_description("Specifies whether Amazon S3 should restrict public bucket policies for this bucket. Setting this element to ``TRUE`` restricts access to this bucket to only AWS-service principals and authorized users within this account if the bucket has a public policy. Enabling this setting doesn't affect previously stored bucket policies, except that public and cross-account access within any public bucket policy, including non-public delegation to specific accounts, is blocked.").with_provider_name("RestrictPublicBuckets")
                     ],
                 })
-                .with_description("Configuration that defines how Amazon S3 handles public access.")
-                .with_provider_name("PublicAccessBlockConfiguration"),
-        )
-        .attribute(
-            AttributeSchema::new("regional_domain_name", AttributeType::String)
-                .read_only()
-                .with_description(" (read-only)")
-                .with_provider_name("RegionalDomainName"),
-        )
-        .attribute(
-            AttributeSchema::new("replication_configuration", AttributeType::Struct {
+        .with_def("RecordExpiration", AttributeType::Struct {
+                    name: "RecordExpiration".to_string(),
+                    fields: vec![
+                    StructField::new("days", AttributeType::Int).with_description("If you enable journal table record expiration, you can set the number of days to retain your journal table records. Journal table records must be retained for a minimum of 7 days. To set this value, specify any whole number from ``7`` to ``2147483647``. For example, to retain your journal table records for one year, set this value to ``365``.").with_provider_name("Days"),
+                    StructField::new("expiration", AttributeType::StringEnum {
+                name: "Expiration".to_string(),
+                values: vec!["ENABLED".to_string(), "DISABLED".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("Expiration", Some("awscc.s3.Bucket"))),
+                dsl_aliases: vec![("ENABLED".to_string(), "enabled".to_string()), ("DISABLED".to_string(), "disabled".to_string())],
+            }).required().with_description("Specifies whether journal table record expiration is enabled or disabled.").with_provider_name("Expiration")
+                    ],
+                })
+        .with_def("RedirectAllRequestsTo", AttributeType::Struct {
+                    name: "RedirectAllRequestsTo".to_string(),
+                    fields: vec![
+                    StructField::new("host_name", AttributeType::String).required().with_description("Name of the host where requests are redirected.").with_provider_name("HostName"),
+                    StructField::new("protocol", AttributeType::StringEnum {
+                name: "Protocol".to_string(),
+                values: vec!["http".to_string(), "https".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("Protocol", Some("awscc.s3.Bucket"))),
+                dsl_aliases: vec![("http".to_string(), "http".to_string()), ("https".to_string(), "https".to_string())],
+            }).with_description("Protocol to use when redirecting requests. The default is the protocol that is used in the original request.").with_provider_name("Protocol")
+                    ],
+                })
+        .with_def("RedirectRule", AttributeType::Struct {
+                    name: "RedirectRule".to_string(),
+                    fields: vec![
+                    StructField::new("host_name", AttributeType::String).with_description("The host name to use in the redirect request.").with_provider_name("HostName"),
+                    StructField::new("http_redirect_code", AttributeType::String).with_description("The HTTP redirect code to use on the response. Not required if one of the siblings is present.").with_provider_name("HttpRedirectCode"),
+                    StructField::new("protocol", AttributeType::StringEnum {
+                name: "Protocol".to_string(),
+                values: vec!["http".to_string(), "https".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("Protocol", Some("awscc.s3.Bucket"))),
+                dsl_aliases: vec![("http".to_string(), "http".to_string()), ("https".to_string(), "https".to_string())],
+            }).with_description("Protocol to use when redirecting requests. The default is the protocol that is used in the original request.").with_provider_name("Protocol"),
+                    StructField::new("replace_key_prefix_with", AttributeType::String).with_description("The object key prefix to use in the redirect request. For example, to redirect requests for all pages with prefix ``docs/`` (objects in the ``docs/`` folder) to ``documents/``, you can set a condition block with ``KeyPrefixEquals`` set to ``docs/`` and in the Redirect set ``ReplaceKeyPrefixWith`` to ``/documents``. Not required if one of the siblings is present. Can be present only if ``ReplaceKeyWith`` is not provided. Replacement must be made for object keys containing special characters (such as carriage returns) when using XML requests. For more information, see [XML related object key constraints](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints).").with_provider_name("ReplaceKeyPrefixWith"),
+                    StructField::new("replace_key_with", AttributeType::String).with_description("The specific object key to use in the redirect request. For example, redirect request to ``error.html``. Not required if one of the siblings is present. Can be present only if ``ReplaceKeyPrefixWith`` is not provided. Replacement must be made for object keys containing special characters (such as carriage returns) when using XML requests. For more information, see [XML related object key constraints](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints).").with_provider_name("ReplaceKeyWith")
+                    ],
+                })
+        .with_def("ReplicaModifications", AttributeType::Struct {
+                    name: "ReplicaModifications".to_string(),
+                    fields: vec![
+                    StructField::new("status", AttributeType::StringEnum {
+                name: "Status".to_string(),
+                values: vec!["Enabled".to_string(), "Disabled".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("Status", Some("awscc.s3.Bucket"))),
+                dsl_aliases: vec![("Enabled".to_string(), "enabled".to_string()), ("Disabled".to_string(), "disabled".to_string())],
+            }).required().with_description("Specifies whether Amazon S3 replicates modifications on replicas. *Allowed values*: ``Enabled`` | ``Disabled``").with_provider_name("Status")
+                    ],
+                })
+        .with_def("ReplicationConfiguration", AttributeType::Struct {
                     name: "ReplicationConfiguration".to_string(),
                     fields: vec![
                     StructField::new("role", super::iam_role_arn()).required().with_description("The Amazon Resource Name (ARN) of the IAMlong (IAM) role that Amazon S3 assumes when replicating objects. For more information, see [How to Set Up Replication](https://docs.aws.amazon.com/AmazonS3/latest/dev/replication-how-setup.html) in the *Amazon S3 User Guide*.").with_provider_name("Role"),
@@ -983,9 +1250,9 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     name: "DeleteMarkerReplication".to_string(),
                     fields: vec![
                     StructField::new("status", AttributeType::StringEnum {
-                name: "DeleteMarkerReplicationStatus".to_string(),
+                name: "Status".to_string(),
                 values: vec!["Disabled".to_string(), "Enabled".to_string()],
-                identity: Some(carina_core::schema::string_enum_identity("DeleteMarkerReplicationStatus", Some("awscc.s3.Bucket"))),
+                identity: Some(carina_core::schema::string_enum_identity("Status", Some("awscc.s3.Bucket"))),
                 dsl_aliases: vec![("Disabled".to_string(), "disabled".to_string()), ("Enabled".to_string(), "enabled".to_string())],
             }).with_description("Indicates whether to replicate delete markers.").with_provider_name("Status")
                     ],
@@ -1022,9 +1289,9 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     ],
                 }).with_description("A container specifying the time threshold for emitting the ``s3:Replication:OperationMissedThreshold`` event.").with_provider_name("EventThreshold"),
                     StructField::new("status", AttributeType::StringEnum {
-                name: "MetricsStatus".to_string(),
+                name: "Status".to_string(),
                 values: vec!["Disabled".to_string(), "Enabled".to_string()],
-                identity: Some(carina_core::schema::string_enum_identity("MetricsStatus", Some("awscc.s3.Bucket"))),
+                identity: Some(carina_core::schema::string_enum_identity("Status", Some("awscc.s3.Bucket"))),
                 dsl_aliases: vec![("Disabled".to_string(), "disabled".to_string()), ("Enabled".to_string(), "enabled".to_string())],
             }).required().with_description("Specifies whether the replication metrics are enabled.").with_provider_name("Status")
                     ],
@@ -1033,23 +1300,18 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     name: "ReplicationTime".to_string(),
                     fields: vec![
                     StructField::new("status", AttributeType::StringEnum {
-                name: "ReplicationTimeStatus".to_string(),
+                name: "Status".to_string(),
                 values: vec!["Disabled".to_string(), "Enabled".to_string()],
-                identity: Some(carina_core::schema::string_enum_identity("ReplicationTimeStatus", Some("awscc.s3.Bucket"))),
+                identity: Some(carina_core::schema::string_enum_identity("Status", Some("awscc.s3.Bucket"))),
                 dsl_aliases: vec![("Disabled".to_string(), "disabled".to_string()), ("Enabled".to_string(), "enabled".to_string())],
             }).required().with_description("Specifies whether the replication time is enabled.").with_provider_name("Status"),
-                    StructField::new("time", AttributeType::Struct {
-                    name: "ReplicationTimeValue".to_string(),
-                    fields: vec![
-                    StructField::new("minutes", AttributeType::Int).required().with_description("Contains an integer specifying time in minutes. Valid value: 15").with_provider_name("Minutes")
-                    ],
-                }).required().with_description("A container specifying the time by which replication should be complete for all objects and operations on objects.").with_provider_name("Time")
+                    StructField::new("time", AttributeType::Ref("ReplicationTimeValue".to_string())).required().with_description("A container specifying the time by which replication should be complete for all objects and operations on objects.").with_provider_name("Time")
                     ],
                 }).with_description("A container specifying S3 Replication Time Control (S3 RTC), including whether S3 RTC is enabled and the time when all objects and operations on objects must be replicated. Must be specified together with a ``Metrics`` block.").with_provider_name("ReplicationTime"),
                     StructField::new("storage_class", AttributeType::StringEnum {
-                name: "ReplicationDestinationStorageClass".to_string(),
+                name: "StorageClass".to_string(),
                 values: vec!["DEEP_ARCHIVE".to_string(), "GLACIER".to_string(), "GLACIER_IR".to_string(), "INTELLIGENT_TIERING".to_string(), "ONEZONE_IA".to_string(), "REDUCED_REDUNDANCY".to_string(), "STANDARD".to_string(), "STANDARD_IA".to_string()],
-                identity: Some(carina_core::schema::string_enum_identity("ReplicationDestinationStorageClass", Some("awscc.s3.Bucket"))),
+                identity: Some(carina_core::schema::string_enum_identity("StorageClass", Some("awscc.s3.Bucket"))),
                 dsl_aliases: vec![("DEEP_ARCHIVE".to_string(), "deep_archive".to_string()), ("GLACIER".to_string(), "glacier".to_string()), ("GLACIER_IR".to_string(), "glacier_ir".to_string()), ("INTELLIGENT_TIERING".to_string(), "intelligent_tiering".to_string()), ("ONEZONE_IA".to_string(), "onezone_ia".to_string()), ("REDUCED_REDUNDANCY".to_string(), "reduced_redundancy".to_string()), ("STANDARD".to_string(), "standard".to_string()), ("STANDARD_IA".to_string(), "standard_ia".to_string())],
             }).with_description("The storage class to use when replicating objects, such as S3 Standard or reduced redundancy. By default, Amazon S3 uses the storage class of the source object to create the object replica. For valid values, see the ``StorageClass`` element of the [PUT Bucket replication](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTreplication.html) action in the *Amazon S3 API Reference*. ``FSX_OPENZFS`` is not an accepted value when replicating objects.").with_provider_name("StorageClass")
                     ],
@@ -1092,9 +1354,9 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     name: "ReplicaModifications".to_string(),
                     fields: vec![
                     StructField::new("status", AttributeType::StringEnum {
-                name: "ReplicaModificationsStatus".to_string(),
+                name: "Status".to_string(),
                 values: vec!["Enabled".to_string(), "Disabled".to_string()],
-                identity: Some(carina_core::schema::string_enum_identity("ReplicaModificationsStatus", Some("awscc.s3.Bucket"))),
+                identity: Some(carina_core::schema::string_enum_identity("Status", Some("awscc.s3.Bucket"))),
                 dsl_aliases: vec![("Enabled".to_string(), "enabled".to_string()), ("Disabled".to_string(), "disabled".to_string())],
             }).required().with_description("Specifies whether Amazon S3 replicates modifications on replicas. *Allowed values*: ``Enabled`` | ``Disabled``").with_provider_name("Status")
                     ],
@@ -1103,9 +1365,9 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     name: "SseKmsEncryptedObjects".to_string(),
                     fields: vec![
                     StructField::new("status", AttributeType::StringEnum {
-                name: "SseKmsEncryptedObjectsStatus".to_string(),
+                name: "Status".to_string(),
                 values: vec!["Disabled".to_string(), "Enabled".to_string()],
-                identity: Some(carina_core::schema::string_enum_identity("SseKmsEncryptedObjectsStatus", Some("awscc.s3.Bucket"))),
+                identity: Some(carina_core::schema::string_enum_identity("Status", Some("awscc.s3.Bucket"))),
                 dsl_aliases: vec![("Disabled".to_string(), "disabled".to_string()), ("Enabled".to_string(), "enabled".to_string())],
             }).required().with_description("Specifies whether Amazon S3 replicates objects created with server-side encryption using an AWS KMS key stored in AWS Key Management Service.").with_provider_name("Status")
                     ],
@@ -1113,41 +1375,280 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                     ],
                 }).with_description("A container that describes additional filters for identifying the source objects that you want to replicate. You can choose to enable or disable the replication of these objects.").with_provider_name("SourceSelectionCriteria"),
                     StructField::new("status", AttributeType::StringEnum {
-                name: "ReplicationRuleStatus".to_string(),
+                name: "Status".to_string(),
                 values: vec!["Disabled".to_string(), "Enabled".to_string()],
-                identity: Some(carina_core::schema::string_enum_identity("ReplicationRuleStatus", Some("awscc.s3.Bucket"))),
+                identity: Some(carina_core::schema::string_enum_identity("Status", Some("awscc.s3.Bucket"))),
                 dsl_aliases: vec![("Disabled".to_string(), "disabled".to_string()), ("Enabled".to_string(), "enabled".to_string())],
             }).required().with_description("Specifies whether the rule is enabled.").with_provider_name("Status")
                     ],
                 })).required().with_description("A container for one or more replication rules. A replication configuration must have at least one rule and can contain a maximum of 1,000 rules.").with_provider_name("Rules").with_block_name("rule")
                     ],
                 })
-                .with_description("Configuration for replicating objects in an S3 bucket. To enable replication, you must also enable versioning by using the ``VersioningConfiguration`` property. Amazon S3 can store replicated objects in a single destination bucket or multiple destination buckets. The destination bucket or buckets must already exist.")
-                .with_provider_name("ReplicationConfiguration")
-                .with_block_name("replication_configuration"),
-        )
-        .attribute(
-            AttributeSchema::new("tags", tags_type())
-                .with_description("An arbitrary set of tags (key-value pairs) for this S3 bucket.")
-                .with_provider_name("Tags"),
-        )
-        .attribute(
-            AttributeSchema::new("versioning_configuration", AttributeType::Struct {
+        .with_def("ReplicationDestination", AttributeType::Struct {
+                    name: "ReplicationDestination".to_string(),
+                    fields: vec![
+                    StructField::new("access_control_translation", AttributeType::Struct {
+                    name: "AccessControlTranslation".to_string(),
+                    fields: vec![
+                    StructField::new("owner", AttributeType::StringEnum {
+                name: "Owner".to_string(),
+                values: vec!["Destination".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("Owner", Some("awscc.s3.Bucket"))),
+                dsl_aliases: vec![("Destination".to_string(), "destination".to_string())],
+            }).required().with_description("Specifies the replica ownership. For default and valid values, see [PUT bucket replication](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTreplication.html) in the *Amazon S3 API Reference*.").with_provider_name("Owner")
+                    ],
+                }).with_description("Specify this only in a cross-account scenario (where source and destination bucket owners are not the same), and you want to change replica ownership to the AWS-account that owns the destination bucket. If this is not specified in the replication configuration, the replicas are owned by same AWS-account that owns the source object.").with_provider_name("AccessControlTranslation"),
+                    StructField::new("account", super::aws_account_id()).with_description("Destination bucket owner account ID. In a cross-account scenario, if you direct Amazon S3 to change replica ownership to the AWS-account that owns the destination bucket by specifying the ``AccessControlTranslation`` property, this is the account ID of the destination bucket owner. For more information, see [Cross-Region Replication Additional Configuration: Change Replica Owner](https://docs.aws.amazon.com/AmazonS3/latest/dev/crr-change-owner.html) in the *Amazon S3 User Guide*. If you specify the ``AccessControlTranslation`` property, the ``Account`` property is required.").with_provider_name("Account"),
+                    StructField::new("bucket", AttributeType::String).required().with_description("The Amazon Resource Name (ARN) of the bucket where you want Amazon S3 to store the results.").with_provider_name("Bucket"),
+                    StructField::new("encryption_configuration", AttributeType::Struct {
+                    name: "EncryptionConfiguration".to_string(),
+                    fields: vec![
+                    StructField::new("replica_kms_key_id", super::kms_key_id()).required().with_description("Specifies the ID (Key ARN or Alias ARN) of the customer managed AWS KMS key stored in AWS Key Management Service (KMS) for the destination bucket. Amazon S3 uses this key to encrypt replica objects. Amazon S3 only supports symmetric encryption KMS keys. For more information, see [Asymmetric keys in KMS](https://docs.aws.amazon.com//kms/latest/developerguide/symmetric-asymmetric.html) in the *Key Management Service Developer Guide*.").with_provider_name("ReplicaKmsKeyID")
+                    ],
+                }).with_description("Specifies encryption-related information.").with_provider_name("EncryptionConfiguration"),
+                    StructField::new("metrics", AttributeType::Struct {
+                    name: "Metrics".to_string(),
+                    fields: vec![
+                    StructField::new("event_threshold", AttributeType::Struct {
+                    name: "ReplicationTimeValue".to_string(),
+                    fields: vec![
+                    StructField::new("minutes", AttributeType::Int).required().with_description("Contains an integer specifying time in minutes. Valid value: 15").with_provider_name("Minutes")
+                    ],
+                }).with_description("A container specifying the time threshold for emitting the ``s3:Replication:OperationMissedThreshold`` event.").with_provider_name("EventThreshold"),
+                    StructField::new("status", AttributeType::StringEnum {
+                name: "Status".to_string(),
+                values: vec!["Disabled".to_string(), "Enabled".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("Status", Some("awscc.s3.Bucket"))),
+                dsl_aliases: vec![("Disabled".to_string(), "disabled".to_string()), ("Enabled".to_string(), "enabled".to_string())],
+            }).required().with_description("Specifies whether the replication metrics are enabled.").with_provider_name("Status")
+                    ],
+                }).with_description("A container specifying replication metrics-related settings enabling replication metrics and events.").with_provider_name("Metrics"),
+                    StructField::new("replication_time", AttributeType::Struct {
+                    name: "ReplicationTime".to_string(),
+                    fields: vec![
+                    StructField::new("status", AttributeType::StringEnum {
+                name: "Status".to_string(),
+                values: vec!["Disabled".to_string(), "Enabled".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("Status", Some("awscc.s3.Bucket"))),
+                dsl_aliases: vec![("Disabled".to_string(), "disabled".to_string()), ("Enabled".to_string(), "enabled".to_string())],
+            }).required().with_description("Specifies whether the replication time is enabled.").with_provider_name("Status"),
+                    StructField::new("time", AttributeType::Ref("ReplicationTimeValue".to_string())).required().with_description("A container specifying the time by which replication should be complete for all objects and operations on objects.").with_provider_name("Time")
+                    ],
+                }).with_description("A container specifying S3 Replication Time Control (S3 RTC), including whether S3 RTC is enabled and the time when all objects and operations on objects must be replicated. Must be specified together with a ``Metrics`` block.").with_provider_name("ReplicationTime"),
+                    StructField::new("storage_class", AttributeType::StringEnum {
+                name: "StorageClass".to_string(),
+                values: vec!["DEEP_ARCHIVE".to_string(), "GLACIER".to_string(), "GLACIER_IR".to_string(), "INTELLIGENT_TIERING".to_string(), "ONEZONE_IA".to_string(), "REDUCED_REDUNDANCY".to_string(), "STANDARD".to_string(), "STANDARD_IA".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("StorageClass", Some("awscc.s3.Bucket"))),
+                dsl_aliases: vec![("DEEP_ARCHIVE".to_string(), "deep_archive".to_string()), ("GLACIER".to_string(), "glacier".to_string()), ("GLACIER_IR".to_string(), "glacier_ir".to_string()), ("INTELLIGENT_TIERING".to_string(), "intelligent_tiering".to_string()), ("ONEZONE_IA".to_string(), "onezone_ia".to_string()), ("REDUCED_REDUNDANCY".to_string(), "reduced_redundancy".to_string()), ("STANDARD".to_string(), "standard".to_string()), ("STANDARD_IA".to_string(), "standard_ia".to_string())],
+            }).with_description("The storage class to use when replicating objects, such as S3 Standard or reduced redundancy. By default, Amazon S3 uses the storage class of the source object to create the object replica. For valid values, see the ``StorageClass`` element of the [PUT Bucket replication](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTreplication.html) action in the *Amazon S3 API Reference*. ``FSX_OPENZFS`` is not an accepted value when replicating objects.").with_provider_name("StorageClass")
+                    ],
+                })
+        .with_def("ReplicationRuleAndOperator", AttributeType::Struct {
+                    name: "ReplicationRuleAndOperator".to_string(),
+                    fields: vec![
+                    StructField::new("prefix", AttributeType::String).with_description("An object key name prefix that identifies the subset of objects to which the rule applies.").with_provider_name("Prefix"),
+                    StructField::new("tag_filters", AttributeType::list(tags_type())).with_description("An array of tags containing key and value pairs.").with_provider_name("TagFilters")
+                    ],
+                })
+        .with_def("ReplicationRuleFilter", AttributeType::Struct {
+                    name: "ReplicationRuleFilter".to_string(),
+                    fields: vec![
+                    StructField::new("and", AttributeType::Struct {
+                    name: "ReplicationRuleAndOperator".to_string(),
+                    fields: vec![
+                    StructField::new("prefix", AttributeType::String).with_description("An object key name prefix that identifies the subset of objects to which the rule applies.").with_provider_name("Prefix"),
+                    StructField::new("tag_filters", AttributeType::list(tags_type())).with_description("An array of tags containing key and value pairs.").with_provider_name("TagFilters")
+                    ],
+                }).with_description("A container for specifying rule filters. The filters determine the subset of objects to which the rule applies. This element is required only if you specify more than one filter. For example: + If you specify both a ``Prefix`` and a ``TagFilter``, wrap these filters in an ``And`` tag. + If you specify a filter based on multiple tags, wrap the ``TagFilter`` elements in an ``And`` tag.").with_provider_name("And"),
+                    StructField::new("prefix", AttributeType::String).with_description("An object key name prefix that identifies the subset of objects to which the rule applies. Replacement must be made for object keys containing special characters (such as carriage returns) when using XML requests. For more information, see [XML related object key constraints](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints).").with_provider_name("Prefix"),
+                    StructField::new("tag_filter", tags_type()).with_description("A container for specifying a tag key and value. The rule applies only to objects that have the tag in their tag set.").with_provider_name("TagFilter")
+                    ],
+                })
+        .with_def("ReplicationTime", AttributeType::Struct {
+                    name: "ReplicationTime".to_string(),
+                    fields: vec![
+                    StructField::new("status", AttributeType::StringEnum {
+                name: "Status".to_string(),
+                values: vec!["Disabled".to_string(), "Enabled".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("Status", Some("awscc.s3.Bucket"))),
+                dsl_aliases: vec![("Disabled".to_string(), "disabled".to_string()), ("Enabled".to_string(), "enabled".to_string())],
+            }).required().with_description("Specifies whether the replication time is enabled.").with_provider_name("Status"),
+                    StructField::new("time", AttributeType::Ref("ReplicationTimeValue".to_string())).required().with_description("A container specifying the time by which replication should be complete for all objects and operations on objects.").with_provider_name("Time")
+                    ],
+                })
+        .with_def("ReplicationTimeValue", AttributeType::Struct {
+                    name: "ReplicationTimeValue".to_string(),
+                    fields: vec![
+                    StructField::new("minutes", AttributeType::Int).required().with_description("Contains an integer specifying time in minutes. Valid value: 15").with_provider_name("Minutes")
+                    ],
+                })
+        .with_def("RoutingRuleCondition", AttributeType::Struct {
+                    name: "RoutingRuleCondition".to_string(),
+                    fields: vec![
+                    StructField::new("http_error_code_returned_equals", AttributeType::String).with_description("The HTTP error code when the redirect is applied. In the event of an error, if the error code equals this value, then the specified redirect is applied. Required when parent element ``Condition`` is specified and sibling ``KeyPrefixEquals`` is not specified. If both are specified, then both must be true for the redirect to be applied.").with_provider_name("HttpErrorCodeReturnedEquals"),
+                    StructField::new("key_prefix_equals", AttributeType::String).with_description("The object key name prefix when the redirect is applied. For example, to redirect requests for ``ExamplePage.html``, the key prefix will be ``ExamplePage.html``. To redirect request for all pages with the prefix ``docs/``, the key prefix will be ``docs/``, which identifies all objects in the docs/ folder. Required when the parent element ``Condition`` is specified and sibling ``HttpErrorCodeReturnedEquals`` is not specified. If both conditions are specified, both must be true for the redirect to be applied.").with_provider_name("KeyPrefixEquals")
+                    ],
+                })
+        .with_def("S3KeyFilter", AttributeType::Struct {
+                    name: "S3KeyFilter".to_string(),
+                    fields: vec![
+                    StructField::new("rules", AttributeType::unordered_list(AttributeType::Struct {
+                    name: "FilterRule".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: Some((None, Some(1024))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_length_max_1024),
+                to_dsl: None,
+            }).required().with_description("The object key name prefix or suffix identifying one or more objects to which the filtering rule applies. The maximum length is 1,024 characters. Overlapping prefixes and suffixes are not supported. For more information, see [Configuring Event Notifications](https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html) in the *Amazon S3 User Guide*.").with_provider_name("Name"),
+                    StructField::new("value", AttributeType::String).required().with_description("The value that the filter searches for in object key names.").with_provider_name("Value")
+                    ],
+                })).required().with_description("A list of containers for the key-value pair that defines the criteria for the filter rule.").with_provider_name("Rules").with_block_name("rule")
+                    ],
+                })
+        .with_def("S3TablesDestination", AttributeType::Struct {
+                    name: "S3TablesDestination".to_string(),
+                    fields: vec![
+                    StructField::new("table_arn", super::arn()).with_description("The Amazon Resource Name (ARN) for the metadata table in the metadata table configuration. The specified metadata table name must be unique within the ``aws_s3_metadata`` namespace in the destination table bucket.").with_provider_name("TableArn"),
+                    StructField::new("table_bucket_arn", super::arn()).required().with_description("The Amazon Resource Name (ARN) for the table bucket that's specified as the destination in the metadata table configuration. The destination table bucket must be in the same Region and AWS-account as the general purpose bucket.").with_provider_name("TableBucketArn"),
+                    StructField::new("table_name", AttributeType::String).required().with_description("The name for the metadata table in your metadata table configuration. The specified metadata table name must be unique within the ``aws_s3_metadata`` namespace in the destination table bucket.").with_provider_name("TableName"),
+                    StructField::new("table_namespace", AttributeType::String).with_description("The table bucket namespace for the metadata table in your metadata table configuration. This value is always ``aws_s3_metadata``.").with_provider_name("TableNamespace")
+                    ],
+                })
+        .with_def("ServerSideEncryptionByDefault", AttributeType::Struct {
+                    name: "ServerSideEncryptionByDefault".to_string(),
+                    fields: vec![
+                    StructField::new("kms_master_key_id", super::kms_key_id()).with_description("AWS Key Management Service (KMS) customer managed key ID to use for the default encryption. + *General purpose buckets* - This parameter is allowed if and only if ``SSEAlgorithm`` is set to ``aws:kms`` or ``aws:kms:dsse``. + *Directory buckets* - This parameter is allowed if and only if ``SSEAlgorithm`` is set to ``aws:kms``. You can specify the key ID, key alias, or the Amazon Resource Name (ARN) of the KMS key. + Key ID: ``1234abcd-12ab-34cd-56ef-1234567890ab`` + Key ARN: ``arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab`` + Key Alias: ``alias/alias-name`` If you are using encryption with cross-account or AWS service operations, you must use a fully qualified KMS key ARN. For more information, see [Using encryption for cross-account operations](https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html#bucket-encryption-update-bucket-policy). + *General purpose buckets* - If you're specifying a customer managed KMS key, we recommend using a fully qualified KMS key ARN. If you use a KMS key alias instead, then KMS resolves the key within the requester?s account. This behavior can result in data that's encrypted with a KMS key that belongs to the requester, and not the bucket owner. Also, if you use a key ID, you can run into a LogDestination undeliverable error when creating a VPC flow log. + *Directory buckets* - When you specify an [customer managed key](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk) for encryption in your directory bucket, only use the key ID or key ARN. The key alias format of the KMS key isn't supported. Amazon S3 only supports symmetric encryption KMS keys. For more information, see [Asymmetric keys in KMS](https://docs.aws.amazon.com//kms/latest/developerguide/symmetric-asymmetric.html) in the *Key Management Service Developer Guide*.").with_provider_name("KMSMasterKeyID"),
+                    StructField::new("sse_algorithm", AttributeType::StringEnum {
+                name: "SseAlgorithm".to_string(),
+                values: vec!["aws:kms".to_string(), "AES256".to_string(), "aws:kms:dsse".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("SseAlgorithm", Some("awscc.s3.Bucket"))),
+                dsl_aliases: vec![("aws:kms".to_string(), "aws_kms".to_string()), ("AES256".to_string(), "aes256".to_string()), ("aws:kms:dsse".to_string(), "aws_kms_dsse".to_string())],
+            }).required().with_description("Server-side encryption algorithm to use for the default encryption. For directory buckets, there are only two supported values for server-side encryption: ``AES256`` and ``aws:kms``.").with_provider_name("SSEAlgorithm")
+                    ],
+                })
+        .with_def("SourceSelectionCriteria", AttributeType::Struct {
+                    name: "SourceSelectionCriteria".to_string(),
+                    fields: vec![
+                    StructField::new("replica_modifications", AttributeType::Struct {
+                    name: "ReplicaModifications".to_string(),
+                    fields: vec![
+                    StructField::new("status", AttributeType::StringEnum {
+                name: "Status".to_string(),
+                values: vec!["Enabled".to_string(), "Disabled".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("Status", Some("awscc.s3.Bucket"))),
+                dsl_aliases: vec![("Enabled".to_string(), "enabled".to_string()), ("Disabled".to_string(), "disabled".to_string())],
+            }).required().with_description("Specifies whether Amazon S3 replicates modifications on replicas. *Allowed values*: ``Enabled`` | ``Disabled``").with_provider_name("Status")
+                    ],
+                }).with_description("A filter that you can specify for selection for modifications on replicas.").with_provider_name("ReplicaModifications"),
+                    StructField::new("sse_kms_encrypted_objects", AttributeType::Struct {
+                    name: "SseKmsEncryptedObjects".to_string(),
+                    fields: vec![
+                    StructField::new("status", AttributeType::StringEnum {
+                name: "Status".to_string(),
+                values: vec!["Disabled".to_string(), "Enabled".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("Status", Some("awscc.s3.Bucket"))),
+                dsl_aliases: vec![("Disabled".to_string(), "disabled".to_string()), ("Enabled".to_string(), "enabled".to_string())],
+            }).required().with_description("Specifies whether Amazon S3 replicates objects created with server-side encryption using an AWS KMS key stored in AWS Key Management Service.").with_provider_name("Status")
+                    ],
+                }).with_description("A container for filter information for the selection of Amazon S3 objects encrypted with AWS KMS.").with_provider_name("SseKmsEncryptedObjects")
+                    ],
+                })
+        .with_def("SseKmsEncryptedObjects", AttributeType::Struct {
+                    name: "SseKmsEncryptedObjects".to_string(),
+                    fields: vec![
+                    StructField::new("status", AttributeType::StringEnum {
+                name: "Status".to_string(),
+                values: vec!["Disabled".to_string(), "Enabled".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("Status", Some("awscc.s3.Bucket"))),
+                dsl_aliases: vec![("Disabled".to_string(), "disabled".to_string()), ("Enabled".to_string(), "enabled".to_string())],
+            }).required().with_description("Specifies whether Amazon S3 replicates objects created with server-side encryption using an AWS KMS key stored in AWS Key Management Service.").with_provider_name("Status")
+                    ],
+                })
+        .with_def("StorageClassAnalysis", AttributeType::Struct {
+                    name: "StorageClassAnalysis".to_string(),
+                    fields: vec![
+                    StructField::new("data_export", AttributeType::Struct {
+                    name: "DataExport".to_string(),
+                    fields: vec![
+                    StructField::new("destination", AttributeType::Struct {
+                    name: "Destination".to_string(),
+                    fields: vec![
+                    StructField::new("bucket_account_id", super::aws_account_id()).with_description("The account ID that owns the destination S3 bucket. If no account ID is provided, the owner is not validated before exporting data. Although this value is optional, we strongly recommend that you set it to help prevent problems if the destination bucket ownership changes.").with_provider_name("BucketAccountId"),
+                    StructField::new("bucket_arn", super::arn()).required().with_description("The Amazon Resource Name (ARN) of the bucket to which data is exported.").with_provider_name("BucketArn"),
+                    StructField::new("format", AttributeType::StringEnum {
+                name: "Format".to_string(),
+                values: vec!["CSV".to_string(), "ORC".to_string(), "Parquet".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("Format", Some("awscc.s3.Bucket"))),
+                dsl_aliases: vec![("CSV".to_string(), "csv".to_string()), ("ORC".to_string(), "orc".to_string()), ("Parquet".to_string(), "parquet".to_string())],
+            }).required().with_description("Specifies the file format used when exporting data to Amazon S3. *Allowed values*: ``CSV`` | ``ORC`` | ``Parquet``").with_provider_name("Format"),
+                    StructField::new("prefix", AttributeType::String).with_description("The prefix to use when exporting data. The prefix is prepended to all results.").with_provider_name("Prefix")
+                    ],
+                }).required().with_description("The place to store the data for an analysis.").with_provider_name("Destination"),
+                    StructField::new("output_schema_version", AttributeType::StringEnum {
+                name: "OutputSchemaVersion".to_string(),
+                values: vec!["V_1".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("OutputSchemaVersion", Some("awscc.s3.Bucket"))),
+                dsl_aliases: vec![("V_1".to_string(), "v_1".to_string())],
+            }).required().with_description("The version of the output schema to use when exporting data. Must be ``V_1``.").with_provider_name("OutputSchemaVersion")
+                    ],
+                }).with_description("Specifies how data related to the storage class analysis for an Amazon S3 bucket should be exported.").with_provider_name("DataExport")
+                    ],
+                })
+        .with_def("TargetObjectKeyFormat", AttributeType::Struct {
+                    name: "TargetObjectKeyFormat".to_string(),
+                    fields: vec![
+                    StructField::new("partitioned_prefix", AttributeType::Struct {
+                    name: "PartitionedPrefix".to_string(),
+                    fields: vec![
+                    StructField::new("partition_date_source", AttributeType::StringEnum {
+                name: "PartitionDateSource".to_string(),
+                values: vec!["EventTime".to_string(), "DeliveryTime".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("PartitionDateSource", Some("awscc.s3.Bucket"))),
+                dsl_aliases: vec![("EventTime".to_string(), "event_time".to_string()), ("DeliveryTime".to_string(), "delivery_time".to_string())],
+            }).with_description("Specifies the partition date source for the partitioned prefix. ``PartitionDateSource`` can be ``EventTime`` or ``DeliveryTime``. For ``DeliveryTime``, the time in the log file names corresponds to the delivery time for the log files. For ``EventTime``, The logs delivered are for a specific day only. The year, month, and day correspond to the day on which the event occurred, and the hour, minutes and seconds are set to 00 in the key.").with_provider_name("PartitionDateSource")
+                    ],
+                }).with_provider_name("PartitionedPrefix"),
+                    StructField::new("simple_prefix", AttributeType::Struct {
+                    name: "SimplePrefix".to_string(),
+                    fields: vec![],
+                }).with_description("This format defaults the prefix to the given log file prefix for delivering server access log file.").with_provider_name("SimplePrefix")
+                    ],
+                })
+        .with_def("Transition", AttributeType::Struct {
+                    name: "Transition".to_string(),
+                    fields: vec![
+                    StructField::new("storage_class", AttributeType::StringEnum {
+                name: "StorageClass".to_string(),
+                values: vec!["DEEP_ARCHIVE".to_string(), "GLACIER".to_string(), "GLACIER_IR".to_string(), "INTELLIGENT_TIERING".to_string(), "ONEZONE_IA".to_string(), "STANDARD_IA".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("StorageClass", Some("awscc.s3.Bucket"))),
+                dsl_aliases: vec![("DEEP_ARCHIVE".to_string(), "deep_archive".to_string()), ("GLACIER".to_string(), "glacier".to_string()), ("GLACIER_IR".to_string(), "glacier_ir".to_string()), ("INTELLIGENT_TIERING".to_string(), "intelligent_tiering".to_string()), ("ONEZONE_IA".to_string(), "onezone_ia".to_string()), ("STANDARD_IA".to_string(), "standard_ia".to_string())],
+            }).required().with_description("The storage class to which you want the object to transition.").with_provider_name("StorageClass"),
+                    StructField::new("transition_date", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^(\\d{4})-(0[0-9]|1[0-2])-([0-2]\\d|3[01])T([01]\\d|2[0-4]):([0-5]\\d):([0-6]\\d)((\\.\\d{3})?)Z$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_cc806c69dc4cdaf7),
+                to_dsl: None,
+            }).with_description("Indicates when objects are transitioned to the specified storage class. The date value must be in ISO 8601 format. The time is always midnight UTC.").with_provider_name("TransitionDate"),
+                    StructField::new("transition_in_days", AttributeType::Int).with_description("Indicates the number of days after creation when objects are transitioned to the specified storage class. If the specified storage class is ``INTELLIGENT_TIERING``, ``GLACIER_IR``, ``GLACIER``, or ``DEEP_ARCHIVE``, valid values are ``0`` or positive integers. If the specified storage class is ``STANDARD_IA`` or ``ONEZONE_IA``, valid values are positive integers greater than ``30``. Be aware that some storage classes have a minimum storage duration and that you're charged for transitioning objects before their minimum storage duration. For more information, see [Constraints and considerations for transitions](https://docs.aws.amazon.com/AmazonS3/latest/userguide/lifecycle-transition-general-considerations.html#lifecycle-configuration-constraints) in the *Amazon S3 User Guide*.").with_provider_name("TransitionInDays")
+                    ],
+                })
+        .with_def("VersioningConfiguration", AttributeType::Struct {
                     name: "VersioningConfiguration".to_string(),
                     fields: vec![
                     StructField::new("status", AttributeType::StringEnum {
-                name: "VersioningConfigurationStatus".to_string(),
+                name: "Status".to_string(),
                 values: vec!["Enabled".to_string(), "Suspended".to_string()],
-                identity: Some(carina_core::schema::string_enum_identity("VersioningConfigurationStatus", Some("awscc.s3.Bucket"))),
+                identity: Some(carina_core::schema::string_enum_identity("Status", Some("awscc.s3.Bucket"))),
                 dsl_aliases: vec![("Enabled".to_string(), "enabled".to_string()), ("Suspended".to_string(), "suspended".to_string())],
             }).required().with_description("The versioning state of the bucket.").with_provider_name("Status")
                     ],
                 })
-                .with_description("Enables multiple versions of all objects in this bucket. You might enable versioning to prevent objects from being deleted or overwritten by mistake or to archive objects so that you can retrieve previous versions of them. When you enable versioning on a bucket for the first time, it might take a short amount of time for the change to be fully propagated. We recommend that you wait for 15 minutes after enabling versioning before issuing write operations (``PUT`` or ``DELETE``) on objects in the bucket.")
-                .with_provider_name("VersioningConfiguration"),
-        )
-        .attribute(
-            AttributeSchema::new("website_configuration", AttributeType::Struct {
+        .with_def("WebsiteConfiguration", AttributeType::Struct {
                     name: "WebsiteConfiguration".to_string(),
                     fields: vec![
                     StructField::new("error_document", AttributeType::String).with_description("The name of the error document for the website.").with_provider_name("ErrorDocument"),
@@ -1193,31 +1694,6 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 })).with_description("Rules that define when a redirect is applied and the redirect behavior.").with_provider_name("RoutingRules").with_block_name("routing_rule")
                     ],
                 })
-                .with_description("Information used to configure the bucket as a static website. For more information, see [Hosting Websites on Amazon S3](https://docs.aws.amazon.com/AmazonS3/latest/dev/WebsiteHosting.html).")
-                .with_provider_name("WebsiteConfiguration")
-                .with_block_name("website_configuration"),
-        )
-        .attribute(
-            AttributeSchema::new("website_url", AttributeType::Custom {
-                identity: None,
-                pattern: None,
-                length: None,
-                base: Box::new(AttributeType::String),
-                validate: noop_validator(),
-                to_dsl: None,
-            })
-                .read_only()
-                .with_description(" (read-only)")
-                .with_provider_name("WebsiteURL"),
-        )
-        .with_name_attribute("bucket_name")
-        .with_validator(|attrs| {
-            let mut errors = Vec::new();
-            if let Err(mut e) = validate_tags_map(attrs) {
-                errors.append(&mut e);
-            }
-            if errors.is_empty() { Ok(()) } else { Err(errors) }
-        })
     }
 }
 

--- a/carina-provider-awscc/src/schemas/generated/sso/permission_set.rs
+++ b/carina-provider-awscc/src/schemas/generated/sso/permission_set.rs
@@ -277,33 +277,7 @@ pub fn sso_permission_set_config() -> AwsccSchemaConfig {
                 .with_provider_name("PermissionSetArn"),
         )
         .attribute(
-            AttributeSchema::new("permissions_boundary", AttributeType::Struct {
-                    name: "PermissionsBoundary".to_string(),
-                    fields: vec![
-                    StructField::new("customer_managed_policy_reference", AttributeType::Struct {
-                    name: "CustomerManagedPolicyReference".to_string(),
-                    fields: vec![
-                    StructField::new("name", AttributeType::Custom {
-                identity: None,
-                pattern: Some("[\\w+=,.@-]+".to_string()),
-                length: Some((Some(1), Some(128))),
-                base: Box::new(AttributeType::String),
-                validate: legacy_validator(validate_string_pattern_9b83f4f8f3673df5_len_1_128),
-                to_dsl: None,
-            }).required().with_provider_name("Name"),
-                    StructField::new("path", AttributeType::Custom {
-                identity: None,
-                pattern: Some("((/[A-Za-z0-9\\.,\\+@=_-]+)*)/".to_string()),
-                length: Some((Some(1), Some(512))),
-                base: Box::new(AttributeType::String),
-                validate: legacy_validator(validate_string_pattern_b84fa12576539ca9_len_1_512),
-                to_dsl: None,
-            }).with_provider_name("Path")
-                    ],
-                }).with_provider_name("CustomerManagedPolicyReference"),
-                    StructField::new("managed_policy_arn", super::arn()).with_provider_name("ManagedPolicyArn")
-                    ],
-                })
+            AttributeSchema::new("permissions_boundary", AttributeType::Ref("PermissionsBoundary".to_string()))
                 .with_provider_name("PermissionsBoundary"),
         )
         .attribute(
@@ -341,6 +315,54 @@ pub fn sso_permission_set_config() -> AwsccSchemaConfig {
             }
             if errors.is_empty() { Ok(()) } else { Err(errors) }
         })
+        .with_def("CustomerManagedPolicyReference", AttributeType::Struct {
+                    name: "CustomerManagedPolicyReference".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some("[\\w+=,.@-]+".to_string()),
+                length: Some((Some(1), Some(128))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_9b83f4f8f3673df5_len_1_128),
+                to_dsl: None,
+            }).required().with_provider_name("Name"),
+                    StructField::new("path", AttributeType::Custom {
+                identity: None,
+                pattern: Some("((/[A-Za-z0-9\\.,\\+@=_-]+)*)/".to_string()),
+                length: Some((Some(1), Some(512))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_b84fa12576539ca9_len_1_512),
+                to_dsl: None,
+            }).with_provider_name("Path")
+                    ],
+                })
+        .with_def("PermissionsBoundary", AttributeType::Struct {
+                    name: "PermissionsBoundary".to_string(),
+                    fields: vec![
+                    StructField::new("customer_managed_policy_reference", AttributeType::Struct {
+                    name: "CustomerManagedPolicyReference".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some("[\\w+=,.@-]+".to_string()),
+                length: Some((Some(1), Some(128))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_9b83f4f8f3673df5_len_1_128),
+                to_dsl: None,
+            }).required().with_provider_name("Name"),
+                    StructField::new("path", AttributeType::Custom {
+                identity: None,
+                pattern: Some("((/[A-Za-z0-9\\.,\\+@=_-]+)*)/".to_string()),
+                length: Some((Some(1), Some(512))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_b84fa12576539ca9_len_1_512),
+                to_dsl: None,
+            }).with_provider_name("Path")
+                    ],
+                }).with_provider_name("CustomerManagedPolicyReference"),
+                    StructField::new("managed_policy_arn", super::arn()).with_provider_name("ManagedPolicyArn")
+                    ],
+                })
     }
 }
 

--- a/carina-provider-awscc/src/schemas/generated/wafv2/mod.rs
+++ b/carina-provider-awscc/src/schemas/generated/wafv2/mod.rs
@@ -1,0 +1,9 @@
+//! Auto-generated — DO NOT EDIT MANUALLY
+//!
+//! Regenerate with:
+//!   aws-vault exec <profile> -- ./carina-provider-awscc/scripts/generate-schemas.sh
+
+// Re-export parent types so resource modules can use `super::` to access them.
+pub use super::*;
+
+pub mod web_acl;

--- a/carina-provider-awscc/src/schemas/generated/wafv2/web_acl.rs
+++ b/carina-provider-awscc/src/schemas/generated/wafv2/web_acl.rs
@@ -1,0 +1,6145 @@
+//! web_acl schema definition for AWS Cloud Control
+//!
+//! Auto-generated from CloudFormation schema: AWS::WAFv2::WebACL
+//!
+//! DO NOT EDIT MANUALLY - regenerate with carina-codegen
+
+use super::AwsccSchemaConfig;
+use super::tags_type;
+use super::validate_tags_map;
+use carina_core::resource::{ConcreteValue, Value};
+use carina_core::schema::{
+    AttributeSchema, AttributeType, ResourceSchema, StructField, legacy_validator, types,
+};
+use regex::Regex;
+
+const VALID_AWS_MANAGED_RULES_ANTI_D_DO_S_RULE_SET_SENSITIVITY_TO_BLOCK: &[&str] =
+    &["LOW", "MEDIUM", "HIGH"];
+
+const VALID_AWS_MANAGED_RULES_BOT_CONTROL_RULE_SET_INSPECTION_LEVEL: &[&str] =
+    &["COMMON", "TARGETED"];
+
+const VALID_BODY_OVERSIZE_HANDLING: &[&str] = &["CONTINUE", "MATCH", "NO_MATCH"];
+
+const VALID_BYTE_MATCH_STATEMENT_POSITIONAL_CONSTRAINT: &[&str] = &[
+    "EXACTLY",
+    "STARTS_WITH",
+    "ENDS_WITH",
+    "CONTAINS",
+    "CONTAINS_WORD",
+];
+
+const VALID_CLIENT_SIDE_ACTION_SENSITIVITY: &[&str] = &["LOW", "MEDIUM", "HIGH"];
+
+const VALID_CLIENT_SIDE_ACTION_USAGE_OF_ACTION: &[&str] = &["ENABLED", "DISABLED"];
+
+const VALID_COOKIES_MATCH_SCOPE: &[&str] = &["ALL", "KEY", "VALUE"];
+
+const VALID_COOKIES_OVERSIZE_HANDLING: &[&str] = &["CONTINUE", "MATCH", "NO_MATCH"];
+
+const VALID_CUSTOM_RESPONSE_BODY_CONTENT_TYPE: &[&str] =
+    &["TEXT_PLAIN", "TEXT_HTML", "APPLICATION_JSON"];
+
+const VALID_DATA_PROTECT_ACTION: &[&str] = &["SUBSTITUTION", "HASH"];
+
+const VALID_FIELD_TO_PROTECT_FIELD_TYPE: &[&str] = &[
+    "SINGLE_HEADER",
+    "SINGLE_COOKIE",
+    "SINGLE_QUERY_ARGUMENT",
+    "QUERY_STRING",
+    "BODY",
+];
+
+const VALID_FORWARDED_IP_CONFIGURATION_FALLBACK_BEHAVIOR: &[&str] = &["MATCH", "NO_MATCH"];
+
+const VALID_HEADER_ORDER_OVERSIZE_HANDLING: &[&str] = &["CONTINUE", "MATCH", "NO_MATCH"];
+
+const VALID_HEADERS_MATCH_SCOPE: &[&str] = &["ALL", "KEY", "VALUE"];
+
+const VALID_HEADERS_OVERSIZE_HANDLING: &[&str] = &["CONTINUE", "MATCH", "NO_MATCH"];
+
+const VALID_IP_SET_FORWARDED_IP_CONFIGURATION_FALLBACK_BEHAVIOR: &[&str] = &["MATCH", "NO_MATCH"];
+
+const VALID_IP_SET_FORWARDED_IP_CONFIGURATION_POSITION: &[&str] = &["FIRST", "LAST", "ANY"];
+
+const VALID_JA3_FINGERPRINT_FALLBACK_BEHAVIOR: &[&str] = &["MATCH", "NO_MATCH"];
+
+const VALID_JA4_FINGERPRINT_FALLBACK_BEHAVIOR: &[&str] = &["MATCH", "NO_MATCH"];
+
+const VALID_JSON_BODY_INVALID_FALLBACK_BEHAVIOR: &[&str] =
+    &["MATCH", "NO_MATCH", "EVALUATE_AS_STRING"];
+
+const VALID_JSON_BODY_MATCH_SCOPE: &[&str] = &["ALL", "KEY", "VALUE"];
+
+const VALID_JSON_BODY_OVERSIZE_HANDLING: &[&str] = &["CONTINUE", "MATCH", "NO_MATCH"];
+
+const VALID_MANAGED_RULE_GROUP_CONFIG_PAYLOAD_TYPE: &[&str] = &["JSON", "FORM_ENCODED"];
+
+const VALID_ON_SOURCE_D_DO_S_PROTECTION_CONFIG_ALB_LOW_REPUTATION_MODE: &[&str] =
+    &["ACTIVE_UNDER_DDOS", "ALWAYS_ON"];
+
+const VALID_RATE_BASED_STATEMENT_AGGREGATE_KEY_TYPE: &[&str] =
+    &["CONSTANT", "IP", "FORWARDED_IP", "CUSTOM_KEYS"];
+
+const VALID_RATE_BASED_STATEMENT_EVALUATION_WINDOW_SEC: &[&str] = &["60", "120", "300", "600"];
+
+const VALID_RATE_LIMIT_JA3_FINGERPRINT_FALLBACK_BEHAVIOR: &[&str] = &["MATCH", "NO_MATCH"];
+
+const VALID_RATE_LIMIT_JA4_FINGERPRINT_FALLBACK_BEHAVIOR: &[&str] = &["MATCH", "NO_MATCH"];
+
+const VALID_REQUEST_BODY_ASSOCIATED_RESOURCE_TYPE_CONFIG_DEFAULT_SIZE_INSPECTION_LIMIT: &[&str] =
+    &["KB_16", "KB_32", "KB_48", "KB_64"];
+
+const VALID_REQUEST_INSPECTION_PAYLOAD_TYPE: &[&str] = &["JSON", "FORM_ENCODED"];
+
+const VALID_REQUEST_INSPECTION_ACFP_PAYLOAD_TYPE: &[&str] = &["JSON", "FORM_ENCODED"];
+
+const VALID_SCOPE: &[&str] = &["CLOUDFRONT", "REGIONAL"];
+
+const VALID_SIZE_CONSTRAINT_STATEMENT_COMPARISON_OPERATOR: &[&str] =
+    &["EQ", "NE", "LE", "LT", "GE", "GT"];
+
+const VALID_SQLI_MATCH_STATEMENT_SENSITIVITY_LEVEL: &[&str] = &["LOW", "HIGH"];
+
+const VALID_TEXT_TRANSFORMATION_TYPE: &[&str] = &[
+    "NONE",
+    "COMPRESS_WHITE_SPACE",
+    "HTML_ENTITY_DECODE",
+    "LOWERCASE",
+    "CMD_LINE",
+    "URL_DECODE",
+    "BASE64_DECODE",
+    "HEX_DECODE",
+    "MD5",
+    "REPLACE_COMMENTS",
+    "ESCAPE_SEQ_DECODE",
+    "SQL_HEX_DECODE",
+    "CSS_DECODE",
+    "JS_DECODE",
+    "NORMALIZE_PATH",
+    "NORMALIZE_PATH_WIN",
+    "REMOVE_NULLS",
+    "REPLACE_NULLS",
+    "BASE64_DECODE_EXT",
+    "URL_DECODE_UNI",
+    "UTF8_TO_UNICODE",
+];
+
+const VALID_URI_FRAGMENT_FALLBACK_BEHAVIOR: &[&str] = &["MATCH", "NO_MATCH"];
+
+fn validate_capacity_range(value: &Value) -> Result<(), String> {
+    if let Value::Concrete(ConcreteValue::Int(n)) = value {
+        if *n < 0 {
+            Err(format!("Value {} is out of range 0..", n))
+        } else {
+            Ok(())
+        }
+    } else {
+        Err("Expected integer".to_string())
+    }
+}
+
+fn validate_immunity_time_range(value: &Value) -> Result<(), String> {
+    if let Value::Concrete(ConcreteValue::Int(n)) = value {
+        if *n < 60 || *n > 259200 {
+            Err(format!("Value {} is out of range 60..=259200", n))
+        } else {
+            Ok(())
+        }
+    } else {
+        Err("Expected integer".to_string())
+    }
+}
+
+fn validate_size_range(value: &Value) -> Result<(), String> {
+    let n = match value {
+        Value::Concrete(ConcreteValue::Int(i)) => *i as f64,
+        Value::Concrete(ConcreteValue::Float(f)) => *f,
+        _ => return Err("Expected number".to_string()),
+    };
+    if !(0.0..=21474836480.0).contains(&n) {
+        Err(format!("Value {} is out of range 0..=21474836480", n))
+    } else {
+        Ok(())
+    }
+}
+
+#[allow(dead_code)]
+fn validate_string_pattern_6fd4a12c0ce64c08(value: &Value) -> Result<(), String> {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
+        static RE: std::sync::LazyLock<Regex> =
+            std::sync::LazyLock::new(|| Regex::new("^[\\w\\-]+$").expect("invalid pattern regex"));
+        if RE.is_match(s) {
+            Ok(())
+        } else {
+            Err(format!("Value '{}' does not match pattern ^[\\w\\-]+$", s))
+        }
+    } else {
+        Err("Expected string".to_string())
+    }
+}
+
+#[allow(dead_code)]
+fn validate_string_pattern_eef4eb302f1cdd5a(value: &Value) -> Result<(), String> {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
+        static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+            Regex::new(
+                "^[a-zA-Z0-9=:#@/\\-,.][a-zA-Z0-9+=:#@/\\-,.\\s]+[a-zA-Z0-9+=:#@/\\-,.]{1,256}$",
+            )
+            .expect("invalid pattern regex")
+        });
+        if RE.is_match(s) {
+            Ok(())
+        } else {
+            Err(format!(
+                "Value '{}' does not match pattern ^[a-zA-Z0-9=:#@/\\-,.][a-zA-Z0-9+=:#@/\\-,.\\s]+[a-zA-Z0-9+=:#@/\\-,.]{{1,256}}$",
+                s
+            ))
+        }
+    } else {
+        Err("Expected string".to_string())
+    }
+}
+
+#[allow(dead_code)]
+fn validate_string_pattern_2d93cc844f6d4014(value: &Value) -> Result<(), String> {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
+        static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+            Regex::new("^[a-zA-Z0-9-]+{1,255}$").expect("invalid pattern regex")
+        });
+        if RE.is_match(s) {
+            Ok(())
+        } else {
+            Err(format!(
+                "Value '{}' does not match pattern ^[a-zA-Z0-9-]+{{1,255}}$",
+                s
+            ))
+        }
+    } else {
+        Err("Expected string".to_string())
+    }
+}
+
+#[allow(dead_code)]
+fn validate_string_pattern_d04f4c3802439b73(value: &Value) -> Result<(), String> {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
+        static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+            Regex::new("^[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$")
+                .expect("invalid pattern regex")
+        });
+        if RE.is_match(s) {
+            Ok(())
+        } else {
+            Err(format!(
+                "Value '{}' does not match pattern ^[0-9a-f]{{8}}-(?:[0-9a-f]{{4}}-){{3}}[0-9a-f]{{12}}$",
+                s
+            ))
+        }
+    } else {
+        Err("Expected string".to_string())
+    }
+}
+
+#[allow(dead_code)]
+fn validate_string_pattern_b3fc65b549fb77bd(value: &Value) -> Result<(), String> {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
+        static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+            Regex::new("^[0-9A-Za-z_:-]{1,1024}$").expect("invalid pattern regex")
+        });
+        if RE.is_match(s) {
+            Ok(())
+        } else {
+            Err(format!(
+                "Value '{}' does not match pattern ^[0-9A-Za-z_:-]{{1,1024}}$",
+                s
+            ))
+        }
+    } else {
+        Err("Expected string".to_string())
+    }
+}
+
+#[allow(dead_code)]
+fn validate_string_pattern_42f7eceb887966ad(value: &Value) -> Result<(), String> {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
+        static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+            Regex::new("^[0-9A-Za-z_-]{1,128}$").expect("invalid pattern regex")
+        });
+        if RE.is_match(s) {
+            Ok(())
+        } else {
+            Err(format!(
+                "Value '{}' does not match pattern ^[0-9A-Za-z_-]{{1,128}}$",
+                s
+            ))
+        }
+    } else {
+        Err("Expected string".to_string())
+    }
+}
+
+#[allow(dead_code)]
+fn validate_list_items_max_5(value: &Value) -> Result<(), String> {
+    if let Value::Concrete(ConcreteValue::List(items)) = value {
+        let len = items.len();
+        if len > 5 {
+            Err(format!("List has {} items, expected ..=5", len))
+        } else {
+            Ok(())
+        }
+    } else {
+        Err("Expected list".to_string())
+    }
+}
+
+#[allow(dead_code)]
+fn validate_list_items_1_199(value: &Value) -> Result<(), String> {
+    if let Value::Concrete(ConcreteValue::List(items)) = value {
+        let len = items.len();
+        if !(1..=199).contains(&len) {
+            Err(format!("List has {} items, expected 1..=199", len))
+        } else {
+            Ok(())
+        }
+    } else {
+        Err("Expected list".to_string())
+    }
+}
+
+#[allow(dead_code)]
+fn validate_list_items_1_10(value: &Value) -> Result<(), String> {
+    if let Value::Concrete(ConcreteValue::List(items)) = value {
+        let len = items.len();
+        if !(1..=10).contains(&len) {
+            Err(format!("List has {} items, expected 1..=10", len))
+        } else {
+            Ok(())
+        }
+    } else {
+        Err("Expected list".to_string())
+    }
+}
+
+#[allow(dead_code)]
+fn validate_list_items_1_5(value: &Value) -> Result<(), String> {
+    if let Value::Concrete(ConcreteValue::List(items)) = value {
+        let len = items.len();
+        if !(1..=5).contains(&len) {
+            Err(format!("List has {} items, expected 1..=5", len))
+        } else {
+            Ok(())
+        }
+    } else {
+        Err("Expected list".to_string())
+    }
+}
+
+#[allow(dead_code)]
+fn validate_list_items_1_3(value: &Value) -> Result<(), String> {
+    if let Value::Concrete(ConcreteValue::List(items)) = value {
+        let len = items.len();
+        if !(1..=3).contains(&len) {
+            Err(format!("List has {} items, expected 1..=3", len))
+        } else {
+            Ok(())
+        }
+    } else {
+        Err("Expected list".to_string())
+    }
+}
+
+#[allow(dead_code)]
+fn validate_list_items_min_1(value: &Value) -> Result<(), String> {
+    if let Value::Concrete(ConcreteValue::List(items)) = value {
+        let len = items.len();
+        if len < 1 {
+            Err(format!("List has {} items, expected 1..", len))
+        } else {
+            Ok(())
+        }
+    } else {
+        Err("Expected list".to_string())
+    }
+}
+
+#[allow(dead_code)]
+fn validate_list_items_max_100(value: &Value) -> Result<(), String> {
+    if let Value::Concrete(ConcreteValue::List(items)) = value {
+        let len = items.len();
+        if len > 100 {
+            Err(format!("List has {} items, expected ..=100", len))
+        } else {
+            Ok(())
+        }
+    } else {
+        Err("Expected list".to_string())
+    }
+}
+
+fn validate_string_length_1_2(value: &Value) -> Result<(), String> {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
+        let len = s.chars().count();
+        if !(1..=2).contains(&len) {
+            Err(format!("String length {} is out of range 1..=2", len))
+        } else {
+            Ok(())
+        }
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_string_length_1_128(value: &Value) -> Result<(), String> {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
+        let len = s.chars().count();
+        if !(1..=128).contains(&len) {
+            Err(format!("String length {} is out of range 1..=128", len))
+        } else {
+            Ok(())
+        }
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_string_length_1_512(value: &Value) -> Result<(), String> {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
+        let len = s.chars().count();
+        if !(1..=512).contains(&len) {
+            Err(format!("String length {} is out of range 1..=512", len))
+        } else {
+            Ok(())
+        }
+    } else {
+        Ok(())
+    }
+}
+
+#[allow(dead_code)]
+fn validate_string_pattern_4e09c821aed9e752_len_1_256(value: &Value) -> Result<(), String> {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
+        static RE: std::sync::LazyLock<Regex> =
+            std::sync::LazyLock::new(|| Regex::new(".*\\S.*").expect("invalid pattern regex"));
+        if !RE.is_match(s) {
+            return Err(format!("Value '{}' does not match pattern .*\\S.*", s));
+        }
+        let len = s.chars().count();
+        if !(1..=256).contains(&len) {
+            return Err(format!("String length {} is out of range 1..=256", len));
+        }
+        Ok(())
+    } else {
+        Err("Expected string".to_string())
+    }
+}
+
+#[allow(dead_code)]
+fn validate_string_pattern_4e09c821aed9e752_len_1_512(value: &Value) -> Result<(), String> {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
+        static RE: std::sync::LazyLock<Regex> =
+            std::sync::LazyLock::new(|| Regex::new(".*\\S.*").expect("invalid pattern regex"));
+        if !RE.is_match(s) {
+            return Err(format!("Value '{}' does not match pattern .*\\S.*", s));
+        }
+        let len = s.chars().count();
+        if !(1..=512).contains(&len) {
+            return Err(format!("String length {} is out of range 1..=512", len));
+        }
+        Ok(())
+    } else {
+        Err("Expected string".to_string())
+    }
+}
+
+#[allow(dead_code)]
+fn validate_string_pattern_82a037d29be8d222_len_1_64(value: &Value) -> Result<(), String> {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
+        static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+            Regex::new("^[\\w#:\\.\\-/]+$").expect("invalid pattern regex")
+        });
+        if !RE.is_match(s) {
+            return Err(format!(
+                "Value '{}' does not match pattern ^[\\w#:\\.\\-/]+$",
+                s
+            ));
+        }
+        let len = s.chars().count();
+        if !(1..=64).contains(&len) {
+            return Err(format!("String length {} is out of range 1..=64", len));
+        }
+        Ok(())
+    } else {
+        Err("Expected string".to_string())
+    }
+}
+
+/// Returns the schema config for wafv2_web_acl (AWS::WAFv2::WebACL)
+pub fn wafv2_web_acl_config() -> AwsccSchemaConfig {
+    AwsccSchemaConfig {
+        aws_type_name: "AWS::WAFv2::WebACL",
+        resource_type_name: "wafv2.WebAcl",
+        has_tags: true,
+        schema: ResourceSchema::new("wafv2.WebAcl")
+        .with_description("Contains the Rules that identify the requests that you want to allow, block, or count. In a WebACL, you also specify a default action (ALLOW or BLOCK), and the action for each Rule that you add to a WebACL, for example, block requests from specified IP addresses or block requests from specified referrers. You also associate the WebACL with a CloudFront distribution to identify the requests that you want AWS WAF to filter. If you add more than one Rule to a WebACL, a request needs to match only one of the specifications to be allowed, blocked, or counted.")
+        .attribute(
+            AttributeSchema::new("application_config", AttributeType::Ref("ApplicationConfig".to_string()))
+                .with_description("Collection of application attributes.")
+                .with_provider_name("ApplicationConfig"),
+        )
+        .attribute(
+            AttributeSchema::new("arn", super::arn())
+                .read_only()
+                .with_provider_name("Arn"),
+        )
+        .attribute(
+            AttributeSchema::new("association_config", AttributeType::Ref("AssociationConfig".to_string()))
+                .with_provider_name("AssociationConfig"),
+        )
+        .attribute(
+            AttributeSchema::new("capacity", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::Int),
+                validate: legacy_validator(validate_capacity_range),
+                to_dsl: None,
+            })
+                .read_only()
+                .with_provider_name("Capacity"),
+        )
+        .attribute(
+            AttributeSchema::new("captcha_config", AttributeType::Ref("CaptchaConfig".to_string()))
+                .with_provider_name("CaptchaConfig"),
+        )
+        .attribute(
+            AttributeSchema::new("challenge_config", AttributeType::Ref("ChallengeConfig".to_string()))
+                .with_provider_name("ChallengeConfig"),
+        )
+        .attribute(
+            AttributeSchema::new("custom_response_bodies", AttributeType::String)
+                .with_provider_name("CustomResponseBodies"),
+        )
+        .attribute(
+            AttributeSchema::new("data_protection_config", AttributeType::Ref("DataProtectionConfig".to_string()))
+                .with_description("Collection of dataProtects.")
+                .with_provider_name("DataProtectionConfig"),
+        )
+        .attribute(
+            AttributeSchema::new("default_action", AttributeType::Ref("DefaultAction".to_string()))
+                .required()
+                .with_provider_name("DefaultAction"),
+        )
+        .attribute(
+            AttributeSchema::new("description", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[a-zA-Z0-9=:#@/\\-,.][a-zA-Z0-9+=:#@/\\-,.\\s]+[a-zA-Z0-9+=:#@/\\-,.]{1,256}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_eef4eb302f1cdd5a),
+                to_dsl: None,
+            })
+                .with_provider_name("Description"),
+        )
+        .attribute(
+            AttributeSchema::new("id", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_d04f4c3802439b73),
+                to_dsl: None,
+            })
+                .read_only()
+                .with_provider_name("Id"),
+        )
+        .attribute(
+            AttributeSchema::new("label_namespace", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[0-9A-Za-z_:-]{1,1024}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_b3fc65b549fb77bd),
+                to_dsl: None,
+            })
+                .read_only()
+                .with_provider_name("LabelNamespace"),
+        )
+        .attribute(
+            AttributeSchema::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[0-9A-Za-z_-]{1,128}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_42f7eceb887966ad),
+                to_dsl: None,
+            })
+                .create_only()
+                .with_provider_name("Name"),
+        )
+        .attribute(
+            AttributeSchema::new("on_source_d_do_s_protection_config", AttributeType::Ref("OnSourceDDoSProtectionConfig".to_string()))
+                .with_provider_name("OnSourceDDoSProtectionConfig"),
+        )
+        .attribute(
+            AttributeSchema::new("rules", AttributeType::list(AttributeType::Struct {
+                    name: "Rule".to_string(),
+                    fields: vec![
+                    StructField::new("action", AttributeType::Ref("RuleAction".to_string())).with_provider_name("Action"),
+                    StructField::new("captcha_config", AttributeType::Ref("CaptchaConfig".to_string())).with_provider_name("CaptchaConfig"),
+                    StructField::new("challenge_config", AttributeType::Ref("ChallengeConfig".to_string())).with_provider_name("ChallengeConfig"),
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[0-9A-Za-z_-]{1,128}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_42f7eceb887966ad),
+                to_dsl: None,
+            }).required().with_provider_name("Name"),
+                    StructField::new("override_action", AttributeType::Ref("OverrideAction".to_string())).with_provider_name("OverrideAction"),
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("rule_labels", AttributeType::list(AttributeType::Struct {
+                    name: "Label".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[0-9A-Za-z_:-]{1,1024}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_b3fc65b549fb77bd),
+                to_dsl: None,
+            }).required().with_provider_name("Name")
+                    ],
+                })).with_description("Collection of Rule Labels.").with_provider_name("RuleLabels").with_block_name("rule_label"),
+                    StructField::new("statement", AttributeType::Ref("Statement".to_string())).required().with_provider_name("Statement"),
+                    StructField::new("visibility_config", AttributeType::Ref("VisibilityConfig".to_string())).required().with_provider_name("VisibilityConfig")
+                    ],
+                }))
+                .with_description("Collection of Rules.")
+                .with_provider_name("Rules")
+                .with_block_name("rule"),
+        )
+        .attribute(
+            AttributeSchema::new("scope", AttributeType::StringEnum {
+                name: "Scope".to_string(),
+                values: vec!["CLOUDFRONT".to_string(), "REGIONAL".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("Scope", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("CLOUDFRONT".to_string(), "cloudfront".to_string()), ("REGIONAL".to_string(), "regional".to_string())],
+            })
+                .required()
+                .create_only()
+                .with_provider_name("Scope"),
+        )
+        .attribute(
+            AttributeSchema::new("tags", tags_type())
+                .with_provider_name("Tags"),
+        )
+        .attribute(
+            AttributeSchema::new("token_domains", AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[\\w\\.\\-/]+$".to_string()),
+                length: Some((Some(1), Some(253))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_7dc332c889f363a0_len_1_253),
+                to_dsl: None,
+            }))
+                .with_provider_name("TokenDomains"),
+        )
+        .attribute(
+            AttributeSchema::new("visibility_config", AttributeType::Ref("VisibilityConfig".to_string()))
+                .required()
+                .with_provider_name("VisibilityConfig"),
+        )
+        .with_validator(|attrs| {
+            let mut errors = Vec::new();
+            if let Err(mut e) = validate_tags_map(attrs) {
+                errors.append(&mut e);
+            }
+            if errors.is_empty() { Ok(()) } else { Err(errors) }
+        })
+        .with_def("AWSManagedRulesACFPRuleSet", AttributeType::Struct {
+                    name: "AWSManagedRulesACFPRuleSet".to_string(),
+                    fields: vec![
+                    StructField::new("creation_path", AttributeType::String).required().with_provider_name("CreationPath"),
+                    StructField::new("enable_regex_in_path", AttributeType::Bool).with_provider_name("EnableRegexInPath"),
+                    StructField::new("registration_page_path", AttributeType::String).required().with_provider_name("RegistrationPagePath"),
+                    StructField::new("request_inspection", AttributeType::Struct {
+                    name: "RequestInspectionACFP".to_string(),
+                    fields: vec![
+                    StructField::new("address_fields", AttributeType::list(AttributeType::String)).with_provider_name("AddressFields"),
+                    StructField::new("email_field", AttributeType::Struct {
+                    name: "FieldIdentifier".to_string(),
+                    fields: vec![
+                    StructField::new("identifier", AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(512))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_512),
+                to_dsl: None,
+            }).required().with_provider_name("Identifier")
+                    ],
+                }).with_provider_name("EmailField"),
+                    StructField::new("password_field", AttributeType::Ref("FieldIdentifier".to_string())).with_provider_name("PasswordField"),
+                    StructField::new("payload_type", AttributeType::StringEnum {
+                name: "PayloadType".to_string(),
+                values: vec!["JSON".to_string(), "FORM_ENCODED".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("PayloadType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("JSON".to_string(), "json".to_string()), ("FORM_ENCODED".to_string(), "form_encoded".to_string())],
+            }).required().with_provider_name("PayloadType"),
+                    StructField::new("phone_number_fields", AttributeType::list(AttributeType::String)).with_provider_name("PhoneNumberFields"),
+                    StructField::new("username_field", AttributeType::Ref("FieldIdentifier".to_string())).with_provider_name("UsernameField")
+                    ],
+                }).required().with_provider_name("RequestInspection"),
+                    StructField::new("response_inspection", AttributeType::Struct {
+                    name: "ResponseInspection".to_string(),
+                    fields: vec![
+                    StructField::new("body_contains", AttributeType::Struct {
+                    name: "ResponseInspectionBodyContains".to_string(),
+                    fields: vec![
+                    StructField::new("failure_strings", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(100))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_100),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_5),
+                to_dsl: None,
+            }).required().with_provider_name("FailureStrings"),
+                    StructField::new("success_strings", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(100))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_100),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_5),
+                to_dsl: None,
+            }).required().with_provider_name("SuccessStrings")
+                    ],
+                }).with_provider_name("BodyContains"),
+                    StructField::new("header", AttributeType::Struct {
+                    name: "ResponseInspectionHeader".to_string(),
+                    fields: vec![
+                    StructField::new("failure_values", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(100))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_100),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_3),
+                to_dsl: None,
+            }).required().with_provider_name("FailureValues"),
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(200))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_200),
+                to_dsl: None,
+            }).required().with_provider_name("Name"),
+                    StructField::new("success_values", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(100))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_100),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_3),
+                to_dsl: None,
+            }).required().with_provider_name("SuccessValues")
+                    ],
+                }).with_provider_name("Header"),
+                    StructField::new("json", AttributeType::Struct {
+                    name: "ResponseInspectionJson".to_string(),
+                    fields: vec![
+                    StructField::new("failure_values", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(100))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_100),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_5),
+                to_dsl: None,
+            }).required().with_provider_name("FailureValues"),
+                    StructField::new("identifier", AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(512))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_512),
+                to_dsl: None,
+            }).required().with_provider_name("Identifier"),
+                    StructField::new("success_values", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(100))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_100),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_5),
+                to_dsl: None,
+            }).required().with_provider_name("SuccessValues")
+                    ],
+                }).with_provider_name("Json"),
+                    StructField::new("status_code", AttributeType::Struct {
+                    name: "ResponseInspectionStatusCode".to_string(),
+                    fields: vec![
+                    StructField::new("failure_codes", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Int)),
+                validate: legacy_validator(validate_list_items_1_10),
+                to_dsl: None,
+            }).required().with_provider_name("FailureCodes"),
+                    StructField::new("success_codes", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Int)),
+                validate: legacy_validator(validate_list_items_1_10),
+                to_dsl: None,
+            }).required().with_provider_name("SuccessCodes")
+                    ],
+                }).with_provider_name("StatusCode")
+                    ],
+                }).with_provider_name("ResponseInspection")
+                    ],
+                })
+        .with_def("AWSManagedRulesATPRuleSet", AttributeType::Struct {
+                    name: "AWSManagedRulesATPRuleSet".to_string(),
+                    fields: vec![
+                    StructField::new("enable_regex_in_path", AttributeType::Bool).with_provider_name("EnableRegexInPath"),
+                    StructField::new("login_path", AttributeType::String).required().with_provider_name("LoginPath"),
+                    StructField::new("request_inspection", AttributeType::Struct {
+                    name: "RequestInspection".to_string(),
+                    fields: vec![
+                    StructField::new("password_field", AttributeType::Ref("FieldIdentifier".to_string())).required().with_provider_name("PasswordField"),
+                    StructField::new("payload_type", AttributeType::StringEnum {
+                name: "PayloadType".to_string(),
+                values: vec!["JSON".to_string(), "FORM_ENCODED".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("PayloadType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("JSON".to_string(), "json".to_string()), ("FORM_ENCODED".to_string(), "form_encoded".to_string())],
+            }).required().with_provider_name("PayloadType"),
+                    StructField::new("username_field", AttributeType::Ref("FieldIdentifier".to_string())).required().with_provider_name("UsernameField")
+                    ],
+                }).with_provider_name("RequestInspection"),
+                    StructField::new("response_inspection", AttributeType::Ref("ResponseInspection".to_string())).with_provider_name("ResponseInspection")
+                    ],
+                })
+        .with_def("AWSManagedRulesAntiDDoSRuleSet", AttributeType::Struct {
+                    name: "AWSManagedRulesAntiDDoSRuleSet".to_string(),
+                    fields: vec![
+                    StructField::new("client_side_action_config", AttributeType::Struct {
+                    name: "ClientSideActionConfig".to_string(),
+                    fields: vec![
+                    StructField::new("challenge", AttributeType::Struct {
+                    name: "ClientSideAction".to_string(),
+                    fields: vec![
+                    StructField::new("exempt_uri_regular_expressions", AttributeType::list(AttributeType::Struct {
+                    name: "Regex".to_string(),
+                    fields: vec![
+                    StructField::new("regex_string", AttributeType::String).with_provider_name("RegexString")
+                    ],
+                })).with_provider_name("ExemptUriRegularExpressions").with_block_name("exempt_uri_regular_expression"),
+                    StructField::new("sensitivity", AttributeType::StringEnum {
+                name: "SensitivityToAct".to_string(),
+                values: vec!["LOW".to_string(), "MEDIUM".to_string(), "HIGH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("SensitivityToAct", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("LOW".to_string(), "low".to_string()), ("MEDIUM".to_string(), "medium".to_string()), ("HIGH".to_string(), "high".to_string())],
+            }).with_provider_name("Sensitivity"),
+                    StructField::new("usage_of_action", AttributeType::StringEnum {
+                name: "UsageOfAction".to_string(),
+                values: vec!["ENABLED".to_string(), "DISABLED".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("UsageOfAction", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("ENABLED".to_string(), "enabled".to_string()), ("DISABLED".to_string(), "disabled".to_string())],
+            }).required().with_provider_name("UsageOfAction")
+                    ],
+                }).required().with_provider_name("Challenge").with_block_name("challenge")
+                    ],
+                }).required().with_provider_name("ClientSideActionConfig").with_block_name("client_side_action_config"),
+                    StructField::new("sensitivity_to_block", AttributeType::StringEnum {
+                name: "SensitivityToAct".to_string(),
+                values: vec!["LOW".to_string(), "MEDIUM".to_string(), "HIGH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("SensitivityToAct", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("LOW".to_string(), "low".to_string()), ("MEDIUM".to_string(), "medium".to_string()), ("HIGH".to_string(), "high".to_string())],
+            }).with_provider_name("SensitivityToBlock")
+                    ],
+                })
+        .with_def("AWSManagedRulesBotControlRuleSet", AttributeType::Struct {
+                    name: "AWSManagedRulesBotControlRuleSet".to_string(),
+                    fields: vec![
+                    StructField::new("enable_machine_learning", AttributeType::Bool).with_provider_name("EnableMachineLearning"),
+                    StructField::new("inspection_level", AttributeType::StringEnum {
+                name: "InspectionLevel".to_string(),
+                values: vec!["COMMON".to_string(), "TARGETED".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("InspectionLevel", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("COMMON".to_string(), "common".to_string()), ("TARGETED".to_string(), "targeted".to_string())],
+            }).required().with_provider_name("InspectionLevel")
+                    ],
+                })
+        .with_def("AllowAction", AttributeType::Struct {
+                    name: "AllowAction".to_string(),
+                    fields: vec![
+                    StructField::new("custom_request_handling", AttributeType::Struct {
+                    name: "CustomRequestHandling".to_string(),
+                    fields: vec![
+                    StructField::new("insert_headers", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Struct {
+                    name: "CustomHTTPHeader".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::String).required().with_provider_name("Name"),
+                    StructField::new("value", AttributeType::String).required().with_provider_name("Value")
+                    ],
+                })),
+                validate: legacy_validator(validate_list_items_min_1),
+                to_dsl: None,
+            }).required().with_description("Collection of HTTP headers.").with_provider_name("InsertHeaders").with_block_name("insert_header")
+                    ],
+                }).with_provider_name("CustomRequestHandling").with_block_name("custom_request_handling")
+                    ],
+                })
+        .with_def("AndStatement", AttributeType::Struct {
+                    name: "AndStatement".to_string(),
+                    fields: vec![
+                    StructField::new("statements", AttributeType::list(AttributeType::Struct {
+                    name: "Statement".to_string(),
+                    fields: vec![
+                    StructField::new("and_statement", AttributeType::Ref("AndStatement".to_string())).with_provider_name("AndStatement"),
+                    StructField::new("asn_match_statement", AttributeType::Struct {
+                    name: "AsnMatchStatement".to_string(),
+                    fields: vec![
+                    StructField::new("asn_list", AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::Int),
+                validate: legacy_validator(validate_asn_list_range),
+                to_dsl: None,
+            })).with_provider_name("AsnList"),
+                    StructField::new("forwarded_ip_config", AttributeType::Struct {
+                    name: "ForwardedIPConfiguration".to_string(),
+                    fields: vec![
+                    StructField::new("fallback_behavior", AttributeType::StringEnum {
+                name: "FallbackBehavior".to_string(),
+                values: vec!["MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("FallbackBehavior", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).required().with_provider_name("FallbackBehavior"),
+                    StructField::new("header_name", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[a-zA-Z0-9-]+{1,255}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_2d93cc844f6d4014),
+                to_dsl: None,
+            }).required().with_provider_name("HeaderName")
+                    ],
+                }).with_provider_name("ForwardedIPConfig")
+                    ],
+                }).with_provider_name("AsnMatchStatement"),
+                    StructField::new("byte_match_statement", AttributeType::Struct {
+                    name: "ByteMatchStatement".to_string(),
+                    fields: vec![
+                    StructField::new("field_to_match", AttributeType::Struct {
+                    name: "FieldToMatch".to_string(),
+                    fields: vec![
+                    StructField::new("all_query_arguments", AttributeType::map(AttributeType::String)).with_description("All query arguments of a web request.").with_provider_name("AllQueryArguments"),
+                    StructField::new("body", AttributeType::Struct {
+                    name: "Body".to_string(),
+                    fields: vec![
+                    StructField::new("oversize_handling", AttributeType::StringEnum {
+                name: "OversizeHandling".to_string(),
+                values: vec!["CONTINUE".to_string(), "MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("OversizeHandling", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("CONTINUE".to_string(), "continue".to_string()), ("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).with_provider_name("OversizeHandling")
+                    ],
+                }).with_provider_name("Body"),
+                    StructField::new("cookies", AttributeType::Struct {
+                    name: "Cookies".to_string(),
+                    fields: vec![
+                    StructField::new("match_pattern", AttributeType::Struct {
+                    name: "CookieMatchPattern".to_string(),
+                    fields: vec![
+                    StructField::new("all", AttributeType::map(AttributeType::String)).with_description("Inspect all parts of the web request cookies.").with_provider_name("All"),
+                    StructField::new("excluded_cookies", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(60))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_60),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_199),
+                to_dsl: None,
+            }).with_provider_name("ExcludedCookies"),
+                    StructField::new("included_cookies", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(60))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_60),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_199),
+                to_dsl: None,
+            }).with_provider_name("IncludedCookies")
+                    ],
+                }).required().with_provider_name("MatchPattern"),
+                    StructField::new("match_scope", AttributeType::StringEnum {
+                name: "MapMatchScope".to_string(),
+                values: vec!["ALL".to_string(), "KEY".to_string(), "VALUE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("MapMatchScope", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("ALL".to_string(), "all".to_string()), ("KEY".to_string(), "key".to_string()), ("VALUE".to_string(), "value".to_string())],
+            }).required().with_provider_name("MatchScope"),
+                    StructField::new("oversize_handling", AttributeType::StringEnum {
+                name: "OversizeHandling".to_string(),
+                values: vec!["CONTINUE".to_string(), "MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("OversizeHandling", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("CONTINUE".to_string(), "continue".to_string()), ("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).required().with_provider_name("OversizeHandling")
+                    ],
+                }).with_provider_name("Cookies"),
+                    StructField::new("header_order", AttributeType::Struct {
+                    name: "HeaderOrder".to_string(),
+                    fields: vec![
+                    StructField::new("oversize_handling", AttributeType::StringEnum {
+                name: "OversizeHandling".to_string(),
+                values: vec!["CONTINUE".to_string(), "MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("OversizeHandling", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("CONTINUE".to_string(), "continue".to_string()), ("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).required().with_provider_name("OversizeHandling")
+                    ],
+                }).with_provider_name("HeaderOrder"),
+                    StructField::new("headers", AttributeType::Struct {
+                    name: "Headers".to_string(),
+                    fields: vec![
+                    StructField::new("match_pattern", AttributeType::Struct {
+                    name: "HeaderMatchPattern".to_string(),
+                    fields: vec![
+                    StructField::new("all", AttributeType::map(AttributeType::String)).with_description("Inspect all parts of the web request headers.").with_provider_name("All"),
+                    StructField::new("excluded_headers", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(64))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_64),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_199),
+                to_dsl: None,
+            }).with_provider_name("ExcludedHeaders"),
+                    StructField::new("included_headers", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(64))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_64),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_199),
+                to_dsl: None,
+            }).with_provider_name("IncludedHeaders")
+                    ],
+                }).required().with_provider_name("MatchPattern"),
+                    StructField::new("match_scope", AttributeType::StringEnum {
+                name: "MapMatchScope".to_string(),
+                values: vec!["ALL".to_string(), "KEY".to_string(), "VALUE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("MapMatchScope", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("ALL".to_string(), "all".to_string()), ("KEY".to_string(), "key".to_string()), ("VALUE".to_string(), "value".to_string())],
+            }).required().with_provider_name("MatchScope"),
+                    StructField::new("oversize_handling", AttributeType::StringEnum {
+                name: "OversizeHandling".to_string(),
+                values: vec!["CONTINUE".to_string(), "MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("OversizeHandling", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("CONTINUE".to_string(), "continue".to_string()), ("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).required().with_provider_name("OversizeHandling")
+                    ],
+                }).with_provider_name("Headers"),
+                    StructField::new("ja3_fingerprint", AttributeType::Struct {
+                    name: "JA3Fingerprint".to_string(),
+                    fields: vec![
+                    StructField::new("fallback_behavior", AttributeType::StringEnum {
+                name: "FallbackBehavior".to_string(),
+                values: vec!["MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("FallbackBehavior", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).required().with_provider_name("FallbackBehavior")
+                    ],
+                }).with_provider_name("JA3Fingerprint"),
+                    StructField::new("ja4_fingerprint", AttributeType::Struct {
+                    name: "JA4Fingerprint".to_string(),
+                    fields: vec![
+                    StructField::new("fallback_behavior", AttributeType::StringEnum {
+                name: "FallbackBehavior".to_string(),
+                values: vec!["MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("FallbackBehavior", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).required().with_provider_name("FallbackBehavior")
+                    ],
+                }).with_provider_name("JA4Fingerprint"),
+                    StructField::new("json_body", AttributeType::Struct {
+                    name: "JsonBody".to_string(),
+                    fields: vec![
+                    StructField::new("invalid_fallback_behavior", AttributeType::StringEnum {
+                name: "BodyParsingFallbackBehavior".to_string(),
+                values: vec!["MATCH".to_string(), "NO_MATCH".to_string(), "EVALUATE_AS_STRING".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("BodyParsingFallbackBehavior", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string()), ("EVALUATE_AS_STRING".to_string(), "evaluate_as_string".to_string())],
+            }).with_provider_name("InvalidFallbackBehavior"),
+                    StructField::new("match_pattern", AttributeType::Struct {
+                    name: "JsonMatchPattern".to_string(),
+                    fields: vec![
+                    StructField::new("all", AttributeType::map(AttributeType::String)).with_description("Inspect all parts of the web request's JSON body.").with_provider_name("All"),
+                    StructField::new("included_paths", AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[\\/]+([^~]*(~[01])*)*{1,512}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_c77cf75cf1a75ade),
+                to_dsl: None,
+            })).with_provider_name("IncludedPaths")
+                    ],
+                }).required().with_provider_name("MatchPattern"),
+                    StructField::new("match_scope", AttributeType::StringEnum {
+                name: "JsonMatchScope".to_string(),
+                values: vec!["ALL".to_string(), "KEY".to_string(), "VALUE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("JsonMatchScope", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("ALL".to_string(), "all".to_string()), ("KEY".to_string(), "key".to_string()), ("VALUE".to_string(), "value".to_string())],
+            }).required().with_provider_name("MatchScope"),
+                    StructField::new("oversize_handling", AttributeType::StringEnum {
+                name: "OversizeHandling".to_string(),
+                values: vec!["CONTINUE".to_string(), "MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("OversizeHandling", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("CONTINUE".to_string(), "continue".to_string()), ("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).with_provider_name("OversizeHandling")
+                    ],
+                }).with_provider_name("JsonBody"),
+                    StructField::new("method", AttributeType::map(AttributeType::String)).with_description("The HTTP method of a web request. The method indicates the type of operation that the request is asking the origin to perform.").with_provider_name("Method"),
+                    StructField::new("query_string", AttributeType::map(AttributeType::String)).with_description("The query string of a web request. This is the part of a URL that appears after a ? character, if any.").with_provider_name("QueryString"),
+                    StructField::new("single_header", AttributeType::Struct {
+                    name: "SingleHeader".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::String).required().with_provider_name("Name")
+                    ],
+                }).with_provider_name("SingleHeader"),
+                    StructField::new("single_query_argument", AttributeType::Struct {
+                    name: "SingleQueryArgument".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::String).required().with_provider_name("Name")
+                    ],
+                }).with_description("One query argument in a web request, identified by name, for example UserName or SalesRegion. The name can be up to 30 characters long and isn't case sensitive.").with_provider_name("SingleQueryArgument"),
+                    StructField::new("uri_fragment", AttributeType::Struct {
+                    name: "UriFragment".to_string(),
+                    fields: vec![
+                    StructField::new("fallback_behavior", AttributeType::StringEnum {
+                name: "FallbackBehavior".to_string(),
+                values: vec!["MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("FallbackBehavior", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).with_provider_name("FallbackBehavior")
+                    ],
+                }).with_provider_name("UriFragment"),
+                    StructField::new("uri_path", AttributeType::map(AttributeType::String)).with_description("The path component of the URI of a web request. This is the part of a web request that identifies a resource, for example, /images/daily-ad.jpg.").with_provider_name("UriPath")
+                    ],
+                }).required().with_provider_name("FieldToMatch"),
+                    StructField::new("positional_constraint", AttributeType::StringEnum {
+                name: "PositionalConstraint".to_string(),
+                values: vec!["EXACTLY".to_string(), "STARTS_WITH".to_string(), "ENDS_WITH".to_string(), "CONTAINS".to_string(), "CONTAINS_WORD".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("PositionalConstraint", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("EXACTLY".to_string(), "exactly".to_string()), ("STARTS_WITH".to_string(), "starts_with".to_string()), ("ENDS_WITH".to_string(), "ends_with".to_string()), ("CONTAINS".to_string(), "contains".to_string()), ("CONTAINS_WORD".to_string(), "contains_word".to_string())],
+            }).required().with_provider_name("PositionalConstraint"),
+                    StructField::new("search_string", AttributeType::String).with_provider_name("SearchString"),
+                    StructField::new("search_string_base64", AttributeType::String).with_provider_name("SearchStringBase64"),
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                }).with_provider_name("ByteMatchStatement").with_block_name("byte_match_statement"),
+                    StructField::new("geo_match_statement", AttributeType::Struct {
+                    name: "GeoMatchStatement".to_string(),
+                    fields: vec![
+                    StructField::new("country_codes", AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: Some((Some(1), Some(2))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_length_1_2),
+                to_dsl: None,
+            })).with_provider_name("CountryCodes"),
+                    StructField::new("forwarded_ip_config", AttributeType::Ref("ForwardedIPConfiguration".to_string())).with_provider_name("ForwardedIPConfig")
+                    ],
+                }).with_provider_name("GeoMatchStatement"),
+                    StructField::new("ip_set_reference_statement", AttributeType::Struct {
+                    name: "IPSetReferenceStatement".to_string(),
+                    fields: vec![
+                    StructField::new("arn", super::arn()).required().with_provider_name("Arn"),
+                    StructField::new("ip_set_forwarded_ip_config", AttributeType::Struct {
+                    name: "IPSetForwardedIPConfiguration".to_string(),
+                    fields: vec![
+                    StructField::new("fallback_behavior", AttributeType::StringEnum {
+                name: "FallbackBehavior".to_string(),
+                values: vec!["MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("FallbackBehavior", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).required().with_provider_name("FallbackBehavior"),
+                    StructField::new("header_name", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[a-zA-Z0-9-]+{1,255}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_2d93cc844f6d4014),
+                to_dsl: None,
+            }).required().with_provider_name("HeaderName"),
+                    StructField::new("position", AttributeType::StringEnum {
+                name: "Position".to_string(),
+                values: vec!["FIRST".to_string(), "LAST".to_string(), "ANY".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("Position", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("FIRST".to_string(), "first".to_string()), ("LAST".to_string(), "last".to_string()), ("ANY".to_string(), "any".to_string())],
+            }).required().with_provider_name("Position")
+                    ],
+                }).with_provider_name("IPSetForwardedIPConfig")
+                    ],
+                }).with_provider_name("IPSetReferenceStatement"),
+                    StructField::new("label_match_statement", AttributeType::Struct {
+                    name: "LabelMatchStatement".to_string(),
+                    fields: vec![
+                    StructField::new("key", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[0-9A-Za-z_:-]{1,1024}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_b3fc65b549fb77bd),
+                to_dsl: None,
+            }).required().with_provider_name("Key"),
+                    StructField::new("scope", AttributeType::StringEnum {
+                name: "LabelMatchScope".to_string(),
+                values: vec!["LABEL".to_string(), "NAMESPACE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("LabelMatchScope", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("LABEL".to_string(), "label".to_string()), ("NAMESPACE".to_string(), "namespace".to_string())],
+            }).required().with_provider_name("Scope")
+                    ],
+                }).with_provider_name("LabelMatchStatement"),
+                    StructField::new("managed_rule_group_statement", AttributeType::Struct {
+                    name: "ManagedRuleGroupStatement".to_string(),
+                    fields: vec![
+                    StructField::new("excluded_rules", AttributeType::list(AttributeType::Struct {
+                    name: "ExcludedRule".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[0-9A-Za-z_-]{1,128}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_42f7eceb887966ad),
+                to_dsl: None,
+            }).required().with_provider_name("Name")
+                    ],
+                })).with_provider_name("ExcludedRules").with_block_name("excluded_rule"),
+                    StructField::new("managed_rule_group_configs", AttributeType::list(AttributeType::Struct {
+                    name: "ManagedRuleGroupConfig".to_string(),
+                    fields: vec![
+                    StructField::new("aws_managed_rules_acfp_rule_set", AttributeType::Struct {
+                    name: "AWSManagedRulesACFPRuleSet".to_string(),
+                    fields: vec![
+                    StructField::new("creation_path", AttributeType::String).required().with_provider_name("CreationPath"),
+                    StructField::new("enable_regex_in_path", AttributeType::Bool).with_provider_name("EnableRegexInPath"),
+                    StructField::new("registration_page_path", AttributeType::String).required().with_provider_name("RegistrationPagePath"),
+                    StructField::new("request_inspection", AttributeType::Struct {
+                    name: "RequestInspectionACFP".to_string(),
+                    fields: vec![
+                    StructField::new("address_fields", AttributeType::list(AttributeType::String)).with_provider_name("AddressFields"),
+                    StructField::new("email_field", AttributeType::Struct {
+                    name: "FieldIdentifier".to_string(),
+                    fields: vec![
+                    StructField::new("identifier", AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(512))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_512),
+                to_dsl: None,
+            }).required().with_provider_name("Identifier")
+                    ],
+                }).with_provider_name("EmailField"),
+                    StructField::new("password_field", AttributeType::Ref("FieldIdentifier".to_string())).with_provider_name("PasswordField"),
+                    StructField::new("payload_type", AttributeType::StringEnum {
+                name: "PayloadType".to_string(),
+                values: vec!["JSON".to_string(), "FORM_ENCODED".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("PayloadType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("JSON".to_string(), "json".to_string()), ("FORM_ENCODED".to_string(), "form_encoded".to_string())],
+            }).required().with_provider_name("PayloadType"),
+                    StructField::new("phone_number_fields", AttributeType::list(AttributeType::String)).with_provider_name("PhoneNumberFields"),
+                    StructField::new("username_field", AttributeType::Ref("FieldIdentifier".to_string())).with_provider_name("UsernameField")
+                    ],
+                }).required().with_provider_name("RequestInspection"),
+                    StructField::new("response_inspection", AttributeType::Struct {
+                    name: "ResponseInspection".to_string(),
+                    fields: vec![
+                    StructField::new("body_contains", AttributeType::Struct {
+                    name: "ResponseInspectionBodyContains".to_string(),
+                    fields: vec![
+                    StructField::new("failure_strings", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(100))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_100),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_5),
+                to_dsl: None,
+            }).required().with_provider_name("FailureStrings"),
+                    StructField::new("success_strings", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(100))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_100),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_5),
+                to_dsl: None,
+            }).required().with_provider_name("SuccessStrings")
+                    ],
+                }).with_provider_name("BodyContains"),
+                    StructField::new("header", AttributeType::Struct {
+                    name: "ResponseInspectionHeader".to_string(),
+                    fields: vec![
+                    StructField::new("failure_values", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(100))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_100),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_3),
+                to_dsl: None,
+            }).required().with_provider_name("FailureValues"),
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(200))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_200),
+                to_dsl: None,
+            }).required().with_provider_name("Name"),
+                    StructField::new("success_values", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(100))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_100),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_3),
+                to_dsl: None,
+            }).required().with_provider_name("SuccessValues")
+                    ],
+                }).with_provider_name("Header"),
+                    StructField::new("json", AttributeType::Struct {
+                    name: "ResponseInspectionJson".to_string(),
+                    fields: vec![
+                    StructField::new("failure_values", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(100))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_100),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_5),
+                to_dsl: None,
+            }).required().with_provider_name("FailureValues"),
+                    StructField::new("identifier", AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(512))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_512),
+                to_dsl: None,
+            }).required().with_provider_name("Identifier"),
+                    StructField::new("success_values", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(100))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_100),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_5),
+                to_dsl: None,
+            }).required().with_provider_name("SuccessValues")
+                    ],
+                }).with_provider_name("Json"),
+                    StructField::new("status_code", AttributeType::Struct {
+                    name: "ResponseInspectionStatusCode".to_string(),
+                    fields: vec![
+                    StructField::new("failure_codes", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Int)),
+                validate: legacy_validator(validate_list_items_1_10),
+                to_dsl: None,
+            }).required().with_provider_name("FailureCodes"),
+                    StructField::new("success_codes", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Int)),
+                validate: legacy_validator(validate_list_items_1_10),
+                to_dsl: None,
+            }).required().with_provider_name("SuccessCodes")
+                    ],
+                }).with_provider_name("StatusCode")
+                    ],
+                }).with_provider_name("ResponseInspection")
+                    ],
+                }).with_provider_name("AWSManagedRulesACFPRuleSet"),
+                    StructField::new("aws_managed_rules_atp_rule_set", AttributeType::Struct {
+                    name: "AWSManagedRulesATPRuleSet".to_string(),
+                    fields: vec![
+                    StructField::new("enable_regex_in_path", AttributeType::Bool).with_provider_name("EnableRegexInPath"),
+                    StructField::new("login_path", AttributeType::String).required().with_provider_name("LoginPath"),
+                    StructField::new("request_inspection", AttributeType::Struct {
+                    name: "RequestInspection".to_string(),
+                    fields: vec![
+                    StructField::new("password_field", AttributeType::Ref("FieldIdentifier".to_string())).required().with_provider_name("PasswordField"),
+                    StructField::new("payload_type", AttributeType::StringEnum {
+                name: "PayloadType".to_string(),
+                values: vec!["JSON".to_string(), "FORM_ENCODED".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("PayloadType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("JSON".to_string(), "json".to_string()), ("FORM_ENCODED".to_string(), "form_encoded".to_string())],
+            }).required().with_provider_name("PayloadType"),
+                    StructField::new("username_field", AttributeType::Ref("FieldIdentifier".to_string())).required().with_provider_name("UsernameField")
+                    ],
+                }).with_provider_name("RequestInspection"),
+                    StructField::new("response_inspection", AttributeType::Ref("ResponseInspection".to_string())).with_provider_name("ResponseInspection")
+                    ],
+                }).with_provider_name("AWSManagedRulesATPRuleSet"),
+                    StructField::new("aws_managed_rules_anti_d_do_s_rule_set", AttributeType::Struct {
+                    name: "AWSManagedRulesAntiDDoSRuleSet".to_string(),
+                    fields: vec![
+                    StructField::new("client_side_action_config", AttributeType::Struct {
+                    name: "ClientSideActionConfig".to_string(),
+                    fields: vec![
+                    StructField::new("challenge", AttributeType::Struct {
+                    name: "ClientSideAction".to_string(),
+                    fields: vec![
+                    StructField::new("exempt_uri_regular_expressions", AttributeType::list(AttributeType::Struct {
+                    name: "Regex".to_string(),
+                    fields: vec![
+                    StructField::new("regex_string", AttributeType::String).with_provider_name("RegexString")
+                    ],
+                })).with_provider_name("ExemptUriRegularExpressions").with_block_name("exempt_uri_regular_expression"),
+                    StructField::new("sensitivity", AttributeType::StringEnum {
+                name: "SensitivityToAct".to_string(),
+                values: vec!["LOW".to_string(), "MEDIUM".to_string(), "HIGH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("SensitivityToAct", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("LOW".to_string(), "low".to_string()), ("MEDIUM".to_string(), "medium".to_string()), ("HIGH".to_string(), "high".to_string())],
+            }).with_provider_name("Sensitivity"),
+                    StructField::new("usage_of_action", AttributeType::StringEnum {
+                name: "UsageOfAction".to_string(),
+                values: vec!["ENABLED".to_string(), "DISABLED".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("UsageOfAction", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("ENABLED".to_string(), "enabled".to_string()), ("DISABLED".to_string(), "disabled".to_string())],
+            }).required().with_provider_name("UsageOfAction")
+                    ],
+                }).required().with_provider_name("Challenge").with_block_name("challenge")
+                    ],
+                }).required().with_provider_name("ClientSideActionConfig").with_block_name("client_side_action_config"),
+                    StructField::new("sensitivity_to_block", AttributeType::StringEnum {
+                name: "SensitivityToAct".to_string(),
+                values: vec!["LOW".to_string(), "MEDIUM".to_string(), "HIGH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("SensitivityToAct", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("LOW".to_string(), "low".to_string()), ("MEDIUM".to_string(), "medium".to_string()), ("HIGH".to_string(), "high".to_string())],
+            }).with_provider_name("SensitivityToBlock")
+                    ],
+                }).with_provider_name("AWSManagedRulesAntiDDoSRuleSet").with_block_name("aws_managed_rules_anti_d_do_s_rule_set"),
+                    StructField::new("aws_managed_rules_bot_control_rule_set", AttributeType::Struct {
+                    name: "AWSManagedRulesBotControlRuleSet".to_string(),
+                    fields: vec![
+                    StructField::new("enable_machine_learning", AttributeType::Bool).with_provider_name("EnableMachineLearning"),
+                    StructField::new("inspection_level", AttributeType::StringEnum {
+                name: "InspectionLevel".to_string(),
+                values: vec!["COMMON".to_string(), "TARGETED".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("InspectionLevel", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("COMMON".to_string(), "common".to_string()), ("TARGETED".to_string(), "targeted".to_string())],
+            }).required().with_provider_name("InspectionLevel")
+                    ],
+                }).with_provider_name("AWSManagedRulesBotControlRuleSet"),
+                    StructField::new("login_path", AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(256))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_256),
+                to_dsl: None,
+            }).with_provider_name("LoginPath"),
+                    StructField::new("password_field", AttributeType::Ref("FieldIdentifier".to_string())).with_provider_name("PasswordField"),
+                    StructField::new("payload_type", AttributeType::StringEnum {
+                name: "PayloadType".to_string(),
+                values: vec!["JSON".to_string(), "FORM_ENCODED".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("PayloadType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("JSON".to_string(), "json".to_string()), ("FORM_ENCODED".to_string(), "form_encoded".to_string())],
+            }).with_provider_name("PayloadType"),
+                    StructField::new("username_field", AttributeType::Ref("FieldIdentifier".to_string())).with_provider_name("UsernameField")
+                    ],
+                })).with_description("Collection of ManagedRuleGroupConfig.").with_provider_name("ManagedRuleGroupConfigs").with_block_name("managed_rule_group_config"),
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[0-9A-Za-z_-]{1,128}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_42f7eceb887966ad),
+                to_dsl: None,
+            }).required().with_provider_name("Name"),
+                    StructField::new("rule_action_overrides", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Struct {
+                    name: "RuleActionOverride".to_string(),
+                    fields: vec![
+                    StructField::new("action_to_use", AttributeType::Ref("RuleAction".to_string())).required().with_provider_name("ActionToUse"),
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[0-9A-Za-z_-]{1,128}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_42f7eceb887966ad),
+                to_dsl: None,
+            }).required().with_provider_name("Name")
+                    ],
+                })),
+                validate: legacy_validator(validate_list_items_max_100),
+                to_dsl: None,
+            }).with_description("Action overrides for rules in the rule group.").with_provider_name("RuleActionOverrides").with_block_name("rule_action_override"),
+                    StructField::new("scope_down_statement", AttributeType::Ref("Statement".to_string())).with_provider_name("ScopeDownStatement"),
+                    StructField::new("vendor_name", AttributeType::String).required().with_provider_name("VendorName"),
+                    StructField::new("version", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[\\w#:\\.\\-/]+$".to_string()),
+                length: Some((Some(1), Some(64))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_82a037d29be8d222_len_1_64),
+                to_dsl: None,
+            }).with_provider_name("Version")
+                    ],
+                }).with_provider_name("ManagedRuleGroupStatement").with_block_name("managed_rule_group_statement"),
+                    StructField::new("not_statement", AttributeType::Struct {
+                    name: "NotStatement".to_string(),
+                    fields: vec![
+                    StructField::new("statement", AttributeType::Ref("Statement".to_string())).required().with_provider_name("Statement")
+                    ],
+                }).with_provider_name("NotStatement"),
+                    StructField::new("or_statement", AttributeType::Struct {
+                    name: "OrStatement".to_string(),
+                    fields: vec![
+                    StructField::new("statements", AttributeType::list(AttributeType::Struct {
+                    name: "Statement".to_string(),
+                    fields: vec![
+                    StructField::new("and_statement", AttributeType::Ref("AndStatement".to_string())).with_provider_name("AndStatement"),
+                    StructField::new("asn_match_statement", AttributeType::Ref("AsnMatchStatement".to_string())).with_provider_name("AsnMatchStatement"),
+                    StructField::new("byte_match_statement", AttributeType::Ref("ByteMatchStatement".to_string())).with_provider_name("ByteMatchStatement"),
+                    StructField::new("geo_match_statement", AttributeType::Ref("GeoMatchStatement".to_string())).with_provider_name("GeoMatchStatement"),
+                    StructField::new("ip_set_reference_statement", AttributeType::Ref("IPSetReferenceStatement".to_string())).with_provider_name("IPSetReferenceStatement"),
+                    StructField::new("label_match_statement", AttributeType::Ref("LabelMatchStatement".to_string())).with_provider_name("LabelMatchStatement"),
+                    StructField::new("managed_rule_group_statement", AttributeType::Ref("ManagedRuleGroupStatement".to_string())).with_provider_name("ManagedRuleGroupStatement"),
+                    StructField::new("not_statement", AttributeType::Ref("NotStatement".to_string())).with_provider_name("NotStatement"),
+                    StructField::new("or_statement", AttributeType::Ref("OrStatement".to_string())).with_provider_name("OrStatement"),
+                    StructField::new("rate_based_statement", AttributeType::Struct {
+                    name: "RateBasedStatement".to_string(),
+                    fields: vec![
+                    StructField::new("aggregate_key_type", AttributeType::StringEnum {
+                name: "AggregateKeyType".to_string(),
+                values: vec!["CONSTANT".to_string(), "IP".to_string(), "FORWARDED_IP".to_string(), "CUSTOM_KEYS".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("AggregateKeyType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("CONSTANT".to_string(), "constant".to_string()), ("IP".to_string(), "ip".to_string()), ("FORWARDED_IP".to_string(), "forwarded_ip".to_string()), ("CUSTOM_KEYS".to_string(), "custom_keys".to_string())],
+            }).required().with_provider_name("AggregateKeyType"),
+                    StructField::new("custom_keys", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Struct {
+                    name: "RateBasedStatementCustomKey".to_string(),
+                    fields: vec![
+                    StructField::new("asn", AttributeType::String).with_provider_name("ASN"),
+                    StructField::new("cookie", AttributeType::Struct {
+                    name: "RateLimitCookie".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(64))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_64),
+                to_dsl: None,
+            }).required().with_description("The name of the cookie to use.").with_provider_name("Name"),
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                }).with_provider_name("Cookie").with_block_name("cookie"),
+                    StructField::new("forwarded_ip", types::ipv4_address()).with_provider_name("ForwardedIP"),
+                    StructField::new("http_method", AttributeType::String).with_provider_name("HTTPMethod"),
+                    StructField::new("header", AttributeType::Struct {
+                    name: "RateLimitHeader".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(64))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_64),
+                to_dsl: None,
+            }).required().with_description("The name of the header to use.").with_provider_name("Name"),
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                }).with_provider_name("Header").with_block_name("header"),
+                    StructField::new("ip", types::ipv4_address()).with_provider_name("IP"),
+                    StructField::new("ja3_fingerprint", AttributeType::Struct {
+                    name: "RateLimitJA3Fingerprint".to_string(),
+                    fields: vec![
+                    StructField::new("fallback_behavior", AttributeType::StringEnum {
+                name: "FallbackBehavior".to_string(),
+                values: vec!["MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("FallbackBehavior", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).required().with_provider_name("FallbackBehavior")
+                    ],
+                }).with_provider_name("JA3Fingerprint"),
+                    StructField::new("ja4_fingerprint", AttributeType::Struct {
+                    name: "RateLimitJA4Fingerprint".to_string(),
+                    fields: vec![
+                    StructField::new("fallback_behavior", AttributeType::StringEnum {
+                name: "FallbackBehavior".to_string(),
+                values: vec!["MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("FallbackBehavior", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).required().with_provider_name("FallbackBehavior")
+                    ],
+                }).with_provider_name("JA4Fingerprint"),
+                    StructField::new("label_namespace", AttributeType::Struct {
+                    name: "RateLimitLabelNamespace".to_string(),
+                    fields: vec![
+                    StructField::new("namespace", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[0-9A-Za-z_:-]{1,1024}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_b3fc65b549fb77bd),
+                to_dsl: None,
+            }).required().with_description("The namespace to use for aggregation.").with_provider_name("Namespace")
+                    ],
+                }).with_provider_name("LabelNamespace"),
+                    StructField::new("query_argument", AttributeType::Struct {
+                    name: "RateLimitQueryArgument".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(64))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_64),
+                to_dsl: None,
+            }).required().with_description("The name of the query argument to use.").with_provider_name("Name"),
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                }).with_provider_name("QueryArgument").with_block_name("query_argument"),
+                    StructField::new("query_string", AttributeType::Struct {
+                    name: "RateLimitQueryString".to_string(),
+                    fields: vec![
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                }).with_provider_name("QueryString").with_block_name("query_string"),
+                    StructField::new("uri_path", AttributeType::Struct {
+                    name: "RateLimitUriPath".to_string(),
+                    fields: vec![
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                }).with_provider_name("UriPath").with_block_name("uri_path")
+                    ],
+                })),
+                validate: legacy_validator(validate_list_items_max_5),
+                to_dsl: None,
+            }).with_description("Specifies the aggregate keys to use in a rate-base rule.").with_provider_name("CustomKeys").with_block_name("custom_key"),
+                    StructField::new("evaluation_window_sec", AttributeType::StringEnum {
+                name: "EvaluationWindowSec".to_string(),
+                values: vec!["60".to_string(), "120".to_string(), "300".to_string(), "600".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("EvaluationWindowSec", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("60".to_string(), "60".to_string()), ("120".to_string(), "120".to_string()), ("300".to_string(), "300".to_string()), ("600".to_string(), "600".to_string())],
+            }).with_provider_name("EvaluationWindowSec"),
+                    StructField::new("forwarded_ip_config", AttributeType::Ref("ForwardedIPConfiguration".to_string())).with_provider_name("ForwardedIPConfig"),
+                    StructField::new("limit", AttributeType::String).required().with_provider_name("Limit"),
+                    StructField::new("scope_down_statement", AttributeType::Ref("Statement".to_string())).with_provider_name("ScopeDownStatement")
+                    ],
+                }).with_provider_name("RateBasedStatement").with_block_name("rate_based_statement"),
+                    StructField::new("regex_match_statement", AttributeType::Struct {
+                    name: "RegexMatchStatement".to_string(),
+                    fields: vec![
+                    StructField::new("field_to_match", AttributeType::Ref("FieldToMatch".to_string())).required().with_provider_name("FieldToMatch"),
+                    StructField::new("regex_string", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: Some((Some(1), Some(512))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_length_1_512),
+                to_dsl: None,
+            }).required().with_provider_name("RegexString"),
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                }).with_provider_name("RegexMatchStatement").with_block_name("regex_match_statement"),
+                    StructField::new("regex_pattern_set_reference_statement", AttributeType::Struct {
+                    name: "RegexPatternSetReferenceStatement".to_string(),
+                    fields: vec![
+                    StructField::new("arn", super::arn()).required().with_provider_name("Arn"),
+                    StructField::new("field_to_match", AttributeType::Ref("FieldToMatch".to_string())).required().with_provider_name("FieldToMatch"),
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                }).with_provider_name("RegexPatternSetReferenceStatement").with_block_name("regex_pattern_set_reference_statement"),
+                    StructField::new("rule_group_reference_statement", AttributeType::Struct {
+                    name: "RuleGroupReferenceStatement".to_string(),
+                    fields: vec![
+                    StructField::new("arn", super::arn()).required().with_provider_name("Arn"),
+                    StructField::new("excluded_rules", AttributeType::list(AttributeType::Struct {
+                    name: "ExcludedRule".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[0-9A-Za-z_-]{1,128}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_42f7eceb887966ad),
+                to_dsl: None,
+            }).required().with_provider_name("Name")
+                    ],
+                })).with_provider_name("ExcludedRules").with_block_name("excluded_rule"),
+                    StructField::new("rule_action_overrides", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Struct {
+                    name: "RuleActionOverride".to_string(),
+                    fields: vec![
+                    StructField::new("action_to_use", AttributeType::Ref("RuleAction".to_string())).required().with_provider_name("ActionToUse"),
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[0-9A-Za-z_-]{1,128}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_42f7eceb887966ad),
+                to_dsl: None,
+            }).required().with_provider_name("Name")
+                    ],
+                })),
+                validate: legacy_validator(validate_list_items_max_100),
+                to_dsl: None,
+            }).with_description("Action overrides for rules in the rule group.").with_provider_name("RuleActionOverrides").with_block_name("rule_action_override")
+                    ],
+                }).with_provider_name("RuleGroupReferenceStatement").with_block_name("rule_group_reference_statement"),
+                    StructField::new("size_constraint_statement", AttributeType::Struct {
+                    name: "SizeConstraintStatement".to_string(),
+                    fields: vec![
+                    StructField::new("comparison_operator", AttributeType::StringEnum {
+                name: "ComparisonOperator".to_string(),
+                values: vec!["EQ".to_string(), "NE".to_string(), "LE".to_string(), "LT".to_string(), "GE".to_string(), "GT".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("ComparisonOperator", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("EQ".to_string(), "eq".to_string()), ("NE".to_string(), "ne".to_string()), ("LE".to_string(), "le".to_string()), ("LT".to_string(), "lt".to_string()), ("GE".to_string(), "ge".to_string()), ("GT".to_string(), "gt".to_string())],
+            }).required().with_provider_name("ComparisonOperator"),
+                    StructField::new("field_to_match", AttributeType::Ref("FieldToMatch".to_string())).required().with_provider_name("FieldToMatch"),
+                    StructField::new("size", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::Float),
+                validate: legacy_validator(validate_size_range),
+                to_dsl: None,
+            }).required().with_provider_name("Size"),
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                }).with_provider_name("SizeConstraintStatement").with_block_name("size_constraint_statement"),
+                    StructField::new("sqli_match_statement", AttributeType::Struct {
+                    name: "SqliMatchStatement".to_string(),
+                    fields: vec![
+                    StructField::new("field_to_match", AttributeType::Ref("FieldToMatch".to_string())).required().with_provider_name("FieldToMatch"),
+                    StructField::new("sensitivity_level", AttributeType::StringEnum {
+                name: "SensitivityLevel".to_string(),
+                values: vec!["LOW".to_string(), "HIGH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("SensitivityLevel", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("LOW".to_string(), "low".to_string()), ("HIGH".to_string(), "high".to_string())],
+            }).with_provider_name("SensitivityLevel"),
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                }).with_provider_name("SqliMatchStatement").with_block_name("sqli_match_statement"),
+                    StructField::new("xss_match_statement", AttributeType::Struct {
+                    name: "XssMatchStatement".to_string(),
+                    fields: vec![
+                    StructField::new("field_to_match", AttributeType::Ref("FieldToMatch".to_string())).required().with_provider_name("FieldToMatch"),
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                }).with_provider_name("XssMatchStatement").with_block_name("xss_match_statement")
+                    ],
+                })).required().with_provider_name("Statements").with_block_name("statement")
+                    ],
+                }).with_provider_name("OrStatement").with_block_name("or_statement"),
+                    StructField::new("rate_based_statement", AttributeType::Ref("RateBasedStatement".to_string())).with_provider_name("RateBasedStatement"),
+                    StructField::new("regex_match_statement", AttributeType::Ref("RegexMatchStatement".to_string())).with_provider_name("RegexMatchStatement"),
+                    StructField::new("regex_pattern_set_reference_statement", AttributeType::Ref("RegexPatternSetReferenceStatement".to_string())).with_provider_name("RegexPatternSetReferenceStatement"),
+                    StructField::new("rule_group_reference_statement", AttributeType::Ref("RuleGroupReferenceStatement".to_string())).with_provider_name("RuleGroupReferenceStatement"),
+                    StructField::new("size_constraint_statement", AttributeType::Ref("SizeConstraintStatement".to_string())).with_provider_name("SizeConstraintStatement"),
+                    StructField::new("sqli_match_statement", AttributeType::Ref("SqliMatchStatement".to_string())).with_provider_name("SqliMatchStatement"),
+                    StructField::new("xss_match_statement", AttributeType::Ref("XssMatchStatement".to_string())).with_provider_name("XssMatchStatement")
+                    ],
+                })).required().with_provider_name("Statements").with_block_name("statement")
+                    ],
+                })
+        .with_def("ApplicationAttribute", AttributeType::Struct {
+                    name: "ApplicationAttribute".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[\\w\\-]+$".to_string()),
+                length: Some((Some(1), Some(64))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_6fd4a12c0ce64c08_len_1_64),
+                to_dsl: None,
+            }).required().with_provider_name("Name"),
+                    StructField::new("values", AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[\\w\\-]+$".to_string()),
+                length: Some((Some(1), Some(64))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_6fd4a12c0ce64c08_len_1_64),
+                to_dsl: None,
+            })).required().with_provider_name("Values")
+                    ],
+                })
+        .with_def("ApplicationConfig", AttributeType::Struct {
+                    name: "ApplicationConfig".to_string(),
+                    fields: vec![
+                    StructField::new("attributes", AttributeType::list(AttributeType::Struct {
+                    name: "ApplicationAttribute".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[\\w\\-]+$".to_string()),
+                length: Some((Some(1), Some(64))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_6fd4a12c0ce64c08_len_1_64),
+                to_dsl: None,
+            }).required().with_provider_name("Name"),
+                    StructField::new("values", AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[\\w\\-]+$".to_string()),
+                length: Some((Some(1), Some(64))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_6fd4a12c0ce64c08_len_1_64),
+                to_dsl: None,
+            })).required().with_provider_name("Values")
+                    ],
+                })).required().with_provider_name("Attributes").with_block_name("attribute")
+                    ],
+                })
+        .with_def("AsnMatchStatement", AttributeType::Struct {
+                    name: "AsnMatchStatement".to_string(),
+                    fields: vec![
+                    StructField::new("asn_list", AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::Int),
+                validate: legacy_validator(validate_asn_list_range),
+                to_dsl: None,
+            })).with_provider_name("AsnList"),
+                    StructField::new("forwarded_ip_config", AttributeType::Struct {
+                    name: "ForwardedIPConfiguration".to_string(),
+                    fields: vec![
+                    StructField::new("fallback_behavior", AttributeType::StringEnum {
+                name: "FallbackBehavior".to_string(),
+                values: vec!["MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("FallbackBehavior", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).required().with_provider_name("FallbackBehavior"),
+                    StructField::new("header_name", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[a-zA-Z0-9-]+{1,255}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_2d93cc844f6d4014),
+                to_dsl: None,
+            }).required().with_provider_name("HeaderName")
+                    ],
+                }).with_provider_name("ForwardedIPConfig")
+                    ],
+                })
+        .with_def("AssociationConfig", AttributeType::Struct {
+                    name: "AssociationConfig".to_string(),
+                    fields: vec![
+                    StructField::new("request_body", AttributeType::String).with_provider_name("RequestBody")
+                    ],
+                })
+        .with_def("BlockAction", AttributeType::Struct {
+                    name: "BlockAction".to_string(),
+                    fields: vec![
+                    StructField::new("custom_response", AttributeType::Struct {
+                    name: "CustomResponse".to_string(),
+                    fields: vec![
+                    StructField::new("custom_response_body_key", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[\\w\\-]+$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_6fd4a12c0ce64c08),
+                to_dsl: None,
+            }).with_description("Custom response body key.").with_provider_name("CustomResponseBodyKey"),
+                    StructField::new("response_code", AttributeType::String).required().with_provider_name("ResponseCode"),
+                    StructField::new("response_headers", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Struct {
+                    name: "CustomHTTPHeader".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::String).required().with_provider_name("Name"),
+                    StructField::new("value", AttributeType::String).required().with_provider_name("Value")
+                    ],
+                })),
+                validate: legacy_validator(validate_list_items_min_1),
+                to_dsl: None,
+            }).with_description("Collection of HTTP headers.").with_provider_name("ResponseHeaders").with_block_name("response_header")
+                    ],
+                }).with_provider_name("CustomResponse").with_block_name("custom_response")
+                    ],
+                })
+        .with_def("Body", AttributeType::Struct {
+                    name: "Body".to_string(),
+                    fields: vec![
+                    StructField::new("oversize_handling", AttributeType::StringEnum {
+                name: "OversizeHandling".to_string(),
+                values: vec!["CONTINUE".to_string(), "MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("OversizeHandling", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("CONTINUE".to_string(), "continue".to_string()), ("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).with_provider_name("OversizeHandling")
+                    ],
+                })
+        .with_def("ByteMatchStatement", AttributeType::Struct {
+                    name: "ByteMatchStatement".to_string(),
+                    fields: vec![
+                    StructField::new("field_to_match", AttributeType::Struct {
+                    name: "FieldToMatch".to_string(),
+                    fields: vec![
+                    StructField::new("all_query_arguments", AttributeType::map(AttributeType::String)).with_description("All query arguments of a web request.").with_provider_name("AllQueryArguments"),
+                    StructField::new("body", AttributeType::Struct {
+                    name: "Body".to_string(),
+                    fields: vec![
+                    StructField::new("oversize_handling", AttributeType::StringEnum {
+                name: "OversizeHandling".to_string(),
+                values: vec!["CONTINUE".to_string(), "MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("OversizeHandling", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("CONTINUE".to_string(), "continue".to_string()), ("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).with_provider_name("OversizeHandling")
+                    ],
+                }).with_provider_name("Body"),
+                    StructField::new("cookies", AttributeType::Struct {
+                    name: "Cookies".to_string(),
+                    fields: vec![
+                    StructField::new("match_pattern", AttributeType::Struct {
+                    name: "CookieMatchPattern".to_string(),
+                    fields: vec![
+                    StructField::new("all", AttributeType::map(AttributeType::String)).with_description("Inspect all parts of the web request cookies.").with_provider_name("All"),
+                    StructField::new("excluded_cookies", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(60))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_60),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_199),
+                to_dsl: None,
+            }).with_provider_name("ExcludedCookies"),
+                    StructField::new("included_cookies", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(60))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_60),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_199),
+                to_dsl: None,
+            }).with_provider_name("IncludedCookies")
+                    ],
+                }).required().with_provider_name("MatchPattern"),
+                    StructField::new("match_scope", AttributeType::StringEnum {
+                name: "MapMatchScope".to_string(),
+                values: vec!["ALL".to_string(), "KEY".to_string(), "VALUE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("MapMatchScope", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("ALL".to_string(), "all".to_string()), ("KEY".to_string(), "key".to_string()), ("VALUE".to_string(), "value".to_string())],
+            }).required().with_provider_name("MatchScope"),
+                    StructField::new("oversize_handling", AttributeType::StringEnum {
+                name: "OversizeHandling".to_string(),
+                values: vec!["CONTINUE".to_string(), "MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("OversizeHandling", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("CONTINUE".to_string(), "continue".to_string()), ("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).required().with_provider_name("OversizeHandling")
+                    ],
+                }).with_provider_name("Cookies"),
+                    StructField::new("header_order", AttributeType::Struct {
+                    name: "HeaderOrder".to_string(),
+                    fields: vec![
+                    StructField::new("oversize_handling", AttributeType::StringEnum {
+                name: "OversizeHandling".to_string(),
+                values: vec!["CONTINUE".to_string(), "MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("OversizeHandling", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("CONTINUE".to_string(), "continue".to_string()), ("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).required().with_provider_name("OversizeHandling")
+                    ],
+                }).with_provider_name("HeaderOrder"),
+                    StructField::new("headers", AttributeType::Struct {
+                    name: "Headers".to_string(),
+                    fields: vec![
+                    StructField::new("match_pattern", AttributeType::Struct {
+                    name: "HeaderMatchPattern".to_string(),
+                    fields: vec![
+                    StructField::new("all", AttributeType::map(AttributeType::String)).with_description("Inspect all parts of the web request headers.").with_provider_name("All"),
+                    StructField::new("excluded_headers", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(64))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_64),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_199),
+                to_dsl: None,
+            }).with_provider_name("ExcludedHeaders"),
+                    StructField::new("included_headers", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(64))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_64),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_199),
+                to_dsl: None,
+            }).with_provider_name("IncludedHeaders")
+                    ],
+                }).required().with_provider_name("MatchPattern"),
+                    StructField::new("match_scope", AttributeType::StringEnum {
+                name: "MapMatchScope".to_string(),
+                values: vec!["ALL".to_string(), "KEY".to_string(), "VALUE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("MapMatchScope", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("ALL".to_string(), "all".to_string()), ("KEY".to_string(), "key".to_string()), ("VALUE".to_string(), "value".to_string())],
+            }).required().with_provider_name("MatchScope"),
+                    StructField::new("oversize_handling", AttributeType::StringEnum {
+                name: "OversizeHandling".to_string(),
+                values: vec!["CONTINUE".to_string(), "MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("OversizeHandling", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("CONTINUE".to_string(), "continue".to_string()), ("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).required().with_provider_name("OversizeHandling")
+                    ],
+                }).with_provider_name("Headers"),
+                    StructField::new("ja3_fingerprint", AttributeType::Struct {
+                    name: "JA3Fingerprint".to_string(),
+                    fields: vec![
+                    StructField::new("fallback_behavior", AttributeType::StringEnum {
+                name: "FallbackBehavior".to_string(),
+                values: vec!["MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("FallbackBehavior", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).required().with_provider_name("FallbackBehavior")
+                    ],
+                }).with_provider_name("JA3Fingerprint"),
+                    StructField::new("ja4_fingerprint", AttributeType::Struct {
+                    name: "JA4Fingerprint".to_string(),
+                    fields: vec![
+                    StructField::new("fallback_behavior", AttributeType::StringEnum {
+                name: "FallbackBehavior".to_string(),
+                values: vec!["MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("FallbackBehavior", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).required().with_provider_name("FallbackBehavior")
+                    ],
+                }).with_provider_name("JA4Fingerprint"),
+                    StructField::new("json_body", AttributeType::Struct {
+                    name: "JsonBody".to_string(),
+                    fields: vec![
+                    StructField::new("invalid_fallback_behavior", AttributeType::StringEnum {
+                name: "BodyParsingFallbackBehavior".to_string(),
+                values: vec!["MATCH".to_string(), "NO_MATCH".to_string(), "EVALUATE_AS_STRING".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("BodyParsingFallbackBehavior", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string()), ("EVALUATE_AS_STRING".to_string(), "evaluate_as_string".to_string())],
+            }).with_provider_name("InvalidFallbackBehavior"),
+                    StructField::new("match_pattern", AttributeType::Struct {
+                    name: "JsonMatchPattern".to_string(),
+                    fields: vec![
+                    StructField::new("all", AttributeType::map(AttributeType::String)).with_description("Inspect all parts of the web request's JSON body.").with_provider_name("All"),
+                    StructField::new("included_paths", AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[\\/]+([^~]*(~[01])*)*{1,512}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_c77cf75cf1a75ade),
+                to_dsl: None,
+            })).with_provider_name("IncludedPaths")
+                    ],
+                }).required().with_provider_name("MatchPattern"),
+                    StructField::new("match_scope", AttributeType::StringEnum {
+                name: "JsonMatchScope".to_string(),
+                values: vec!["ALL".to_string(), "KEY".to_string(), "VALUE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("JsonMatchScope", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("ALL".to_string(), "all".to_string()), ("KEY".to_string(), "key".to_string()), ("VALUE".to_string(), "value".to_string())],
+            }).required().with_provider_name("MatchScope"),
+                    StructField::new("oversize_handling", AttributeType::StringEnum {
+                name: "OversizeHandling".to_string(),
+                values: vec!["CONTINUE".to_string(), "MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("OversizeHandling", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("CONTINUE".to_string(), "continue".to_string()), ("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).with_provider_name("OversizeHandling")
+                    ],
+                }).with_provider_name("JsonBody"),
+                    StructField::new("method", AttributeType::map(AttributeType::String)).with_description("The HTTP method of a web request. The method indicates the type of operation that the request is asking the origin to perform.").with_provider_name("Method"),
+                    StructField::new("query_string", AttributeType::map(AttributeType::String)).with_description("The query string of a web request. This is the part of a URL that appears after a ? character, if any.").with_provider_name("QueryString"),
+                    StructField::new("single_header", AttributeType::Struct {
+                    name: "SingleHeader".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::String).required().with_provider_name("Name")
+                    ],
+                }).with_provider_name("SingleHeader"),
+                    StructField::new("single_query_argument", AttributeType::Struct {
+                    name: "SingleQueryArgument".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::String).required().with_provider_name("Name")
+                    ],
+                }).with_description("One query argument in a web request, identified by name, for example UserName or SalesRegion. The name can be up to 30 characters long and isn't case sensitive.").with_provider_name("SingleQueryArgument"),
+                    StructField::new("uri_fragment", AttributeType::Struct {
+                    name: "UriFragment".to_string(),
+                    fields: vec![
+                    StructField::new("fallback_behavior", AttributeType::StringEnum {
+                name: "FallbackBehavior".to_string(),
+                values: vec!["MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("FallbackBehavior", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).with_provider_name("FallbackBehavior")
+                    ],
+                }).with_provider_name("UriFragment"),
+                    StructField::new("uri_path", AttributeType::map(AttributeType::String)).with_description("The path component of the URI of a web request. This is the part of a web request that identifies a resource, for example, /images/daily-ad.jpg.").with_provider_name("UriPath")
+                    ],
+                }).required().with_provider_name("FieldToMatch"),
+                    StructField::new("positional_constraint", AttributeType::StringEnum {
+                name: "PositionalConstraint".to_string(),
+                values: vec!["EXACTLY".to_string(), "STARTS_WITH".to_string(), "ENDS_WITH".to_string(), "CONTAINS".to_string(), "CONTAINS_WORD".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("PositionalConstraint", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("EXACTLY".to_string(), "exactly".to_string()), ("STARTS_WITH".to_string(), "starts_with".to_string()), ("ENDS_WITH".to_string(), "ends_with".to_string()), ("CONTAINS".to_string(), "contains".to_string()), ("CONTAINS_WORD".to_string(), "contains_word".to_string())],
+            }).required().with_provider_name("PositionalConstraint"),
+                    StructField::new("search_string", AttributeType::String).with_provider_name("SearchString"),
+                    StructField::new("search_string_base64", AttributeType::String).with_provider_name("SearchStringBase64"),
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                })
+        .with_def("CaptchaAction", AttributeType::Struct {
+                    name: "CaptchaAction".to_string(),
+                    fields: vec![
+                    StructField::new("custom_request_handling", AttributeType::Ref("CustomRequestHandling".to_string())).with_provider_name("CustomRequestHandling")
+                    ],
+                })
+        .with_def("CaptchaConfig", AttributeType::Struct {
+                    name: "CaptchaConfig".to_string(),
+                    fields: vec![
+                    StructField::new("immunity_time_property", AttributeType::Struct {
+                    name: "ImmunityTimeProperty".to_string(),
+                    fields: vec![
+                    StructField::new("immunity_time", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::Int),
+                validate: legacy_validator(validate_immunity_time_range),
+                to_dsl: None,
+            }).required().with_provider_name("ImmunityTime")
+                    ],
+                }).with_provider_name("ImmunityTimeProperty")
+                    ],
+                })
+        .with_def("ChallengeAction", AttributeType::Struct {
+                    name: "ChallengeAction".to_string(),
+                    fields: vec![
+                    StructField::new("custom_request_handling", AttributeType::Ref("CustomRequestHandling".to_string())).with_provider_name("CustomRequestHandling")
+                    ],
+                })
+        .with_def("ChallengeConfig", AttributeType::Struct {
+                    name: "ChallengeConfig".to_string(),
+                    fields: vec![
+                    StructField::new("immunity_time_property", AttributeType::Ref("ImmunityTimeProperty".to_string())).with_provider_name("ImmunityTimeProperty")
+                    ],
+                })
+        .with_def("ClientSideAction", AttributeType::Struct {
+                    name: "ClientSideAction".to_string(),
+                    fields: vec![
+                    StructField::new("exempt_uri_regular_expressions", AttributeType::list(AttributeType::Struct {
+                    name: "Regex".to_string(),
+                    fields: vec![
+                    StructField::new("regex_string", AttributeType::String).with_provider_name("RegexString")
+                    ],
+                })).with_provider_name("ExemptUriRegularExpressions").with_block_name("exempt_uri_regular_expression"),
+                    StructField::new("sensitivity", AttributeType::StringEnum {
+                name: "SensitivityToAct".to_string(),
+                values: vec!["LOW".to_string(), "MEDIUM".to_string(), "HIGH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("SensitivityToAct", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("LOW".to_string(), "low".to_string()), ("MEDIUM".to_string(), "medium".to_string()), ("HIGH".to_string(), "high".to_string())],
+            }).with_provider_name("Sensitivity"),
+                    StructField::new("usage_of_action", AttributeType::StringEnum {
+                name: "UsageOfAction".to_string(),
+                values: vec!["ENABLED".to_string(), "DISABLED".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("UsageOfAction", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("ENABLED".to_string(), "enabled".to_string()), ("DISABLED".to_string(), "disabled".to_string())],
+            }).required().with_provider_name("UsageOfAction")
+                    ],
+                })
+        .with_def("ClientSideActionConfig", AttributeType::Struct {
+                    name: "ClientSideActionConfig".to_string(),
+                    fields: vec![
+                    StructField::new("challenge", AttributeType::Struct {
+                    name: "ClientSideAction".to_string(),
+                    fields: vec![
+                    StructField::new("exempt_uri_regular_expressions", AttributeType::list(AttributeType::Struct {
+                    name: "Regex".to_string(),
+                    fields: vec![
+                    StructField::new("regex_string", AttributeType::String).with_provider_name("RegexString")
+                    ],
+                })).with_provider_name("ExemptUriRegularExpressions").with_block_name("exempt_uri_regular_expression"),
+                    StructField::new("sensitivity", AttributeType::StringEnum {
+                name: "SensitivityToAct".to_string(),
+                values: vec!["LOW".to_string(), "MEDIUM".to_string(), "HIGH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("SensitivityToAct", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("LOW".to_string(), "low".to_string()), ("MEDIUM".to_string(), "medium".to_string()), ("HIGH".to_string(), "high".to_string())],
+            }).with_provider_name("Sensitivity"),
+                    StructField::new("usage_of_action", AttributeType::StringEnum {
+                name: "UsageOfAction".to_string(),
+                values: vec!["ENABLED".to_string(), "DISABLED".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("UsageOfAction", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("ENABLED".to_string(), "enabled".to_string()), ("DISABLED".to_string(), "disabled".to_string())],
+            }).required().with_provider_name("UsageOfAction")
+                    ],
+                }).required().with_provider_name("Challenge").with_block_name("challenge")
+                    ],
+                })
+        .with_def("CookieMatchPattern", AttributeType::Struct {
+                    name: "CookieMatchPattern".to_string(),
+                    fields: vec![
+                    StructField::new("all", AttributeType::map(AttributeType::String)).with_description("Inspect all parts of the web request cookies.").with_provider_name("All"),
+                    StructField::new("excluded_cookies", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(60))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_60),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_199),
+                to_dsl: None,
+            }).with_provider_name("ExcludedCookies"),
+                    StructField::new("included_cookies", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(60))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_60),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_199),
+                to_dsl: None,
+            }).with_provider_name("IncludedCookies")
+                    ],
+                })
+        .with_def("Cookies", AttributeType::Struct {
+                    name: "Cookies".to_string(),
+                    fields: vec![
+                    StructField::new("match_pattern", AttributeType::Struct {
+                    name: "CookieMatchPattern".to_string(),
+                    fields: vec![
+                    StructField::new("all", AttributeType::map(AttributeType::String)).with_description("Inspect all parts of the web request cookies.").with_provider_name("All"),
+                    StructField::new("excluded_cookies", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(60))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_60),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_199),
+                to_dsl: None,
+            }).with_provider_name("ExcludedCookies"),
+                    StructField::new("included_cookies", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(60))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_60),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_199),
+                to_dsl: None,
+            }).with_provider_name("IncludedCookies")
+                    ],
+                }).required().with_provider_name("MatchPattern"),
+                    StructField::new("match_scope", AttributeType::StringEnum {
+                name: "MapMatchScope".to_string(),
+                values: vec!["ALL".to_string(), "KEY".to_string(), "VALUE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("MapMatchScope", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("ALL".to_string(), "all".to_string()), ("KEY".to_string(), "key".to_string()), ("VALUE".to_string(), "value".to_string())],
+            }).required().with_provider_name("MatchScope"),
+                    StructField::new("oversize_handling", AttributeType::StringEnum {
+                name: "OversizeHandling".to_string(),
+                values: vec!["CONTINUE".to_string(), "MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("OversizeHandling", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("CONTINUE".to_string(), "continue".to_string()), ("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).required().with_provider_name("OversizeHandling")
+                    ],
+                })
+        .with_def("CountAction", AttributeType::Struct {
+                    name: "CountAction".to_string(),
+                    fields: vec![
+                    StructField::new("custom_request_handling", AttributeType::Ref("CustomRequestHandling".to_string())).with_provider_name("CustomRequestHandling")
+                    ],
+                })
+        .with_def("CustomRequestHandling", AttributeType::Struct {
+                    name: "CustomRequestHandling".to_string(),
+                    fields: vec![
+                    StructField::new("insert_headers", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Struct {
+                    name: "CustomHTTPHeader".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::String).required().with_provider_name("Name"),
+                    StructField::new("value", AttributeType::String).required().with_provider_name("Value")
+                    ],
+                })),
+                validate: legacy_validator(validate_list_items_min_1),
+                to_dsl: None,
+            }).required().with_description("Collection of HTTP headers.").with_provider_name("InsertHeaders").with_block_name("insert_header")
+                    ],
+                })
+        .with_def("CustomResponse", AttributeType::Struct {
+                    name: "CustomResponse".to_string(),
+                    fields: vec![
+                    StructField::new("custom_response_body_key", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[\\w\\-]+$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_6fd4a12c0ce64c08),
+                to_dsl: None,
+            }).with_description("Custom response body key.").with_provider_name("CustomResponseBodyKey"),
+                    StructField::new("response_code", AttributeType::String).required().with_provider_name("ResponseCode"),
+                    StructField::new("response_headers", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Struct {
+                    name: "CustomHTTPHeader".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::String).required().with_provider_name("Name"),
+                    StructField::new("value", AttributeType::String).required().with_provider_name("Value")
+                    ],
+                })),
+                validate: legacy_validator(validate_list_items_min_1),
+                to_dsl: None,
+            }).with_description("Collection of HTTP headers.").with_provider_name("ResponseHeaders").with_block_name("response_header")
+                    ],
+                })
+        .with_def("DataProtect", AttributeType::Struct {
+                    name: "DataProtect".to_string(),
+                    fields: vec![
+                    StructField::new("action", AttributeType::StringEnum {
+                name: "DataProtectionAction".to_string(),
+                values: vec!["SUBSTITUTION".to_string(), "HASH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("DataProtectionAction", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("SUBSTITUTION".to_string(), "substitution".to_string()), ("HASH".to_string(), "hash".to_string())],
+            }).required().with_provider_name("Action"),
+                    StructField::new("exclude_rate_based_details", AttributeType::Bool).with_provider_name("ExcludeRateBasedDetails"),
+                    StructField::new("exclude_rule_match_details", AttributeType::Bool).with_provider_name("ExcludeRuleMatchDetails"),
+                    StructField::new("field", AttributeType::Struct {
+                    name: "FieldToProtect".to_string(),
+                    fields: vec![
+                    StructField::new("field_keys", AttributeType::list(AttributeType::String)).with_description("List of field keys to protect").with_provider_name("FieldKeys"),
+                    StructField::new("field_type", AttributeType::StringEnum {
+                name: "FieldType".to_string(),
+                values: vec!["SINGLE_HEADER".to_string(), "SINGLE_COOKIE".to_string(), "SINGLE_QUERY_ARGUMENT".to_string(), "QUERY_STRING".to_string(), "BODY".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("FieldType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("SINGLE_HEADER".to_string(), "single_header".to_string()), ("SINGLE_COOKIE".to_string(), "single_cookie".to_string()), ("SINGLE_QUERY_ARGUMENT".to_string(), "single_query_argument".to_string()), ("QUERY_STRING".to_string(), "query_string".to_string()), ("BODY".to_string(), "body".to_string())],
+            }).required().with_description("Field type to protect").with_provider_name("FieldType")
+                    ],
+                }).required().with_provider_name("Field")
+                    ],
+                })
+        .with_def("DataProtectionConfig", AttributeType::Struct {
+                    name: "DataProtectionConfig".to_string(),
+                    fields: vec![
+                    StructField::new("data_protections", AttributeType::list(AttributeType::Struct {
+                    name: "DataProtect".to_string(),
+                    fields: vec![
+                    StructField::new("action", AttributeType::StringEnum {
+                name: "DataProtectionAction".to_string(),
+                values: vec!["SUBSTITUTION".to_string(), "HASH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("DataProtectionAction", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("SUBSTITUTION".to_string(), "substitution".to_string()), ("HASH".to_string(), "hash".to_string())],
+            }).required().with_provider_name("Action"),
+                    StructField::new("exclude_rate_based_details", AttributeType::Bool).with_provider_name("ExcludeRateBasedDetails"),
+                    StructField::new("exclude_rule_match_details", AttributeType::Bool).with_provider_name("ExcludeRuleMatchDetails"),
+                    StructField::new("field", AttributeType::Struct {
+                    name: "FieldToProtect".to_string(),
+                    fields: vec![
+                    StructField::new("field_keys", AttributeType::list(AttributeType::String)).with_description("List of field keys to protect").with_provider_name("FieldKeys"),
+                    StructField::new("field_type", AttributeType::StringEnum {
+                name: "FieldType".to_string(),
+                values: vec!["SINGLE_HEADER".to_string(), "SINGLE_COOKIE".to_string(), "SINGLE_QUERY_ARGUMENT".to_string(), "QUERY_STRING".to_string(), "BODY".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("FieldType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("SINGLE_HEADER".to_string(), "single_header".to_string()), ("SINGLE_COOKIE".to_string(), "single_cookie".to_string()), ("SINGLE_QUERY_ARGUMENT".to_string(), "single_query_argument".to_string()), ("QUERY_STRING".to_string(), "query_string".to_string()), ("BODY".to_string(), "body".to_string())],
+            }).required().with_description("Field type to protect").with_provider_name("FieldType")
+                    ],
+                }).required().with_provider_name("Field")
+                    ],
+                })).required().with_provider_name("DataProtections").with_block_name("data_protection")
+                    ],
+                })
+        .with_def("DefaultAction", AttributeType::Struct {
+                    name: "DefaultAction".to_string(),
+                    fields: vec![
+                    StructField::new("allow", AttributeType::Struct {
+                    name: "AllowAction".to_string(),
+                    fields: vec![
+                    StructField::new("custom_request_handling", AttributeType::Struct {
+                    name: "CustomRequestHandling".to_string(),
+                    fields: vec![
+                    StructField::new("insert_headers", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Struct {
+                    name: "CustomHTTPHeader".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::String).required().with_provider_name("Name"),
+                    StructField::new("value", AttributeType::String).required().with_provider_name("Value")
+                    ],
+                })),
+                validate: legacy_validator(validate_list_items_min_1),
+                to_dsl: None,
+            }).required().with_description("Collection of HTTP headers.").with_provider_name("InsertHeaders").with_block_name("insert_header")
+                    ],
+                }).with_provider_name("CustomRequestHandling").with_block_name("custom_request_handling")
+                    ],
+                }).with_provider_name("Allow").with_block_name("allow"),
+                    StructField::new("block", AttributeType::Struct {
+                    name: "BlockAction".to_string(),
+                    fields: vec![
+                    StructField::new("custom_response", AttributeType::Struct {
+                    name: "CustomResponse".to_string(),
+                    fields: vec![
+                    StructField::new("custom_response_body_key", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[\\w\\-]+$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_6fd4a12c0ce64c08),
+                to_dsl: None,
+            }).with_description("Custom response body key.").with_provider_name("CustomResponseBodyKey"),
+                    StructField::new("response_code", AttributeType::String).required().with_provider_name("ResponseCode"),
+                    StructField::new("response_headers", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Struct {
+                    name: "CustomHTTPHeader".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::String).required().with_provider_name("Name"),
+                    StructField::new("value", AttributeType::String).required().with_provider_name("Value")
+                    ],
+                })),
+                validate: legacy_validator(validate_list_items_min_1),
+                to_dsl: None,
+            }).with_description("Collection of HTTP headers.").with_provider_name("ResponseHeaders").with_block_name("response_header")
+                    ],
+                }).with_provider_name("CustomResponse").with_block_name("custom_response")
+                    ],
+                }).with_provider_name("Block").with_block_name("block")
+                    ],
+                })
+        .with_def("FieldIdentifier", AttributeType::Struct {
+                    name: "FieldIdentifier".to_string(),
+                    fields: vec![
+                    StructField::new("identifier", AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(512))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_512),
+                to_dsl: None,
+            }).required().with_provider_name("Identifier")
+                    ],
+                })
+        .with_def("FieldToMatch", AttributeType::Struct {
+                    name: "FieldToMatch".to_string(),
+                    fields: vec![
+                    StructField::new("all_query_arguments", AttributeType::map(AttributeType::String)).with_description("All query arguments of a web request.").with_provider_name("AllQueryArguments"),
+                    StructField::new("body", AttributeType::Struct {
+                    name: "Body".to_string(),
+                    fields: vec![
+                    StructField::new("oversize_handling", AttributeType::StringEnum {
+                name: "OversizeHandling".to_string(),
+                values: vec!["CONTINUE".to_string(), "MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("OversizeHandling", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("CONTINUE".to_string(), "continue".to_string()), ("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).with_provider_name("OversizeHandling")
+                    ],
+                }).with_provider_name("Body"),
+                    StructField::new("cookies", AttributeType::Struct {
+                    name: "Cookies".to_string(),
+                    fields: vec![
+                    StructField::new("match_pattern", AttributeType::Struct {
+                    name: "CookieMatchPattern".to_string(),
+                    fields: vec![
+                    StructField::new("all", AttributeType::map(AttributeType::String)).with_description("Inspect all parts of the web request cookies.").with_provider_name("All"),
+                    StructField::new("excluded_cookies", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(60))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_60),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_199),
+                to_dsl: None,
+            }).with_provider_name("ExcludedCookies"),
+                    StructField::new("included_cookies", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(60))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_60),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_199),
+                to_dsl: None,
+            }).with_provider_name("IncludedCookies")
+                    ],
+                }).required().with_provider_name("MatchPattern"),
+                    StructField::new("match_scope", AttributeType::StringEnum {
+                name: "MapMatchScope".to_string(),
+                values: vec!["ALL".to_string(), "KEY".to_string(), "VALUE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("MapMatchScope", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("ALL".to_string(), "all".to_string()), ("KEY".to_string(), "key".to_string()), ("VALUE".to_string(), "value".to_string())],
+            }).required().with_provider_name("MatchScope"),
+                    StructField::new("oversize_handling", AttributeType::StringEnum {
+                name: "OversizeHandling".to_string(),
+                values: vec!["CONTINUE".to_string(), "MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("OversizeHandling", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("CONTINUE".to_string(), "continue".to_string()), ("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).required().with_provider_name("OversizeHandling")
+                    ],
+                }).with_provider_name("Cookies"),
+                    StructField::new("header_order", AttributeType::Struct {
+                    name: "HeaderOrder".to_string(),
+                    fields: vec![
+                    StructField::new("oversize_handling", AttributeType::StringEnum {
+                name: "OversizeHandling".to_string(),
+                values: vec!["CONTINUE".to_string(), "MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("OversizeHandling", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("CONTINUE".to_string(), "continue".to_string()), ("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).required().with_provider_name("OversizeHandling")
+                    ],
+                }).with_provider_name("HeaderOrder"),
+                    StructField::new("headers", AttributeType::Struct {
+                    name: "Headers".to_string(),
+                    fields: vec![
+                    StructField::new("match_pattern", AttributeType::Struct {
+                    name: "HeaderMatchPattern".to_string(),
+                    fields: vec![
+                    StructField::new("all", AttributeType::map(AttributeType::String)).with_description("Inspect all parts of the web request headers.").with_provider_name("All"),
+                    StructField::new("excluded_headers", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(64))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_64),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_199),
+                to_dsl: None,
+            }).with_provider_name("ExcludedHeaders"),
+                    StructField::new("included_headers", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(64))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_64),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_199),
+                to_dsl: None,
+            }).with_provider_name("IncludedHeaders")
+                    ],
+                }).required().with_provider_name("MatchPattern"),
+                    StructField::new("match_scope", AttributeType::StringEnum {
+                name: "MapMatchScope".to_string(),
+                values: vec!["ALL".to_string(), "KEY".to_string(), "VALUE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("MapMatchScope", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("ALL".to_string(), "all".to_string()), ("KEY".to_string(), "key".to_string()), ("VALUE".to_string(), "value".to_string())],
+            }).required().with_provider_name("MatchScope"),
+                    StructField::new("oversize_handling", AttributeType::StringEnum {
+                name: "OversizeHandling".to_string(),
+                values: vec!["CONTINUE".to_string(), "MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("OversizeHandling", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("CONTINUE".to_string(), "continue".to_string()), ("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).required().with_provider_name("OversizeHandling")
+                    ],
+                }).with_provider_name("Headers"),
+                    StructField::new("ja3_fingerprint", AttributeType::Struct {
+                    name: "JA3Fingerprint".to_string(),
+                    fields: vec![
+                    StructField::new("fallback_behavior", AttributeType::StringEnum {
+                name: "FallbackBehavior".to_string(),
+                values: vec!["MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("FallbackBehavior", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).required().with_provider_name("FallbackBehavior")
+                    ],
+                }).with_provider_name("JA3Fingerprint"),
+                    StructField::new("ja4_fingerprint", AttributeType::Struct {
+                    name: "JA4Fingerprint".to_string(),
+                    fields: vec![
+                    StructField::new("fallback_behavior", AttributeType::StringEnum {
+                name: "FallbackBehavior".to_string(),
+                values: vec!["MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("FallbackBehavior", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).required().with_provider_name("FallbackBehavior")
+                    ],
+                }).with_provider_name("JA4Fingerprint"),
+                    StructField::new("json_body", AttributeType::Struct {
+                    name: "JsonBody".to_string(),
+                    fields: vec![
+                    StructField::new("invalid_fallback_behavior", AttributeType::StringEnum {
+                name: "BodyParsingFallbackBehavior".to_string(),
+                values: vec!["MATCH".to_string(), "NO_MATCH".to_string(), "EVALUATE_AS_STRING".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("BodyParsingFallbackBehavior", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string()), ("EVALUATE_AS_STRING".to_string(), "evaluate_as_string".to_string())],
+            }).with_provider_name("InvalidFallbackBehavior"),
+                    StructField::new("match_pattern", AttributeType::Struct {
+                    name: "JsonMatchPattern".to_string(),
+                    fields: vec![
+                    StructField::new("all", AttributeType::map(AttributeType::String)).with_description("Inspect all parts of the web request's JSON body.").with_provider_name("All"),
+                    StructField::new("included_paths", AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[\\/]+([^~]*(~[01])*)*{1,512}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_c77cf75cf1a75ade),
+                to_dsl: None,
+            })).with_provider_name("IncludedPaths")
+                    ],
+                }).required().with_provider_name("MatchPattern"),
+                    StructField::new("match_scope", AttributeType::StringEnum {
+                name: "JsonMatchScope".to_string(),
+                values: vec!["ALL".to_string(), "KEY".to_string(), "VALUE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("JsonMatchScope", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("ALL".to_string(), "all".to_string()), ("KEY".to_string(), "key".to_string()), ("VALUE".to_string(), "value".to_string())],
+            }).required().with_provider_name("MatchScope"),
+                    StructField::new("oversize_handling", AttributeType::StringEnum {
+                name: "OversizeHandling".to_string(),
+                values: vec!["CONTINUE".to_string(), "MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("OversizeHandling", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("CONTINUE".to_string(), "continue".to_string()), ("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).with_provider_name("OversizeHandling")
+                    ],
+                }).with_provider_name("JsonBody"),
+                    StructField::new("method", AttributeType::map(AttributeType::String)).with_description("The HTTP method of a web request. The method indicates the type of operation that the request is asking the origin to perform.").with_provider_name("Method"),
+                    StructField::new("query_string", AttributeType::map(AttributeType::String)).with_description("The query string of a web request. This is the part of a URL that appears after a ? character, if any.").with_provider_name("QueryString"),
+                    StructField::new("single_header", AttributeType::Struct {
+                    name: "SingleHeader".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::String).required().with_provider_name("Name")
+                    ],
+                }).with_provider_name("SingleHeader"),
+                    StructField::new("single_query_argument", AttributeType::Struct {
+                    name: "SingleQueryArgument".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::String).required().with_provider_name("Name")
+                    ],
+                }).with_description("One query argument in a web request, identified by name, for example UserName or SalesRegion. The name can be up to 30 characters long and isn't case sensitive.").with_provider_name("SingleQueryArgument"),
+                    StructField::new("uri_fragment", AttributeType::Struct {
+                    name: "UriFragment".to_string(),
+                    fields: vec![
+                    StructField::new("fallback_behavior", AttributeType::StringEnum {
+                name: "FallbackBehavior".to_string(),
+                values: vec!["MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("FallbackBehavior", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).with_provider_name("FallbackBehavior")
+                    ],
+                }).with_provider_name("UriFragment"),
+                    StructField::new("uri_path", AttributeType::map(AttributeType::String)).with_description("The path component of the URI of a web request. This is the part of a web request that identifies a resource, for example, /images/daily-ad.jpg.").with_provider_name("UriPath")
+                    ],
+                })
+        .with_def("FieldToProtect", AttributeType::Struct {
+                    name: "FieldToProtect".to_string(),
+                    fields: vec![
+                    StructField::new("field_keys", AttributeType::list(AttributeType::String)).with_description("List of field keys to protect").with_provider_name("FieldKeys"),
+                    StructField::new("field_type", AttributeType::StringEnum {
+                name: "FieldType".to_string(),
+                values: vec!["SINGLE_HEADER".to_string(), "SINGLE_COOKIE".to_string(), "SINGLE_QUERY_ARGUMENT".to_string(), "QUERY_STRING".to_string(), "BODY".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("FieldType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("SINGLE_HEADER".to_string(), "single_header".to_string()), ("SINGLE_COOKIE".to_string(), "single_cookie".to_string()), ("SINGLE_QUERY_ARGUMENT".to_string(), "single_query_argument".to_string()), ("QUERY_STRING".to_string(), "query_string".to_string()), ("BODY".to_string(), "body".to_string())],
+            }).required().with_description("Field type to protect").with_provider_name("FieldType")
+                    ],
+                })
+        .with_def("ForwardedIPConfiguration", AttributeType::Struct {
+                    name: "ForwardedIPConfiguration".to_string(),
+                    fields: vec![
+                    StructField::new("fallback_behavior", AttributeType::StringEnum {
+                name: "FallbackBehavior".to_string(),
+                values: vec!["MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("FallbackBehavior", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).required().with_provider_name("FallbackBehavior"),
+                    StructField::new("header_name", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[a-zA-Z0-9-]+{1,255}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_2d93cc844f6d4014),
+                to_dsl: None,
+            }).required().with_provider_name("HeaderName")
+                    ],
+                })
+        .with_def("GeoMatchStatement", AttributeType::Struct {
+                    name: "GeoMatchStatement".to_string(),
+                    fields: vec![
+                    StructField::new("country_codes", AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: Some((Some(1), Some(2))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_length_1_2),
+                to_dsl: None,
+            })).with_provider_name("CountryCodes"),
+                    StructField::new("forwarded_ip_config", AttributeType::Ref("ForwardedIPConfiguration".to_string())).with_provider_name("ForwardedIPConfig")
+                    ],
+                })
+        .with_def("HeaderMatchPattern", AttributeType::Struct {
+                    name: "HeaderMatchPattern".to_string(),
+                    fields: vec![
+                    StructField::new("all", AttributeType::map(AttributeType::String)).with_description("Inspect all parts of the web request headers.").with_provider_name("All"),
+                    StructField::new("excluded_headers", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(64))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_64),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_199),
+                to_dsl: None,
+            }).with_provider_name("ExcludedHeaders"),
+                    StructField::new("included_headers", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(64))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_64),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_199),
+                to_dsl: None,
+            }).with_provider_name("IncludedHeaders")
+                    ],
+                })
+        .with_def("HeaderOrder", AttributeType::Struct {
+                    name: "HeaderOrder".to_string(),
+                    fields: vec![
+                    StructField::new("oversize_handling", AttributeType::StringEnum {
+                name: "OversizeHandling".to_string(),
+                values: vec!["CONTINUE".to_string(), "MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("OversizeHandling", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("CONTINUE".to_string(), "continue".to_string()), ("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).required().with_provider_name("OversizeHandling")
+                    ],
+                })
+        .with_def("Headers", AttributeType::Struct {
+                    name: "Headers".to_string(),
+                    fields: vec![
+                    StructField::new("match_pattern", AttributeType::Struct {
+                    name: "HeaderMatchPattern".to_string(),
+                    fields: vec![
+                    StructField::new("all", AttributeType::map(AttributeType::String)).with_description("Inspect all parts of the web request headers.").with_provider_name("All"),
+                    StructField::new("excluded_headers", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(64))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_64),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_199),
+                to_dsl: None,
+            }).with_provider_name("ExcludedHeaders"),
+                    StructField::new("included_headers", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(64))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_64),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_199),
+                to_dsl: None,
+            }).with_provider_name("IncludedHeaders")
+                    ],
+                }).required().with_provider_name("MatchPattern"),
+                    StructField::new("match_scope", AttributeType::StringEnum {
+                name: "MapMatchScope".to_string(),
+                values: vec!["ALL".to_string(), "KEY".to_string(), "VALUE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("MapMatchScope", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("ALL".to_string(), "all".to_string()), ("KEY".to_string(), "key".to_string()), ("VALUE".to_string(), "value".to_string())],
+            }).required().with_provider_name("MatchScope"),
+                    StructField::new("oversize_handling", AttributeType::StringEnum {
+                name: "OversizeHandling".to_string(),
+                values: vec!["CONTINUE".to_string(), "MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("OversizeHandling", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("CONTINUE".to_string(), "continue".to_string()), ("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).required().with_provider_name("OversizeHandling")
+                    ],
+                })
+        .with_def("IPSetForwardedIPConfiguration", AttributeType::Struct {
+                    name: "IPSetForwardedIPConfiguration".to_string(),
+                    fields: vec![
+                    StructField::new("fallback_behavior", AttributeType::StringEnum {
+                name: "FallbackBehavior".to_string(),
+                values: vec!["MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("FallbackBehavior", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).required().with_provider_name("FallbackBehavior"),
+                    StructField::new("header_name", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[a-zA-Z0-9-]+{1,255}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_2d93cc844f6d4014),
+                to_dsl: None,
+            }).required().with_provider_name("HeaderName"),
+                    StructField::new("position", AttributeType::StringEnum {
+                name: "Position".to_string(),
+                values: vec!["FIRST".to_string(), "LAST".to_string(), "ANY".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("Position", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("FIRST".to_string(), "first".to_string()), ("LAST".to_string(), "last".to_string()), ("ANY".to_string(), "any".to_string())],
+            }).required().with_provider_name("Position")
+                    ],
+                })
+        .with_def("IPSetReferenceStatement", AttributeType::Struct {
+                    name: "IPSetReferenceStatement".to_string(),
+                    fields: vec![
+                    StructField::new("arn", super::arn()).required().with_provider_name("Arn"),
+                    StructField::new("ip_set_forwarded_ip_config", AttributeType::Struct {
+                    name: "IPSetForwardedIPConfiguration".to_string(),
+                    fields: vec![
+                    StructField::new("fallback_behavior", AttributeType::StringEnum {
+                name: "FallbackBehavior".to_string(),
+                values: vec!["MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("FallbackBehavior", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).required().with_provider_name("FallbackBehavior"),
+                    StructField::new("header_name", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[a-zA-Z0-9-]+{1,255}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_2d93cc844f6d4014),
+                to_dsl: None,
+            }).required().with_provider_name("HeaderName"),
+                    StructField::new("position", AttributeType::StringEnum {
+                name: "Position".to_string(),
+                values: vec!["FIRST".to_string(), "LAST".to_string(), "ANY".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("Position", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("FIRST".to_string(), "first".to_string()), ("LAST".to_string(), "last".to_string()), ("ANY".to_string(), "any".to_string())],
+            }).required().with_provider_name("Position")
+                    ],
+                }).with_provider_name("IPSetForwardedIPConfig")
+                    ],
+                })
+        .with_def("ImmunityTimeProperty", AttributeType::Struct {
+                    name: "ImmunityTimeProperty".to_string(),
+                    fields: vec![
+                    StructField::new("immunity_time", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::Int),
+                validate: legacy_validator(validate_immunity_time_range),
+                to_dsl: None,
+            }).required().with_provider_name("ImmunityTime")
+                    ],
+                })
+        .with_def("JA3Fingerprint", AttributeType::Struct {
+                    name: "JA3Fingerprint".to_string(),
+                    fields: vec![
+                    StructField::new("fallback_behavior", AttributeType::StringEnum {
+                name: "FallbackBehavior".to_string(),
+                values: vec!["MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("FallbackBehavior", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).required().with_provider_name("FallbackBehavior")
+                    ],
+                })
+        .with_def("JA4Fingerprint", AttributeType::Struct {
+                    name: "JA4Fingerprint".to_string(),
+                    fields: vec![
+                    StructField::new("fallback_behavior", AttributeType::StringEnum {
+                name: "FallbackBehavior".to_string(),
+                values: vec!["MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("FallbackBehavior", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).required().with_provider_name("FallbackBehavior")
+                    ],
+                })
+        .with_def("JsonBody", AttributeType::Struct {
+                    name: "JsonBody".to_string(),
+                    fields: vec![
+                    StructField::new("invalid_fallback_behavior", AttributeType::StringEnum {
+                name: "BodyParsingFallbackBehavior".to_string(),
+                values: vec!["MATCH".to_string(), "NO_MATCH".to_string(), "EVALUATE_AS_STRING".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("BodyParsingFallbackBehavior", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string()), ("EVALUATE_AS_STRING".to_string(), "evaluate_as_string".to_string())],
+            }).with_provider_name("InvalidFallbackBehavior"),
+                    StructField::new("match_pattern", AttributeType::Struct {
+                    name: "JsonMatchPattern".to_string(),
+                    fields: vec![
+                    StructField::new("all", AttributeType::map(AttributeType::String)).with_description("Inspect all parts of the web request's JSON body.").with_provider_name("All"),
+                    StructField::new("included_paths", AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[\\/]+([^~]*(~[01])*)*{1,512}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_c77cf75cf1a75ade),
+                to_dsl: None,
+            })).with_provider_name("IncludedPaths")
+                    ],
+                }).required().with_provider_name("MatchPattern"),
+                    StructField::new("match_scope", AttributeType::StringEnum {
+                name: "JsonMatchScope".to_string(),
+                values: vec!["ALL".to_string(), "KEY".to_string(), "VALUE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("JsonMatchScope", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("ALL".to_string(), "all".to_string()), ("KEY".to_string(), "key".to_string()), ("VALUE".to_string(), "value".to_string())],
+            }).required().with_provider_name("MatchScope"),
+                    StructField::new("oversize_handling", AttributeType::StringEnum {
+                name: "OversizeHandling".to_string(),
+                values: vec!["CONTINUE".to_string(), "MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("OversizeHandling", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("CONTINUE".to_string(), "continue".to_string()), ("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).with_provider_name("OversizeHandling")
+                    ],
+                })
+        .with_def("JsonMatchPattern", AttributeType::Struct {
+                    name: "JsonMatchPattern".to_string(),
+                    fields: vec![
+                    StructField::new("all", AttributeType::map(AttributeType::String)).with_description("Inspect all parts of the web request's JSON body.").with_provider_name("All"),
+                    StructField::new("included_paths", AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[\\/]+([^~]*(~[01])*)*{1,512}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_c77cf75cf1a75ade),
+                to_dsl: None,
+            })).with_provider_name("IncludedPaths")
+                    ],
+                })
+        .with_def("LabelMatchStatement", AttributeType::Struct {
+                    name: "LabelMatchStatement".to_string(),
+                    fields: vec![
+                    StructField::new("key", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[0-9A-Za-z_:-]{1,1024}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_b3fc65b549fb77bd),
+                to_dsl: None,
+            }).required().with_provider_name("Key"),
+                    StructField::new("scope", AttributeType::StringEnum {
+                name: "LabelMatchScope".to_string(),
+                values: vec!["LABEL".to_string(), "NAMESPACE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("LabelMatchScope", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("LABEL".to_string(), "label".to_string()), ("NAMESPACE".to_string(), "namespace".to_string())],
+            }).required().with_provider_name("Scope")
+                    ],
+                })
+        .with_def("ManagedRuleGroupStatement", AttributeType::Struct {
+                    name: "ManagedRuleGroupStatement".to_string(),
+                    fields: vec![
+                    StructField::new("excluded_rules", AttributeType::list(AttributeType::Struct {
+                    name: "ExcludedRule".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[0-9A-Za-z_-]{1,128}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_42f7eceb887966ad),
+                to_dsl: None,
+            }).required().with_provider_name("Name")
+                    ],
+                })).with_provider_name("ExcludedRules").with_block_name("excluded_rule"),
+                    StructField::new("managed_rule_group_configs", AttributeType::list(AttributeType::Struct {
+                    name: "ManagedRuleGroupConfig".to_string(),
+                    fields: vec![
+                    StructField::new("aws_managed_rules_acfp_rule_set", AttributeType::Struct {
+                    name: "AWSManagedRulesACFPRuleSet".to_string(),
+                    fields: vec![
+                    StructField::new("creation_path", AttributeType::String).required().with_provider_name("CreationPath"),
+                    StructField::new("enable_regex_in_path", AttributeType::Bool).with_provider_name("EnableRegexInPath"),
+                    StructField::new("registration_page_path", AttributeType::String).required().with_provider_name("RegistrationPagePath"),
+                    StructField::new("request_inspection", AttributeType::Struct {
+                    name: "RequestInspectionACFP".to_string(),
+                    fields: vec![
+                    StructField::new("address_fields", AttributeType::list(AttributeType::String)).with_provider_name("AddressFields"),
+                    StructField::new("email_field", AttributeType::Struct {
+                    name: "FieldIdentifier".to_string(),
+                    fields: vec![
+                    StructField::new("identifier", AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(512))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_512),
+                to_dsl: None,
+            }).required().with_provider_name("Identifier")
+                    ],
+                }).with_provider_name("EmailField"),
+                    StructField::new("password_field", AttributeType::Ref("FieldIdentifier".to_string())).with_provider_name("PasswordField"),
+                    StructField::new("payload_type", AttributeType::StringEnum {
+                name: "PayloadType".to_string(),
+                values: vec!["JSON".to_string(), "FORM_ENCODED".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("PayloadType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("JSON".to_string(), "json".to_string()), ("FORM_ENCODED".to_string(), "form_encoded".to_string())],
+            }).required().with_provider_name("PayloadType"),
+                    StructField::new("phone_number_fields", AttributeType::list(AttributeType::String)).with_provider_name("PhoneNumberFields"),
+                    StructField::new("username_field", AttributeType::Ref("FieldIdentifier".to_string())).with_provider_name("UsernameField")
+                    ],
+                }).required().with_provider_name("RequestInspection"),
+                    StructField::new("response_inspection", AttributeType::Struct {
+                    name: "ResponseInspection".to_string(),
+                    fields: vec![
+                    StructField::new("body_contains", AttributeType::Struct {
+                    name: "ResponseInspectionBodyContains".to_string(),
+                    fields: vec![
+                    StructField::new("failure_strings", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(100))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_100),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_5),
+                to_dsl: None,
+            }).required().with_provider_name("FailureStrings"),
+                    StructField::new("success_strings", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(100))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_100),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_5),
+                to_dsl: None,
+            }).required().with_provider_name("SuccessStrings")
+                    ],
+                }).with_provider_name("BodyContains"),
+                    StructField::new("header", AttributeType::Struct {
+                    name: "ResponseInspectionHeader".to_string(),
+                    fields: vec![
+                    StructField::new("failure_values", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(100))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_100),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_3),
+                to_dsl: None,
+            }).required().with_provider_name("FailureValues"),
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(200))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_200),
+                to_dsl: None,
+            }).required().with_provider_name("Name"),
+                    StructField::new("success_values", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(100))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_100),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_3),
+                to_dsl: None,
+            }).required().with_provider_name("SuccessValues")
+                    ],
+                }).with_provider_name("Header"),
+                    StructField::new("json", AttributeType::Struct {
+                    name: "ResponseInspectionJson".to_string(),
+                    fields: vec![
+                    StructField::new("failure_values", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(100))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_100),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_5),
+                to_dsl: None,
+            }).required().with_provider_name("FailureValues"),
+                    StructField::new("identifier", AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(512))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_512),
+                to_dsl: None,
+            }).required().with_provider_name("Identifier"),
+                    StructField::new("success_values", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(100))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_100),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_5),
+                to_dsl: None,
+            }).required().with_provider_name("SuccessValues")
+                    ],
+                }).with_provider_name("Json"),
+                    StructField::new("status_code", AttributeType::Struct {
+                    name: "ResponseInspectionStatusCode".to_string(),
+                    fields: vec![
+                    StructField::new("failure_codes", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Int)),
+                validate: legacy_validator(validate_list_items_1_10),
+                to_dsl: None,
+            }).required().with_provider_name("FailureCodes"),
+                    StructField::new("success_codes", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Int)),
+                validate: legacy_validator(validate_list_items_1_10),
+                to_dsl: None,
+            }).required().with_provider_name("SuccessCodes")
+                    ],
+                }).with_provider_name("StatusCode")
+                    ],
+                }).with_provider_name("ResponseInspection")
+                    ],
+                }).with_provider_name("AWSManagedRulesACFPRuleSet"),
+                    StructField::new("aws_managed_rules_atp_rule_set", AttributeType::Struct {
+                    name: "AWSManagedRulesATPRuleSet".to_string(),
+                    fields: vec![
+                    StructField::new("enable_regex_in_path", AttributeType::Bool).with_provider_name("EnableRegexInPath"),
+                    StructField::new("login_path", AttributeType::String).required().with_provider_name("LoginPath"),
+                    StructField::new("request_inspection", AttributeType::Struct {
+                    name: "RequestInspection".to_string(),
+                    fields: vec![
+                    StructField::new("password_field", AttributeType::Ref("FieldIdentifier".to_string())).required().with_provider_name("PasswordField"),
+                    StructField::new("payload_type", AttributeType::StringEnum {
+                name: "PayloadType".to_string(),
+                values: vec!["JSON".to_string(), "FORM_ENCODED".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("PayloadType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("JSON".to_string(), "json".to_string()), ("FORM_ENCODED".to_string(), "form_encoded".to_string())],
+            }).required().with_provider_name("PayloadType"),
+                    StructField::new("username_field", AttributeType::Ref("FieldIdentifier".to_string())).required().with_provider_name("UsernameField")
+                    ],
+                }).with_provider_name("RequestInspection"),
+                    StructField::new("response_inspection", AttributeType::Ref("ResponseInspection".to_string())).with_provider_name("ResponseInspection")
+                    ],
+                }).with_provider_name("AWSManagedRulesATPRuleSet"),
+                    StructField::new("aws_managed_rules_anti_d_do_s_rule_set", AttributeType::Struct {
+                    name: "AWSManagedRulesAntiDDoSRuleSet".to_string(),
+                    fields: vec![
+                    StructField::new("client_side_action_config", AttributeType::Struct {
+                    name: "ClientSideActionConfig".to_string(),
+                    fields: vec![
+                    StructField::new("challenge", AttributeType::Struct {
+                    name: "ClientSideAction".to_string(),
+                    fields: vec![
+                    StructField::new("exempt_uri_regular_expressions", AttributeType::list(AttributeType::Struct {
+                    name: "Regex".to_string(),
+                    fields: vec![
+                    StructField::new("regex_string", AttributeType::String).with_provider_name("RegexString")
+                    ],
+                })).with_provider_name("ExemptUriRegularExpressions").with_block_name("exempt_uri_regular_expression"),
+                    StructField::new("sensitivity", AttributeType::StringEnum {
+                name: "SensitivityToAct".to_string(),
+                values: vec!["LOW".to_string(), "MEDIUM".to_string(), "HIGH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("SensitivityToAct", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("LOW".to_string(), "low".to_string()), ("MEDIUM".to_string(), "medium".to_string()), ("HIGH".to_string(), "high".to_string())],
+            }).with_provider_name("Sensitivity"),
+                    StructField::new("usage_of_action", AttributeType::StringEnum {
+                name: "UsageOfAction".to_string(),
+                values: vec!["ENABLED".to_string(), "DISABLED".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("UsageOfAction", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("ENABLED".to_string(), "enabled".to_string()), ("DISABLED".to_string(), "disabled".to_string())],
+            }).required().with_provider_name("UsageOfAction")
+                    ],
+                }).required().with_provider_name("Challenge").with_block_name("challenge")
+                    ],
+                }).required().with_provider_name("ClientSideActionConfig").with_block_name("client_side_action_config"),
+                    StructField::new("sensitivity_to_block", AttributeType::StringEnum {
+                name: "SensitivityToAct".to_string(),
+                values: vec!["LOW".to_string(), "MEDIUM".to_string(), "HIGH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("SensitivityToAct", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("LOW".to_string(), "low".to_string()), ("MEDIUM".to_string(), "medium".to_string()), ("HIGH".to_string(), "high".to_string())],
+            }).with_provider_name("SensitivityToBlock")
+                    ],
+                }).with_provider_name("AWSManagedRulesAntiDDoSRuleSet").with_block_name("aws_managed_rules_anti_d_do_s_rule_set"),
+                    StructField::new("aws_managed_rules_bot_control_rule_set", AttributeType::Struct {
+                    name: "AWSManagedRulesBotControlRuleSet".to_string(),
+                    fields: vec![
+                    StructField::new("enable_machine_learning", AttributeType::Bool).with_provider_name("EnableMachineLearning"),
+                    StructField::new("inspection_level", AttributeType::StringEnum {
+                name: "InspectionLevel".to_string(),
+                values: vec!["COMMON".to_string(), "TARGETED".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("InspectionLevel", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("COMMON".to_string(), "common".to_string()), ("TARGETED".to_string(), "targeted".to_string())],
+            }).required().with_provider_name("InspectionLevel")
+                    ],
+                }).with_provider_name("AWSManagedRulesBotControlRuleSet"),
+                    StructField::new("login_path", AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(256))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_256),
+                to_dsl: None,
+            }).with_provider_name("LoginPath"),
+                    StructField::new("password_field", AttributeType::Ref("FieldIdentifier".to_string())).with_provider_name("PasswordField"),
+                    StructField::new("payload_type", AttributeType::StringEnum {
+                name: "PayloadType".to_string(),
+                values: vec!["JSON".to_string(), "FORM_ENCODED".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("PayloadType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("JSON".to_string(), "json".to_string()), ("FORM_ENCODED".to_string(), "form_encoded".to_string())],
+            }).with_provider_name("PayloadType"),
+                    StructField::new("username_field", AttributeType::Ref("FieldIdentifier".to_string())).with_provider_name("UsernameField")
+                    ],
+                })).with_description("Collection of ManagedRuleGroupConfig.").with_provider_name("ManagedRuleGroupConfigs").with_block_name("managed_rule_group_config"),
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[0-9A-Za-z_-]{1,128}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_42f7eceb887966ad),
+                to_dsl: None,
+            }).required().with_provider_name("Name"),
+                    StructField::new("rule_action_overrides", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Struct {
+                    name: "RuleActionOverride".to_string(),
+                    fields: vec![
+                    StructField::new("action_to_use", AttributeType::Ref("RuleAction".to_string())).required().with_provider_name("ActionToUse"),
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[0-9A-Za-z_-]{1,128}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_42f7eceb887966ad),
+                to_dsl: None,
+            }).required().with_provider_name("Name")
+                    ],
+                })),
+                validate: legacy_validator(validate_list_items_max_100),
+                to_dsl: None,
+            }).with_description("Action overrides for rules in the rule group.").with_provider_name("RuleActionOverrides").with_block_name("rule_action_override"),
+                    StructField::new("scope_down_statement", AttributeType::Ref("Statement".to_string())).with_provider_name("ScopeDownStatement"),
+                    StructField::new("vendor_name", AttributeType::String).required().with_provider_name("VendorName"),
+                    StructField::new("version", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[\\w#:\\.\\-/]+$".to_string()),
+                length: Some((Some(1), Some(64))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_82a037d29be8d222_len_1_64),
+                to_dsl: None,
+            }).with_provider_name("Version")
+                    ],
+                })
+        .with_def("NotStatement", AttributeType::Struct {
+                    name: "NotStatement".to_string(),
+                    fields: vec![
+                    StructField::new("statement", AttributeType::Ref("Statement".to_string())).required().with_provider_name("Statement")
+                    ],
+                })
+        .with_def("OnSourceDDoSProtectionConfig", AttributeType::Struct {
+                    name: "OnSourceDDoSProtectionConfig".to_string(),
+                    fields: vec![
+                    StructField::new("alb_low_reputation_mode", AttributeType::StringEnum {
+                name: "AlbLowReputationMode".to_string(),
+                values: vec!["ACTIVE_UNDER_DDOS".to_string(), "ALWAYS_ON".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("AlbLowReputationMode", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("ACTIVE_UNDER_DDOS".to_string(), "active_under_ddos".to_string()), ("ALWAYS_ON".to_string(), "always_on".to_string())],
+            }).required().with_provider_name("ALBLowReputationMode")
+                    ],
+                })
+        .with_def("OrStatement", AttributeType::Struct {
+                    name: "OrStatement".to_string(),
+                    fields: vec![
+                    StructField::new("statements", AttributeType::list(AttributeType::Struct {
+                    name: "Statement".to_string(),
+                    fields: vec![
+                    StructField::new("and_statement", AttributeType::Ref("AndStatement".to_string())).with_provider_name("AndStatement"),
+                    StructField::new("asn_match_statement", AttributeType::Ref("AsnMatchStatement".to_string())).with_provider_name("AsnMatchStatement"),
+                    StructField::new("byte_match_statement", AttributeType::Ref("ByteMatchStatement".to_string())).with_provider_name("ByteMatchStatement"),
+                    StructField::new("geo_match_statement", AttributeType::Ref("GeoMatchStatement".to_string())).with_provider_name("GeoMatchStatement"),
+                    StructField::new("ip_set_reference_statement", AttributeType::Ref("IPSetReferenceStatement".to_string())).with_provider_name("IPSetReferenceStatement"),
+                    StructField::new("label_match_statement", AttributeType::Ref("LabelMatchStatement".to_string())).with_provider_name("LabelMatchStatement"),
+                    StructField::new("managed_rule_group_statement", AttributeType::Ref("ManagedRuleGroupStatement".to_string())).with_provider_name("ManagedRuleGroupStatement"),
+                    StructField::new("not_statement", AttributeType::Ref("NotStatement".to_string())).with_provider_name("NotStatement"),
+                    StructField::new("or_statement", AttributeType::Ref("OrStatement".to_string())).with_provider_name("OrStatement"),
+                    StructField::new("rate_based_statement", AttributeType::Struct {
+                    name: "RateBasedStatement".to_string(),
+                    fields: vec![
+                    StructField::new("aggregate_key_type", AttributeType::StringEnum {
+                name: "AggregateKeyType".to_string(),
+                values: vec!["CONSTANT".to_string(), "IP".to_string(), "FORWARDED_IP".to_string(), "CUSTOM_KEYS".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("AggregateKeyType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("CONSTANT".to_string(), "constant".to_string()), ("IP".to_string(), "ip".to_string()), ("FORWARDED_IP".to_string(), "forwarded_ip".to_string()), ("CUSTOM_KEYS".to_string(), "custom_keys".to_string())],
+            }).required().with_provider_name("AggregateKeyType"),
+                    StructField::new("custom_keys", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Struct {
+                    name: "RateBasedStatementCustomKey".to_string(),
+                    fields: vec![
+                    StructField::new("asn", AttributeType::String).with_provider_name("ASN"),
+                    StructField::new("cookie", AttributeType::Struct {
+                    name: "RateLimitCookie".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(64))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_64),
+                to_dsl: None,
+            }).required().with_description("The name of the cookie to use.").with_provider_name("Name"),
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                }).with_provider_name("Cookie").with_block_name("cookie"),
+                    StructField::new("forwarded_ip", types::ipv4_address()).with_provider_name("ForwardedIP"),
+                    StructField::new("http_method", AttributeType::String).with_provider_name("HTTPMethod"),
+                    StructField::new("header", AttributeType::Struct {
+                    name: "RateLimitHeader".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(64))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_64),
+                to_dsl: None,
+            }).required().with_description("The name of the header to use.").with_provider_name("Name"),
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                }).with_provider_name("Header").with_block_name("header"),
+                    StructField::new("ip", types::ipv4_address()).with_provider_name("IP"),
+                    StructField::new("ja3_fingerprint", AttributeType::Struct {
+                    name: "RateLimitJA3Fingerprint".to_string(),
+                    fields: vec![
+                    StructField::new("fallback_behavior", AttributeType::StringEnum {
+                name: "FallbackBehavior".to_string(),
+                values: vec!["MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("FallbackBehavior", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).required().with_provider_name("FallbackBehavior")
+                    ],
+                }).with_provider_name("JA3Fingerprint"),
+                    StructField::new("ja4_fingerprint", AttributeType::Struct {
+                    name: "RateLimitJA4Fingerprint".to_string(),
+                    fields: vec![
+                    StructField::new("fallback_behavior", AttributeType::StringEnum {
+                name: "FallbackBehavior".to_string(),
+                values: vec!["MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("FallbackBehavior", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).required().with_provider_name("FallbackBehavior")
+                    ],
+                }).with_provider_name("JA4Fingerprint"),
+                    StructField::new("label_namespace", AttributeType::Struct {
+                    name: "RateLimitLabelNamespace".to_string(),
+                    fields: vec![
+                    StructField::new("namespace", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[0-9A-Za-z_:-]{1,1024}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_b3fc65b549fb77bd),
+                to_dsl: None,
+            }).required().with_description("The namespace to use for aggregation.").with_provider_name("Namespace")
+                    ],
+                }).with_provider_name("LabelNamespace"),
+                    StructField::new("query_argument", AttributeType::Struct {
+                    name: "RateLimitQueryArgument".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(64))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_64),
+                to_dsl: None,
+            }).required().with_description("The name of the query argument to use.").with_provider_name("Name"),
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                }).with_provider_name("QueryArgument").with_block_name("query_argument"),
+                    StructField::new("query_string", AttributeType::Struct {
+                    name: "RateLimitQueryString".to_string(),
+                    fields: vec![
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                }).with_provider_name("QueryString").with_block_name("query_string"),
+                    StructField::new("uri_path", AttributeType::Struct {
+                    name: "RateLimitUriPath".to_string(),
+                    fields: vec![
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                }).with_provider_name("UriPath").with_block_name("uri_path")
+                    ],
+                })),
+                validate: legacy_validator(validate_list_items_max_5),
+                to_dsl: None,
+            }).with_description("Specifies the aggregate keys to use in a rate-base rule.").with_provider_name("CustomKeys").with_block_name("custom_key"),
+                    StructField::new("evaluation_window_sec", AttributeType::StringEnum {
+                name: "EvaluationWindowSec".to_string(),
+                values: vec!["60".to_string(), "120".to_string(), "300".to_string(), "600".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("EvaluationWindowSec", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("60".to_string(), "60".to_string()), ("120".to_string(), "120".to_string()), ("300".to_string(), "300".to_string()), ("600".to_string(), "600".to_string())],
+            }).with_provider_name("EvaluationWindowSec"),
+                    StructField::new("forwarded_ip_config", AttributeType::Ref("ForwardedIPConfiguration".to_string())).with_provider_name("ForwardedIPConfig"),
+                    StructField::new("limit", AttributeType::String).required().with_provider_name("Limit"),
+                    StructField::new("scope_down_statement", AttributeType::Ref("Statement".to_string())).with_provider_name("ScopeDownStatement")
+                    ],
+                }).with_provider_name("RateBasedStatement").with_block_name("rate_based_statement"),
+                    StructField::new("regex_match_statement", AttributeType::Struct {
+                    name: "RegexMatchStatement".to_string(),
+                    fields: vec![
+                    StructField::new("field_to_match", AttributeType::Ref("FieldToMatch".to_string())).required().with_provider_name("FieldToMatch"),
+                    StructField::new("regex_string", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: Some((Some(1), Some(512))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_length_1_512),
+                to_dsl: None,
+            }).required().with_provider_name("RegexString"),
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                }).with_provider_name("RegexMatchStatement").with_block_name("regex_match_statement"),
+                    StructField::new("regex_pattern_set_reference_statement", AttributeType::Struct {
+                    name: "RegexPatternSetReferenceStatement".to_string(),
+                    fields: vec![
+                    StructField::new("arn", super::arn()).required().with_provider_name("Arn"),
+                    StructField::new("field_to_match", AttributeType::Ref("FieldToMatch".to_string())).required().with_provider_name("FieldToMatch"),
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                }).with_provider_name("RegexPatternSetReferenceStatement").with_block_name("regex_pattern_set_reference_statement"),
+                    StructField::new("rule_group_reference_statement", AttributeType::Struct {
+                    name: "RuleGroupReferenceStatement".to_string(),
+                    fields: vec![
+                    StructField::new("arn", super::arn()).required().with_provider_name("Arn"),
+                    StructField::new("excluded_rules", AttributeType::list(AttributeType::Struct {
+                    name: "ExcludedRule".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[0-9A-Za-z_-]{1,128}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_42f7eceb887966ad),
+                to_dsl: None,
+            }).required().with_provider_name("Name")
+                    ],
+                })).with_provider_name("ExcludedRules").with_block_name("excluded_rule"),
+                    StructField::new("rule_action_overrides", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Struct {
+                    name: "RuleActionOverride".to_string(),
+                    fields: vec![
+                    StructField::new("action_to_use", AttributeType::Ref("RuleAction".to_string())).required().with_provider_name("ActionToUse"),
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[0-9A-Za-z_-]{1,128}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_42f7eceb887966ad),
+                to_dsl: None,
+            }).required().with_provider_name("Name")
+                    ],
+                })),
+                validate: legacy_validator(validate_list_items_max_100),
+                to_dsl: None,
+            }).with_description("Action overrides for rules in the rule group.").with_provider_name("RuleActionOverrides").with_block_name("rule_action_override")
+                    ],
+                }).with_provider_name("RuleGroupReferenceStatement").with_block_name("rule_group_reference_statement"),
+                    StructField::new("size_constraint_statement", AttributeType::Struct {
+                    name: "SizeConstraintStatement".to_string(),
+                    fields: vec![
+                    StructField::new("comparison_operator", AttributeType::StringEnum {
+                name: "ComparisonOperator".to_string(),
+                values: vec!["EQ".to_string(), "NE".to_string(), "LE".to_string(), "LT".to_string(), "GE".to_string(), "GT".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("ComparisonOperator", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("EQ".to_string(), "eq".to_string()), ("NE".to_string(), "ne".to_string()), ("LE".to_string(), "le".to_string()), ("LT".to_string(), "lt".to_string()), ("GE".to_string(), "ge".to_string()), ("GT".to_string(), "gt".to_string())],
+            }).required().with_provider_name("ComparisonOperator"),
+                    StructField::new("field_to_match", AttributeType::Ref("FieldToMatch".to_string())).required().with_provider_name("FieldToMatch"),
+                    StructField::new("size", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::Float),
+                validate: legacy_validator(validate_size_range),
+                to_dsl: None,
+            }).required().with_provider_name("Size"),
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                }).with_provider_name("SizeConstraintStatement").with_block_name("size_constraint_statement"),
+                    StructField::new("sqli_match_statement", AttributeType::Struct {
+                    name: "SqliMatchStatement".to_string(),
+                    fields: vec![
+                    StructField::new("field_to_match", AttributeType::Ref("FieldToMatch".to_string())).required().with_provider_name("FieldToMatch"),
+                    StructField::new("sensitivity_level", AttributeType::StringEnum {
+                name: "SensitivityLevel".to_string(),
+                values: vec!["LOW".to_string(), "HIGH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("SensitivityLevel", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("LOW".to_string(), "low".to_string()), ("HIGH".to_string(), "high".to_string())],
+            }).with_provider_name("SensitivityLevel"),
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                }).with_provider_name("SqliMatchStatement").with_block_name("sqli_match_statement"),
+                    StructField::new("xss_match_statement", AttributeType::Struct {
+                    name: "XssMatchStatement".to_string(),
+                    fields: vec![
+                    StructField::new("field_to_match", AttributeType::Ref("FieldToMatch".to_string())).required().with_provider_name("FieldToMatch"),
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                }).with_provider_name("XssMatchStatement").with_block_name("xss_match_statement")
+                    ],
+                })).required().with_provider_name("Statements").with_block_name("statement")
+                    ],
+                })
+        .with_def("OverrideAction", AttributeType::Struct {
+                    name: "OverrideAction".to_string(),
+                    fields: vec![
+                    StructField::new("count", AttributeType::map(AttributeType::String)).with_description("Count traffic towards application.").with_provider_name("Count"),
+                    StructField::new("none", AttributeType::map(AttributeType::String)).with_description("Keep the RuleGroup or ManagedRuleGroup behavior as is.").with_provider_name("None")
+                    ],
+                })
+        .with_def("RateBasedStatement", AttributeType::Struct {
+                    name: "RateBasedStatement".to_string(),
+                    fields: vec![
+                    StructField::new("aggregate_key_type", AttributeType::StringEnum {
+                name: "AggregateKeyType".to_string(),
+                values: vec!["CONSTANT".to_string(), "IP".to_string(), "FORWARDED_IP".to_string(), "CUSTOM_KEYS".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("AggregateKeyType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("CONSTANT".to_string(), "constant".to_string()), ("IP".to_string(), "ip".to_string()), ("FORWARDED_IP".to_string(), "forwarded_ip".to_string()), ("CUSTOM_KEYS".to_string(), "custom_keys".to_string())],
+            }).required().with_provider_name("AggregateKeyType"),
+                    StructField::new("custom_keys", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Struct {
+                    name: "RateBasedStatementCustomKey".to_string(),
+                    fields: vec![
+                    StructField::new("asn", AttributeType::String).with_provider_name("ASN"),
+                    StructField::new("cookie", AttributeType::Struct {
+                    name: "RateLimitCookie".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(64))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_64),
+                to_dsl: None,
+            }).required().with_description("The name of the cookie to use.").with_provider_name("Name"),
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                }).with_provider_name("Cookie").with_block_name("cookie"),
+                    StructField::new("forwarded_ip", types::ipv4_address()).with_provider_name("ForwardedIP"),
+                    StructField::new("http_method", AttributeType::String).with_provider_name("HTTPMethod"),
+                    StructField::new("header", AttributeType::Struct {
+                    name: "RateLimitHeader".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(64))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_64),
+                to_dsl: None,
+            }).required().with_description("The name of the header to use.").with_provider_name("Name"),
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                }).with_provider_name("Header").with_block_name("header"),
+                    StructField::new("ip", types::ipv4_address()).with_provider_name("IP"),
+                    StructField::new("ja3_fingerprint", AttributeType::Struct {
+                    name: "RateLimitJA3Fingerprint".to_string(),
+                    fields: vec![
+                    StructField::new("fallback_behavior", AttributeType::StringEnum {
+                name: "FallbackBehavior".to_string(),
+                values: vec!["MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("FallbackBehavior", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).required().with_provider_name("FallbackBehavior")
+                    ],
+                }).with_provider_name("JA3Fingerprint"),
+                    StructField::new("ja4_fingerprint", AttributeType::Struct {
+                    name: "RateLimitJA4Fingerprint".to_string(),
+                    fields: vec![
+                    StructField::new("fallback_behavior", AttributeType::StringEnum {
+                name: "FallbackBehavior".to_string(),
+                values: vec!["MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("FallbackBehavior", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).required().with_provider_name("FallbackBehavior")
+                    ],
+                }).with_provider_name("JA4Fingerprint"),
+                    StructField::new("label_namespace", AttributeType::Struct {
+                    name: "RateLimitLabelNamespace".to_string(),
+                    fields: vec![
+                    StructField::new("namespace", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[0-9A-Za-z_:-]{1,1024}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_b3fc65b549fb77bd),
+                to_dsl: None,
+            }).required().with_description("The namespace to use for aggregation.").with_provider_name("Namespace")
+                    ],
+                }).with_provider_name("LabelNamespace"),
+                    StructField::new("query_argument", AttributeType::Struct {
+                    name: "RateLimitQueryArgument".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(64))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_64),
+                to_dsl: None,
+            }).required().with_description("The name of the query argument to use.").with_provider_name("Name"),
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                }).with_provider_name("QueryArgument").with_block_name("query_argument"),
+                    StructField::new("query_string", AttributeType::Struct {
+                    name: "RateLimitQueryString".to_string(),
+                    fields: vec![
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                }).with_provider_name("QueryString").with_block_name("query_string"),
+                    StructField::new("uri_path", AttributeType::Struct {
+                    name: "RateLimitUriPath".to_string(),
+                    fields: vec![
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                }).with_provider_name("UriPath").with_block_name("uri_path")
+                    ],
+                })),
+                validate: legacy_validator(validate_list_items_max_5),
+                to_dsl: None,
+            }).with_description("Specifies the aggregate keys to use in a rate-base rule.").with_provider_name("CustomKeys").with_block_name("custom_key"),
+                    StructField::new("evaluation_window_sec", AttributeType::StringEnum {
+                name: "EvaluationWindowSec".to_string(),
+                values: vec!["60".to_string(), "120".to_string(), "300".to_string(), "600".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("EvaluationWindowSec", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("60".to_string(), "60".to_string()), ("120".to_string(), "120".to_string()), ("300".to_string(), "300".to_string()), ("600".to_string(), "600".to_string())],
+            }).with_provider_name("EvaluationWindowSec"),
+                    StructField::new("forwarded_ip_config", AttributeType::Ref("ForwardedIPConfiguration".to_string())).with_provider_name("ForwardedIPConfig"),
+                    StructField::new("limit", AttributeType::String).required().with_provider_name("Limit"),
+                    StructField::new("scope_down_statement", AttributeType::Ref("Statement".to_string())).with_provider_name("ScopeDownStatement")
+                    ],
+                })
+        .with_def("RateLimitCookie", AttributeType::Struct {
+                    name: "RateLimitCookie".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(64))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_64),
+                to_dsl: None,
+            }).required().with_description("The name of the cookie to use.").with_provider_name("Name"),
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                })
+        .with_def("RateLimitHeader", AttributeType::Struct {
+                    name: "RateLimitHeader".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(64))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_64),
+                to_dsl: None,
+            }).required().with_description("The name of the header to use.").with_provider_name("Name"),
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                })
+        .with_def("RateLimitJA3Fingerprint", AttributeType::Struct {
+                    name: "RateLimitJA3Fingerprint".to_string(),
+                    fields: vec![
+                    StructField::new("fallback_behavior", AttributeType::StringEnum {
+                name: "FallbackBehavior".to_string(),
+                values: vec!["MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("FallbackBehavior", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).required().with_provider_name("FallbackBehavior")
+                    ],
+                })
+        .with_def("RateLimitJA4Fingerprint", AttributeType::Struct {
+                    name: "RateLimitJA4Fingerprint".to_string(),
+                    fields: vec![
+                    StructField::new("fallback_behavior", AttributeType::StringEnum {
+                name: "FallbackBehavior".to_string(),
+                values: vec!["MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("FallbackBehavior", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).required().with_provider_name("FallbackBehavior")
+                    ],
+                })
+        .with_def("RateLimitLabelNamespace", AttributeType::Struct {
+                    name: "RateLimitLabelNamespace".to_string(),
+                    fields: vec![
+                    StructField::new("namespace", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[0-9A-Za-z_:-]{1,1024}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_b3fc65b549fb77bd),
+                to_dsl: None,
+            }).required().with_description("The namespace to use for aggregation.").with_provider_name("Namespace")
+                    ],
+                })
+        .with_def("RateLimitQueryArgument", AttributeType::Struct {
+                    name: "RateLimitQueryArgument".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(64))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_64),
+                to_dsl: None,
+            }).required().with_description("The name of the query argument to use.").with_provider_name("Name"),
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                })
+        .with_def("RateLimitQueryString", AttributeType::Struct {
+                    name: "RateLimitQueryString".to_string(),
+                    fields: vec![
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                })
+        .with_def("RateLimitUriPath", AttributeType::Struct {
+                    name: "RateLimitUriPath".to_string(),
+                    fields: vec![
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                })
+        .with_def("Regex", AttributeType::Struct {
+                    name: "Regex".to_string(),
+                    fields: vec![
+                    StructField::new("regex_string", AttributeType::String).with_provider_name("RegexString")
+                    ],
+                })
+        .with_def("RegexMatchStatement", AttributeType::Struct {
+                    name: "RegexMatchStatement".to_string(),
+                    fields: vec![
+                    StructField::new("field_to_match", AttributeType::Ref("FieldToMatch".to_string())).required().with_provider_name("FieldToMatch"),
+                    StructField::new("regex_string", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: Some((Some(1), Some(512))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_length_1_512),
+                to_dsl: None,
+            }).required().with_provider_name("RegexString"),
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                })
+        .with_def("RegexPatternSetReferenceStatement", AttributeType::Struct {
+                    name: "RegexPatternSetReferenceStatement".to_string(),
+                    fields: vec![
+                    StructField::new("arn", super::arn()).required().with_provider_name("Arn"),
+                    StructField::new("field_to_match", AttributeType::Ref("FieldToMatch".to_string())).required().with_provider_name("FieldToMatch"),
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                })
+        .with_def("RequestInspection", AttributeType::Struct {
+                    name: "RequestInspection".to_string(),
+                    fields: vec![
+                    StructField::new("password_field", AttributeType::Ref("FieldIdentifier".to_string())).required().with_provider_name("PasswordField"),
+                    StructField::new("payload_type", AttributeType::StringEnum {
+                name: "PayloadType".to_string(),
+                values: vec!["JSON".to_string(), "FORM_ENCODED".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("PayloadType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("JSON".to_string(), "json".to_string()), ("FORM_ENCODED".to_string(), "form_encoded".to_string())],
+            }).required().with_provider_name("PayloadType"),
+                    StructField::new("username_field", AttributeType::Ref("FieldIdentifier".to_string())).required().with_provider_name("UsernameField")
+                    ],
+                })
+        .with_def("RequestInspectionACFP", AttributeType::Struct {
+                    name: "RequestInspectionACFP".to_string(),
+                    fields: vec![
+                    StructField::new("address_fields", AttributeType::list(AttributeType::String)).with_provider_name("AddressFields"),
+                    StructField::new("email_field", AttributeType::Struct {
+                    name: "FieldIdentifier".to_string(),
+                    fields: vec![
+                    StructField::new("identifier", AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(512))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_512),
+                to_dsl: None,
+            }).required().with_provider_name("Identifier")
+                    ],
+                }).with_provider_name("EmailField"),
+                    StructField::new("password_field", AttributeType::Ref("FieldIdentifier".to_string())).with_provider_name("PasswordField"),
+                    StructField::new("payload_type", AttributeType::StringEnum {
+                name: "PayloadType".to_string(),
+                values: vec!["JSON".to_string(), "FORM_ENCODED".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("PayloadType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("JSON".to_string(), "json".to_string()), ("FORM_ENCODED".to_string(), "form_encoded".to_string())],
+            }).required().with_provider_name("PayloadType"),
+                    StructField::new("phone_number_fields", AttributeType::list(AttributeType::String)).with_provider_name("PhoneNumberFields"),
+                    StructField::new("username_field", AttributeType::Ref("FieldIdentifier".to_string())).with_provider_name("UsernameField")
+                    ],
+                })
+        .with_def("ResponseInspection", AttributeType::Struct {
+                    name: "ResponseInspection".to_string(),
+                    fields: vec![
+                    StructField::new("body_contains", AttributeType::Struct {
+                    name: "ResponseInspectionBodyContains".to_string(),
+                    fields: vec![
+                    StructField::new("failure_strings", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(100))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_100),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_5),
+                to_dsl: None,
+            }).required().with_provider_name("FailureStrings"),
+                    StructField::new("success_strings", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(100))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_100),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_5),
+                to_dsl: None,
+            }).required().with_provider_name("SuccessStrings")
+                    ],
+                }).with_provider_name("BodyContains"),
+                    StructField::new("header", AttributeType::Struct {
+                    name: "ResponseInspectionHeader".to_string(),
+                    fields: vec![
+                    StructField::new("failure_values", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(100))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_100),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_3),
+                to_dsl: None,
+            }).required().with_provider_name("FailureValues"),
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(200))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_200),
+                to_dsl: None,
+            }).required().with_provider_name("Name"),
+                    StructField::new("success_values", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(100))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_100),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_3),
+                to_dsl: None,
+            }).required().with_provider_name("SuccessValues")
+                    ],
+                }).with_provider_name("Header"),
+                    StructField::new("json", AttributeType::Struct {
+                    name: "ResponseInspectionJson".to_string(),
+                    fields: vec![
+                    StructField::new("failure_values", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(100))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_100),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_5),
+                to_dsl: None,
+            }).required().with_provider_name("FailureValues"),
+                    StructField::new("identifier", AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(512))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_512),
+                to_dsl: None,
+            }).required().with_provider_name("Identifier"),
+                    StructField::new("success_values", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(100))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_100),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_5),
+                to_dsl: None,
+            }).required().with_provider_name("SuccessValues")
+                    ],
+                }).with_provider_name("Json"),
+                    StructField::new("status_code", AttributeType::Struct {
+                    name: "ResponseInspectionStatusCode".to_string(),
+                    fields: vec![
+                    StructField::new("failure_codes", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Int)),
+                validate: legacy_validator(validate_list_items_1_10),
+                to_dsl: None,
+            }).required().with_provider_name("FailureCodes"),
+                    StructField::new("success_codes", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Int)),
+                validate: legacy_validator(validate_list_items_1_10),
+                to_dsl: None,
+            }).required().with_provider_name("SuccessCodes")
+                    ],
+                }).with_provider_name("StatusCode")
+                    ],
+                })
+        .with_def("ResponseInspectionBodyContains", AttributeType::Struct {
+                    name: "ResponseInspectionBodyContains".to_string(),
+                    fields: vec![
+                    StructField::new("failure_strings", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(100))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_100),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_5),
+                to_dsl: None,
+            }).required().with_provider_name("FailureStrings"),
+                    StructField::new("success_strings", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(100))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_100),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_5),
+                to_dsl: None,
+            }).required().with_provider_name("SuccessStrings")
+                    ],
+                })
+        .with_def("ResponseInspectionHeader", AttributeType::Struct {
+                    name: "ResponseInspectionHeader".to_string(),
+                    fields: vec![
+                    StructField::new("failure_values", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(100))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_100),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_3),
+                to_dsl: None,
+            }).required().with_provider_name("FailureValues"),
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(200))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_200),
+                to_dsl: None,
+            }).required().with_provider_name("Name"),
+                    StructField::new("success_values", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(100))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_100),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_3),
+                to_dsl: None,
+            }).required().with_provider_name("SuccessValues")
+                    ],
+                })
+        .with_def("ResponseInspectionJson", AttributeType::Struct {
+                    name: "ResponseInspectionJson".to_string(),
+                    fields: vec![
+                    StructField::new("failure_values", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(100))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_100),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_5),
+                to_dsl: None,
+            }).required().with_provider_name("FailureValues"),
+                    StructField::new("identifier", AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(512))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_512),
+                to_dsl: None,
+            }).required().with_provider_name("Identifier"),
+                    StructField::new("success_values", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(100))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_100),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_5),
+                to_dsl: None,
+            }).required().with_provider_name("SuccessValues")
+                    ],
+                })
+        .with_def("ResponseInspectionStatusCode", AttributeType::Struct {
+                    name: "ResponseInspectionStatusCode".to_string(),
+                    fields: vec![
+                    StructField::new("failure_codes", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Int)),
+                validate: legacy_validator(validate_list_items_1_10),
+                to_dsl: None,
+            }).required().with_provider_name("FailureCodes"),
+                    StructField::new("success_codes", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Int)),
+                validate: legacy_validator(validate_list_items_1_10),
+                to_dsl: None,
+            }).required().with_provider_name("SuccessCodes")
+                    ],
+                })
+        .with_def("RuleAction", AttributeType::Struct {
+                    name: "RuleAction".to_string(),
+                    fields: vec![
+                    StructField::new("allow", AttributeType::Ref("AllowAction".to_string())).with_provider_name("Allow"),
+                    StructField::new("block", AttributeType::Ref("BlockAction".to_string())).with_provider_name("Block"),
+                    StructField::new("captcha", AttributeType::Struct {
+                    name: "CaptchaAction".to_string(),
+                    fields: vec![
+                    StructField::new("custom_request_handling", AttributeType::Ref("CustomRequestHandling".to_string())).with_provider_name("CustomRequestHandling")
+                    ],
+                }).with_provider_name("Captcha"),
+                    StructField::new("challenge", AttributeType::Struct {
+                    name: "ChallengeAction".to_string(),
+                    fields: vec![
+                    StructField::new("custom_request_handling", AttributeType::Ref("CustomRequestHandling".to_string())).with_provider_name("CustomRequestHandling")
+                    ],
+                }).with_provider_name("Challenge"),
+                    StructField::new("count", AttributeType::Struct {
+                    name: "CountAction".to_string(),
+                    fields: vec![
+                    StructField::new("custom_request_handling", AttributeType::Ref("CustomRequestHandling".to_string())).with_provider_name("CustomRequestHandling")
+                    ],
+                }).with_provider_name("Count")
+                    ],
+                })
+        .with_def("RuleGroupReferenceStatement", AttributeType::Struct {
+                    name: "RuleGroupReferenceStatement".to_string(),
+                    fields: vec![
+                    StructField::new("arn", super::arn()).required().with_provider_name("Arn"),
+                    StructField::new("excluded_rules", AttributeType::list(AttributeType::Struct {
+                    name: "ExcludedRule".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[0-9A-Za-z_-]{1,128}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_42f7eceb887966ad),
+                to_dsl: None,
+            }).required().with_provider_name("Name")
+                    ],
+                })).with_provider_name("ExcludedRules").with_block_name("excluded_rule"),
+                    StructField::new("rule_action_overrides", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Struct {
+                    name: "RuleActionOverride".to_string(),
+                    fields: vec![
+                    StructField::new("action_to_use", AttributeType::Ref("RuleAction".to_string())).required().with_provider_name("ActionToUse"),
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[0-9A-Za-z_-]{1,128}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_42f7eceb887966ad),
+                to_dsl: None,
+            }).required().with_provider_name("Name")
+                    ],
+                })),
+                validate: legacy_validator(validate_list_items_max_100),
+                to_dsl: None,
+            }).with_description("Action overrides for rules in the rule group.").with_provider_name("RuleActionOverrides").with_block_name("rule_action_override")
+                    ],
+                })
+        .with_def("SizeConstraintStatement", AttributeType::Struct {
+                    name: "SizeConstraintStatement".to_string(),
+                    fields: vec![
+                    StructField::new("comparison_operator", AttributeType::StringEnum {
+                name: "ComparisonOperator".to_string(),
+                values: vec!["EQ".to_string(), "NE".to_string(), "LE".to_string(), "LT".to_string(), "GE".to_string(), "GT".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("ComparisonOperator", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("EQ".to_string(), "eq".to_string()), ("NE".to_string(), "ne".to_string()), ("LE".to_string(), "le".to_string()), ("LT".to_string(), "lt".to_string()), ("GE".to_string(), "ge".to_string()), ("GT".to_string(), "gt".to_string())],
+            }).required().with_provider_name("ComparisonOperator"),
+                    StructField::new("field_to_match", AttributeType::Ref("FieldToMatch".to_string())).required().with_provider_name("FieldToMatch"),
+                    StructField::new("size", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::Float),
+                validate: legacy_validator(validate_size_range),
+                to_dsl: None,
+            }).required().with_provider_name("Size"),
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                })
+        .with_def("SqliMatchStatement", AttributeType::Struct {
+                    name: "SqliMatchStatement".to_string(),
+                    fields: vec![
+                    StructField::new("field_to_match", AttributeType::Ref("FieldToMatch".to_string())).required().with_provider_name("FieldToMatch"),
+                    StructField::new("sensitivity_level", AttributeType::StringEnum {
+                name: "SensitivityLevel".to_string(),
+                values: vec!["LOW".to_string(), "HIGH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("SensitivityLevel", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("LOW".to_string(), "low".to_string()), ("HIGH".to_string(), "high".to_string())],
+            }).with_provider_name("SensitivityLevel"),
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                })
+        .with_def("Statement", AttributeType::Struct {
+                    name: "Statement".to_string(),
+                    fields: vec![
+                    StructField::new("and_statement", AttributeType::Struct {
+                    name: "AndStatement".to_string(),
+                    fields: vec![
+                    StructField::new("statements", AttributeType::list(AttributeType::Struct {
+                    name: "Statement".to_string(),
+                    fields: vec![
+                    StructField::new("and_statement", AttributeType::Ref("AndStatement".to_string())).with_provider_name("AndStatement"),
+                    StructField::new("asn_match_statement", AttributeType::Struct {
+                    name: "AsnMatchStatement".to_string(),
+                    fields: vec![
+                    StructField::new("asn_list", AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::Int),
+                validate: legacy_validator(validate_asn_list_range),
+                to_dsl: None,
+            })).with_provider_name("AsnList"),
+                    StructField::new("forwarded_ip_config", AttributeType::Struct {
+                    name: "ForwardedIPConfiguration".to_string(),
+                    fields: vec![
+                    StructField::new("fallback_behavior", AttributeType::StringEnum {
+                name: "FallbackBehavior".to_string(),
+                values: vec!["MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("FallbackBehavior", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).required().with_provider_name("FallbackBehavior"),
+                    StructField::new("header_name", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[a-zA-Z0-9-]+{1,255}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_2d93cc844f6d4014),
+                to_dsl: None,
+            }).required().with_provider_name("HeaderName")
+                    ],
+                }).with_provider_name("ForwardedIPConfig")
+                    ],
+                }).with_provider_name("AsnMatchStatement"),
+                    StructField::new("byte_match_statement", AttributeType::Struct {
+                    name: "ByteMatchStatement".to_string(),
+                    fields: vec![
+                    StructField::new("field_to_match", AttributeType::Struct {
+                    name: "FieldToMatch".to_string(),
+                    fields: vec![
+                    StructField::new("all_query_arguments", AttributeType::map(AttributeType::String)).with_description("All query arguments of a web request.").with_provider_name("AllQueryArguments"),
+                    StructField::new("body", AttributeType::Struct {
+                    name: "Body".to_string(),
+                    fields: vec![
+                    StructField::new("oversize_handling", AttributeType::StringEnum {
+                name: "OversizeHandling".to_string(),
+                values: vec!["CONTINUE".to_string(), "MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("OversizeHandling", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("CONTINUE".to_string(), "continue".to_string()), ("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).with_provider_name("OversizeHandling")
+                    ],
+                }).with_provider_name("Body"),
+                    StructField::new("cookies", AttributeType::Struct {
+                    name: "Cookies".to_string(),
+                    fields: vec![
+                    StructField::new("match_pattern", AttributeType::Struct {
+                    name: "CookieMatchPattern".to_string(),
+                    fields: vec![
+                    StructField::new("all", AttributeType::map(AttributeType::String)).with_description("Inspect all parts of the web request cookies.").with_provider_name("All"),
+                    StructField::new("excluded_cookies", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(60))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_60),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_199),
+                to_dsl: None,
+            }).with_provider_name("ExcludedCookies"),
+                    StructField::new("included_cookies", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(60))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_60),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_199),
+                to_dsl: None,
+            }).with_provider_name("IncludedCookies")
+                    ],
+                }).required().with_provider_name("MatchPattern"),
+                    StructField::new("match_scope", AttributeType::StringEnum {
+                name: "MapMatchScope".to_string(),
+                values: vec!["ALL".to_string(), "KEY".to_string(), "VALUE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("MapMatchScope", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("ALL".to_string(), "all".to_string()), ("KEY".to_string(), "key".to_string()), ("VALUE".to_string(), "value".to_string())],
+            }).required().with_provider_name("MatchScope"),
+                    StructField::new("oversize_handling", AttributeType::StringEnum {
+                name: "OversizeHandling".to_string(),
+                values: vec!["CONTINUE".to_string(), "MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("OversizeHandling", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("CONTINUE".to_string(), "continue".to_string()), ("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).required().with_provider_name("OversizeHandling")
+                    ],
+                }).with_provider_name("Cookies"),
+                    StructField::new("header_order", AttributeType::Struct {
+                    name: "HeaderOrder".to_string(),
+                    fields: vec![
+                    StructField::new("oversize_handling", AttributeType::StringEnum {
+                name: "OversizeHandling".to_string(),
+                values: vec!["CONTINUE".to_string(), "MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("OversizeHandling", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("CONTINUE".to_string(), "continue".to_string()), ("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).required().with_provider_name("OversizeHandling")
+                    ],
+                }).with_provider_name("HeaderOrder"),
+                    StructField::new("headers", AttributeType::Struct {
+                    name: "Headers".to_string(),
+                    fields: vec![
+                    StructField::new("match_pattern", AttributeType::Struct {
+                    name: "HeaderMatchPattern".to_string(),
+                    fields: vec![
+                    StructField::new("all", AttributeType::map(AttributeType::String)).with_description("Inspect all parts of the web request headers.").with_provider_name("All"),
+                    StructField::new("excluded_headers", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(64))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_64),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_199),
+                to_dsl: None,
+            }).with_provider_name("ExcludedHeaders"),
+                    StructField::new("included_headers", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(64))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_64),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_199),
+                to_dsl: None,
+            }).with_provider_name("IncludedHeaders")
+                    ],
+                }).required().with_provider_name("MatchPattern"),
+                    StructField::new("match_scope", AttributeType::StringEnum {
+                name: "MapMatchScope".to_string(),
+                values: vec!["ALL".to_string(), "KEY".to_string(), "VALUE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("MapMatchScope", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("ALL".to_string(), "all".to_string()), ("KEY".to_string(), "key".to_string()), ("VALUE".to_string(), "value".to_string())],
+            }).required().with_provider_name("MatchScope"),
+                    StructField::new("oversize_handling", AttributeType::StringEnum {
+                name: "OversizeHandling".to_string(),
+                values: vec!["CONTINUE".to_string(), "MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("OversizeHandling", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("CONTINUE".to_string(), "continue".to_string()), ("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).required().with_provider_name("OversizeHandling")
+                    ],
+                }).with_provider_name("Headers"),
+                    StructField::new("ja3_fingerprint", AttributeType::Struct {
+                    name: "JA3Fingerprint".to_string(),
+                    fields: vec![
+                    StructField::new("fallback_behavior", AttributeType::StringEnum {
+                name: "FallbackBehavior".to_string(),
+                values: vec!["MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("FallbackBehavior", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).required().with_provider_name("FallbackBehavior")
+                    ],
+                }).with_provider_name("JA3Fingerprint"),
+                    StructField::new("ja4_fingerprint", AttributeType::Struct {
+                    name: "JA4Fingerprint".to_string(),
+                    fields: vec![
+                    StructField::new("fallback_behavior", AttributeType::StringEnum {
+                name: "FallbackBehavior".to_string(),
+                values: vec!["MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("FallbackBehavior", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).required().with_provider_name("FallbackBehavior")
+                    ],
+                }).with_provider_name("JA4Fingerprint"),
+                    StructField::new("json_body", AttributeType::Struct {
+                    name: "JsonBody".to_string(),
+                    fields: vec![
+                    StructField::new("invalid_fallback_behavior", AttributeType::StringEnum {
+                name: "BodyParsingFallbackBehavior".to_string(),
+                values: vec!["MATCH".to_string(), "NO_MATCH".to_string(), "EVALUATE_AS_STRING".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("BodyParsingFallbackBehavior", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string()), ("EVALUATE_AS_STRING".to_string(), "evaluate_as_string".to_string())],
+            }).with_provider_name("InvalidFallbackBehavior"),
+                    StructField::new("match_pattern", AttributeType::Struct {
+                    name: "JsonMatchPattern".to_string(),
+                    fields: vec![
+                    StructField::new("all", AttributeType::map(AttributeType::String)).with_description("Inspect all parts of the web request's JSON body.").with_provider_name("All"),
+                    StructField::new("included_paths", AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[\\/]+([^~]*(~[01])*)*{1,512}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_c77cf75cf1a75ade),
+                to_dsl: None,
+            })).with_provider_name("IncludedPaths")
+                    ],
+                }).required().with_provider_name("MatchPattern"),
+                    StructField::new("match_scope", AttributeType::StringEnum {
+                name: "JsonMatchScope".to_string(),
+                values: vec!["ALL".to_string(), "KEY".to_string(), "VALUE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("JsonMatchScope", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("ALL".to_string(), "all".to_string()), ("KEY".to_string(), "key".to_string()), ("VALUE".to_string(), "value".to_string())],
+            }).required().with_provider_name("MatchScope"),
+                    StructField::new("oversize_handling", AttributeType::StringEnum {
+                name: "OversizeHandling".to_string(),
+                values: vec!["CONTINUE".to_string(), "MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("OversizeHandling", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("CONTINUE".to_string(), "continue".to_string()), ("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).with_provider_name("OversizeHandling")
+                    ],
+                }).with_provider_name("JsonBody"),
+                    StructField::new("method", AttributeType::map(AttributeType::String)).with_description("The HTTP method of a web request. The method indicates the type of operation that the request is asking the origin to perform.").with_provider_name("Method"),
+                    StructField::new("query_string", AttributeType::map(AttributeType::String)).with_description("The query string of a web request. This is the part of a URL that appears after a ? character, if any.").with_provider_name("QueryString"),
+                    StructField::new("single_header", AttributeType::Struct {
+                    name: "SingleHeader".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::String).required().with_provider_name("Name")
+                    ],
+                }).with_provider_name("SingleHeader"),
+                    StructField::new("single_query_argument", AttributeType::Struct {
+                    name: "SingleQueryArgument".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::String).required().with_provider_name("Name")
+                    ],
+                }).with_description("One query argument in a web request, identified by name, for example UserName or SalesRegion. The name can be up to 30 characters long and isn't case sensitive.").with_provider_name("SingleQueryArgument"),
+                    StructField::new("uri_fragment", AttributeType::Struct {
+                    name: "UriFragment".to_string(),
+                    fields: vec![
+                    StructField::new("fallback_behavior", AttributeType::StringEnum {
+                name: "FallbackBehavior".to_string(),
+                values: vec!["MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("FallbackBehavior", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).with_provider_name("FallbackBehavior")
+                    ],
+                }).with_provider_name("UriFragment"),
+                    StructField::new("uri_path", AttributeType::map(AttributeType::String)).with_description("The path component of the URI of a web request. This is the part of a web request that identifies a resource, for example, /images/daily-ad.jpg.").with_provider_name("UriPath")
+                    ],
+                }).required().with_provider_name("FieldToMatch"),
+                    StructField::new("positional_constraint", AttributeType::StringEnum {
+                name: "PositionalConstraint".to_string(),
+                values: vec!["EXACTLY".to_string(), "STARTS_WITH".to_string(), "ENDS_WITH".to_string(), "CONTAINS".to_string(), "CONTAINS_WORD".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("PositionalConstraint", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("EXACTLY".to_string(), "exactly".to_string()), ("STARTS_WITH".to_string(), "starts_with".to_string()), ("ENDS_WITH".to_string(), "ends_with".to_string()), ("CONTAINS".to_string(), "contains".to_string()), ("CONTAINS_WORD".to_string(), "contains_word".to_string())],
+            }).required().with_provider_name("PositionalConstraint"),
+                    StructField::new("search_string", AttributeType::String).with_provider_name("SearchString"),
+                    StructField::new("search_string_base64", AttributeType::String).with_provider_name("SearchStringBase64"),
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                }).with_provider_name("ByteMatchStatement").with_block_name("byte_match_statement"),
+                    StructField::new("geo_match_statement", AttributeType::Struct {
+                    name: "GeoMatchStatement".to_string(),
+                    fields: vec![
+                    StructField::new("country_codes", AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: Some((Some(1), Some(2))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_length_1_2),
+                to_dsl: None,
+            })).with_provider_name("CountryCodes"),
+                    StructField::new("forwarded_ip_config", AttributeType::Ref("ForwardedIPConfiguration".to_string())).with_provider_name("ForwardedIPConfig")
+                    ],
+                }).with_provider_name("GeoMatchStatement"),
+                    StructField::new("ip_set_reference_statement", AttributeType::Struct {
+                    name: "IPSetReferenceStatement".to_string(),
+                    fields: vec![
+                    StructField::new("arn", super::arn()).required().with_provider_name("Arn"),
+                    StructField::new("ip_set_forwarded_ip_config", AttributeType::Struct {
+                    name: "IPSetForwardedIPConfiguration".to_string(),
+                    fields: vec![
+                    StructField::new("fallback_behavior", AttributeType::StringEnum {
+                name: "FallbackBehavior".to_string(),
+                values: vec!["MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("FallbackBehavior", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).required().with_provider_name("FallbackBehavior"),
+                    StructField::new("header_name", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[a-zA-Z0-9-]+{1,255}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_2d93cc844f6d4014),
+                to_dsl: None,
+            }).required().with_provider_name("HeaderName"),
+                    StructField::new("position", AttributeType::StringEnum {
+                name: "Position".to_string(),
+                values: vec!["FIRST".to_string(), "LAST".to_string(), "ANY".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("Position", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("FIRST".to_string(), "first".to_string()), ("LAST".to_string(), "last".to_string()), ("ANY".to_string(), "any".to_string())],
+            }).required().with_provider_name("Position")
+                    ],
+                }).with_provider_name("IPSetForwardedIPConfig")
+                    ],
+                }).with_provider_name("IPSetReferenceStatement"),
+                    StructField::new("label_match_statement", AttributeType::Struct {
+                    name: "LabelMatchStatement".to_string(),
+                    fields: vec![
+                    StructField::new("key", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[0-9A-Za-z_:-]{1,1024}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_b3fc65b549fb77bd),
+                to_dsl: None,
+            }).required().with_provider_name("Key"),
+                    StructField::new("scope", AttributeType::StringEnum {
+                name: "LabelMatchScope".to_string(),
+                values: vec!["LABEL".to_string(), "NAMESPACE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("LabelMatchScope", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("LABEL".to_string(), "label".to_string()), ("NAMESPACE".to_string(), "namespace".to_string())],
+            }).required().with_provider_name("Scope")
+                    ],
+                }).with_provider_name("LabelMatchStatement"),
+                    StructField::new("managed_rule_group_statement", AttributeType::Struct {
+                    name: "ManagedRuleGroupStatement".to_string(),
+                    fields: vec![
+                    StructField::new("excluded_rules", AttributeType::list(AttributeType::Struct {
+                    name: "ExcludedRule".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[0-9A-Za-z_-]{1,128}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_42f7eceb887966ad),
+                to_dsl: None,
+            }).required().with_provider_name("Name")
+                    ],
+                })).with_provider_name("ExcludedRules").with_block_name("excluded_rule"),
+                    StructField::new("managed_rule_group_configs", AttributeType::list(AttributeType::Struct {
+                    name: "ManagedRuleGroupConfig".to_string(),
+                    fields: vec![
+                    StructField::new("aws_managed_rules_acfp_rule_set", AttributeType::Struct {
+                    name: "AWSManagedRulesACFPRuleSet".to_string(),
+                    fields: vec![
+                    StructField::new("creation_path", AttributeType::String).required().with_provider_name("CreationPath"),
+                    StructField::new("enable_regex_in_path", AttributeType::Bool).with_provider_name("EnableRegexInPath"),
+                    StructField::new("registration_page_path", AttributeType::String).required().with_provider_name("RegistrationPagePath"),
+                    StructField::new("request_inspection", AttributeType::Struct {
+                    name: "RequestInspectionACFP".to_string(),
+                    fields: vec![
+                    StructField::new("address_fields", AttributeType::list(AttributeType::String)).with_provider_name("AddressFields"),
+                    StructField::new("email_field", AttributeType::Struct {
+                    name: "FieldIdentifier".to_string(),
+                    fields: vec![
+                    StructField::new("identifier", AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(512))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_512),
+                to_dsl: None,
+            }).required().with_provider_name("Identifier")
+                    ],
+                }).with_provider_name("EmailField"),
+                    StructField::new("password_field", AttributeType::Ref("FieldIdentifier".to_string())).with_provider_name("PasswordField"),
+                    StructField::new("payload_type", AttributeType::StringEnum {
+                name: "PayloadType".to_string(),
+                values: vec!["JSON".to_string(), "FORM_ENCODED".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("PayloadType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("JSON".to_string(), "json".to_string()), ("FORM_ENCODED".to_string(), "form_encoded".to_string())],
+            }).required().with_provider_name("PayloadType"),
+                    StructField::new("phone_number_fields", AttributeType::list(AttributeType::String)).with_provider_name("PhoneNumberFields"),
+                    StructField::new("username_field", AttributeType::Ref("FieldIdentifier".to_string())).with_provider_name("UsernameField")
+                    ],
+                }).required().with_provider_name("RequestInspection"),
+                    StructField::new("response_inspection", AttributeType::Struct {
+                    name: "ResponseInspection".to_string(),
+                    fields: vec![
+                    StructField::new("body_contains", AttributeType::Struct {
+                    name: "ResponseInspectionBodyContains".to_string(),
+                    fields: vec![
+                    StructField::new("failure_strings", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(100))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_100),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_5),
+                to_dsl: None,
+            }).required().with_provider_name("FailureStrings"),
+                    StructField::new("success_strings", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(100))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_100),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_5),
+                to_dsl: None,
+            }).required().with_provider_name("SuccessStrings")
+                    ],
+                }).with_provider_name("BodyContains"),
+                    StructField::new("header", AttributeType::Struct {
+                    name: "ResponseInspectionHeader".to_string(),
+                    fields: vec![
+                    StructField::new("failure_values", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(100))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_100),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_3),
+                to_dsl: None,
+            }).required().with_provider_name("FailureValues"),
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(200))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_200),
+                to_dsl: None,
+            }).required().with_provider_name("Name"),
+                    StructField::new("success_values", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(100))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_100),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_3),
+                to_dsl: None,
+            }).required().with_provider_name("SuccessValues")
+                    ],
+                }).with_provider_name("Header"),
+                    StructField::new("json", AttributeType::Struct {
+                    name: "ResponseInspectionJson".to_string(),
+                    fields: vec![
+                    StructField::new("failure_values", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(100))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_100),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_5),
+                to_dsl: None,
+            }).required().with_provider_name("FailureValues"),
+                    StructField::new("identifier", AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(512))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_512),
+                to_dsl: None,
+            }).required().with_provider_name("Identifier"),
+                    StructField::new("success_values", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(100))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_100),
+                to_dsl: None,
+            })),
+                validate: legacy_validator(validate_list_items_1_5),
+                to_dsl: None,
+            }).required().with_provider_name("SuccessValues")
+                    ],
+                }).with_provider_name("Json"),
+                    StructField::new("status_code", AttributeType::Struct {
+                    name: "ResponseInspectionStatusCode".to_string(),
+                    fields: vec![
+                    StructField::new("failure_codes", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Int)),
+                validate: legacy_validator(validate_list_items_1_10),
+                to_dsl: None,
+            }).required().with_provider_name("FailureCodes"),
+                    StructField::new("success_codes", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Int)),
+                validate: legacy_validator(validate_list_items_1_10),
+                to_dsl: None,
+            }).required().with_provider_name("SuccessCodes")
+                    ],
+                }).with_provider_name("StatusCode")
+                    ],
+                }).with_provider_name("ResponseInspection")
+                    ],
+                }).with_provider_name("AWSManagedRulesACFPRuleSet"),
+                    StructField::new("aws_managed_rules_atp_rule_set", AttributeType::Struct {
+                    name: "AWSManagedRulesATPRuleSet".to_string(),
+                    fields: vec![
+                    StructField::new("enable_regex_in_path", AttributeType::Bool).with_provider_name("EnableRegexInPath"),
+                    StructField::new("login_path", AttributeType::String).required().with_provider_name("LoginPath"),
+                    StructField::new("request_inspection", AttributeType::Struct {
+                    name: "RequestInspection".to_string(),
+                    fields: vec![
+                    StructField::new("password_field", AttributeType::Ref("FieldIdentifier".to_string())).required().with_provider_name("PasswordField"),
+                    StructField::new("payload_type", AttributeType::StringEnum {
+                name: "PayloadType".to_string(),
+                values: vec!["JSON".to_string(), "FORM_ENCODED".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("PayloadType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("JSON".to_string(), "json".to_string()), ("FORM_ENCODED".to_string(), "form_encoded".to_string())],
+            }).required().with_provider_name("PayloadType"),
+                    StructField::new("username_field", AttributeType::Ref("FieldIdentifier".to_string())).required().with_provider_name("UsernameField")
+                    ],
+                }).with_provider_name("RequestInspection"),
+                    StructField::new("response_inspection", AttributeType::Ref("ResponseInspection".to_string())).with_provider_name("ResponseInspection")
+                    ],
+                }).with_provider_name("AWSManagedRulesATPRuleSet"),
+                    StructField::new("aws_managed_rules_anti_d_do_s_rule_set", AttributeType::Struct {
+                    name: "AWSManagedRulesAntiDDoSRuleSet".to_string(),
+                    fields: vec![
+                    StructField::new("client_side_action_config", AttributeType::Struct {
+                    name: "ClientSideActionConfig".to_string(),
+                    fields: vec![
+                    StructField::new("challenge", AttributeType::Struct {
+                    name: "ClientSideAction".to_string(),
+                    fields: vec![
+                    StructField::new("exempt_uri_regular_expressions", AttributeType::list(AttributeType::Struct {
+                    name: "Regex".to_string(),
+                    fields: vec![
+                    StructField::new("regex_string", AttributeType::String).with_provider_name("RegexString")
+                    ],
+                })).with_provider_name("ExemptUriRegularExpressions").with_block_name("exempt_uri_regular_expression"),
+                    StructField::new("sensitivity", AttributeType::StringEnum {
+                name: "SensitivityToAct".to_string(),
+                values: vec!["LOW".to_string(), "MEDIUM".to_string(), "HIGH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("SensitivityToAct", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("LOW".to_string(), "low".to_string()), ("MEDIUM".to_string(), "medium".to_string()), ("HIGH".to_string(), "high".to_string())],
+            }).with_provider_name("Sensitivity"),
+                    StructField::new("usage_of_action", AttributeType::StringEnum {
+                name: "UsageOfAction".to_string(),
+                values: vec!["ENABLED".to_string(), "DISABLED".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("UsageOfAction", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("ENABLED".to_string(), "enabled".to_string()), ("DISABLED".to_string(), "disabled".to_string())],
+            }).required().with_provider_name("UsageOfAction")
+                    ],
+                }).required().with_provider_name("Challenge").with_block_name("challenge")
+                    ],
+                }).required().with_provider_name("ClientSideActionConfig").with_block_name("client_side_action_config"),
+                    StructField::new("sensitivity_to_block", AttributeType::StringEnum {
+                name: "SensitivityToAct".to_string(),
+                values: vec!["LOW".to_string(), "MEDIUM".to_string(), "HIGH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("SensitivityToAct", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("LOW".to_string(), "low".to_string()), ("MEDIUM".to_string(), "medium".to_string()), ("HIGH".to_string(), "high".to_string())],
+            }).with_provider_name("SensitivityToBlock")
+                    ],
+                }).with_provider_name("AWSManagedRulesAntiDDoSRuleSet").with_block_name("aws_managed_rules_anti_d_do_s_rule_set"),
+                    StructField::new("aws_managed_rules_bot_control_rule_set", AttributeType::Struct {
+                    name: "AWSManagedRulesBotControlRuleSet".to_string(),
+                    fields: vec![
+                    StructField::new("enable_machine_learning", AttributeType::Bool).with_provider_name("EnableMachineLearning"),
+                    StructField::new("inspection_level", AttributeType::StringEnum {
+                name: "InspectionLevel".to_string(),
+                values: vec!["COMMON".to_string(), "TARGETED".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("InspectionLevel", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("COMMON".to_string(), "common".to_string()), ("TARGETED".to_string(), "targeted".to_string())],
+            }).required().with_provider_name("InspectionLevel")
+                    ],
+                }).with_provider_name("AWSManagedRulesBotControlRuleSet"),
+                    StructField::new("login_path", AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(256))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_256),
+                to_dsl: None,
+            }).with_provider_name("LoginPath"),
+                    StructField::new("password_field", AttributeType::Ref("FieldIdentifier".to_string())).with_provider_name("PasswordField"),
+                    StructField::new("payload_type", AttributeType::StringEnum {
+                name: "PayloadType".to_string(),
+                values: vec!["JSON".to_string(), "FORM_ENCODED".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("PayloadType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("JSON".to_string(), "json".to_string()), ("FORM_ENCODED".to_string(), "form_encoded".to_string())],
+            }).with_provider_name("PayloadType"),
+                    StructField::new("username_field", AttributeType::Ref("FieldIdentifier".to_string())).with_provider_name("UsernameField")
+                    ],
+                })).with_description("Collection of ManagedRuleGroupConfig.").with_provider_name("ManagedRuleGroupConfigs").with_block_name("managed_rule_group_config"),
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[0-9A-Za-z_-]{1,128}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_42f7eceb887966ad),
+                to_dsl: None,
+            }).required().with_provider_name("Name"),
+                    StructField::new("rule_action_overrides", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Struct {
+                    name: "RuleActionOverride".to_string(),
+                    fields: vec![
+                    StructField::new("action_to_use", AttributeType::Ref("RuleAction".to_string())).required().with_provider_name("ActionToUse"),
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[0-9A-Za-z_-]{1,128}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_42f7eceb887966ad),
+                to_dsl: None,
+            }).required().with_provider_name("Name")
+                    ],
+                })),
+                validate: legacy_validator(validate_list_items_max_100),
+                to_dsl: None,
+            }).with_description("Action overrides for rules in the rule group.").with_provider_name("RuleActionOverrides").with_block_name("rule_action_override"),
+                    StructField::new("scope_down_statement", AttributeType::Ref("Statement".to_string())).with_provider_name("ScopeDownStatement"),
+                    StructField::new("vendor_name", AttributeType::String).required().with_provider_name("VendorName"),
+                    StructField::new("version", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[\\w#:\\.\\-/]+$".to_string()),
+                length: Some((Some(1), Some(64))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_82a037d29be8d222_len_1_64),
+                to_dsl: None,
+            }).with_provider_name("Version")
+                    ],
+                }).with_provider_name("ManagedRuleGroupStatement").with_block_name("managed_rule_group_statement"),
+                    StructField::new("not_statement", AttributeType::Struct {
+                    name: "NotStatement".to_string(),
+                    fields: vec![
+                    StructField::new("statement", AttributeType::Ref("Statement".to_string())).required().with_provider_name("Statement")
+                    ],
+                }).with_provider_name("NotStatement"),
+                    StructField::new("or_statement", AttributeType::Struct {
+                    name: "OrStatement".to_string(),
+                    fields: vec![
+                    StructField::new("statements", AttributeType::list(AttributeType::Struct {
+                    name: "Statement".to_string(),
+                    fields: vec![
+                    StructField::new("and_statement", AttributeType::Ref("AndStatement".to_string())).with_provider_name("AndStatement"),
+                    StructField::new("asn_match_statement", AttributeType::Ref("AsnMatchStatement".to_string())).with_provider_name("AsnMatchStatement"),
+                    StructField::new("byte_match_statement", AttributeType::Ref("ByteMatchStatement".to_string())).with_provider_name("ByteMatchStatement"),
+                    StructField::new("geo_match_statement", AttributeType::Ref("GeoMatchStatement".to_string())).with_provider_name("GeoMatchStatement"),
+                    StructField::new("ip_set_reference_statement", AttributeType::Ref("IPSetReferenceStatement".to_string())).with_provider_name("IPSetReferenceStatement"),
+                    StructField::new("label_match_statement", AttributeType::Ref("LabelMatchStatement".to_string())).with_provider_name("LabelMatchStatement"),
+                    StructField::new("managed_rule_group_statement", AttributeType::Ref("ManagedRuleGroupStatement".to_string())).with_provider_name("ManagedRuleGroupStatement"),
+                    StructField::new("not_statement", AttributeType::Ref("NotStatement".to_string())).with_provider_name("NotStatement"),
+                    StructField::new("or_statement", AttributeType::Ref("OrStatement".to_string())).with_provider_name("OrStatement"),
+                    StructField::new("rate_based_statement", AttributeType::Struct {
+                    name: "RateBasedStatement".to_string(),
+                    fields: vec![
+                    StructField::new("aggregate_key_type", AttributeType::StringEnum {
+                name: "AggregateKeyType".to_string(),
+                values: vec!["CONSTANT".to_string(), "IP".to_string(), "FORWARDED_IP".to_string(), "CUSTOM_KEYS".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("AggregateKeyType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("CONSTANT".to_string(), "constant".to_string()), ("IP".to_string(), "ip".to_string()), ("FORWARDED_IP".to_string(), "forwarded_ip".to_string()), ("CUSTOM_KEYS".to_string(), "custom_keys".to_string())],
+            }).required().with_provider_name("AggregateKeyType"),
+                    StructField::new("custom_keys", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Struct {
+                    name: "RateBasedStatementCustomKey".to_string(),
+                    fields: vec![
+                    StructField::new("asn", AttributeType::String).with_provider_name("ASN"),
+                    StructField::new("cookie", AttributeType::Struct {
+                    name: "RateLimitCookie".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(64))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_64),
+                to_dsl: None,
+            }).required().with_description("The name of the cookie to use.").with_provider_name("Name"),
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                }).with_provider_name("Cookie").with_block_name("cookie"),
+                    StructField::new("forwarded_ip", types::ipv4_address()).with_provider_name("ForwardedIP"),
+                    StructField::new("http_method", AttributeType::String).with_provider_name("HTTPMethod"),
+                    StructField::new("header", AttributeType::Struct {
+                    name: "RateLimitHeader".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(64))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_64),
+                to_dsl: None,
+            }).required().with_description("The name of the header to use.").with_provider_name("Name"),
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                }).with_provider_name("Header").with_block_name("header"),
+                    StructField::new("ip", types::ipv4_address()).with_provider_name("IP"),
+                    StructField::new("ja3_fingerprint", AttributeType::Struct {
+                    name: "RateLimitJA3Fingerprint".to_string(),
+                    fields: vec![
+                    StructField::new("fallback_behavior", AttributeType::StringEnum {
+                name: "FallbackBehavior".to_string(),
+                values: vec!["MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("FallbackBehavior", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).required().with_provider_name("FallbackBehavior")
+                    ],
+                }).with_provider_name("JA3Fingerprint"),
+                    StructField::new("ja4_fingerprint", AttributeType::Struct {
+                    name: "RateLimitJA4Fingerprint".to_string(),
+                    fields: vec![
+                    StructField::new("fallback_behavior", AttributeType::StringEnum {
+                name: "FallbackBehavior".to_string(),
+                values: vec!["MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("FallbackBehavior", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).required().with_provider_name("FallbackBehavior")
+                    ],
+                }).with_provider_name("JA4Fingerprint"),
+                    StructField::new("label_namespace", AttributeType::Struct {
+                    name: "RateLimitLabelNamespace".to_string(),
+                    fields: vec![
+                    StructField::new("namespace", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[0-9A-Za-z_:-]{1,1024}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_b3fc65b549fb77bd),
+                to_dsl: None,
+            }).required().with_description("The namespace to use for aggregation.").with_provider_name("Namespace")
+                    ],
+                }).with_provider_name("LabelNamespace"),
+                    StructField::new("query_argument", AttributeType::Struct {
+                    name: "RateLimitQueryArgument".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some(".*\\S.*".to_string()),
+                length: Some((Some(1), Some(64))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_4e09c821aed9e752_len_1_64),
+                to_dsl: None,
+            }).required().with_description("The name of the query argument to use.").with_provider_name("Name"),
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                }).with_provider_name("QueryArgument").with_block_name("query_argument"),
+                    StructField::new("query_string", AttributeType::Struct {
+                    name: "RateLimitQueryString".to_string(),
+                    fields: vec![
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                }).with_provider_name("QueryString").with_block_name("query_string"),
+                    StructField::new("uri_path", AttributeType::Struct {
+                    name: "RateLimitUriPath".to_string(),
+                    fields: vec![
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                }).with_provider_name("UriPath").with_block_name("uri_path")
+                    ],
+                })),
+                validate: legacy_validator(validate_list_items_max_5),
+                to_dsl: None,
+            }).with_description("Specifies the aggregate keys to use in a rate-base rule.").with_provider_name("CustomKeys").with_block_name("custom_key"),
+                    StructField::new("evaluation_window_sec", AttributeType::StringEnum {
+                name: "EvaluationWindowSec".to_string(),
+                values: vec!["60".to_string(), "120".to_string(), "300".to_string(), "600".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("EvaluationWindowSec", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("60".to_string(), "60".to_string()), ("120".to_string(), "120".to_string()), ("300".to_string(), "300".to_string()), ("600".to_string(), "600".to_string())],
+            }).with_provider_name("EvaluationWindowSec"),
+                    StructField::new("forwarded_ip_config", AttributeType::Ref("ForwardedIPConfiguration".to_string())).with_provider_name("ForwardedIPConfig"),
+                    StructField::new("limit", AttributeType::String).required().with_provider_name("Limit"),
+                    StructField::new("scope_down_statement", AttributeType::Ref("Statement".to_string())).with_provider_name("ScopeDownStatement")
+                    ],
+                }).with_provider_name("RateBasedStatement").with_block_name("rate_based_statement"),
+                    StructField::new("regex_match_statement", AttributeType::Struct {
+                    name: "RegexMatchStatement".to_string(),
+                    fields: vec![
+                    StructField::new("field_to_match", AttributeType::Ref("FieldToMatch".to_string())).required().with_provider_name("FieldToMatch"),
+                    StructField::new("regex_string", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: Some((Some(1), Some(512))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_length_1_512),
+                to_dsl: None,
+            }).required().with_provider_name("RegexString"),
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                }).with_provider_name("RegexMatchStatement").with_block_name("regex_match_statement"),
+                    StructField::new("regex_pattern_set_reference_statement", AttributeType::Struct {
+                    name: "RegexPatternSetReferenceStatement".to_string(),
+                    fields: vec![
+                    StructField::new("arn", super::arn()).required().with_provider_name("Arn"),
+                    StructField::new("field_to_match", AttributeType::Ref("FieldToMatch".to_string())).required().with_provider_name("FieldToMatch"),
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                }).with_provider_name("RegexPatternSetReferenceStatement").with_block_name("regex_pattern_set_reference_statement"),
+                    StructField::new("rule_group_reference_statement", AttributeType::Struct {
+                    name: "RuleGroupReferenceStatement".to_string(),
+                    fields: vec![
+                    StructField::new("arn", super::arn()).required().with_provider_name("Arn"),
+                    StructField::new("excluded_rules", AttributeType::list(AttributeType::Struct {
+                    name: "ExcludedRule".to_string(),
+                    fields: vec![
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[0-9A-Za-z_-]{1,128}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_42f7eceb887966ad),
+                to_dsl: None,
+            }).required().with_provider_name("Name")
+                    ],
+                })).with_provider_name("ExcludedRules").with_block_name("excluded_rule"),
+                    StructField::new("rule_action_overrides", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::list(AttributeType::Struct {
+                    name: "RuleActionOverride".to_string(),
+                    fields: vec![
+                    StructField::new("action_to_use", AttributeType::Ref("RuleAction".to_string())).required().with_provider_name("ActionToUse"),
+                    StructField::new("name", AttributeType::Custom {
+                identity: None,
+                pattern: Some("^[0-9A-Za-z_-]{1,128}$".to_string()),
+                length: None,
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_pattern_42f7eceb887966ad),
+                to_dsl: None,
+            }).required().with_provider_name("Name")
+                    ],
+                })),
+                validate: legacy_validator(validate_list_items_max_100),
+                to_dsl: None,
+            }).with_description("Action overrides for rules in the rule group.").with_provider_name("RuleActionOverrides").with_block_name("rule_action_override")
+                    ],
+                }).with_provider_name("RuleGroupReferenceStatement").with_block_name("rule_group_reference_statement"),
+                    StructField::new("size_constraint_statement", AttributeType::Struct {
+                    name: "SizeConstraintStatement".to_string(),
+                    fields: vec![
+                    StructField::new("comparison_operator", AttributeType::StringEnum {
+                name: "ComparisonOperator".to_string(),
+                values: vec!["EQ".to_string(), "NE".to_string(), "LE".to_string(), "LT".to_string(), "GE".to_string(), "GT".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("ComparisonOperator", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("EQ".to_string(), "eq".to_string()), ("NE".to_string(), "ne".to_string()), ("LE".to_string(), "le".to_string()), ("LT".to_string(), "lt".to_string()), ("GE".to_string(), "ge".to_string()), ("GT".to_string(), "gt".to_string())],
+            }).required().with_provider_name("ComparisonOperator"),
+                    StructField::new("field_to_match", AttributeType::Ref("FieldToMatch".to_string())).required().with_provider_name("FieldToMatch"),
+                    StructField::new("size", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: None,
+                base: Box::new(AttributeType::Float),
+                validate: legacy_validator(validate_size_range),
+                to_dsl: None,
+            }).required().with_provider_name("Size"),
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                }).with_provider_name("SizeConstraintStatement").with_block_name("size_constraint_statement"),
+                    StructField::new("sqli_match_statement", AttributeType::Struct {
+                    name: "SqliMatchStatement".to_string(),
+                    fields: vec![
+                    StructField::new("field_to_match", AttributeType::Ref("FieldToMatch".to_string())).required().with_provider_name("FieldToMatch"),
+                    StructField::new("sensitivity_level", AttributeType::StringEnum {
+                name: "SensitivityLevel".to_string(),
+                values: vec!["LOW".to_string(), "HIGH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("SensitivityLevel", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("LOW".to_string(), "low".to_string()), ("HIGH".to_string(), "high".to_string())],
+            }).with_provider_name("SensitivityLevel"),
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                }).with_provider_name("SqliMatchStatement").with_block_name("sqli_match_statement"),
+                    StructField::new("xss_match_statement", AttributeType::Struct {
+                    name: "XssMatchStatement".to_string(),
+                    fields: vec![
+                    StructField::new("field_to_match", AttributeType::Ref("FieldToMatch".to_string())).required().with_provider_name("FieldToMatch"),
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                }).with_provider_name("XssMatchStatement").with_block_name("xss_match_statement")
+                    ],
+                })).required().with_provider_name("Statements").with_block_name("statement")
+                    ],
+                }).with_provider_name("OrStatement").with_block_name("or_statement"),
+                    StructField::new("rate_based_statement", AttributeType::Ref("RateBasedStatement".to_string())).with_provider_name("RateBasedStatement"),
+                    StructField::new("regex_match_statement", AttributeType::Ref("RegexMatchStatement".to_string())).with_provider_name("RegexMatchStatement"),
+                    StructField::new("regex_pattern_set_reference_statement", AttributeType::Ref("RegexPatternSetReferenceStatement".to_string())).with_provider_name("RegexPatternSetReferenceStatement"),
+                    StructField::new("rule_group_reference_statement", AttributeType::Ref("RuleGroupReferenceStatement".to_string())).with_provider_name("RuleGroupReferenceStatement"),
+                    StructField::new("size_constraint_statement", AttributeType::Ref("SizeConstraintStatement".to_string())).with_provider_name("SizeConstraintStatement"),
+                    StructField::new("sqli_match_statement", AttributeType::Ref("SqliMatchStatement".to_string())).with_provider_name("SqliMatchStatement"),
+                    StructField::new("xss_match_statement", AttributeType::Ref("XssMatchStatement".to_string())).with_provider_name("XssMatchStatement")
+                    ],
+                })).required().with_provider_name("Statements").with_block_name("statement")
+                    ],
+                }).with_provider_name("AndStatement").with_block_name("and_statement"),
+                    StructField::new("asn_match_statement", AttributeType::Ref("AsnMatchStatement".to_string())).with_provider_name("AsnMatchStatement"),
+                    StructField::new("byte_match_statement", AttributeType::Ref("ByteMatchStatement".to_string())).with_provider_name("ByteMatchStatement"),
+                    StructField::new("geo_match_statement", AttributeType::Ref("GeoMatchStatement".to_string())).with_provider_name("GeoMatchStatement"),
+                    StructField::new("ip_set_reference_statement", AttributeType::Ref("IPSetReferenceStatement".to_string())).with_provider_name("IPSetReferenceStatement"),
+                    StructField::new("label_match_statement", AttributeType::Ref("LabelMatchStatement".to_string())).with_provider_name("LabelMatchStatement"),
+                    StructField::new("managed_rule_group_statement", AttributeType::Ref("ManagedRuleGroupStatement".to_string())).with_provider_name("ManagedRuleGroupStatement"),
+                    StructField::new("not_statement", AttributeType::Ref("NotStatement".to_string())).with_provider_name("NotStatement"),
+                    StructField::new("or_statement", AttributeType::Ref("OrStatement".to_string())).with_provider_name("OrStatement"),
+                    StructField::new("rate_based_statement", AttributeType::Ref("RateBasedStatement".to_string())).with_provider_name("RateBasedStatement"),
+                    StructField::new("regex_match_statement", AttributeType::Ref("RegexMatchStatement".to_string())).with_provider_name("RegexMatchStatement"),
+                    StructField::new("regex_pattern_set_reference_statement", AttributeType::Ref("RegexPatternSetReferenceStatement".to_string())).with_provider_name("RegexPatternSetReferenceStatement"),
+                    StructField::new("rule_group_reference_statement", AttributeType::Ref("RuleGroupReferenceStatement".to_string())).with_provider_name("RuleGroupReferenceStatement"),
+                    StructField::new("size_constraint_statement", AttributeType::Ref("SizeConstraintStatement".to_string())).with_provider_name("SizeConstraintStatement"),
+                    StructField::new("sqli_match_statement", AttributeType::Ref("SqliMatchStatement".to_string())).with_provider_name("SqliMatchStatement"),
+                    StructField::new("xss_match_statement", AttributeType::Ref("XssMatchStatement".to_string())).with_provider_name("XssMatchStatement")
+                    ],
+                })
+        .with_def("UriFragment", AttributeType::Struct {
+                    name: "UriFragment".to_string(),
+                    fields: vec![
+                    StructField::new("fallback_behavior", AttributeType::StringEnum {
+                name: "FallbackBehavior".to_string(),
+                values: vec!["MATCH".to_string(), "NO_MATCH".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("FallbackBehavior", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("MATCH".to_string(), "match".to_string()), ("NO_MATCH".to_string(), "no_match".to_string())],
+            }).with_provider_name("FallbackBehavior")
+                    ],
+                })
+        .with_def("VisibilityConfig", AttributeType::Struct {
+                    name: "VisibilityConfig".to_string(),
+                    fields: vec![
+                    StructField::new("cloud_watch_metrics_enabled", AttributeType::Bool).required().with_provider_name("CloudWatchMetricsEnabled"),
+                    StructField::new("metric_name", AttributeType::Custom {
+                identity: None,
+                pattern: None,
+                length: Some((Some(1), Some(128))),
+                base: Box::new(AttributeType::String),
+                validate: legacy_validator(validate_string_length_1_128),
+                to_dsl: None,
+            }).required().with_provider_name("MetricName"),
+                    StructField::new("sampled_requests_enabled", AttributeType::Bool).required().with_provider_name("SampledRequestsEnabled")
+                    ],
+                })
+        .with_def("XssMatchStatement", AttributeType::Struct {
+                    name: "XssMatchStatement".to_string(),
+                    fields: vec![
+                    StructField::new("field_to_match", AttributeType::Ref("FieldToMatch".to_string())).required().with_provider_name("FieldToMatch"),
+                    StructField::new("text_transformations", AttributeType::list(AttributeType::Struct {
+                    name: "TextTransformation".to_string(),
+                    fields: vec![
+                    StructField::new("priority", AttributeType::String).required().with_provider_name("Priority"),
+                    StructField::new("type", AttributeType::StringEnum {
+                name: "TextTransformationType".to_string(),
+                values: vec!["NONE".to_string(), "COMPRESS_WHITE_SPACE".to_string(), "HTML_ENTITY_DECODE".to_string(), "LOWERCASE".to_string(), "CMD_LINE".to_string(), "URL_DECODE".to_string(), "BASE64_DECODE".to_string(), "HEX_DECODE".to_string(), "MD5".to_string(), "REPLACE_COMMENTS".to_string(), "ESCAPE_SEQ_DECODE".to_string(), "SQL_HEX_DECODE".to_string(), "CSS_DECODE".to_string(), "JS_DECODE".to_string(), "NORMALIZE_PATH".to_string(), "NORMALIZE_PATH_WIN".to_string(), "REMOVE_NULLS".to_string(), "REPLACE_NULLS".to_string(), "BASE64_DECODE_EXT".to_string(), "URL_DECODE_UNI".to_string(), "UTF8_TO_UNICODE".to_string()],
+                identity: Some(carina_core::schema::string_enum_identity("TextTransformationType", Some("awscc.wafv2.WebAcl"))),
+                dsl_aliases: vec![("NONE".to_string(), "none".to_string()), ("COMPRESS_WHITE_SPACE".to_string(), "compress_white_space".to_string()), ("HTML_ENTITY_DECODE".to_string(), "html_entity_decode".to_string()), ("LOWERCASE".to_string(), "lowercase".to_string()), ("CMD_LINE".to_string(), "cmd_line".to_string()), ("URL_DECODE".to_string(), "url_decode".to_string()), ("BASE64_DECODE".to_string(), "base64_decode".to_string()), ("HEX_DECODE".to_string(), "hex_decode".to_string()), ("MD5".to_string(), "md5".to_string()), ("REPLACE_COMMENTS".to_string(), "replace_comments".to_string()), ("ESCAPE_SEQ_DECODE".to_string(), "escape_seq_decode".to_string()), ("SQL_HEX_DECODE".to_string(), "sql_hex_decode".to_string()), ("CSS_DECODE".to_string(), "css_decode".to_string()), ("JS_DECODE".to_string(), "js_decode".to_string()), ("NORMALIZE_PATH".to_string(), "normalize_path".to_string()), ("NORMALIZE_PATH_WIN".to_string(), "normalize_path_win".to_string()), ("REMOVE_NULLS".to_string(), "remove_nulls".to_string()), ("REPLACE_NULLS".to_string(), "replace_nulls".to_string()), ("BASE64_DECODE_EXT".to_string(), "base64_decode_ext".to_string()), ("URL_DECODE_UNI".to_string(), "url_decode_uni".to_string()), ("UTF8_TO_UNICODE".to_string(), "utf8_to_unicode".to_string())],
+            }).required().with_provider_name("Type")
+                    ],
+                })).required().with_provider_name("TextTransformations").with_block_name("text_transformation")
+                    ],
+                })
+    }
+}
+
+#[allow(dead_code)]
+fn validate_string_pattern_4e09c821aed9e752_len_1_60(value: &Value) -> Result<(), String> {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
+        static RE: std::sync::LazyLock<Regex> =
+            std::sync::LazyLock::new(|| Regex::new(".*\\S.*").expect("invalid pattern regex"));
+        if !RE.is_match(s) {
+            return Err(format!("Value '{}' does not match pattern .*\\S.*", s));
+        }
+        let len = s.chars().count();
+        if !(1..=60).contains(&len) {
+            return Err(format!("String length {} is out of range 1..=60", len));
+        }
+        Ok(())
+    } else {
+        Err("Expected string".to_string())
+    }
+}
+
+#[allow(dead_code)]
+fn validate_string_pattern_4e09c821aed9e752_len_1_64(value: &Value) -> Result<(), String> {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
+        static RE: std::sync::LazyLock<Regex> =
+            std::sync::LazyLock::new(|| Regex::new(".*\\S.*").expect("invalid pattern regex"));
+        if !RE.is_match(s) {
+            return Err(format!("Value '{}' does not match pattern .*\\S.*", s));
+        }
+        let len = s.chars().count();
+        if !(1..=64).contains(&len) {
+            return Err(format!("String length {} is out of range 1..=64", len));
+        }
+        Ok(())
+    } else {
+        Err("Expected string".to_string())
+    }
+}
+
+#[allow(dead_code)]
+fn validate_string_pattern_4e09c821aed9e752_len_1_100(value: &Value) -> Result<(), String> {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
+        static RE: std::sync::LazyLock<Regex> =
+            std::sync::LazyLock::new(|| Regex::new(".*\\S.*").expect("invalid pattern regex"));
+        if !RE.is_match(s) {
+            return Err(format!("Value '{}' does not match pattern .*\\S.*", s));
+        }
+        let len = s.chars().count();
+        if !(1..=100).contains(&len) {
+            return Err(format!("String length {} is out of range 1..=100", len));
+        }
+        Ok(())
+    } else {
+        Err("Expected string".to_string())
+    }
+}
+
+#[allow(dead_code)]
+fn validate_string_pattern_4e09c821aed9e752_len_1_200(value: &Value) -> Result<(), String> {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
+        static RE: std::sync::LazyLock<Regex> =
+            std::sync::LazyLock::new(|| Regex::new(".*\\S.*").expect("invalid pattern regex"));
+        if !RE.is_match(s) {
+            return Err(format!("Value '{}' does not match pattern .*\\S.*", s));
+        }
+        let len = s.chars().count();
+        if !(1..=200).contains(&len) {
+            return Err(format!("String length {} is out of range 1..=200", len));
+        }
+        Ok(())
+    } else {
+        Err("Expected string".to_string())
+    }
+}
+
+#[allow(dead_code)]
+fn validate_string_pattern_6fd4a12c0ce64c08_len_1_64(value: &Value) -> Result<(), String> {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
+        static RE: std::sync::LazyLock<Regex> =
+            std::sync::LazyLock::new(|| Regex::new("^[\\w\\-]+$").expect("invalid pattern regex"));
+        if !RE.is_match(s) {
+            return Err(format!("Value '{}' does not match pattern ^[\\w\\-]+$", s));
+        }
+        let len = s.chars().count();
+        if !(1..=64).contains(&len) {
+            return Err(format!("String length {} is out of range 1..=64", len));
+        }
+        Ok(())
+    } else {
+        Err("Expected string".to_string())
+    }
+}
+
+#[allow(dead_code)]
+fn validate_string_pattern_7dc332c889f363a0_len_1_253(value: &Value) -> Result<(), String> {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
+        static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+            Regex::new("^[\\w\\.\\-/]+$").expect("invalid pattern regex")
+        });
+        if !RE.is_match(s) {
+            return Err(format!(
+                "Value '{}' does not match pattern ^[\\w\\.\\-/]+$",
+                s
+            ));
+        }
+        let len = s.chars().count();
+        if !(1..=253).contains(&len) {
+            return Err(format!("String length {} is out of range 1..=253", len));
+        }
+        Ok(())
+    } else {
+        Err("Expected string".to_string())
+    }
+}
+
+#[allow(dead_code)]
+fn validate_asn_list_range(value: &Value) -> Result<(), String> {
+    if let Value::Concrete(ConcreteValue::Int(n)) = value {
+        if *n < 0 || *n > 4294967295 {
+            Err(format!("Value {} is out of range 0..=4294967295", n))
+        } else {
+            Ok(())
+        }
+    } else {
+        Err("Expected integer".to_string())
+    }
+}
+
+#[allow(dead_code)]
+fn validate_string_pattern_c77cf75cf1a75ade(value: &Value) -> Result<(), String> {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
+        static RE: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+            Regex::new("^[\\/]+([^~]*(~[01])*)*{1,512}$").expect("invalid pattern regex")
+        });
+        if RE.is_match(s) {
+            Ok(())
+        } else {
+            Err(format!(
+                "Value '{}' does not match pattern ^[\\/]+([^~]*(~[01])*)*{{1,512}}$",
+                s
+            ))
+        }
+    } else {
+        Err("Expected string".to_string())
+    }
+}
+
+/// Returns the resource type name and all enum valid values for this module
+pub fn enum_valid_values() -> (
+    &'static str,
+    &'static [(&'static str, &'static [&'static str])],
+) {
+    (
+        "wafv2.WebAcl",
+        &[
+            (
+                "sensitivity_to_block",
+                VALID_AWS_MANAGED_RULES_ANTI_D_DO_S_RULE_SET_SENSITIVITY_TO_BLOCK,
+            ),
+            (
+                "inspection_level",
+                VALID_AWS_MANAGED_RULES_BOT_CONTROL_RULE_SET_INSPECTION_LEVEL,
+            ),
+            ("oversize_handling", VALID_BODY_OVERSIZE_HANDLING),
+            (
+                "positional_constraint",
+                VALID_BYTE_MATCH_STATEMENT_POSITIONAL_CONSTRAINT,
+            ),
+            ("sensitivity", VALID_CLIENT_SIDE_ACTION_SENSITIVITY),
+            ("usage_of_action", VALID_CLIENT_SIDE_ACTION_USAGE_OF_ACTION),
+            ("match_scope", VALID_COOKIES_MATCH_SCOPE),
+            ("oversize_handling", VALID_COOKIES_OVERSIZE_HANDLING),
+            ("content_type", VALID_CUSTOM_RESPONSE_BODY_CONTENT_TYPE),
+            ("action", VALID_DATA_PROTECT_ACTION),
+            ("field_type", VALID_FIELD_TO_PROTECT_FIELD_TYPE),
+            (
+                "fallback_behavior",
+                VALID_FORWARDED_IP_CONFIGURATION_FALLBACK_BEHAVIOR,
+            ),
+            ("oversize_handling", VALID_HEADER_ORDER_OVERSIZE_HANDLING),
+            ("match_scope", VALID_HEADERS_MATCH_SCOPE),
+            ("oversize_handling", VALID_HEADERS_OVERSIZE_HANDLING),
+            (
+                "fallback_behavior",
+                VALID_IP_SET_FORWARDED_IP_CONFIGURATION_FALLBACK_BEHAVIOR,
+            ),
+            ("position", VALID_IP_SET_FORWARDED_IP_CONFIGURATION_POSITION),
+            ("fallback_behavior", VALID_JA3_FINGERPRINT_FALLBACK_BEHAVIOR),
+            ("fallback_behavior", VALID_JA4_FINGERPRINT_FALLBACK_BEHAVIOR),
+            (
+                "invalid_fallback_behavior",
+                VALID_JSON_BODY_INVALID_FALLBACK_BEHAVIOR,
+            ),
+            ("match_scope", VALID_JSON_BODY_MATCH_SCOPE),
+            ("oversize_handling", VALID_JSON_BODY_OVERSIZE_HANDLING),
+            ("payload_type", VALID_MANAGED_RULE_GROUP_CONFIG_PAYLOAD_TYPE),
+            (
+                "alb_low_reputation_mode",
+                VALID_ON_SOURCE_D_DO_S_PROTECTION_CONFIG_ALB_LOW_REPUTATION_MODE,
+            ),
+            (
+                "aggregate_key_type",
+                VALID_RATE_BASED_STATEMENT_AGGREGATE_KEY_TYPE,
+            ),
+            (
+                "evaluation_window_sec",
+                VALID_RATE_BASED_STATEMENT_EVALUATION_WINDOW_SEC,
+            ),
+            (
+                "fallback_behavior",
+                VALID_RATE_LIMIT_JA3_FINGERPRINT_FALLBACK_BEHAVIOR,
+            ),
+            (
+                "fallback_behavior",
+                VALID_RATE_LIMIT_JA4_FINGERPRINT_FALLBACK_BEHAVIOR,
+            ),
+            (
+                "default_size_inspection_limit",
+                VALID_REQUEST_BODY_ASSOCIATED_RESOURCE_TYPE_CONFIG_DEFAULT_SIZE_INSPECTION_LIMIT,
+            ),
+            ("payload_type", VALID_REQUEST_INSPECTION_PAYLOAD_TYPE),
+            ("payload_type", VALID_REQUEST_INSPECTION_ACFP_PAYLOAD_TYPE),
+            ("scope", VALID_SCOPE),
+            (
+                "comparison_operator",
+                VALID_SIZE_CONSTRAINT_STATEMENT_COMPARISON_OPERATOR,
+            ),
+            (
+                "sensitivity_level",
+                VALID_SQLI_MATCH_STATEMENT_SENSITIVITY_LEVEL,
+            ),
+            ("type", VALID_TEXT_TRANSFORMATION_TYPE),
+            ("fallback_behavior", VALID_URI_FRAGMENT_FALLBACK_BEHAVIOR),
+        ],
+    )
+}

--- a/cfn-schema-cache/AWS__WAFv2__WebACL.json
+++ b/cfn-schema-cache/AWS__WAFv2__WebACL.json
@@ -1,0 +1,2041 @@
+{
+  "typeName" : "AWS::WAFv2::WebACL",
+  "description" : "Contains the Rules that identify the requests that you want to allow, block, or count. In a WebACL, you also specify a default action (ALLOW or BLOCK), and the action for each Rule that you add to a WebACL, for example, block requests from specified IP addresses or block requests from specified referrers. You also associate the WebACL with a CloudFront distribution to identify the requests that you want AWS WAF to filter. If you add more than one Rule to a WebACL, a request needs to match only one of the specifications to be allowed, blocked, or counted.",
+  "sourceUrl" : "https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-wafv2.git",
+  "definitions" : {
+    "ApplicationConfig" : {
+      "description" : "Configures the ability for the WAF; console to store and retrieve application attributes during the webacl; creation process. Application attributes help WAF; give recommendations for protection packs.",
+      "type" : "object",
+      "properties" : {
+        "Attributes" : {
+          "$ref" : "#/definitions/ApplicationAttributes"
+        }
+      },
+      "required" : [ "Attributes" ],
+      "additionalProperties" : false
+    },
+    "ApplicationAttributes" : {
+      "description" : "Contains the attribute name and a list of values for that attribute.",
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/definitions/ApplicationAttribute"
+      },
+      "minItems" : 1,
+      "maxItems" : 10
+    },
+    "ApplicationAttribute" : {
+      "description" : "Application details defined during the &webacl; creation process. Application attributes help WAF; give recommendations for protection packs.",
+      "type" : "object",
+      "properties" : {
+        "Name" : {
+          "$ref" : "#/definitions/AttributeName"
+        },
+        "Values" : {
+          "$ref" : "#/definitions/AttributeValues"
+        }
+      },
+      "required" : [ "Name", "Values" ],
+      "additionalProperties" : false
+    },
+    "AttributeValues" : {
+      "description" : "Contains a list of values for that attribute",
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/definitions/AttributeValue"
+      },
+      "minItems" : 1,
+      "maxItems" : 10
+    },
+    "AttributeValue" : {
+      "description" : "Specifies the attribute value.",
+      "type" : "string",
+      "pattern" : "^[\\w\\-]+$",
+      "minLength" : 1,
+      "maxLength" : 64
+    },
+    "AttributeName" : {
+      "description" : "Specifies the attribute name.",
+      "type" : "string",
+      "pattern" : "^[\\w\\-]+$",
+      "minLength" : 1,
+      "maxLength" : 64
+    },
+    "AndStatement" : {
+      "type" : "object",
+      "properties" : {
+        "Statements" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/Statement"
+          }
+        }
+      },
+      "required" : [ "Statements" ],
+      "additionalProperties" : false
+    },
+    "Body" : {
+      "description" : "The body of a web request. This immediately follows the request headers.",
+      "type" : "object",
+      "properties" : {
+        "OversizeHandling" : {
+          "$ref" : "#/definitions/OversizeHandling"
+        }
+      },
+      "additionalProperties" : false
+    },
+    "ByteMatchStatement" : {
+      "description" : "Byte Match statement.",
+      "type" : "object",
+      "properties" : {
+        "SearchString" : {
+          "$ref" : "#/definitions/SearchString"
+        },
+        "SearchStringBase64" : {
+          "$ref" : "#/definitions/SearchStringBase64"
+        },
+        "FieldToMatch" : {
+          "$ref" : "#/definitions/FieldToMatch"
+        },
+        "TextTransformations" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/TextTransformation"
+          }
+        },
+        "PositionalConstraint" : {
+          "$ref" : "#/definitions/PositionalConstraint"
+        }
+      },
+      "required" : [ "FieldToMatch", "PositionalConstraint", "TextTransformations" ],
+      "additionalProperties" : false
+    },
+    "DefaultAction" : {
+      "description" : "Default Action WebACL will take against ingress traffic when there is no matching Rule.",
+      "type" : "object",
+      "properties" : {
+        "Allow" : {
+          "$ref" : "#/definitions/AllowAction"
+        },
+        "Block" : {
+          "$ref" : "#/definitions/BlockAction"
+        }
+      },
+      "additionalProperties" : false
+    },
+    "EntityDescription" : {
+      "description" : "Description of the entity.",
+      "type" : "string",
+      "pattern" : "^[a-zA-Z0-9=:#@/\\-,.][a-zA-Z0-9+=:#@/\\-,.\\s]+[a-zA-Z0-9+=:#@/\\-,.]{1,256}$"
+    },
+    "EntityName" : {
+      "description" : "Name of the WebACL.",
+      "type" : "string",
+      "pattern" : "^[0-9A-Za-z_-]{1,128}$"
+    },
+    "ExcludedRule" : {
+      "description" : "Excluded Rule in the RuleGroup or ManagedRuleGroup will not be evaluated.",
+      "type" : "object",
+      "properties" : {
+        "Name" : {
+          "$ref" : "#/definitions/EntityName"
+        }
+      },
+      "required" : [ "Name" ],
+      "additionalProperties" : false
+    },
+    "RuleActionOverride" : {
+      "description" : "Action override for rules in the rule group.",
+      "type" : "object",
+      "properties" : {
+        "Name" : {
+          "$ref" : "#/definitions/EntityName"
+        },
+        "ActionToUse" : {
+          "$ref" : "#/definitions/RuleAction"
+        }
+      },
+      "required" : [ "Name", "ActionToUse" ],
+      "additionalProperties" : false
+    },
+    "ExcludedRules" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/definitions/ExcludedRule"
+      }
+    },
+    "FieldToMatch" : {
+      "description" : "Field of the request to match.",
+      "type" : "object",
+      "properties" : {
+        "SingleHeader" : {
+          "type" : "object",
+          "properties" : {
+            "Name" : {
+              "type" : "string"
+            }
+          },
+          "required" : [ "Name" ],
+          "additionalProperties" : false
+        },
+        "SingleQueryArgument" : {
+          "description" : "One query argument in a web request, identified by name, for example UserName or SalesRegion. The name can be up to 30 characters long and isn't case sensitive.",
+          "type" : "object",
+          "properties" : {
+            "Name" : {
+              "type" : "string"
+            }
+          },
+          "required" : [ "Name" ],
+          "additionalProperties" : false
+        },
+        "AllQueryArguments" : {
+          "description" : "All query arguments of a web request.",
+          "type" : "object"
+        },
+        "UriPath" : {
+          "description" : "The path component of the URI of a web request. This is the part of a web request that identifies a resource, for example, /images/daily-ad.jpg.",
+          "type" : "object"
+        },
+        "QueryString" : {
+          "description" : "The query string of a web request. This is the part of a URL that appears after a ? character, if any.",
+          "type" : "object"
+        },
+        "Body" : {
+          "$ref" : "#/definitions/Body"
+        },
+        "Method" : {
+          "description" : "The HTTP method of a web request. The method indicates the type of operation that the request is asking the origin to perform.",
+          "type" : "object"
+        },
+        "JsonBody" : {
+          "$ref" : "#/definitions/JsonBody"
+        },
+        "Headers" : {
+          "$ref" : "#/definitions/Headers"
+        },
+        "Cookies" : {
+          "$ref" : "#/definitions/Cookies"
+        },
+        "JA3Fingerprint" : {
+          "$ref" : "#/definitions/JA3Fingerprint"
+        },
+        "JA4Fingerprint" : {
+          "$ref" : "#/definitions/JA4Fingerprint"
+        },
+        "UriFragment" : {
+          "$ref" : "#/definitions/UriFragment"
+        },
+        "HeaderOrder" : {
+          "$ref" : "#/definitions/HeaderOrder"
+        }
+      },
+      "additionalProperties" : false
+    },
+    "JsonBody" : {
+      "description" : "Inspect the request body as JSON. The request body immediately follows the request headers.",
+      "type" : "object",
+      "properties" : {
+        "MatchPattern" : {
+          "$ref" : "#/definitions/JsonMatchPattern"
+        },
+        "MatchScope" : {
+          "$ref" : "#/definitions/JsonMatchScope"
+        },
+        "InvalidFallbackBehavior" : {
+          "$ref" : "#/definitions/BodyParsingFallbackBehavior"
+        },
+        "OversizeHandling" : {
+          "$ref" : "#/definitions/OversizeHandling"
+        }
+      },
+      "required" : [ "MatchPattern", "MatchScope" ],
+      "additionalProperties" : false
+    },
+    "BodyParsingFallbackBehavior" : {
+      "description" : "The inspection behavior to fall back to if the JSON in the request body is invalid.",
+      "type" : "string",
+      "enum" : [ "MATCH", "NO_MATCH", "EVALUATE_AS_STRING" ]
+    },
+    "JsonMatchScope" : {
+      "description" : "The parts of the JSON to match against using the MatchPattern.",
+      "type" : "string",
+      "enum" : [ "ALL", "KEY", "VALUE" ]
+    },
+    "JsonMatchPattern" : {
+      "description" : "The pattern to look for in the JSON body.",
+      "type" : "object",
+      "properties" : {
+        "All" : {
+          "description" : "Inspect all parts of the web request's JSON body.",
+          "type" : "object"
+        },
+        "IncludedPaths" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/JsonPointerPath"
+          }
+        }
+      },
+      "additionalProperties" : false
+    },
+    "JsonPointerPath" : {
+      "description" : "JSON pointer path in the web request's JSON body",
+      "type" : "string",
+      "pattern" : "^[\\/]+([^~]*(~[01])*)*{1,512}$"
+    },
+    "GeoMatchStatement" : {
+      "type" : "object",
+      "properties" : {
+        "CountryCodes" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "minLength" : 1,
+            "maxLength" : 2
+          }
+        },
+        "ForwardedIPConfig" : {
+          "$ref" : "#/definitions/ForwardedIPConfiguration"
+        }
+      },
+      "additionalProperties" : false
+    },
+    "EntityId" : {
+      "description" : "Id of the WebACL",
+      "type" : "string",
+      "pattern" : "^[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$"
+    },
+    "IPSetReferenceStatement" : {
+      "type" : "object",
+      "properties" : {
+        "Arn" : {
+          "$ref" : "#/definitions/ResourceArn"
+        },
+        "IPSetForwardedIPConfig" : {
+          "$ref" : "#/definitions/IPSetForwardedIPConfiguration"
+        }
+      },
+      "required" : [ "Arn" ],
+      "additionalProperties" : false
+    },
+    "ManagedRuleGroupStatement" : {
+      "type" : "object",
+      "properties" : {
+        "Name" : {
+          "$ref" : "#/definitions/EntityName"
+        },
+        "VendorName" : {
+          "type" : "string"
+        },
+        "Version" : {
+          "type" : "string",
+          "pattern" : "^[\\w#:\\.\\-/]+$",
+          "minLength" : 1,
+          "maxLength" : 64
+        },
+        "ExcludedRules" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ExcludedRule"
+          }
+        },
+        "ScopeDownStatement" : {
+          "$ref" : "#/definitions/Statement"
+        },
+        "ManagedRuleGroupConfigs" : {
+          "description" : "Collection of ManagedRuleGroupConfig.",
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ManagedRuleGroupConfig"
+          }
+        },
+        "RuleActionOverrides" : {
+          "description" : "Action overrides for rules in the rule group.",
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/RuleActionOverride"
+          },
+          "maxItems" : 100
+        }
+      },
+      "required" : [ "VendorName", "Name" ],
+      "additionalProperties" : false
+    },
+    "NotStatement" : {
+      "type" : "object",
+      "properties" : {
+        "Statement" : {
+          "$ref" : "#/definitions/Statement"
+        }
+      },
+      "required" : [ "Statement" ],
+      "additionalProperties" : false
+    },
+    "OrStatement" : {
+      "type" : "object",
+      "properties" : {
+        "Statements" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/Statement"
+          }
+        }
+      },
+      "required" : [ "Statements" ],
+      "additionalProperties" : false
+    },
+    "OverrideAction" : {
+      "description" : "Override a RuleGroup or ManagedRuleGroup behavior. This can only be applied to Rule that has RuleGroupReferenceStatement or ManagedRuleGroupReferenceStatement.",
+      "type" : "object",
+      "properties" : {
+        "Count" : {
+          "description" : "Count traffic towards application.",
+          "type" : "object"
+        },
+        "None" : {
+          "description" : "Keep the RuleGroup or ManagedRuleGroup behavior as is.",
+          "type" : "object"
+        }
+      },
+      "additionalProperties" : false
+    },
+    "PositionalConstraint" : {
+      "description" : "Position of the evaluation in the FieldToMatch of request.",
+      "type" : "string",
+      "enum" : [ "EXACTLY", "STARTS_WITH", "ENDS_WITH", "CONTAINS", "CONTAINS_WORD" ]
+    },
+    "QueryString" : {
+      "type" : "object"
+    },
+    "RateBasedStatement" : {
+      "type" : "object",
+      "properties" : {
+        "Limit" : {
+          "$ref" : "#/definitions/RateLimit"
+        },
+        "EvaluationWindowSec" : {
+          "$ref" : "#/definitions/EvaluationWindowSec"
+        },
+        "AggregateKeyType" : {
+          "type" : "string",
+          "enum" : [ "CONSTANT", "IP", "FORWARDED_IP", "CUSTOM_KEYS" ]
+        },
+        "CustomKeys" : {
+          "description" : "Specifies the aggregate keys to use in a rate-base rule.",
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/RateBasedStatementCustomKey"
+          },
+          "maxItems" : 5
+        },
+        "ScopeDownStatement" : {
+          "$ref" : "#/definitions/Statement"
+        },
+        "ForwardedIPConfig" : {
+          "$ref" : "#/definitions/ForwardedIPConfiguration"
+        }
+      },
+      "required" : [ "Limit", "AggregateKeyType" ],
+      "additionalProperties" : false
+    },
+    "RateBasedStatementCustomKey" : {
+      "description" : "Specifies a single custom aggregate key for a rate-base rule.",
+      "type" : "object",
+      "properties" : {
+        "Cookie" : {
+          "$ref" : "#/definitions/RateLimitCookie"
+        },
+        "ForwardedIP" : {
+          "$ref" : "#/definitions/RateLimitForwardedIP"
+        },
+        "Header" : {
+          "$ref" : "#/definitions/RateLimitHeader"
+        },
+        "HTTPMethod" : {
+          "$ref" : "#/definitions/RateLimitHTTPMethod"
+        },
+        "IP" : {
+          "$ref" : "#/definitions/RateLimitIP"
+        },
+        "LabelNamespace" : {
+          "$ref" : "#/definitions/RateLimitLabelNamespace"
+        },
+        "QueryArgument" : {
+          "$ref" : "#/definitions/RateLimitQueryArgument"
+        },
+        "QueryString" : {
+          "$ref" : "#/definitions/RateLimitQueryString"
+        },
+        "UriPath" : {
+          "$ref" : "#/definitions/RateLimitUriPath"
+        },
+        "JA3Fingerprint" : {
+          "$ref" : "#/definitions/RateLimitJA3Fingerprint"
+        },
+        "JA4Fingerprint" : {
+          "$ref" : "#/definitions/RateLimitJA4Fingerprint"
+        },
+        "ASN" : {
+          "$ref" : "#/definitions/RateLimitAsn"
+        }
+      },
+      "additionalProperties" : false
+    },
+    "RateLimitCookie" : {
+      "description" : "Specifies a cookie as an aggregate key for a rate-based rule.",
+      "type" : "object",
+      "properties" : {
+        "Name" : {
+          "description" : "The name of the cookie to use.",
+          "type" : "string",
+          "pattern" : ".*\\S.*",
+          "minLength" : 1,
+          "maxLength" : 64
+        },
+        "TextTransformations" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/TextTransformation"
+          }
+        }
+      },
+      "required" : [ "Name", "TextTransformations" ],
+      "additionalProperties" : false
+    },
+    "RateLimitForwardedIP" : {
+      "description" : "Specifies the first IP address in an HTTP header as an aggregate key for a rate-based rule.",
+      "type" : "object"
+    },
+    "RateLimitHeader" : {
+      "description" : "Specifies a header as an aggregate key for a rate-based rule.",
+      "type" : "object",
+      "properties" : {
+        "Name" : {
+          "description" : "The name of the header to use.",
+          "type" : "string",
+          "pattern" : ".*\\S.*",
+          "minLength" : 1,
+          "maxLength" : 64
+        },
+        "TextTransformations" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/TextTransformation"
+          }
+        }
+      },
+      "required" : [ "Name", "TextTransformations" ],
+      "additionalProperties" : false
+    },
+    "RateLimitHTTPMethod" : {
+      "description" : "Specifies the request's HTTP method as an aggregate key for a rate-based rule.",
+      "type" : "object"
+    },
+    "RateLimitIP" : {
+      "description" : "Specifies the IP address in the web request as an aggregate key for a rate-based rule.",
+      "type" : "object"
+    },
+    "RateLimitLabelNamespace" : {
+      "description" : "Specifies a label namespace to use as an aggregate key for a rate-based rule.",
+      "type" : "object",
+      "properties" : {
+        "Namespace" : {
+          "description" : "The namespace to use for aggregation.",
+          "type" : "string",
+          "pattern" : "^[0-9A-Za-z_:-]{1,1024}$"
+        }
+      },
+      "required" : [ "Namespace" ],
+      "additionalProperties" : false
+    },
+    "RateLimitQueryArgument" : {
+      "description" : "Specifies a query argument in the request as an aggregate key for a rate-based rule.",
+      "type" : "object",
+      "properties" : {
+        "Name" : {
+          "description" : "The name of the query argument to use.",
+          "type" : "string",
+          "pattern" : ".*\\S.*",
+          "minLength" : 1,
+          "maxLength" : 64
+        },
+        "TextTransformations" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/TextTransformation"
+          }
+        }
+      },
+      "required" : [ "Name", "TextTransformations" ],
+      "additionalProperties" : false
+    },
+    "RateLimitQueryString" : {
+      "description" : "Specifies the request's query string as an aggregate key for a rate-based rule.",
+      "type" : "object",
+      "properties" : {
+        "TextTransformations" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/TextTransformation"
+          }
+        }
+      },
+      "required" : [ "TextTransformations" ],
+      "additionalProperties" : false
+    },
+    "RateLimitUriPath" : {
+      "description" : "Specifies the request's URI Path as an aggregate key for a rate-based rule.",
+      "type" : "object",
+      "properties" : {
+        "TextTransformations" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/TextTransformation"
+          }
+        }
+      },
+      "required" : [ "TextTransformations" ],
+      "additionalProperties" : false
+    },
+    "RateLimitJA3Fingerprint" : {
+      "description" : "Specifies the request's JA3 fingerprint as an aggregate key for a rate-based rule.",
+      "type" : "object",
+      "properties" : {
+        "FallbackBehavior" : {
+          "type" : "string",
+          "enum" : [ "MATCH", "NO_MATCH" ]
+        }
+      },
+      "required" : [ "FallbackBehavior" ],
+      "additionalProperties" : false
+    },
+    "RateLimitJA4Fingerprint" : {
+      "description" : "Specifies the request's JA4 fingerprint as an aggregate key for a rate-based rule.",
+      "type" : "object",
+      "properties" : {
+        "FallbackBehavior" : {
+          "type" : "string",
+          "enum" : [ "MATCH", "NO_MATCH" ]
+        }
+      },
+      "required" : [ "FallbackBehavior" ],
+      "additionalProperties" : false
+    },
+    "RateLimitAsn" : {
+      "description" : "Specifies the request's ASN as an aggregate key for a rate-based rule.",
+      "type" : "object"
+    },
+    "RateLimit" : {
+      "type" : "integer",
+      "minimum" : 10,
+      "maximum" : 2000000000
+    },
+    "EvaluationWindowSec" : {
+      "type" : "integer",
+      "enum" : [ 60, 120, 300, 600 ]
+    },
+    "RegexPatternSetReferenceStatement" : {
+      "type" : "object",
+      "properties" : {
+        "Arn" : {
+          "$ref" : "#/definitions/ResourceArn"
+        },
+        "FieldToMatch" : {
+          "$ref" : "#/definitions/FieldToMatch"
+        },
+        "TextTransformations" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/TextTransformation"
+          }
+        }
+      },
+      "required" : [ "Arn", "FieldToMatch", "TextTransformations" ],
+      "additionalProperties" : false
+    },
+    "ResourceArn" : {
+      "description" : "ARN of the WAF entity.",
+      "type" : "string",
+      "minLength" : 20,
+      "maxLength" : 2048
+    },
+    "ForwardedIPConfiguration" : {
+      "type" : "object",
+      "properties" : {
+        "HeaderName" : {
+          "type" : "string",
+          "pattern" : "^[a-zA-Z0-9-]+{1,255}$"
+        },
+        "FallbackBehavior" : {
+          "type" : "string",
+          "enum" : [ "MATCH", "NO_MATCH" ]
+        }
+      },
+      "required" : [ "HeaderName", "FallbackBehavior" ],
+      "additionalProperties" : false
+    },
+    "IPSetForwardedIPConfiguration" : {
+      "type" : "object",
+      "properties" : {
+        "HeaderName" : {
+          "type" : "string",
+          "pattern" : "^[a-zA-Z0-9-]+{1,255}$"
+        },
+        "FallbackBehavior" : {
+          "type" : "string",
+          "enum" : [ "MATCH", "NO_MATCH" ]
+        },
+        "Position" : {
+          "type" : "string",
+          "enum" : [ "FIRST", "LAST", "ANY" ]
+        }
+      },
+      "required" : [ "HeaderName", "FallbackBehavior", "Position" ],
+      "additionalProperties" : false
+    },
+    "Rule" : {
+      "description" : "Rule of WebACL that contains condition and action.",
+      "type" : "object",
+      "properties" : {
+        "Name" : {
+          "$ref" : "#/definitions/EntityName"
+        },
+        "Priority" : {
+          "$ref" : "#/definitions/RulePriority"
+        },
+        "Statement" : {
+          "$ref" : "#/definitions/Statement"
+        },
+        "Action" : {
+          "$ref" : "#/definitions/RuleAction"
+        },
+        "OverrideAction" : {
+          "$ref" : "#/definitions/OverrideAction"
+        },
+        "RuleLabels" : {
+          "description" : "Collection of Rule Labels.",
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/Label"
+          }
+        },
+        "VisibilityConfig" : {
+          "$ref" : "#/definitions/VisibilityConfig"
+        },
+        "CaptchaConfig" : {
+          "$ref" : "#/definitions/CaptchaConfig"
+        },
+        "ChallengeConfig" : {
+          "$ref" : "#/definitions/ChallengeConfig"
+        }
+      },
+      "required" : [ "Name", "Priority", "Statement", "VisibilityConfig" ],
+      "additionalProperties" : false
+    },
+    "Rules" : {
+      "description" : "Collection of Rules.",
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/definitions/Rule"
+      }
+    },
+    "RuleAction" : {
+      "description" : "Action taken when Rule matches its condition.",
+      "type" : "object",
+      "properties" : {
+        "Allow" : {
+          "$ref" : "#/definitions/AllowAction"
+        },
+        "Block" : {
+          "$ref" : "#/definitions/BlockAction"
+        },
+        "Count" : {
+          "$ref" : "#/definitions/CountAction"
+        },
+        "Captcha" : {
+          "$ref" : "#/definitions/CaptchaAction"
+        },
+        "Challenge" : {
+          "$ref" : "#/definitions/ChallengeAction"
+        }
+      },
+      "additionalProperties" : false
+    },
+    "AllowAction" : {
+      "description" : "Allow traffic towards application.",
+      "type" : "object",
+      "properties" : {
+        "CustomRequestHandling" : {
+          "$ref" : "#/definitions/CustomRequestHandling"
+        }
+      },
+      "additionalProperties" : false
+    },
+    "CountAction" : {
+      "description" : "Allow traffic towards application.",
+      "type" : "object",
+      "properties" : {
+        "CustomRequestHandling" : {
+          "$ref" : "#/definitions/CustomRequestHandling"
+        }
+      },
+      "additionalProperties" : false
+    },
+    "CaptchaAction" : {
+      "description" : "Checks valid token exists with request.",
+      "type" : "object",
+      "properties" : {
+        "CustomRequestHandling" : {
+          "$ref" : "#/definitions/CustomRequestHandling"
+        }
+      },
+      "additionalProperties" : false
+    },
+    "ChallengeAction" : {
+      "description" : "Checks that the request has a valid token with an unexpired challenge timestamp and, if not, returns a browser challenge to the client.",
+      "type" : "object",
+      "properties" : {
+        "CustomRequestHandling" : {
+          "$ref" : "#/definitions/CustomRequestHandling"
+        }
+      },
+      "additionalProperties" : false
+    },
+    "BlockAction" : {
+      "description" : "Block traffic towards application.",
+      "type" : "object",
+      "properties" : {
+        "CustomResponse" : {
+          "$ref" : "#/definitions/CustomResponse"
+        }
+      },
+      "additionalProperties" : false
+    },
+    "CustomHTTPHeaderName" : {
+      "description" : "HTTP header name.",
+      "type" : "string",
+      "minLength" : 1,
+      "maxLength" : 64
+    },
+    "CustomHTTPHeaderValue" : {
+      "description" : "HTTP header value.",
+      "type" : "string",
+      "minLength" : 1,
+      "maxLength" : 255
+    },
+    "CustomHTTPHeader" : {
+      "description" : "HTTP header.",
+      "type" : "object",
+      "properties" : {
+        "Name" : {
+          "$ref" : "#/definitions/CustomHTTPHeaderName"
+        },
+        "Value" : {
+          "$ref" : "#/definitions/CustomHTTPHeaderValue"
+        }
+      },
+      "required" : [ "Name", "Value" ],
+      "additionalProperties" : false
+    },
+    "CustomRequestHandling" : {
+      "description" : "Custom request handling.",
+      "type" : "object",
+      "properties" : {
+        "InsertHeaders" : {
+          "description" : "Collection of HTTP headers.",
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/CustomHTTPHeader"
+          },
+          "minItems" : 1
+        }
+      },
+      "required" : [ "InsertHeaders" ],
+      "additionalProperties" : false
+    },
+    "ResponseStatusCode" : {
+      "description" : "Custom response code.",
+      "type" : "integer",
+      "minimum" : 200,
+      "maximum" : 599
+    },
+    "ResponseContentType" : {
+      "description" : "Valid values are TEXT_PLAIN, TEXT_HTML, and APPLICATION_JSON.",
+      "type" : "string",
+      "enum" : [ "TEXT_PLAIN", "TEXT_HTML", "APPLICATION_JSON" ]
+    },
+    "ResponseContent" : {
+      "description" : "Response content.",
+      "type" : "string",
+      "minLength" : 1,
+      "maxLength" : 10240
+    },
+    "CustomResponseBody" : {
+      "description" : "Custom response body.",
+      "type" : "object",
+      "properties" : {
+        "ContentType" : {
+          "$ref" : "#/definitions/ResponseContentType"
+        },
+        "Content" : {
+          "$ref" : "#/definitions/ResponseContent"
+        }
+      },
+      "required" : [ "ContentType", "Content" ],
+      "additionalProperties" : false
+    },
+    "CustomResponse" : {
+      "description" : "Custom response.",
+      "type" : "object",
+      "properties" : {
+        "ResponseCode" : {
+          "$ref" : "#/definitions/ResponseStatusCode"
+        },
+        "CustomResponseBodyKey" : {
+          "description" : "Custom response body key.",
+          "type" : "string",
+          "pattern" : "^[\\w\\-]+$"
+        },
+        "ResponseHeaders" : {
+          "description" : "Collection of HTTP headers.",
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/CustomHTTPHeader"
+          },
+          "minItems" : 1
+        }
+      },
+      "required" : [ "ResponseCode" ],
+      "additionalProperties" : false
+    },
+    "CustomResponseBodies" : {
+      "description" : "Custom response key and body map.",
+      "type" : "object",
+      "patternProperties" : {
+        "^[\\w\\-]+$" : {
+          "$ref" : "#/definitions/CustomResponseBody"
+        }
+      },
+      "minProperties" : 1,
+      "additionalProperties" : false
+    },
+    "RuleGroupReferenceStatement" : {
+      "type" : "object",
+      "properties" : {
+        "Arn" : {
+          "$ref" : "#/definitions/ResourceArn"
+        },
+        "ExcludedRules" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/ExcludedRule"
+          }
+        },
+        "RuleActionOverrides" : {
+          "description" : "Action overrides for rules in the rule group.",
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/RuleActionOverride"
+          },
+          "maxItems" : 100
+        }
+      },
+      "required" : [ "Arn" ],
+      "additionalProperties" : false
+    },
+    "RulePriority" : {
+      "description" : "Priority of the Rule, Rules get evaluated from lower to higher priority.",
+      "type" : "integer",
+      "minimum" : 0
+    },
+    "Scope" : {
+      "description" : "Use CLOUDFRONT for CloudFront WebACL, use REGIONAL for Application Load Balancer and API Gateway.",
+      "type" : "string",
+      "enum" : [ "CLOUDFRONT", "REGIONAL" ]
+    },
+    "SearchString" : {
+      "description" : "String that is searched to find a match.",
+      "type" : "string"
+    },
+    "SearchStringBase64" : {
+      "description" : "Base64 encoded string that is searched to find a match.",
+      "type" : "string"
+    },
+    "SingleHeader" : {
+      "type" : "object",
+      "properties" : {
+        "Name" : {
+          "type" : "string"
+        }
+      },
+      "additionalProperties" : false
+    },
+    "SingleQueryArgument" : {
+      "type" : "object",
+      "properties" : {
+        "Name" : {
+          "type" : "string"
+        }
+      },
+      "additionalProperties" : false
+    },
+    "SizeConstraintStatement" : {
+      "description" : "Size Constraint statement.",
+      "type" : "object",
+      "properties" : {
+        "FieldToMatch" : {
+          "$ref" : "#/definitions/FieldToMatch"
+        },
+        "ComparisonOperator" : {
+          "type" : "string",
+          "enum" : [ "EQ", "NE", "LE", "LT", "GE", "GT" ]
+        },
+        "Size" : {
+          "type" : "number",
+          "minimum" : 0,
+          "maximum" : 21474836480
+        },
+        "TextTransformations" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/TextTransformation"
+          }
+        }
+      },
+      "required" : [ "FieldToMatch", "ComparisonOperator", "Size", "TextTransformations" ],
+      "additionalProperties" : false
+    },
+    "SqliMatchStatement" : {
+      "description" : "Sqli Match Statement.",
+      "type" : "object",
+      "properties" : {
+        "FieldToMatch" : {
+          "$ref" : "#/definitions/FieldToMatch"
+        },
+        "TextTransformations" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/TextTransformation"
+          }
+        },
+        "SensitivityLevel" : {
+          "$ref" : "#/definitions/SensitivityLevel"
+        }
+      },
+      "required" : [ "FieldToMatch", "TextTransformations" ],
+      "additionalProperties" : false
+    },
+    "Statement" : {
+      "description" : "First level statement that contains conditions, such as ByteMatch, SizeConstraint, etc",
+      "type" : "object",
+      "properties" : {
+        "ByteMatchStatement" : {
+          "$ref" : "#/definitions/ByteMatchStatement"
+        },
+        "SqliMatchStatement" : {
+          "$ref" : "#/definitions/SqliMatchStatement"
+        },
+        "XssMatchStatement" : {
+          "$ref" : "#/definitions/XssMatchStatement"
+        },
+        "SizeConstraintStatement" : {
+          "$ref" : "#/definitions/SizeConstraintStatement"
+        },
+        "GeoMatchStatement" : {
+          "$ref" : "#/definitions/GeoMatchStatement"
+        },
+        "RuleGroupReferenceStatement" : {
+          "$ref" : "#/definitions/RuleGroupReferenceStatement"
+        },
+        "IPSetReferenceStatement" : {
+          "$ref" : "#/definitions/IPSetReferenceStatement"
+        },
+        "RegexPatternSetReferenceStatement" : {
+          "$ref" : "#/definitions/RegexPatternSetReferenceStatement"
+        },
+        "ManagedRuleGroupStatement" : {
+          "$ref" : "#/definitions/ManagedRuleGroupStatement"
+        },
+        "RateBasedStatement" : {
+          "$ref" : "#/definitions/RateBasedStatement"
+        },
+        "AndStatement" : {
+          "$ref" : "#/definitions/AndStatement"
+        },
+        "OrStatement" : {
+          "$ref" : "#/definitions/OrStatement"
+        },
+        "NotStatement" : {
+          "$ref" : "#/definitions/NotStatement"
+        },
+        "LabelMatchStatement" : {
+          "$ref" : "#/definitions/LabelMatchStatement"
+        },
+        "RegexMatchStatement" : {
+          "$ref" : "#/definitions/RegexMatchStatement"
+        },
+        "AsnMatchStatement" : {
+          "$ref" : "#/definitions/AsnMatchStatement"
+        }
+      },
+      "additionalProperties" : false
+    },
+    "Tag" : {
+      "type" : "object",
+      "properties" : {
+        "Key" : {
+          "type" : "string",
+          "minLength" : 1,
+          "maxLength" : 128
+        },
+        "Value" : {
+          "type" : "string",
+          "minLength" : 0,
+          "maxLength" : 256
+        }
+      },
+      "additionalProperties" : false
+    },
+    "TextTransformation" : {
+      "description" : "Text Transformation on the Search String before match.",
+      "type" : "object",
+      "properties" : {
+        "Priority" : {
+          "$ref" : "#/definitions/TextTransformationPriority"
+        },
+        "Type" : {
+          "$ref" : "#/definitions/TextTransformationType"
+        }
+      },
+      "required" : [ "Priority", "Type" ],
+      "additionalProperties" : false
+    },
+    "TextTransformationPriority" : {
+      "description" : "Priority of Rule being evaluated.",
+      "type" : "integer",
+      "minimum" : 0
+    },
+    "TextTransformationType" : {
+      "description" : "Type of text transformation.",
+      "type" : "string",
+      "enum" : [ "NONE", "COMPRESS_WHITE_SPACE", "HTML_ENTITY_DECODE", "LOWERCASE", "CMD_LINE", "URL_DECODE", "BASE64_DECODE", "HEX_DECODE", "MD5", "REPLACE_COMMENTS", "ESCAPE_SEQ_DECODE", "SQL_HEX_DECODE", "CSS_DECODE", "JS_DECODE", "NORMALIZE_PATH", "NORMALIZE_PATH_WIN", "REMOVE_NULLS", "REPLACE_NULLS", "BASE64_DECODE_EXT", "URL_DECODE_UNI", "UTF8_TO_UNICODE" ]
+    },
+    "UriPath" : {
+      "type" : "object"
+    },
+    "VisibilityConfig" : {
+      "description" : "Visibility Metric of the WebACL.",
+      "type" : "object",
+      "properties" : {
+        "SampledRequestsEnabled" : {
+          "type" : "boolean"
+        },
+        "CloudWatchMetricsEnabled" : {
+          "type" : "boolean"
+        },
+        "MetricName" : {
+          "type" : "string",
+          "maxLength" : 128,
+          "minLength" : 1
+        }
+      },
+      "required" : [ "SampledRequestsEnabled", "CloudWatchMetricsEnabled", "MetricName" ],
+      "additionalProperties" : false
+    },
+    "DataProtectionConfig" : {
+      "type" : "object",
+      "properties" : {
+        "DataProtections" : {
+          "$ref" : "#/definitions/DataProtections"
+        }
+      },
+      "required" : [ "DataProtections" ],
+      "additionalProperties" : false
+    },
+    "DataProtections" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/definitions/DataProtect"
+      },
+      "minItems" : 1
+    },
+    "DataProtect" : {
+      "type" : "object",
+      "properties" : {
+        "Field" : {
+          "$ref" : "#/definitions/FieldToProtect"
+        },
+        "Action" : {
+          "$ref" : "#/definitions/DataProtectionAction"
+        },
+        "ExcludeRuleMatchDetails" : {
+          "type" : "boolean"
+        },
+        "ExcludeRateBasedDetails" : {
+          "type" : "boolean"
+        }
+      },
+      "required" : [ "Field", "Action" ],
+      "additionalProperties" : false
+    },
+    "DataProtectionAction" : {
+      "type" : "string",
+      "enum" : [ "SUBSTITUTION", "HASH" ]
+    },
+    "FieldToProtect" : {
+      "description" : "Field in log to protect.",
+      "type" : "object",
+      "properties" : {
+        "FieldType" : {
+          "description" : "Field type to protect",
+          "type" : "string",
+          "enum" : [ "SINGLE_HEADER", "SINGLE_COOKIE", "SINGLE_QUERY_ARGUMENT", "QUERY_STRING", "BODY" ]
+        },
+        "FieldKeys" : {
+          "description" : "List of field keys to protect",
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/FieldToProtectKeyName"
+          }
+        }
+      },
+      "required" : [ "FieldType" ],
+      "additionalProperties" : false
+    },
+    "FieldToProtectKeyName" : {
+      "description" : "Key of the field to protect.",
+      "type" : "string",
+      "minLength" : 1,
+      "maxLength" : 64
+    },
+    "XssMatchStatement" : {
+      "description" : "Xss Match Statement.",
+      "type" : "object",
+      "properties" : {
+        "FieldToMatch" : {
+          "$ref" : "#/definitions/FieldToMatch"
+        },
+        "TextTransformations" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/TextTransformation"
+          }
+        }
+      },
+      "required" : [ "FieldToMatch", "TextTransformations" ],
+      "additionalProperties" : false
+    },
+    "LabelName" : {
+      "description" : "Name of the Label.",
+      "type" : "string",
+      "pattern" : "^[0-9A-Za-z_:-]{1,1024}$"
+    },
+    "Label" : {
+      "type" : "object",
+      "properties" : {
+        "Name" : {
+          "$ref" : "#/definitions/LabelName"
+        }
+      },
+      "required" : [ "Name" ],
+      "additionalProperties" : false
+    },
+    "LabelMatchKey" : {
+      "type" : "string",
+      "pattern" : "^[0-9A-Za-z_:-]{1,1024}$"
+    },
+    "LabelMatchScope" : {
+      "type" : "string",
+      "enum" : [ "LABEL", "NAMESPACE" ]
+    },
+    "LabelMatchStatement" : {
+      "type" : "object",
+      "properties" : {
+        "Scope" : {
+          "$ref" : "#/definitions/LabelMatchScope"
+        },
+        "Key" : {
+          "$ref" : "#/definitions/LabelMatchKey"
+        }
+      },
+      "required" : [ "Scope", "Key" ],
+      "additionalProperties" : false
+    },
+    "RegexMatchStatement" : {
+      "type" : "object",
+      "properties" : {
+        "RegexString" : {
+          "type" : "string",
+          "maxLength" : 512,
+          "minLength" : 1
+        },
+        "FieldToMatch" : {
+          "$ref" : "#/definitions/FieldToMatch"
+        },
+        "TextTransformations" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/TextTransformation"
+          }
+        }
+      },
+      "required" : [ "RegexString", "FieldToMatch", "TextTransformations" ],
+      "additionalProperties" : false
+    },
+    "AsnMatchStatement" : {
+      "type" : "object",
+      "properties" : {
+        "AsnList" : {
+          "type" : "array",
+          "items" : {
+            "type" : "integer",
+            "minimum" : 0,
+            "maximum" : 4294967295
+          }
+        },
+        "ForwardedIPConfig" : {
+          "$ref" : "#/definitions/ForwardedIPConfiguration"
+        }
+      },
+      "additionalProperties" : false
+    },
+    "CaptchaConfig" : {
+      "type" : "object",
+      "properties" : {
+        "ImmunityTimeProperty" : {
+          "$ref" : "#/definitions/ImmunityTimeProperty"
+        }
+      },
+      "additionalProperties" : false
+    },
+    "ChallengeConfig" : {
+      "type" : "object",
+      "properties" : {
+        "ImmunityTimeProperty" : {
+          "$ref" : "#/definitions/ImmunityTimeProperty"
+        }
+      },
+      "additionalProperties" : false
+    },
+    "ImmunityTimeProperty" : {
+      "type" : "object",
+      "properties" : {
+        "ImmunityTime" : {
+          "type" : "integer",
+          "minimum" : 60,
+          "maximum" : 259200
+        }
+      },
+      "required" : [ "ImmunityTime" ],
+      "additionalProperties" : false
+    },
+    "ManagedRuleGroupConfig" : {
+      "description" : "ManagedRuleGroupConfig.",
+      "type" : "object",
+      "properties" : {
+        "LoginPath" : {
+          "type" : "string",
+          "pattern" : ".*\\S.*",
+          "minLength" : 1,
+          "maxLength" : 256
+        },
+        "PayloadType" : {
+          "type" : "string",
+          "enum" : [ "JSON", "FORM_ENCODED" ]
+        },
+        "UsernameField" : {
+          "$ref" : "#/definitions/FieldIdentifier"
+        },
+        "PasswordField" : {
+          "$ref" : "#/definitions/FieldIdentifier"
+        },
+        "AWSManagedRulesBotControlRuleSet" : {
+          "$ref" : "#/definitions/AWSManagedRulesBotControlRuleSet"
+        },
+        "AWSManagedRulesATPRuleSet" : {
+          "$ref" : "#/definitions/AWSManagedRulesATPRuleSet"
+        },
+        "AWSManagedRulesACFPRuleSet" : {
+          "$ref" : "#/definitions/AWSManagedRulesACFPRuleSet"
+        },
+        "AWSManagedRulesAntiDDoSRuleSet" : {
+          "$ref" : "#/definitions/AWSManagedRulesAntiDDoSRuleSet"
+        }
+      },
+      "additionalProperties" : false
+    },
+    "AWSManagedRulesBotControlRuleSet" : {
+      "description" : "Configures how to use the Bot Control managed rule group in the web ACL",
+      "type" : "object",
+      "properties" : {
+        "InspectionLevel" : {
+          "type" : "string",
+          "enum" : [ "COMMON", "TARGETED" ]
+        },
+        "EnableMachineLearning" : {
+          "type" : "boolean"
+        }
+      },
+      "required" : [ "InspectionLevel" ],
+      "additionalProperties" : false
+    },
+    "AWSManagedRulesATPRuleSet" : {
+      "description" : "Configures how to use the Account Takeover Prevention managed rule group in the web ACL",
+      "type" : "object",
+      "properties" : {
+        "LoginPath" : {
+          "type" : "string"
+        },
+        "EnableRegexInPath" : {
+          "type" : "boolean"
+        },
+        "RequestInspection" : {
+          "$ref" : "#/definitions/RequestInspection"
+        },
+        "ResponseInspection" : {
+          "$ref" : "#/definitions/ResponseInspection"
+        }
+      },
+      "required" : [ "LoginPath" ],
+      "additionalProperties" : false
+    },
+    "AWSManagedRulesACFPRuleSet" : {
+      "description" : "Configures how to use the Account creation fraud prevention managed rule group in the web ACL",
+      "type" : "object",
+      "properties" : {
+        "CreationPath" : {
+          "type" : "string"
+        },
+        "RegistrationPagePath" : {
+          "type" : "string"
+        },
+        "RequestInspection" : {
+          "$ref" : "#/definitions/RequestInspectionACFP"
+        },
+        "ResponseInspection" : {
+          "$ref" : "#/definitions/ResponseInspection"
+        },
+        "EnableRegexInPath" : {
+          "type" : "boolean"
+        }
+      },
+      "required" : [ "CreationPath", "RegistrationPagePath", "RequestInspection" ],
+      "additionalProperties" : false
+    },
+    "AWSManagedRulesAntiDDoSRuleSet" : {
+      "description" : "Configures how to use the AntiDDOS AWS managed rule group in the web ACL",
+      "type" : "object",
+      "properties" : {
+        "ClientSideActionConfig" : {
+          "$ref" : "#/definitions/ClientSideActionConfig"
+        },
+        "SensitivityToBlock" : {
+          "$ref" : "#/definitions/SensitivityToAct"
+        }
+      },
+      "required" : [ "ClientSideActionConfig" ],
+      "additionalProperties" : false
+    },
+    "ClientSideActionConfig" : {
+      "description" : "Client side action config for AntiDDOS AMR.",
+      "type" : "object",
+      "properties" : {
+        "Challenge" : {
+          "$ref" : "#/definitions/ClientSideAction"
+        }
+      },
+      "required" : [ "Challenge" ],
+      "additionalProperties" : false
+    },
+    "ClientSideAction" : {
+      "description" : "Client side action config for AntiDDOS AMR.",
+      "type" : "object",
+      "properties" : {
+        "UsageOfAction" : {
+          "$ref" : "#/definitions/UsageOfAction"
+        },
+        "Sensitivity" : {
+          "$ref" : "#/definitions/SensitivityToAct"
+        },
+        "ExemptUriRegularExpressions" : {
+          "$ref" : "#/definitions/RegularExpressionList"
+        }
+      },
+      "required" : [ "UsageOfAction" ],
+      "additionalProperties" : false
+    },
+    "UsageOfAction" : {
+      "type" : "string",
+      "enum" : [ "ENABLED", "DISABLED" ]
+    },
+    "SensitivityToAct" : {
+      "type" : "string",
+      "enum" : [ "LOW", "MEDIUM", "HIGH" ]
+    },
+    "RegularExpressionList" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/definitions/Regex"
+      }
+    },
+    "Regex" : {
+      "description" : "Regex",
+      "type" : "object",
+      "properties" : {
+        "RegexString" : {
+          "$ref" : "#/definitions/RegexPatternString"
+        }
+      }
+    },
+    "RegexPatternString" : {
+      "type" : "string",
+      "maxLength" : 512,
+      "minLength" : 1
+    },
+    "RequestInspection" : {
+      "description" : "Configures the inspection of login requests",
+      "type" : "object",
+      "properties" : {
+        "PayloadType" : {
+          "type" : "string",
+          "enum" : [ "JSON", "FORM_ENCODED" ]
+        },
+        "UsernameField" : {
+          "$ref" : "#/definitions/FieldIdentifier"
+        },
+        "PasswordField" : {
+          "$ref" : "#/definitions/FieldIdentifier"
+        }
+      },
+      "required" : [ "PayloadType", "UsernameField", "PasswordField" ],
+      "additionalProperties" : false
+    },
+    "RequestInspectionACFP" : {
+      "description" : "Configures the inspection of sign-up requests",
+      "type" : "object",
+      "properties" : {
+        "PayloadType" : {
+          "type" : "string",
+          "enum" : [ "JSON", "FORM_ENCODED" ]
+        },
+        "UsernameField" : {
+          "$ref" : "#/definitions/FieldIdentifier"
+        },
+        "PasswordField" : {
+          "$ref" : "#/definitions/FieldIdentifier"
+        },
+        "EmailField" : {
+          "$ref" : "#/definitions/FieldIdentifier"
+        },
+        "PhoneNumberFields" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/PhoneNumberField"
+          }
+        },
+        "AddressFields" : {
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/definitions/AddressField"
+          }
+        }
+      },
+      "required" : [ "PayloadType" ],
+      "additionalProperties" : false
+    },
+    "ResponseInspection" : {
+      "description" : "Configures the inspection of login responses",
+      "type" : "object",
+      "properties" : {
+        "StatusCode" : {
+          "$ref" : "#/definitions/ResponseInspectionStatusCode"
+        },
+        "Header" : {
+          "$ref" : "#/definitions/ResponseInspectionHeader"
+        },
+        "BodyContains" : {
+          "$ref" : "#/definitions/ResponseInspectionBodyContains"
+        },
+        "Json" : {
+          "$ref" : "#/definitions/ResponseInspectionJson"
+        }
+      },
+      "additionalProperties" : false
+    },
+    "ResponseInspectionStatusCode" : {
+      "description" : "Response status codes that indicate success or failure of a login request",
+      "type" : "object",
+      "properties" : {
+        "SuccessCodes" : {
+          "type" : "array",
+          "items" : {
+            "type" : "integer",
+            "minLength" : 0,
+            "maxLength" : 999
+          },
+          "minItems" : 1,
+          "maxItems" : 10
+        },
+        "FailureCodes" : {
+          "type" : "array",
+          "items" : {
+            "type" : "integer",
+            "minLength" : 0,
+            "maxLength" : 999
+          },
+          "minItems" : 1,
+          "maxItems" : 10
+        }
+      },
+      "required" : [ "SuccessCodes", "FailureCodes" ],
+      "additionalProperties" : false
+    },
+    "ResponseInspectionHeader" : {
+      "description" : "Response headers that indicate success or failure of a login request",
+      "type" : "object",
+      "properties" : {
+        "Name" : {
+          "type" : "string",
+          "pattern" : ".*\\S.*",
+          "minLength" : 1,
+          "maxLength" : 200
+        },
+        "SuccessValues" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "pattern" : ".*\\S.*",
+            "minLength" : 1,
+            "maxLength" : 100
+          },
+          "minItems" : 1,
+          "maxItems" : 3
+        },
+        "FailureValues" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "pattern" : ".*\\S.*",
+            "minLength" : 1,
+            "maxLength" : 100
+          },
+          "minItems" : 1,
+          "maxItems" : 3
+        }
+      },
+      "required" : [ "Name", "SuccessValues", "FailureValues" ],
+      "additionalProperties" : false
+    },
+    "ResponseInspectionBodyContains" : {
+      "description" : "Response body contents that indicate success or failure of a login request",
+      "type" : "object",
+      "properties" : {
+        "SuccessStrings" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "pattern" : ".*\\S.*",
+            "minLength" : 1,
+            "maxLength" : 100
+          },
+          "minItems" : 1,
+          "maxItems" : 5
+        },
+        "FailureStrings" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "pattern" : ".*\\S.*",
+            "minLength" : 1,
+            "maxLength" : 100
+          },
+          "minItems" : 1,
+          "maxItems" : 5
+        }
+      },
+      "required" : [ "SuccessStrings", "FailureStrings" ],
+      "additionalProperties" : false
+    },
+    "ResponseInspectionJson" : {
+      "description" : "Response JSON that indicate success or failure of a login request",
+      "type" : "object",
+      "properties" : {
+        "Identifier" : {
+          "type" : "string",
+          "pattern" : ".*\\S.*",
+          "minLength" : 1,
+          "maxLength" : 512
+        },
+        "SuccessValues" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "pattern" : ".*\\S.*",
+            "minLength" : 1,
+            "maxLength" : 100
+          },
+          "minItems" : 1,
+          "maxItems" : 5
+        },
+        "FailureValues" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "pattern" : ".*\\S.*",
+            "minLength" : 1,
+            "maxLength" : 100
+          },
+          "minItems" : 1,
+          "maxItems" : 5
+        }
+      },
+      "required" : [ "Identifier", "SuccessValues", "FailureValues" ],
+      "additionalProperties" : false
+    },
+    "TokenDomains" : {
+      "description" : "List of domains to accept in web request tokens, in addition to the domain of the protected resource.",
+      "type" : "array",
+      "items" : {
+        "type" : "string",
+        "pattern" : "^[\\w\\.\\-/]+$",
+        "minLength" : 1,
+        "maxLength" : 253
+      }
+    },
+    "AssociationConfig" : {
+      "description" : "AssociationConfig for body inspection",
+      "type" : "object",
+      "properties" : {
+        "RequestBody" : {
+          "$ref" : "#/definitions/RequestBody"
+        }
+      },
+      "additionalProperties" : false
+    },
+    "RequestBody" : {
+      "type" : "object",
+      "description" : "Map of AssociatedResourceType and RequestBodyAssociatedResourceTypeConfig",
+      "patternProperties" : {
+        "^(CLOUDFRONT|API_GATEWAY|COGNITO_USER_POOL|APP_RUNNER_SERVICE|VERIFIED_ACCESS_INSTANCE)$" : {
+          "$ref" : "#/definitions/RequestBodyAssociatedResourceTypeConfig"
+        }
+      },
+      "additionalProperties" : false
+    },
+    "RequestBodyAssociatedResourceTypeConfig" : {
+      "description" : "Configures the inspection size in the request body.",
+      "type" : "object",
+      "properties" : {
+        "DefaultSizeInspectionLimit" : {
+          "$ref" : "#/definitions/SizeInspectionLimit"
+        }
+      },
+      "required" : [ "DefaultSizeInspectionLimit" ],
+      "additionalProperties" : false
+    },
+    "SizeInspectionLimit" : {
+      "type" : "string",
+      "enum" : [ "KB_16", "KB_32", "KB_48", "KB_64" ]
+    },
+    "PhoneNumberField" : {
+      "$ref" : "#/definitions/FieldIdentifier"
+    },
+    "AddressField" : {
+      "$ref" : "#/definitions/FieldIdentifier"
+    },
+    "FieldIdentifier" : {
+      "type" : "object",
+      "properties" : {
+        "Identifier" : {
+          "type" : "string",
+          "pattern" : ".*\\S.*",
+          "minLength" : 1,
+          "maxLength" : 512
+        }
+      },
+      "required" : [ "Identifier" ],
+      "additionalProperties" : false
+    },
+    "Headers" : {
+      "description" : "Includes headers of a web request.",
+      "type" : "object",
+      "properties" : {
+        "MatchPattern" : {
+          "$ref" : "#/definitions/HeaderMatchPattern"
+        },
+        "MatchScope" : {
+          "$ref" : "#/definitions/MapMatchScope"
+        },
+        "OversizeHandling" : {
+          "$ref" : "#/definitions/OversizeHandling"
+        }
+      },
+      "required" : [ "MatchPattern", "MatchScope", "OversizeHandling" ],
+      "additionalProperties" : false
+    },
+    "Cookies" : {
+      "description" : "Includes cookies of a web request.",
+      "type" : "object",
+      "properties" : {
+        "MatchPattern" : {
+          "$ref" : "#/definitions/CookieMatchPattern"
+        },
+        "MatchScope" : {
+          "$ref" : "#/definitions/MapMatchScope"
+        },
+        "OversizeHandling" : {
+          "$ref" : "#/definitions/OversizeHandling"
+        }
+      },
+      "required" : [ "MatchPattern", "MatchScope", "OversizeHandling" ],
+      "additionalProperties" : false
+    },
+    "HeaderMatchPattern" : {
+      "description" : "The pattern to look for in the request headers.",
+      "type" : "object",
+      "properties" : {
+        "All" : {
+          "description" : "Inspect all parts of the web request headers.",
+          "type" : "object"
+        },
+        "IncludedHeaders" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "pattern" : ".*\\S.*",
+            "minLength" : 1,
+            "maxLength" : 64
+          },
+          "minItems" : 1,
+          "maxItems" : 199
+        },
+        "ExcludedHeaders" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "pattern" : ".*\\S.*",
+            "minLength" : 1,
+            "maxLength" : 64
+          },
+          "minItems" : 1,
+          "maxItems" : 199
+        }
+      },
+      "additionalProperties" : false
+    },
+    "CookieMatchPattern" : {
+      "description" : "The pattern to look for in the request cookies.",
+      "type" : "object",
+      "properties" : {
+        "All" : {
+          "description" : "Inspect all parts of the web request cookies.",
+          "type" : "object"
+        },
+        "IncludedCookies" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "pattern" : ".*\\S.*",
+            "minLength" : 1,
+            "maxLength" : 60
+          },
+          "minItems" : 1,
+          "maxItems" : 199
+        },
+        "ExcludedCookies" : {
+          "type" : "array",
+          "items" : {
+            "type" : "string",
+            "pattern" : ".*\\S.*",
+            "minLength" : 1,
+            "maxLength" : 60
+          },
+          "minItems" : 1,
+          "maxItems" : 199
+        }
+      },
+      "additionalProperties" : false
+    },
+    "MapMatchScope" : {
+      "description" : "The parts of the request to match against using the MatchPattern.",
+      "type" : "string",
+      "enum" : [ "ALL", "KEY", "VALUE" ]
+    },
+    "OversizeHandling" : {
+      "description" : "Handling of requests containing oversize fields",
+      "type" : "string",
+      "enum" : [ "CONTINUE", "MATCH", "NO_MATCH" ]
+    },
+    "SensitivityLevel" : {
+      "description" : "Sensitivity Level current only used for sqli match statements.",
+      "type" : "string",
+      "enum" : [ "LOW", "HIGH" ]
+    },
+    "JA3Fingerprint" : {
+      "description" : "Includes the JA3 fingerprint of a web request.",
+      "type" : "object",
+      "properties" : {
+        "FallbackBehavior" : {
+          "type" : "string",
+          "enum" : [ "MATCH", "NO_MATCH" ]
+        }
+      },
+      "required" : [ "FallbackBehavior" ],
+      "additionalProperties" : false
+    },
+    "JA4Fingerprint" : {
+      "description" : "Includes the JA4 fingerprint of a web request.",
+      "type" : "object",
+      "properties" : {
+        "FallbackBehavior" : {
+          "type" : "string",
+          "enum" : [ "MATCH", "NO_MATCH" ]
+        }
+      },
+      "required" : [ "FallbackBehavior" ],
+      "additionalProperties" : false
+    },
+    "UriFragment" : {
+      "description" : "The path component of the URI Fragment. This is the part of a web request that identifies a fragment uri, for example, /abcd#introduction",
+      "type" : "object",
+      "properties" : {
+        "FallbackBehavior" : {
+          "type" : "string",
+          "enum" : [ "MATCH", "NO_MATCH" ]
+        }
+      },
+      "additionalProperties" : false
+    },
+    "HeaderOrder" : {
+      "description" : "The string containing the list of a web request's header names, ordered as they appear in the web request, separated by colons.",
+      "type" : "object",
+      "properties" : {
+        "OversizeHandling" : {
+          "$ref" : "#/definitions/OversizeHandling"
+        }
+      },
+      "required" : [ "OversizeHandling" ],
+      "additionalProperties" : false
+    },
+    "OnSourceDDoSProtectionConfig" : {
+      "description" : "Configures the options for on-source DDoS protection provided by supported resource type.",
+      "type" : "object",
+      "properties" : {
+        "ALBLowReputationMode" : {
+          "type" : "string",
+          "enum" : [ "ACTIVE_UNDER_DDOS", "ALWAYS_ON" ]
+        }
+      },
+      "required" : [ "ALBLowReputationMode" ],
+      "additionalProperties" : false
+    }
+  },
+  "properties" : {
+    "Arn" : {
+      "$ref" : "#/definitions/ResourceArn"
+    },
+    "Capacity" : {
+      "type" : "integer",
+      "minimum" : 0
+    },
+    "DefaultAction" : {
+      "$ref" : "#/definitions/DefaultAction"
+    },
+    "Description" : {
+      "$ref" : "#/definitions/EntityDescription"
+    },
+    "Name" : {
+      "$ref" : "#/definitions/EntityName"
+    },
+    "Id" : {
+      "$ref" : "#/definitions/EntityId"
+    },
+    "Scope" : {
+      "$ref" : "#/definitions/Scope"
+    },
+    "Rules" : {
+      "description" : "Collection of Rules.",
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/definitions/Rule"
+      }
+    },
+    "VisibilityConfig" : {
+      "$ref" : "#/definitions/VisibilityConfig"
+    },
+    "DataProtectionConfig" : {
+      "description" : "Collection of dataProtects.",
+      "$ref" : "#/definitions/DataProtectionConfig"
+    },
+    "ApplicationConfig" : {
+      "description" : "Collection of application attributes.",
+      "$ref" : "#/definitions/ApplicationConfig"
+    },
+    "Tags" : {
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/definitions/Tag"
+      },
+      "minItems" : 1
+    },
+    "LabelNamespace" : {
+      "$ref" : "#/definitions/LabelName"
+    },
+    "CustomResponseBodies" : {
+      "$ref" : "#/definitions/CustomResponseBodies"
+    },
+    "CaptchaConfig" : {
+      "$ref" : "#/definitions/CaptchaConfig"
+    },
+    "ChallengeConfig" : {
+      "$ref" : "#/definitions/ChallengeConfig"
+    },
+    "TokenDomains" : {
+      "$ref" : "#/definitions/TokenDomains"
+    },
+    "AssociationConfig" : {
+      "$ref" : "#/definitions/AssociationConfig"
+    },
+    "OnSourceDDoSProtectionConfig" : {
+      "$ref" : "#/definitions/OnSourceDDoSProtectionConfig"
+    }
+  },
+  "required" : [ "DefaultAction", "Scope", "VisibilityConfig" ],
+  "primaryIdentifier" : [ "/properties/Name", "/properties/Id", "/properties/Scope" ],
+  "createOnlyProperties" : [ "/properties/Name", "/properties/Scope" ],
+  "readOnlyProperties" : [ "/properties/Arn", "/properties/Capacity", "/properties/Id", "/properties/LabelNamespace" ],
+  "additionalProperties" : false,
+  "tagging" : {
+    "cloudFormationSystemTags" : true,
+    "tagOnCreate" : true,
+    "tagUpdatable" : true,
+    "taggable" : true,
+    "tagProperty" : "/properties/Tags",
+    "permissions" : [ "wafv2:TagResource", "wafv2:UntagResource", "wafv2:ListTagsForResource" ]
+  },
+  "handlers" : {
+    "create" : {
+      "permissions" : [ "wafv2:CreateWebACL", "wafv2:GetWebACL", "wafv2:ListTagsForResource", "wafv2:TagResource", "wafv2:UntagResource" ]
+    },
+    "delete" : {
+      "permissions" : [ "wafv2:DeleteWebACL", "wafv2:GetWebACL" ]
+    },
+    "read" : {
+      "permissions" : [ "wafv2:GetWebACL", "wafv2:ListTagsForResource" ]
+    },
+    "update" : {
+      "permissions" : [ "wafv2:UpdateWebACL", "wafv2:GetWebACL", "wafv2:ListTagsForResource", "wafv2:TagResource", "wafv2:UntagResource" ]
+    },
+    "list" : {
+      "permissions" : [ "wafv2:listWebACLs" ],
+      "handlerSchema" : {
+        "properties" : {
+          "Scope" : {
+            "$ref" : "resource-schema.json#/properties/Scope"
+          }
+        },
+        "required" : [ "Scope" ]
+      }
+    }
+  }
+}

--- a/generated-docs/awscc/wafv2/web_acl.md
+++ b/generated-docs/awscc/wafv2/web_acl.md
@@ -1,0 +1,953 @@
+---
+title: "awscc.wafv2.WebAcl"
+description: "AWSCC WAFv2 WebAcl resource reference"
+---
+
+
+CloudFormation Type: `AWS::WAFv2::WebACL`
+
+Contains the Rules that identify the requests that you want to allow, block, or count. In a WebACL, you also specify a default action (ALLOW or BLOCK), and the action for each Rule that you add to a WebACL, for example, block requests from specified IP addresses or block requests from specified referrers. You also associate the WebACL with a CloudFront distribution to identify the requests that you want AWS WAF to filter. If you add more than one Rule to a WebACL, a request needs to match only one of the specifications to be allowed, blocked, or counted.
+
+## Argument Reference
+
+### `application_config`
+
+- **Type:** [Struct(ApplicationConfig)](#applicationconfig)
+- **Required:** No
+
+Collection of application attributes.
+
+### `association_config`
+
+- **Type:** [Struct(AssociationConfig)](#associationconfig)
+- **Required:** No
+
+### `captcha_config`
+
+- **Type:** [Struct(CaptchaConfig)](#captchaconfig)
+- **Required:** No
+
+### `challenge_config`
+
+- **Type:** [Struct(ChallengeConfig)](#challengeconfig)
+- **Required:** No
+
+### `custom_response_bodies`
+
+- **Type:** String
+- **Required:** No
+
+### `data_protection_config`
+
+- **Type:** [Struct(DataProtectionConfig)](#dataprotectionconfig)
+- **Required:** No
+
+Collection of dataProtects.
+
+### `default_action`
+
+- **Type:** [Struct(DefaultAction)](#defaultaction)
+- **Required:** Yes
+
+### `description`
+
+- **Type:** String
+- **Required:** No
+
+### `name`
+
+- **Type:** String
+- **Required:** No
+- **Create-only:** Yes
+
+### `on_source_d_do_s_protection_config`
+
+- **Type:** [Struct(OnSourceDDoSProtectionConfig)](#onsourceddosprotectionconfig)
+- **Required:** No
+
+### `rules`
+
+- **Type:** [List\<Rule\>](#rule)
+- **Required:** No
+
+Collection of Rules.
+
+### `scope`
+
+- **Type:** [Enum (Scope)](#scope-scope)
+- **Required:** Yes
+- **Create-only:** Yes
+
+### `tags`
+
+- **Type:** `Map<String, String>`
+- **Required:** No
+
+### `token_domains`
+
+- **Type:** String
+- **Required:** No
+
+### `visibility_config`
+
+- **Type:** [Struct(VisibilityConfig)](#visibilityconfig)
+- **Required:** Yes
+
+## Enum Values
+
+### sensitivity_to_block (SensitivityToAct)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `LOW` | `awscc.wafv2.WebAcl.SensitivityToAct.low` |
+| `MEDIUM` | `awscc.wafv2.WebAcl.SensitivityToAct.medium` |
+| `HIGH` | `awscc.wafv2.WebAcl.SensitivityToAct.high` |
+
+Shorthand formats: `low` or `SensitivityToAct.low`
+
+### inspection_level (InspectionLevel)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `COMMON` | `awscc.wafv2.WebAcl.InspectionLevel.common` |
+| `TARGETED` | `awscc.wafv2.WebAcl.InspectionLevel.targeted` |
+
+Shorthand formats: `common` or `InspectionLevel.common`
+
+### oversize_handling (OversizeHandling)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `CONTINUE` | `awscc.wafv2.WebAcl.OversizeHandling.continue` |
+| `MATCH` | `awscc.wafv2.WebAcl.OversizeHandling.match` |
+| `NO_MATCH` | `awscc.wafv2.WebAcl.OversizeHandling.no_match` |
+
+Shorthand formats: `continue` or `OversizeHandling.continue`
+
+### positional_constraint (PositionalConstraint)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `EXACTLY` | `awscc.wafv2.WebAcl.PositionalConstraint.exactly` |
+| `STARTS_WITH` | `awscc.wafv2.WebAcl.PositionalConstraint.starts_with` |
+| `ENDS_WITH` | `awscc.wafv2.WebAcl.PositionalConstraint.ends_with` |
+| `CONTAINS` | `awscc.wafv2.WebAcl.PositionalConstraint.contains` |
+| `CONTAINS_WORD` | `awscc.wafv2.WebAcl.PositionalConstraint.contains_word` |
+
+Shorthand formats: `exactly` or `PositionalConstraint.exactly`
+
+### usage_of_action (UsageOfAction)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `ENABLED` | `awscc.wafv2.WebAcl.UsageOfAction.enabled` |
+| `DISABLED` | `awscc.wafv2.WebAcl.UsageOfAction.disabled` |
+
+Shorthand formats: `enabled` or `UsageOfAction.enabled`
+
+### match_scope (MapMatchScope)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `ALL` | `awscc.wafv2.WebAcl.MapMatchScope.all` |
+| `KEY` | `awscc.wafv2.WebAcl.MapMatchScope.key` |
+| `VALUE` | `awscc.wafv2.WebAcl.MapMatchScope.value` |
+
+Shorthand formats: `all` or `MapMatchScope.all`
+
+### fallback_behavior (FallbackBehavior)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `MATCH` | `awscc.wafv2.WebAcl.FallbackBehavior.match` |
+| `NO_MATCH` | `awscc.wafv2.WebAcl.FallbackBehavior.no_match` |
+
+Shorthand formats: `match` or `FallbackBehavior.match`
+
+### position (Position)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `FIRST` | `awscc.wafv2.WebAcl.Position.first` |
+| `LAST` | `awscc.wafv2.WebAcl.Position.last` |
+| `ANY` | `awscc.wafv2.WebAcl.Position.any` |
+
+Shorthand formats: `first` or `Position.first`
+
+### invalid_fallback_behavior (BodyParsingFallbackBehavior)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `MATCH` | `awscc.wafv2.WebAcl.BodyParsingFallbackBehavior.match` |
+| `NO_MATCH` | `awscc.wafv2.WebAcl.BodyParsingFallbackBehavior.no_match` |
+| `EVALUATE_AS_STRING` | `awscc.wafv2.WebAcl.BodyParsingFallbackBehavior.evaluate_as_string` |
+
+Shorthand formats: `match` or `BodyParsingFallbackBehavior.match`
+
+### match_scope (JsonMatchScope)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `ALL` | `awscc.wafv2.WebAcl.JsonMatchScope.all` |
+| `KEY` | `awscc.wafv2.WebAcl.JsonMatchScope.key` |
+| `VALUE` | `awscc.wafv2.WebAcl.JsonMatchScope.value` |
+
+Shorthand formats: `all` or `JsonMatchScope.all`
+
+### scope (LabelMatchScope)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `LABEL` | `awscc.wafv2.WebAcl.LabelMatchScope.label` |
+| `NAMESPACE` | `awscc.wafv2.WebAcl.LabelMatchScope.namespace` |
+
+Shorthand formats: `label` or `LabelMatchScope.label`
+
+### payload_type (PayloadType)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `JSON` | `awscc.wafv2.WebAcl.PayloadType.json` |
+| `FORM_ENCODED` | `awscc.wafv2.WebAcl.PayloadType.form_encoded` |
+
+Shorthand formats: `json` or `PayloadType.json`
+
+### alb_low_reputation_mode (AlbLowReputationMode)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `ACTIVE_UNDER_DDOS` | `awscc.wafv2.WebAcl.AlbLowReputationMode.active_under_ddos` |
+| `ALWAYS_ON` | `awscc.wafv2.WebAcl.AlbLowReputationMode.always_on` |
+
+Shorthand formats: `active_under_ddos` or `AlbLowReputationMode.active_under_ddos`
+
+### aggregate_key_type (AggregateKeyType)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `CONSTANT` | `awscc.wafv2.WebAcl.AggregateKeyType.constant` |
+| `IP` | `awscc.wafv2.WebAcl.AggregateKeyType.ip` |
+| `FORWARDED_IP` | `awscc.wafv2.WebAcl.AggregateKeyType.forwarded_ip` |
+| `CUSTOM_KEYS` | `awscc.wafv2.WebAcl.AggregateKeyType.custom_keys` |
+
+Shorthand formats: `constant` or `AggregateKeyType.constant`
+
+### evaluation_window_sec (EvaluationWindowSec)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `60` | `awscc.wafv2.WebAcl.EvaluationWindowSec.60` |
+| `120` | `awscc.wafv2.WebAcl.EvaluationWindowSec.120` |
+| `300` | `awscc.wafv2.WebAcl.EvaluationWindowSec.300` |
+| `600` | `awscc.wafv2.WebAcl.EvaluationWindowSec.600` |
+
+Shorthand formats: `60` or `EvaluationWindowSec.60`
+
+### scope (Scope)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `CLOUDFRONT` | `awscc.wafv2.WebAcl.Scope.cloudfront` |
+| `REGIONAL` | `awscc.wafv2.WebAcl.Scope.regional` |
+
+Shorthand formats: `cloudfront` or `Scope.cloudfront`
+
+### comparison_operator (ComparisonOperator)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `EQ` | `awscc.wafv2.WebAcl.ComparisonOperator.eq` |
+| `NE` | `awscc.wafv2.WebAcl.ComparisonOperator.ne` |
+| `LE` | `awscc.wafv2.WebAcl.ComparisonOperator.le` |
+| `LT` | `awscc.wafv2.WebAcl.ComparisonOperator.lt` |
+| `GE` | `awscc.wafv2.WebAcl.ComparisonOperator.ge` |
+| `GT` | `awscc.wafv2.WebAcl.ComparisonOperator.gt` |
+
+Shorthand formats: `eq` or `ComparisonOperator.eq`
+
+### sensitivity_level (SensitivityLevel)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `LOW` | `awscc.wafv2.WebAcl.SensitivityLevel.low` |
+| `HIGH` | `awscc.wafv2.WebAcl.SensitivityLevel.high` |
+
+Shorthand formats: `low` or `SensitivityLevel.low`
+
+### type (TextTransformationType)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `NONE` | `awscc.wafv2.WebAcl.TextTransformationType.none` |
+| `COMPRESS_WHITE_SPACE` | `awscc.wafv2.WebAcl.TextTransformationType.compress_white_space` |
+| `HTML_ENTITY_DECODE` | `awscc.wafv2.WebAcl.TextTransformationType.html_entity_decode` |
+| `LOWERCASE` | `awscc.wafv2.WebAcl.TextTransformationType.lowercase` |
+| `CMD_LINE` | `awscc.wafv2.WebAcl.TextTransformationType.cmd_line` |
+| `URL_DECODE` | `awscc.wafv2.WebAcl.TextTransformationType.url_decode` |
+| `BASE64_DECODE` | `awscc.wafv2.WebAcl.TextTransformationType.base64_decode` |
+| `HEX_DECODE` | `awscc.wafv2.WebAcl.TextTransformationType.hex_decode` |
+| `MD5` | `awscc.wafv2.WebAcl.TextTransformationType.md5` |
+| `REPLACE_COMMENTS` | `awscc.wafv2.WebAcl.TextTransformationType.replace_comments` |
+| `ESCAPE_SEQ_DECODE` | `awscc.wafv2.WebAcl.TextTransformationType.escape_seq_decode` |
+| `SQL_HEX_DECODE` | `awscc.wafv2.WebAcl.TextTransformationType.sql_hex_decode` |
+| `CSS_DECODE` | `awscc.wafv2.WebAcl.TextTransformationType.css_decode` |
+| `JS_DECODE` | `awscc.wafv2.WebAcl.TextTransformationType.js_decode` |
+| `NORMALIZE_PATH` | `awscc.wafv2.WebAcl.TextTransformationType.normalize_path` |
+| `NORMALIZE_PATH_WIN` | `awscc.wafv2.WebAcl.TextTransformationType.normalize_path_win` |
+| `REMOVE_NULLS` | `awscc.wafv2.WebAcl.TextTransformationType.remove_nulls` |
+| `REPLACE_NULLS` | `awscc.wafv2.WebAcl.TextTransformationType.replace_nulls` |
+| `BASE64_DECODE_EXT` | `awscc.wafv2.WebAcl.TextTransformationType.base64_decode_ext` |
+| `URL_DECODE_UNI` | `awscc.wafv2.WebAcl.TextTransformationType.url_decode_uni` |
+| `UTF8_TO_UNICODE` | `awscc.wafv2.WebAcl.TextTransformationType.utf8_to_unicode` |
+
+Shorthand formats: `none` or `TextTransformationType.none`
+
+## Struct Definitions
+
+### AWSManagedRulesACFPRuleSet
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `creation_path` | String | Yes |  |
+| `enable_regex_in_path` | Bool | No |  |
+| `registration_page_path` | String | Yes |  |
+| `request_inspection` | [Struct(RequestInspectionACFP)](#requestinspectionacfp) | Yes |  |
+| `response_inspection` | [Struct(ResponseInspection)](#responseinspection) | No |  |
+
+### AWSManagedRulesATPRuleSet
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `enable_regex_in_path` | Bool | No |  |
+| `login_path` | String | Yes |  |
+| `request_inspection` | [Struct(RequestInspection)](#requestinspection) | No |  |
+| `response_inspection` | [Struct(ResponseInspection)](#responseinspection) | No |  |
+
+### AWSManagedRulesAntiDDoSRuleSet
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `client_side_action_config` | [Struct(ClientSideActionConfig)](#clientsideactionconfig) | Yes |  |
+| `sensitivity_to_block` | [Enum (SensitivityToAct)](#sensitivity_to_block-sensitivitytoact) | No |  |
+
+### AWSManagedRulesBotControlRuleSet
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `enable_machine_learning` | Bool | No |  |
+| `inspection_level` | [Enum (InspectionLevel)](#inspection_level-inspectionlevel) | Yes |  |
+
+### AllowAction
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `custom_request_handling` | [Struct(CustomRequestHandling)](#customrequesthandling) | No |  |
+
+### AndStatement
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `statements` | [List\<Statement\>](#statement) | Yes |  |
+
+### ApplicationConfig
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `attributes` | String | Yes |  |
+
+### AsnMatchStatement
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `asn_list` | `List<Int>` | No |  |
+| `forwarded_ip_config` | [Struct(ForwardedIPConfiguration)](#forwardedipconfiguration) | No |  |
+
+### AssociationConfig
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `request_body` | String | No |  |
+
+### BlockAction
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `custom_response` | [Struct(CustomResponse)](#customresponse) | No |  |
+
+### Body
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `oversize_handling` | [Enum (OversizeHandling)](#oversize_handling-oversizehandling) | No |  |
+
+### ByteMatchStatement
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `field_to_match` | [Struct(FieldToMatch)](#fieldtomatch) | Yes |  |
+| `positional_constraint` | [Enum (PositionalConstraint)](#positional_constraint-positionalconstraint) | Yes |  |
+| `search_string` | String | No |  |
+| `search_string_base64` | String | No |  |
+| `text_transformations` | [List\<TextTransformation\>](#texttransformation) | Yes |  |
+
+### CaptchaAction
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `custom_request_handling` | [Struct(CustomRequestHandling)](#customrequesthandling) | No |  |
+
+### CaptchaConfig
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `immunity_time_property` | [Struct(ImmunityTimeProperty)](#immunitytimeproperty) | No |  |
+
+### ChallengeAction
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `custom_request_handling` | [Struct(CustomRequestHandling)](#customrequesthandling) | No |  |
+
+### ChallengeConfig
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `immunity_time_property` | [Struct(ImmunityTimeProperty)](#immunitytimeproperty) | No |  |
+
+### ClientSideAction
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `exempt_uri_regular_expressions` | String | No |  |
+| `sensitivity` | [Enum (SensitivityToAct)](#sensitivity-sensitivitytoact) | No |  |
+| `usage_of_action` | [Enum (UsageOfAction)](#usage_of_action-usageofaction) | Yes |  |
+
+### ClientSideActionConfig
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `challenge` | [Struct(ClientSideAction)](#clientsideaction) | Yes |  |
+
+### CookieMatchPattern
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `all` | `Map<String, String>` | No | Inspect all parts of the web request cookies. |
+| `excluded_cookies` | `List<String>` (items: 1..=199) | No |  |
+| `included_cookies` | `List<String>` (items: 1..=199) | No |  |
+
+### Cookies
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `match_pattern` | [Struct(CookieMatchPattern)](#cookiematchpattern) | Yes |  |
+| `match_scope` | [Enum (MapMatchScope)](#match_scope-mapmatchscope) | Yes |  |
+| `oversize_handling` | [Enum (OversizeHandling)](#oversize_handling-oversizehandling) | Yes |  |
+
+### CountAction
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `custom_request_handling` | [Struct(CustomRequestHandling)](#customrequesthandling) | No |  |
+
+### CustomHTTPHeader
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | String | Yes |  |
+| `value` | String | Yes |  |
+
+### CustomRequestHandling
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `insert_headers` | [List\<CustomHTTPHeader\>](#customhttpheader) (items: 1..) | Yes | Collection of HTTP headers. |
+
+### CustomResponse
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `custom_response_body_key` | String | No | Custom response body key. |
+| `response_code` | String | Yes |  |
+| `response_headers` | [List\<CustomHTTPHeader\>](#customhttpheader) (items: 1..) | No | Collection of HTTP headers. |
+
+### DataProtectionConfig
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `data_protections` | String | Yes |  |
+
+### DefaultAction
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `allow` | [Struct(AllowAction)](#allowaction) | No |  |
+| `block` | [Struct(BlockAction)](#blockaction) | No |  |
+
+### ExcludedRule
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | String | Yes |  |
+
+### FieldIdentifier
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `identifier` | String(pattern, len: 1..=512) | Yes |  |
+
+### FieldToMatch
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `all_query_arguments` | `Map<String, String>` | No | All query arguments of a web request. |
+| `body` | [Struct(Body)](#body) | No |  |
+| `cookies` | [Struct(Cookies)](#cookies) | No |  |
+| `header_order` | [Struct(HeaderOrder)](#headerorder) | No |  |
+| `headers` | [Struct(Headers)](#headers) | No |  |
+| `ja3_fingerprint` | [Struct(JA3Fingerprint)](#ja3fingerprint) | No |  |
+| `ja4_fingerprint` | [Struct(JA4Fingerprint)](#ja4fingerprint) | No |  |
+| `json_body` | [Struct(JsonBody)](#jsonbody) | No |  |
+| `method` | `Map<String, String>` | No | The HTTP method of a web request. The method indicates the type of operation that the request is asking the origin to perform. |
+| `query_string` | `Map<String, String>` | No | The query string of a web request. This is the part of a URL that appears after a ? character, if any. |
+| `single_header` | [Struct(SingleHeader)](#singleheader) | No |  |
+| `single_query_argument` | [Struct(SingleQueryArgument)](#singlequeryargument) | No | One query argument in a web request, identified by name, for example UserName or SalesRegion. The name can be up to 30 characters long and isn't case sensitive. |
+| `uri_fragment` | [Struct(UriFragment)](#urifragment) | No |  |
+| `uri_path` | `Map<String, String>` | No | The path component of the URI of a web request. This is the part of a web request that identifies a resource, for example, /images/daily-ad.jpg. |
+
+### ForwardedIPConfiguration
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `fallback_behavior` | [Enum (FallbackBehavior)](#fallback_behavior-fallbackbehavior) | Yes |  |
+| `header_name` | String | Yes |  |
+
+### GeoMatchStatement
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `country_codes` | `List<String>` | No |  |
+| `forwarded_ip_config` | [Struct(ForwardedIPConfiguration)](#forwardedipconfiguration) | No |  |
+
+### HeaderMatchPattern
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `all` | `Map<String, String>` | No | Inspect all parts of the web request headers. |
+| `excluded_headers` | `List<String>` (items: 1..=199) | No |  |
+| `included_headers` | `List<String>` (items: 1..=199) | No |  |
+
+### HeaderOrder
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `oversize_handling` | [Enum (OversizeHandling)](#oversize_handling-oversizehandling) | Yes |  |
+
+### Headers
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `match_pattern` | [Struct(HeaderMatchPattern)](#headermatchpattern) | Yes |  |
+| `match_scope` | [Enum (MapMatchScope)](#match_scope-mapmatchscope) | Yes |  |
+| `oversize_handling` | [Enum (OversizeHandling)](#oversize_handling-oversizehandling) | Yes |  |
+
+### IPSetForwardedIPConfiguration
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `fallback_behavior` | [Enum (FallbackBehavior)](#fallback_behavior-fallbackbehavior) | Yes |  |
+| `header_name` | String | Yes |  |
+| `position` | [Enum (Position)](#position-position) | Yes |  |
+
+### IPSetReferenceStatement
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `arn` | Arn | Yes |  |
+| `ip_set_forwarded_ip_config` | [Struct(IPSetForwardedIPConfiguration)](#ipsetforwardedipconfiguration) | No |  |
+
+### ImmunityTimeProperty
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `immunity_time` | Int(60..=259200) | Yes |  |
+
+### JA3Fingerprint
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `fallback_behavior` | [Enum (FallbackBehavior)](#fallback_behavior-fallbackbehavior) | Yes |  |
+
+### JA4Fingerprint
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `fallback_behavior` | [Enum (FallbackBehavior)](#fallback_behavior-fallbackbehavior) | Yes |  |
+
+### JsonBody
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `invalid_fallback_behavior` | [Enum (BodyParsingFallbackBehavior)](#invalid_fallback_behavior-bodyparsingfallbackbehavior) | No |  |
+| `match_pattern` | [Struct(JsonMatchPattern)](#jsonmatchpattern) | Yes |  |
+| `match_scope` | [Enum (JsonMatchScope)](#match_scope-jsonmatchscope) | Yes |  |
+| `oversize_handling` | [Enum (OversizeHandling)](#oversize_handling-oversizehandling) | No |  |
+
+### JsonMatchPattern
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `all` | `Map<String, String>` | No | Inspect all parts of the web request's JSON body. |
+| `included_paths` | `List<String>` | No |  |
+
+### Label
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | String | Yes |  |
+
+### LabelMatchStatement
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `key` | String | Yes |  |
+| `scope` | [Enum (LabelMatchScope)](#scope-labelmatchscope) | Yes |  |
+
+### ManagedRuleGroupConfig
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `aws_managed_rules_acfp_rule_set` | [Struct(AWSManagedRulesACFPRuleSet)](#awsmanagedrulesacfpruleset) | No |  |
+| `aws_managed_rules_atp_rule_set` | [Struct(AWSManagedRulesATPRuleSet)](#awsmanagedrulesatpruleset) | No |  |
+| `aws_managed_rules_anti_d_do_s_rule_set` | [Struct(AWSManagedRulesAntiDDoSRuleSet)](#awsmanagedrulesantiddosruleset) | No |  |
+| `aws_managed_rules_bot_control_rule_set` | [Struct(AWSManagedRulesBotControlRuleSet)](#awsmanagedrulesbotcontrolruleset) | No |  |
+| `login_path` | String(pattern, len: 1..=256) | No |  |
+| `password_field` | [Struct(FieldIdentifier)](#fieldidentifier) | No |  |
+| `payload_type` | [Enum (PayloadType)](#payload_type-payloadtype) | No |  |
+| `username_field` | [Struct(FieldIdentifier)](#fieldidentifier) | No |  |
+
+### ManagedRuleGroupStatement
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `excluded_rules` | [List\<ExcludedRule\>](#excludedrule) | No |  |
+| `managed_rule_group_configs` | [List\<ManagedRuleGroupConfig\>](#managedrulegroupconfig) | No | Collection of ManagedRuleGroupConfig. |
+| `name` | String | Yes |  |
+| `rule_action_overrides` | [List\<RuleActionOverride\>](#ruleactionoverride) (items: ..=100) | No | Action overrides for rules in the rule group. |
+| `scope_down_statement` | [Struct(Statement)](#statement) | No |  |
+| `vendor_name` | String | Yes |  |
+| `version` | String(pattern, len: 1..=64) | No |  |
+
+### NotStatement
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `statement` | [Struct(Statement)](#statement) | Yes |  |
+
+### OnSourceDDoSProtectionConfig
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `alb_low_reputation_mode` | [Enum (AlbLowReputationMode)](#alb_low_reputation_mode-alblowreputationmode) | Yes |  |
+
+### OrStatement
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `statements` | [List\<Statement\>](#statement) | Yes |  |
+
+### OverrideAction
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `count` | `Map<String, String>` | No | Count traffic towards application. |
+| `none` | `Map<String, String>` | No | Keep the RuleGroup or ManagedRuleGroup behavior as is. |
+
+### RateBasedStatement
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `aggregate_key_type` | [Enum (AggregateKeyType)](#aggregate_key_type-aggregatekeytype) | Yes |  |
+| `custom_keys` | [List\<RateBasedStatementCustomKey\>](#ratebasedstatementcustomkey) (items: ..=5) | No | Specifies the aggregate keys to use in a rate-base rule. |
+| `evaluation_window_sec` | [Enum (EvaluationWindowSec)](#evaluation_window_sec-evaluationwindowsec) | No |  |
+| `forwarded_ip_config` | [Struct(ForwardedIPConfiguration)](#forwardedipconfiguration) | No |  |
+| `limit` | String | Yes |  |
+| `scope_down_statement` | [Struct(Statement)](#statement) | No |  |
+
+### RateBasedStatementCustomKey
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `asn` | String | No |  |
+| `cookie` | [Struct(RateLimitCookie)](#ratelimitcookie) | No |  |
+| `forwarded_ip` | Ipv4Address | No |  |
+| `http_method` | String | No |  |
+| `header` | [Struct(RateLimitHeader)](#ratelimitheader) | No |  |
+| `ip` | Ipv4Address | No |  |
+| `ja3_fingerprint` | [Struct(RateLimitJA3Fingerprint)](#ratelimitja3fingerprint) | No |  |
+| `ja4_fingerprint` | [Struct(RateLimitJA4Fingerprint)](#ratelimitja4fingerprint) | No |  |
+| `label_namespace` | [Struct(RateLimitLabelNamespace)](#ratelimitlabelnamespace) | No |  |
+| `query_argument` | [Struct(RateLimitQueryArgument)](#ratelimitqueryargument) | No |  |
+| `query_string` | [Struct(RateLimitQueryString)](#ratelimitquerystring) | No |  |
+| `uri_path` | [Struct(RateLimitUriPath)](#ratelimituripath) | No |  |
+
+### RateLimitCookie
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | String(pattern, len: 1..=64) | Yes | The name of the cookie to use. |
+| `text_transformations` | [List\<TextTransformation\>](#texttransformation) | Yes |  |
+
+### RateLimitHeader
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | String(pattern, len: 1..=64) | Yes | The name of the header to use. |
+| `text_transformations` | [List\<TextTransformation\>](#texttransformation) | Yes |  |
+
+### RateLimitJA3Fingerprint
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `fallback_behavior` | [Enum (FallbackBehavior)](#fallback_behavior-fallbackbehavior) | Yes |  |
+
+### RateLimitJA4Fingerprint
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `fallback_behavior` | [Enum (FallbackBehavior)](#fallback_behavior-fallbackbehavior) | Yes |  |
+
+### RateLimitLabelNamespace
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `namespace` | String | Yes | The namespace to use for aggregation. |
+
+### RateLimitQueryArgument
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | String(pattern, len: 1..=64) | Yes | The name of the query argument to use. |
+| `text_transformations` | [List\<TextTransformation\>](#texttransformation) | Yes |  |
+
+### RateLimitQueryString
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `text_transformations` | [List\<TextTransformation\>](#texttransformation) | Yes |  |
+
+### RateLimitUriPath
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `text_transformations` | [List\<TextTransformation\>](#texttransformation) | Yes |  |
+
+### RegexMatchStatement
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `field_to_match` | [Struct(FieldToMatch)](#fieldtomatch) | Yes |  |
+| `regex_string` | String(len: 1..=512) | Yes |  |
+| `text_transformations` | [List\<TextTransformation\>](#texttransformation) | Yes |  |
+
+### RegexPatternSetReferenceStatement
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `arn` | Arn | Yes |  |
+| `field_to_match` | [Struct(FieldToMatch)](#fieldtomatch) | Yes |  |
+| `text_transformations` | [List\<TextTransformation\>](#texttransformation) | Yes |  |
+
+### RequestInspection
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `password_field` | [Struct(FieldIdentifier)](#fieldidentifier) | Yes |  |
+| `payload_type` | [Enum (PayloadType)](#payload_type-payloadtype) | Yes |  |
+| `username_field` | [Struct(FieldIdentifier)](#fieldidentifier) | Yes |  |
+
+### RequestInspectionACFP
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `address_fields` | `List<String>` | No |  |
+| `email_field` | [Struct(FieldIdentifier)](#fieldidentifier) | No |  |
+| `password_field` | [Struct(FieldIdentifier)](#fieldidentifier) | No |  |
+| `payload_type` | [Enum (PayloadType)](#payload_type-payloadtype) | Yes |  |
+| `phone_number_fields` | `List<String>` | No |  |
+| `username_field` | [Struct(FieldIdentifier)](#fieldidentifier) | No |  |
+
+### ResponseInspection
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `body_contains` | [Struct(ResponseInspectionBodyContains)](#responseinspectionbodycontains) | No |  |
+| `header` | [Struct(ResponseInspectionHeader)](#responseinspectionheader) | No |  |
+| `json` | [Struct(ResponseInspectionJson)](#responseinspectionjson) | No |  |
+| `status_code` | [Struct(ResponseInspectionStatusCode)](#responseinspectionstatuscode) | No |  |
+
+### ResponseInspectionBodyContains
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `failure_strings` | `List<String>` (items: 1..=5) | Yes |  |
+| `success_strings` | `List<String>` (items: 1..=5) | Yes |  |
+
+### ResponseInspectionHeader
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `failure_values` | `List<String>` (items: 1..=3) | Yes |  |
+| `name` | String(pattern, len: 1..=200) | Yes |  |
+| `success_values` | `List<String>` (items: 1..=3) | Yes |  |
+
+### ResponseInspectionJson
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `failure_values` | `List<String>` (items: 1..=5) | Yes |  |
+| `identifier` | String(pattern, len: 1..=512) | Yes |  |
+| `success_values` | `List<String>` (items: 1..=5) | Yes |  |
+
+### ResponseInspectionStatusCode
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `failure_codes` | `List<Int>` (items: 1..=10) | Yes |  |
+| `success_codes` | `List<Int>` (items: 1..=10) | Yes |  |
+
+### Rule
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `action` | [Struct(RuleAction)](#ruleaction) | No |  |
+| `captcha_config` | [Struct(CaptchaConfig)](#captchaconfig) | No |  |
+| `challenge_config` | [Struct(ChallengeConfig)](#challengeconfig) | No |  |
+| `name` | String | Yes |  |
+| `override_action` | [Struct(OverrideAction)](#overrideaction) | No |  |
+| `priority` | String | Yes |  |
+| `rule_labels` | [List\<Label\>](#label) | No | Collection of Rule Labels. |
+| `statement` | [Struct(Statement)](#statement) | Yes |  |
+| `visibility_config` | [Struct(VisibilityConfig)](#visibilityconfig) | Yes |  |
+
+### RuleAction
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `allow` | [Struct(AllowAction)](#allowaction) | No |  |
+| `block` | [Struct(BlockAction)](#blockaction) | No |  |
+| `captcha` | [Struct(CaptchaAction)](#captchaaction) | No |  |
+| `challenge` | [Struct(ChallengeAction)](#challengeaction) | No |  |
+| `count` | [Struct(CountAction)](#countaction) | No |  |
+
+### RuleActionOverride
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `action_to_use` | [Struct(RuleAction)](#ruleaction) | Yes |  |
+| `name` | String | Yes |  |
+
+### RuleGroupReferenceStatement
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `arn` | Arn | Yes |  |
+| `excluded_rules` | [List\<ExcludedRule\>](#excludedrule) | No |  |
+| `rule_action_overrides` | [List\<RuleActionOverride\>](#ruleactionoverride) (items: ..=100) | No | Action overrides for rules in the rule group. |
+
+### SingleHeader
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | String | Yes |  |
+
+### SingleQueryArgument
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | String | Yes |  |
+
+### SizeConstraintStatement
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `comparison_operator` | [Enum (ComparisonOperator)](#comparison_operator-comparisonoperator) | Yes |  |
+| `field_to_match` | [Struct(FieldToMatch)](#fieldtomatch) | Yes |  |
+| `size` | Float(0..=21474836480) | Yes |  |
+| `text_transformations` | [List\<TextTransformation\>](#texttransformation) | Yes |  |
+
+### SqliMatchStatement
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `field_to_match` | [Struct(FieldToMatch)](#fieldtomatch) | Yes |  |
+| `sensitivity_level` | [Enum (SensitivityLevel)](#sensitivity_level-sensitivitylevel) | No |  |
+| `text_transformations` | [List\<TextTransformation\>](#texttransformation) | Yes |  |
+
+### Statement
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `and_statement` | [Struct(AndStatement)](#andstatement) | No |  |
+| `asn_match_statement` | [Struct(AsnMatchStatement)](#asnmatchstatement) | No |  |
+| `byte_match_statement` | [Struct(ByteMatchStatement)](#bytematchstatement) | No |  |
+| `geo_match_statement` | [Struct(GeoMatchStatement)](#geomatchstatement) | No |  |
+| `ip_set_reference_statement` | [Struct(IPSetReferenceStatement)](#ipsetreferencestatement) | No |  |
+| `label_match_statement` | [Struct(LabelMatchStatement)](#labelmatchstatement) | No |  |
+| `managed_rule_group_statement` | [Struct(ManagedRuleGroupStatement)](#managedrulegroupstatement) | No |  |
+| `not_statement` | [Struct(NotStatement)](#notstatement) | No |  |
+| `or_statement` | [Struct(OrStatement)](#orstatement) | No |  |
+| `rate_based_statement` | [Struct(RateBasedStatement)](#ratebasedstatement) | No |  |
+| `regex_match_statement` | [Struct(RegexMatchStatement)](#regexmatchstatement) | No |  |
+| `regex_pattern_set_reference_statement` | [Struct(RegexPatternSetReferenceStatement)](#regexpatternsetreferencestatement) | No |  |
+| `rule_group_reference_statement` | [Struct(RuleGroupReferenceStatement)](#rulegroupreferencestatement) | No |  |
+| `size_constraint_statement` | [Struct(SizeConstraintStatement)](#sizeconstraintstatement) | No |  |
+| `sqli_match_statement` | [Struct(SqliMatchStatement)](#sqlimatchstatement) | No |  |
+| `xss_match_statement` | [Struct(XssMatchStatement)](#xssmatchstatement) | No |  |
+
+### TextTransformation
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `priority` | String | Yes |  |
+| `type` | [Enum (TextTransformationType)](#type-texttransformationtype) | Yes |  |
+
+### UriFragment
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `fallback_behavior` | [Enum (FallbackBehavior)](#fallback_behavior-fallbackbehavior) | No |  |
+
+### VisibilityConfig
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `cloud_watch_metrics_enabled` | Bool | Yes |  |
+| `metric_name` | String(len: 1..=128) | Yes |  |
+| `sampled_requests_enabled` | Bool | Yes |  |
+
+### XssMatchStatement
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `field_to_match` | [Struct(FieldToMatch)](#fieldtomatch) | Yes |  |
+| `text_transformations` | [List\<TextTransformation\>](#texttransformation) | Yes |  |
+
+## Attribute Reference
+
+### `arn`
+
+- **Type:** Arn
+
+### `capacity`
+
+- **Type:** Int(0..)
+
+### `id`
+
+- **Type:** String
+
+### `label_namespace`
+
+- **Type:** String
+

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -49,6 +49,7 @@ service_display_name() {
         identitystore) echo "Identity Store" ;;
         organizations) echo "Organizations" ;;
         cloudfront)    echo "CloudFront" ;;
+        wafv2)         echo "WAFv2" ;;
         *)             echo "$1" | tr '[:lower:]' '[:upper:]' ;;
     esac
 }


### PR DESCRIPTION
## Summary

Bumps `carina-core` to `8003d7eb` ([carina-rs/carina#3340](https://github.com/carina-rs/carina/issues/3340)) and adds the codegen recursion guard that closes #196, then ships `AWS::WAFv2::WebACL` as the first resource that requires it (#197).

## What changed

1. **`carina-core` rev bump.** Pulls `AttributeType::Ref(name)` + `ResourceSchema.defs` + walk-site `Schema::defs` propagation.
2. **`convert.rs` proto↔core wire mapping.** `ProtoAttributeType::Ref { name }` ↔ `CoreAttributeType::Ref(name)` both directions; the `defs: BTreeMap<String, AttributeType>` field carried across `proto_to_core_schema` / `core_to_proto_schema`.
3. **Codegen recursion guard.** `cfn_type_to_carina_type_with_enum` now consults a thread-local `IN_PROGRESS_DEFS` + `EMITTED_DEFS` set. When a `$ref` def name is on the expansion stack (true cycle) OR already emitted (reuse), the emitter writes `AttributeType::Ref(<name>)` instead of recursing. The recorded def bodies are attached to the schema via `.with_def(...)` so walk-sites resolve `Ref` targets at the host.
4. **Post-body validator-fn drain.** The pre-scan over `definitions` only sees one hop into each def; the recursion guard lets `generate_struct_type` walk N hops deep into a cyclic / shared struct and may reference `validate_*_pattern_*_len_*` / `validate_*_range` / `validate_*_int_enum` symbols the pre-scan never collected. Three new thread-local sets accumulate emissions; after the schema body is built, missing `fn` definitions are appended.
5. **`AWS::WAFv2::WebACL`** added to `carina-provider-awscc/scripts/generate-schemas.sh` and `service_display_name()` in `scripts/generate-docs.sh`. Schema regenerated with `--from-cache-only`; docs regenerated.
6. **`AwsccProvider` conversion paths take defs.** `aws_value_to_dsl_with_defs` / `dsl_value_to_aws_with_defs` are the production entry points; they resolve any leading `Ref` at function entry via `resolve_refs`. `update::build_update_patches` and `operations::*` pass `&config.schema.defs` through.
7. **Existing test walkers updated** to resolve `Ref` against `&config.schema.defs` so they keep working after shared defs replace inline duplicates.

## Why reuse-via-Ref, not cycle-only

The naive ""emit `Ref` only on true cycles"" shape kept the WAFv2 generated file at 40K lines and still overflowed the runtime stack at `ResourceSchema::new()` construction. `Statement` is referenced from 6 parent fields; each inline expansion has cycle-bounded but exponentially-shaped recursion. Promoting any def that already has an emitted body to `Ref` factors the duplication, brings the generated file down to 6.1K lines, and keeps runtime construction flat. The walk-sites carina#3340 sweeps were precisely what made this safe — every traversal already resolves `Ref` through `defs`.

## Test plan

- [x] `cargo nextest run --workspace` — 394 tests pass.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — green.
- [x] `cargo build -p carina-provider-awscc --target wasm32-wasip2 --release` — green.
- [x] `bash scripts/check-docs-drift.sh` — green.

## Closes

- #196 (codegen recursion guard)
- #197 (WAFv2 WebACL addition)

## PR chain

This is PR 3 (final) of the carina#3340 chain.

- [carina-rs/carina#3343](https://github.com/carina-rs/carina/pull/3343) (merged) — `AttributeType::Ref` + walk-site sweep.
- [carina-rs/carina-provider-aws#385](https://github.com/carina-rs/carina-provider-aws/pull/385) (merged) — rev-bump + wire mirror.
- this PR — rev-bump + codegen guard + WAFv2 WebACL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)