### PR TITLE
fix: migrate to Schema-aware validate/canonicalize (awscc#282, carina#3345)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=8003d7eb2c9cb03784b08422b2586970f6c33978#8003d7eb2c9cb03784b08422b2586970f6c33978"
+source = "git+https://github.com/carina-rs/carina?rev=66ba8ae737e0891fd1de7ef2e25788e335a9a790#66ba8ae737e0891fd1de7ef2e25788e335a9a790"
 dependencies = [
  "argon2",
  "futures",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=8003d7eb2c9cb03784b08422b2586970f6c33978#8003d7eb2c9cb03784b08422b2586970f6c33978"
+source = "git+https://github.com/carina-rs/carina?rev=66ba8ae737e0891fd1de7ef2e25788e335a9a790#66ba8ae737e0891fd1de7ef2e25788e335a9a790"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -580,7 +580,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=8003d7eb2c9cb03784b08422b2586970f6c33978#8003d7eb2c9cb03784b08422b2586970f6c33978"
+source = "git+https://github.com/carina-rs/carina?rev=66ba8ae737e0891fd1de7ef2e25788e335a9a790#66ba8ae737e0891fd1de7ef2e25788e335a9a790"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "8003d7eb2c9cb03784b08422b2586970f6c33978" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "66ba8ae737e0891fd1de7ef2e25788e335a9a790" }

--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -1949,7 +1949,9 @@ pub fn validate_condition_operators(value: &Value) -> Result<(), String> {
 
 /// Validate IAM policy document structure and condition operators.
 pub fn validate_iam_policy_document(value: &Value) -> Result<(), String> {
-    iam_policy_document()
+    // The IAM policy schema is flat (no `AttributeType::Ref`), so an
+    // empty `defs` map is sound here (carina#3345).
+    carina_core::schema::Schema::flat(iam_policy_document())
         .validate(value)
         .map_err(|e| e.to_string())?;
     validate_condition_operators(value)
@@ -1994,28 +1996,32 @@ mod tests {
     fn validate_arn_type_with_value() {
         let t = arn();
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::String(
-                "arn:aws:s3:::my-bucket".to_string()
-            )))
-            .is_ok()
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "arn:aws:s3:::my-bucket".to_string()
+                )))
+                .is_ok()
         );
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::String(
-                "not-an-arn".to_string()
-            )))
-            .is_err()
-        );
-        assert!(
-            t.validate(&Value::Concrete(ConcreteValue::Int(42)))
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "not-an-arn".to_string()
+                )))
                 .is_err()
         );
         assert!(
-            t.validate(&Value::resource_ref(
-                "role".to_string(),
-                "arn".to_string(),
-                vec![]
-            ))
-            .is_ok()
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::Int(42)))
+                .is_err()
+        );
+        assert!(
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::resource_ref(
+                    "role".to_string(),
+                    "arn".to_string(),
+                    vec![]
+                ))
+                .is_ok()
         );
     }
 
@@ -2044,26 +2050,30 @@ mod tests {
     fn validate_aws_resource_id_type_with_value() {
         let t = aws_resource_id();
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::String(
-                "vpc-1a2b3c4d".to_string()
-            )))
-            .is_ok()
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "vpc-1a2b3c4d".to_string()
+                )))
+                .is_ok()
         );
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::String("vpc".to_string())))
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::String("vpc".to_string())))
                 .is_err()
         );
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::Int(42)))
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::Int(42)))
                 .is_err()
         );
         assert!(
-            t.validate(&Value::resource_ref(
-                "my_vpc".to_string(),
-                "vpc_id".to_string(),
-                vec![]
-            ))
-            .is_ok()
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::resource_ref(
+                    "my_vpc".to_string(),
+                    "vpc_id".to_string(),
+                    vec![]
+                ))
+                .is_ok()
         );
     }
 
@@ -2071,16 +2081,18 @@ mod tests {
     fn validate_vpc_cidr_block_association_id_valid() {
         let t = vpc_cidr_block_association_id();
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::String(
-                "vpc-cidr-assoc-12345678".to_string()
-            )))
-            .is_ok()
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "vpc-cidr-assoc-12345678".to_string()
+                )))
+                .is_ok()
         );
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::String(
-                "vpc-cidr-assoc-0123456789abcdef0".to_string()
-            )))
-            .is_ok()
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "vpc-cidr-assoc-0123456789abcdef0".to_string()
+                )))
+                .is_ok()
         );
     }
 
@@ -2088,16 +2100,18 @@ mod tests {
     fn validate_vpc_cidr_block_association_id_invalid() {
         let t = vpc_cidr_block_association_id();
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::String(
-                "vpc-12345678".to_string()
-            )))
-            .is_err()
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "vpc-12345678".to_string()
+                )))
+                .is_err()
         );
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::String(
-                "invalid".to_string()
-            )))
-            .is_err()
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "invalid".to_string()
+                )))
+                .is_err()
         );
     }
 
@@ -2105,16 +2119,18 @@ mod tests {
     fn validate_tgw_route_table_id_valid() {
         let t = tgw_route_table_id();
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::String(
-                "tgw-rtb-12345678".to_string()
-            )))
-            .is_ok()
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "tgw-rtb-12345678".to_string()
+                )))
+                .is_ok()
         );
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::String(
-                "tgw-rtb-0123456789abcdef0".to_string()
-            )))
-            .is_ok()
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "tgw-rtb-0123456789abcdef0".to_string()
+                )))
+                .is_ok()
         );
     }
 
@@ -2123,23 +2139,26 @@ mod tests {
         let t = tgw_route_table_id();
         // Regular route table ID should fail
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::String(
-                "rtb-12345678".to_string()
-            )))
-            .is_err()
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "rtb-12345678".to_string()
+                )))
+                .is_err()
         );
         // Transit gateway ID should fail
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::String(
-                "tgw-12345678".to_string()
-            )))
-            .is_err()
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "tgw-12345678".to_string()
+                )))
+                .is_err()
         );
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::String(
-                "invalid".to_string()
-            )))
-            .is_err()
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "invalid".to_string()
+                )))
+                .is_err()
         );
     }
 
@@ -2209,28 +2228,32 @@ mod tests {
     fn validate_availability_zone_id_type_with_value() {
         let t = availability_zone_id();
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::String(
-                "use1-az1".to_string()
-            )))
-            .is_ok()
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "use1-az1".to_string()
+                )))
+                .is_ok()
         );
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::String(
-                "us-east-1a".to_string()
-            )))
-            .is_err()
-        );
-        assert!(
-            t.validate(&Value::Concrete(ConcreteValue::Int(42)))
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "us-east-1a".to_string()
+                )))
                 .is_err()
         );
         assert!(
-            t.validate(&Value::resource_ref(
-                "subnet".to_string(),
-                "availability_zone_id".to_string(),
-                vec![]
-            ))
-            .is_ok()
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::Int(42)))
+                .is_err()
+        );
+        assert!(
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::resource_ref(
+                    "subnet".to_string(),
+                    "availability_zone_id".to_string(),
+                    vec![]
+                ))
+                .is_ok()
         );
     }
 
@@ -2689,7 +2712,11 @@ mod tests {
             .into_iter()
             .collect(),
         ));
-        assert!(t.validate(&valid_doc).is_ok());
+        assert!(
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&valid_doc)
+                .is_ok()
+        );
     }
 
     #[test]
@@ -2743,9 +2770,11 @@ mod tests {
             .collect(),
         ));
         assert!(
-            t.validate(&doc_with_principal_map).is_ok(),
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&doc_with_principal_map)
+                .is_ok(),
             "principal as map (struct) should be valid: {:?}",
-            t.validate(&doc_with_principal_map)
+            carina_core::schema::Schema::flat(t.clone()).validate(&doc_with_principal_map)
         );
     }
 
@@ -2791,9 +2820,11 @@ mod tests {
             .collect(),
         ));
         assert!(
-            t.validate(&doc_with_principal_string).is_ok(),
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&doc_with_principal_string)
+                .is_ok(),
             "principal as string should be valid: {:?}",
-            t.validate(&doc_with_principal_string)
+            carina_core::schema::Schema::flat(t.clone()).validate(&doc_with_principal_string)
         );
     }
 

--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -23,10 +23,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "8003d7eb2c9cb03784b08422b2586970f6c33978" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "66ba8ae737e0891fd1de7ef2e25788e335a9a790" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "8003d7eb2c9cb03784b08422b2586970f6c33978" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "8003d7eb2c9cb03784b08422b2586970f6c33978" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "66ba8ae737e0891fd1de7ef2e25788e335a9a790" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "66ba8ae737e0891fd1de7ef2e25788e335a9a790" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }

--- a/carina-provider-awscc/src/provider/conversion.rs
+++ b/carina-provider-awscc/src/provider/conversion.rs
@@ -1767,8 +1767,9 @@ mod tests {
         let snake_case_value = Value::Concrete(ConcreteValue::EnumIdentifier(
             "awscc.s3.Bucket.ObjectOwnership.bucket_owner_enforced".to_string(),
         ));
-        object_ownership
-            .field_type
+        let ownership_schema =
+            carina_core::schema::Schema::flat(object_ownership.field_type.clone());
+        ownership_schema
             .validate(&snake_case_value)
             .expect("snake_case DSL spelling must validate");
 
@@ -1780,7 +1781,7 @@ mod tests {
             "awscc.s3.Bucket.ObjectOwnership.BucketOwnerEnforced".to_string(),
         ));
         assert!(
-            object_ownership.field_type.validate(&pascal_value).is_err(),
+            ownership_schema.validate(&pascal_value).is_err(),
             "PascalCase API spelling must be rejected in DSL position",
         );
 

--- a/carina-provider-awscc/src/provider/normalizer.rs
+++ b/carina-provider-awscc/src/provider/normalizer.rs
@@ -221,12 +221,18 @@ pub fn canonicalize_string_or_list_states_impl(current_states: &mut HashMap<Reso
             Some(c) => c,
             None => continue,
         };
+        // Route canonicalization through `Schema::canonicalize_attr`
+        // so cyclic CFN attributes (`AttributeType::Ref`) resolve
+        // against this resource's def map. The defs-less
+        // `carina_core::value::canonicalize_with_type` wrapper this
+        // replaced silently used `empty_defs()` and panicked on every
+        // Ref-containing attribute (carina#3345 Symptom B —
+        // `ec2_vpc_endpoint/{gateway,interface}` plan-verify).
+        let schema_view = carina_core::schema::Schema::with_defs(config.schema.defs.clone());
         let mut new_attrs = HashMap::with_capacity(state.attributes.len());
         for (key, value) in std::mem::take(&mut state.attributes) {
             let canon = match config.schema.attributes.get(key.as_str()) {
-                Some(attr_schema) => {
-                    carina_core::value::canonicalize_with_type(value, &attr_schema.attr_type)
-                }
+                Some(attr_schema) => schema_view.canonicalize_attr(&attr_schema.attr_type, value),
                 None => value,
             };
             new_attrs.insert(key, canon);

--- a/carina-provider-awscc/src/schemas/awscc_types.rs
+++ b/carina-provider-awscc/src/schemas/awscc_types.rs
@@ -206,31 +206,35 @@ mod tests {
         // type lives at `awscc.AvailabilityZone.ZoneName`, so the value
         // form carries the kind segment as well.
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::String(
-                "awscc.AvailabilityZone.ZoneName.us_east_1a".to_string()
-            )))
-            .is_ok()
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "awscc.AvailabilityZone.ZoneName.us_east_1a".to_string()
+                )))
+                .is_ok()
         );
         // 2-part shorthand: TypeName matches the identity's kind.
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::String(
-                "ZoneName.us_east_1a".to_string()
-            )))
-            .is_ok()
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "ZoneName.us_east_1a".to_string()
+                )))
+                .is_ok()
         );
         // Shorthand format
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::String(
-                "us_east_1a".to_string()
-            )))
-            .is_ok()
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "us_east_1a".to_string()
+                )))
+                .is_ok()
         );
         // AWS format
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::String(
-                "us-east-1a".to_string()
-            )))
-            .is_ok()
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "us-east-1a".to_string()
+                )))
+                .is_ok()
         );
     }
 
@@ -238,10 +242,11 @@ mod tests {
     fn validate_availability_zone_rejects_wrong_namespace() {
         let t = availability_zone();
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::String(
-                "aws.AvailabilityZone.us_east_1a".to_string()
-            )))
-            .is_err()
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "aws.AvailabilityZone.us_east_1a".to_string()
+                )))
+                .is_err()
         );
     }
 
@@ -249,16 +254,18 @@ mod tests {
     fn validate_availability_zone_rejects_invalid() {
         let t = availability_zone();
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::String(
-                "us-east-1".to_string()
-            )))
-            .is_err()
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "us-east-1".to_string()
+                )))
+                .is_err()
         ); // no zone letter
         assert!(
-            t.validate(&Value::Concrete(ConcreteValue::String(
-                "invalid".to_string()
-            )))
-            .is_err()
+            carina_core::schema::Schema::flat(t.clone())
+                .validate(&Value::Concrete(ConcreteValue::String(
+                    "invalid".to_string()
+                )))
+                .is_err()
         );
     }
 
@@ -279,15 +286,16 @@ mod tests {
     #[test]
     fn awscc_region_accepts_awscc_namespace() {
         let region_type = awscc_region();
+        let schema = carina_core::schema::Schema::flat(region_type);
         assert!(
-            region_type
+            schema
                 .validate(&Value::Concrete(ConcreteValue::String(
                     "awscc.Region.ap_northeast_1".to_string()
                 )))
                 .is_ok()
         );
         assert!(
-            region_type
+            schema
                 .validate(&Value::Concrete(ConcreteValue::String(
                     "ap-northeast-1".to_string()
                 )))
@@ -299,7 +307,7 @@ mod tests {
     fn awscc_region_rejects_aws_namespace() {
         let region_type = awscc_region();
         assert!(
-            region_type
+            carina_core::schema::Schema::flat(region_type)
                 .validate(&Value::Concrete(ConcreteValue::String(
                     "aws.Region.ap_northeast_1".to_string()
                 )))


### PR DESCRIPTION
## Summary

Closes #282. carina#3345 (PR carina-rs/carina#3346, merged 2026-05-29) deleted the defs-less public wrappers `AttributeType::validate(&Value)`, `validate_collect(&Value)`, and `canonicalize_with_type(value, attr)` from carina-core. carina#3347 (PR carina-rs/carina#3348, merged 2026-05-29) additionally fixed a latent `Schema::validate_attr` Map-key lift bug that surfaced in this PR's testing.

This PR bumps the `carina-core` / `-plugin-sdk` / `-provider-protocol` pins to the carina#3348 merge (`66ba8ae7`) and migrates every call site to the Schema-aware API.

## Key changes

- **`carina-provider-awscc/src/provider/normalizer.rs:228`** (the original issue target — carina#3345 Symptom B for `ec2_vpc_endpoint/{gateway,interface}`):
  ```rust
  // Before
  carina_core::value::canonicalize_with_type(value, &attr_schema.attr_type)
  // After (hoisted per-resource so defs.clone() happens once)
  let schema_view = carina_core::schema::Schema::with_defs(config.schema.defs.clone());
  schema_view.canonicalize_attr(&attr_schema.attr_type, value)
  ```
- **`carina-aws-types/src/lib.rs`**: production `iam_policy_document().validate(value)` and ~27 test sites switched to `Schema::flat(...)`.
- **`carina-provider-awscc/src/schemas/awscc_types.rs`** and **`carina-provider-awscc/src/provider/conversion.rs`**: test sites switched to `Schema::flat(t.clone()).validate(...)`.

## Pin check

`66ba8ae7` is the carina#3348 merge (lineage: `66ba8ae7` ← `a7565eb6` carina#3347 ← `0cf9c70a` carina#3346 ← `aa031165` carina#3345). `scripts/check-carina-pin.sh` confirms ancestry.

## Test plan

- [x] `cargo nextest run --workspace` — 490 tests, all passing.
- [x] `cargo test --workspace --doc` — green.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `bash scripts/check-carina-pin.sh` — pass.
- [x] `bash scripts/check-docs-drift.sh` — pass.
- [ ] Real-infra acceptance (user-driven): `./acceptance-tests/run-tests.sh full ec2_vpc_endpoint/gateway ec2_vpc_endpoint/interface s3_bucket/encryption s3_bucket/lifecycle` should now pass (Symptom B + Symptom A both fixed at compile time).

## Follow-up

Same migration is needed in `carina-rs/carina-provider-aws`. Tracker: carina-rs/carina-provider-aws#386 — filed alongside this PR so the next aws-side rev bump finds the migration spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
