### PR TITLE
Bump carina-core pin to 3c3d3f3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=2af9da677c235e042eca7dc59ea5a472063a2747#2af9da677c235e042eca7dc59ea5a472063a2747"
+source = "git+https://github.com/carina-rs/carina?rev=3c3d3f36b5d875f9025a01ad900e02900e59c169#3c3d3f36b5d875f9025a01ad900e02900e59c169"
 dependencies = [
  "argon2",
  "futures",
@@ -534,7 +534,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=2af9da677c235e042eca7dc59ea5a472063a2747#2af9da677c235e042eca7dc59ea5a472063a2747"
+source = "git+https://github.com/carina-rs/carina?rev=3c3d3f36b5d875f9025a01ad900e02900e59c169#3c3d3f36b5d875f9025a01ad900e02900e59c169"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -580,7 +580,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=2af9da677c235e042eca7dc59ea5a472063a2747#2af9da677c235e042eca7dc59ea5a472063a2747"
+source = "git+https://github.com/carina-rs/carina?rev=3c3d3f36b5d875f9025a01ad900e02900e59c169#3c3d3f36b5d875f9025a01ad900e02900e59c169"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "2af9da677c235e042eca7dc59ea5a472063a2747" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "3c3d3f36b5d875f9025a01ad900e02900e59c169" }

--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -23,10 +23,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "2af9da677c235e042eca7dc59ea5a472063a2747" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "3c3d3f36b5d875f9025a01ad900e02900e59c169" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "2af9da677c235e042eca7dc59ea5a472063a2747" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "2af9da677c235e042eca7dc59ea5a472063a2747" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "3c3d3f36b5d875f9025a01ad900e02900e59c169" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "3c3d3f36b5d875f9025a01ad900e02900e59c169" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }


### PR DESCRIPTION
Picks up carina#3353 (per-provider-kind env allowlist) and carina#3355 (provider-agnostic `send_request` over wasi:http). No code change — `WasiHttpClient` and all existing behavior unchanged; keeps the carina-core pin current alongside the carina-provider-github bootstrap chain (carina#3342).

## Test plan
- [x] `cargo check` — green
- [x] `./scripts/check-carina-pin.sh` — all pins on 3c3d3f3, at/after min-rev
- [ ] CI green

Refs carina-rs/carina#3342.
