### PR TITLE
docs: replace git wt with standard git worktree commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,12 +65,10 @@ cargo run --bin codegen -- <schema-path>
 
 ### Worktree-Based Development
 
-**IMPORTANT: Use `git wt` (NOT `git worktree`).** `git wt` is a separate tool with its own syntax.
-
 ```bash
-git wt <branch-name> main    # Create worktree
-git wt                       # List worktrees
-git wt -d <branch-name>      # Delete worktree (from main worktree)
+git worktree add .worktrees/<branch-name> -b <branch-name> main   # Create worktree
+git worktree list                                                  # List worktrees
+git worktree remove .worktrees/<branch-name>                       # Delete worktree (from the main worktree)
 ```
 
 ### Submodule Initialization

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -9,7 +9,7 @@
 current_branch=$(git symbolic-ref --short HEAD 2>/dev/null)
 if [ "$current_branch" = "main" ] || [ "$current_branch" = "master" ]; then
     echo "ERROR: Direct commits to '$current_branch' are not allowed."
-    echo "Create a feature branch first: git wt <branch-name> main"
+    echo "Create a feature branch first: git worktree add .worktrees/<branch-name> -b <branch-name> main"
     exit 1
 fi
 


### PR DESCRIPTION
Replace all `git wt` wrapper-tool references with the standard `git worktree` commands.

`git wt` was a local-only wrapper that has been dropped repo-wide in favor of standard `git worktree`. The worktree-based **workflow** is unchanged; only the command spellings change. This follows carina#3361.

## Changes

- **CLAUDE.md** — "Worktree-Based Development" section now uses `git worktree add/list/remove`, and drops the obsolete "IMPORTANT: Use `git wt`" line.
- **scripts/pre-commit** — the feature-branch hint printed when committing to `main`/`master` now suggests `git worktree add .worktrees/<branch-name> -b <branch-name> main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)