### PR TITLE
chore: bump carina-core to post-shim-removal rev (carina#3371 PR4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,7 +516,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=6fdcff64457a6bf3fc9c1cee6978eed8cc29a9c0#6fdcff64457a6bf3fc9c1cee6978eed8cc29a9c0"
+source = "git+https://github.com/carina-rs/carina?rev=0d7cd724af787cd28dcf8838f8941f0bca68c230#0d7cd724af787cd28dcf8838f8941f0bca68c230"
 dependencies = [
  "argon2",
  "futures",
@@ -535,7 +535,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=6fdcff64457a6bf3fc9c1cee6978eed8cc29a9c0#6fdcff64457a6bf3fc9c1cee6978eed8cc29a9c0"
+source = "git+https://github.com/carina-rs/carina?rev=0d7cd724af787cd28dcf8838f8941f0bca68c230#0d7cd724af787cd28dcf8838f8941f0bca68c230"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -581,7 +581,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=6fdcff64457a6bf3fc9c1cee6978eed8cc29a9c0#6fdcff64457a6bf3fc9c1cee6978eed8cc29a9c0"
+source = "git+https://github.com/carina-rs/carina?rev=0d7cd724af787cd28dcf8838f8941f0bca68c230#0d7cd724af787cd28dcf8838f8941f0bca68c230"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "6fdcff64457a6bf3fc9c1cee6978eed8cc29a9c0" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "0d7cd724af787cd28dcf8838f8941f0bca68c230" }

--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -23,10 +23,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "6fdcff64457a6bf3fc9c1cee6978eed8cc29a9c0" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "0d7cd724af787cd28dcf8838f8941f0bca68c230" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "6fdcff64457a6bf3fc9c1cee6978eed8cc29a9c0" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "6fdcff64457a6bf3fc9c1cee6978eed8cc29a9c0" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "0d7cd724af787cd28dcf8838f8941f0bca68c230" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "0d7cd724af787cd28dcf8838f8941f0bca68c230" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }


### PR DESCRIPTION
## Summary

Bump carina-core to the carina#3371 PR4 merge commit (`0d7cd724af787cd`), which **removed** the deprecated `shape(defs)` / `resolve_refs(defs)` / `empty_defs()` shims.

This repo already migrated to the new `shape_of` / `resolve_of` / `shape_ref_free` API (PR #302, which also forced the four latent `normalizer.rs` sites to thread the real `config.schema.defs`). This bump completes the seal: with the shims gone from the carina-core dependency, the `shape(empty_defs())` foot-gun behind awscc#290 hazard-1 / awscc#286 / awscc#288 is unreachable from this repo too.

## Verify

- `cargo check -p carina-provider-awscc` — clean
- `cargo nextest run -p carina-provider-awscc --lib` — 191 passed
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `scripts/check-carina-pin.sh` (4 pins on new rev) / `check-docs-drift.sh` (38 resources) — OK

Refs carina-rs/carina#3371. Completes carina-rs/carina-provider-awscc#290 hazard-1 on the provider side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
