### PR TITLE
fix(types): awscc IAM policy-document enums use awscc.* namespace (carina#3384)

### DIFF
--- a/acceptance-tests/attribute_removal/ec2_vpc_endpoint_step1.crn
+++ b/acceptance-tests/attribute_removal/ec2_vpc_endpoint_step1.crn
@@ -21,7 +21,7 @@ awscc.ec2.VpcEndpoint {
   route_table_ids   = [rt.route_table_id]
 
   policy_document = {
-    version = aws.iam.PolicyDocument.Version.2012_10_17
+    version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
       effect    = 'Allow'
       principal = '*'

--- a/acceptance-tests/create_before_destroy/iam_role_step1.crn
+++ b/acceptance-tests/create_before_destroy/iam_role_step1.crn
@@ -13,9 +13,9 @@ awscc.iam.Role {
   path      = '/'
 
   assume_role_policy_document = {
-    version = aws.iam.PolicyDocument.Version.2012_10_17
+    version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = aws.iam.PolicyDocument.Effect.allow
+      effect = awscc.iam.PolicyDocument.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/create_before_destroy/iam_role_step2.crn
+++ b/acceptance-tests/create_before_destroy/iam_role_step2.crn
@@ -20,9 +20,9 @@ awscc.iam.Role {
   }
 
   assume_role_policy_document = {
-    version = aws.iam.PolicyDocument.Version.2012_10_17
+    version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = aws.iam.PolicyDocument.Effect.allow
+      effect = awscc.iam.PolicyDocument.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/ec2_flow_log/cloudwatch.crn
+++ b/acceptance-tests/ec2_flow_log/cloudwatch.crn
@@ -20,9 +20,9 @@ let flow_log_role = awscc.iam.Role {
   role_name = 'acceptance-test-flow-log-role'
 
   assume_role_policy_document = {
-    version = aws.iam.PolicyDocument.Version.2012_10_17
+    version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = aws.iam.PolicyDocument.Effect.allow
+      effect = awscc.iam.PolicyDocument.Effect.allow
 
       principal = {
         service = 'vpc-flow-logs.amazonaws.com'

--- a/acceptance-tests/ec2_vpc_endpoint/gateway.crn
+++ b/acceptance-tests/ec2_vpc_endpoint/gateway.crn
@@ -21,9 +21,9 @@ awscc.ec2.VpcEndpoint {
   route_table_ids   = [rt.route_table_id]
 
   policy_document = {
-    version = aws.iam.PolicyDocument.Version.2012_10_17
+    version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect    = aws.iam.PolicyDocument.Effect.allow
+      effect    = awscc.iam.PolicyDocument.Effect.allow
       principal = '*'
       action    = 's3:GetObject'
       resource  = 'arn:aws:s3:::*'

--- a/acceptance-tests/iam_role/managed_policy.crn
+++ b/acceptance-tests/iam_role/managed_policy.crn
@@ -10,9 +10,9 @@ awscc.iam.Role {
   role_name_prefix = 'carina-acc-test-'
 
   assume_role_policy_document = {
-    version = aws.iam.PolicyDocument.Version.2012_10_17
+    version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = aws.iam.PolicyDocument.Effect.allow
+      effect = awscc.iam.PolicyDocument.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/iam_role/prefix.crn
+++ b/acceptance-tests/iam_role/prefix.crn
@@ -12,9 +12,9 @@ awscc.iam.Role {
   role_name_prefix = 'carina-acc-test-'
 
   assume_role_policy_document = {
-    version = aws.iam.PolicyDocument.Version.2012_10_17
+    version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = aws.iam.PolicyDocument.Effect.allow
+      effect = awscc.iam.PolicyDocument.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/iam_role/with_path.crn
+++ b/acceptance-tests/iam_role/with_path.crn
@@ -11,9 +11,9 @@ awscc.iam.Role {
   path             = '/carina/acceptance-test/'
 
   assume_role_policy_document = {
-    version = aws.iam.PolicyDocument.Version.2012_10_17
+    version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = aws.iam.PolicyDocument.Effect.allow
+      effect = awscc.iam.PolicyDocument.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/iam_role/with_policy.crn
+++ b/acceptance-tests/iam_role/with_policy.crn
@@ -13,9 +13,9 @@ awscc.iam.Role {
   max_session_duration = 7200
 
   assume_role_policy_document = {
-    version = aws.iam.PolicyDocument.Version.2012_10_17
+    version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = aws.iam.PolicyDocument.Effect.allow
+      effect = awscc.iam.PolicyDocument.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'
@@ -29,9 +29,9 @@ awscc.iam.Role {
     policy_name = 'test-policy'
 
     policy_document = {
-      version = aws.iam.PolicyDocument.Version.2012_10_17
+      version = awscc.iam.PolicyDocument.Version.2012_10_17
       statement {
-        effect   = aws.iam.PolicyDocument.Effect.allow
+        effect   = awscc.iam.PolicyDocument.Effect.allow
         action   = 'logs:CreateLogGroup'
         resource = '*'
       }

--- a/acceptance-tests/in_place_update/ec2_flow_log_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_flow_log_step1.crn
@@ -19,9 +19,9 @@ let flow_log_role = awscc.iam.Role {
   role_name = 'carina-acc-test-update-flow-log-role'
 
   assume_role_policy_document = {
-    version = aws.iam.PolicyDocument.Version.2012_10_17
+    version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = aws.iam.PolicyDocument.Effect.allow
+      effect = awscc.iam.PolicyDocument.Effect.allow
 
       principal = {
         service = 'vpc-flow-logs.amazonaws.com'

--- a/acceptance-tests/in_place_update/ec2_flow_log_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_flow_log_step2.crn
@@ -19,9 +19,9 @@ let flow_log_role = awscc.iam.Role {
   role_name = 'carina-acc-test-update-flow-log-role'
 
   assume_role_policy_document = {
-    version = aws.iam.PolicyDocument.Version.2012_10_17
+    version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = aws.iam.PolicyDocument.Effect.allow
+      effect = awscc.iam.PolicyDocument.Effect.allow
 
       principal = {
         service = 'vpc-flow-logs.amazonaws.com'

--- a/acceptance-tests/in_place_update/ec2_vpc_endpoint_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_vpc_endpoint_step2.crn
@@ -21,7 +21,7 @@ awscc.ec2.VpcEndpoint {
   route_table_ids   = [rt.route_table_id]
 
   policy_document = {
-    version = aws.iam.PolicyDocument.Version.2012_10_17
+    version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
       effect    = 'Allow'
       principal = '*'

--- a/acceptance-tests/in_place_update/iam_role_step1.crn
+++ b/acceptance-tests/in_place_update/iam_role_step1.crn
@@ -10,9 +10,9 @@ awscc.iam.Role {
   role_name_prefix = 'carina-acc-test-update-'
 
   assume_role_policy_document = {
-    version = aws.iam.PolicyDocument.Version.2012_10_17
+    version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = aws.iam.PolicyDocument.Effect.allow
+      effect = awscc.iam.PolicyDocument.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/in_place_update/iam_role_step2.crn
+++ b/acceptance-tests/in_place_update/iam_role_step2.crn
@@ -10,9 +10,9 @@ awscc.iam.Role {
   role_name_prefix = 'carina-acc-test-update-'
 
   assume_role_policy_document = {
-    version = aws.iam.PolicyDocument.Version.2012_10_17
+    version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = aws.iam.PolicyDocument.Effect.allow
+      effect = awscc.iam.PolicyDocument.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/tag_deletion/iam_role_step1.crn
+++ b/acceptance-tests/tag_deletion/iam_role_step1.crn
@@ -11,9 +11,9 @@ awscc.iam.Role {
   role_name_prefix = 'carina-acc-test-tag-del-'
 
   assume_role_policy_document = {
-    version = aws.iam.PolicyDocument.Version.2012_10_17
+    version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = aws.iam.PolicyDocument.Effect.allow
+      effect = awscc.iam.PolicyDocument.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/tag_deletion/iam_role_step2.crn
+++ b/acceptance-tests/tag_deletion/iam_role_step2.crn
@@ -12,9 +12,9 @@ awscc.iam.Role {
   role_name_prefix = 'carina-acc-test-tag-del-'
 
   assume_role_policy_document = {
-    version = aws.iam.PolicyDocument.Version.2012_10_17
+    version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = aws.iam.PolicyDocument.Effect.allow
+      effect = awscc.iam.PolicyDocument.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/tag_deletion/iam_role_step3.crn
+++ b/acceptance-tests/tag_deletion/iam_role_step3.crn
@@ -12,9 +12,9 @@ awscc.iam.Role {
   role_name_prefix = 'carina-acc-test-tag-del-'
 
   assume_role_policy_document = {
-    version = aws.iam.PolicyDocument.Version.2012_10_17
+    version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = aws.iam.PolicyDocument.Effect.allow
+      effect = awscc.iam.PolicyDocument.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -1427,19 +1427,17 @@ fn string_or_principal_struct() -> AttributeType {
 /// users can write `effect = allow` as a bare identifier, matching the
 /// bare-identifier convention used by every other enum field in the
 /// same `.crn` file. The namespace also makes the fully-qualified form
-/// `aws.iam.PolicyDocument.Effect.allow` parse and resolve: the
+/// `awscc.iam.PolicyDocument.Effect.allow` parse and resolve: the
 /// resolver's canonical shape is namespace then type_name then value,
 /// so `type_name` is the trailing `Effect` segment and `namespace` is
-/// `aws.iam.PolicyDocument`. Mirrors carina-provider-aws #311 so the
-/// shared `iam_policy_document()` Struct canonicalizes identically on
-/// both providers (aws#313).
+/// `awscc.iam.PolicyDocument`.
 fn iam_policy_effect() -> AttributeType {
     AttributeType::string_enum(
         "Effect".to_string(),
         vec!["Allow".to_string(), "Deny".to_string()],
         Some(carina_core::schema::string_enum_identity(
             "Effect",
-            Some("aws.iam.PolicyDocument"),
+            Some("awscc.iam.PolicyDocument"),
         )),
         vec![
             ("Allow".to_string(), "allow".to_string()),
@@ -1452,21 +1450,19 @@ fn iam_policy_effect() -> AttributeType {
 /// `2008-10-17` (AWS canonical) with snake_case DSL aliases
 /// `2012_10_17` / `2008_10_17`, so users can write `version` as
 /// `2012_10_17`. The fully-qualified form
-/// `aws.iam.PolicyDocument.Version.2012_10_17` parses via the
+/// `awscc.iam.PolicyDocument.Version.2012_10_17` parses via the
 /// `namespaced_id` numeric-tail extension from `carina-rs/carina#3051`
 /// and resolves through this namespace: the resolver's canonical shape
 /// is namespace then type_name then value, so `type_name` is the
 /// trailing `Version` segment and `namespace` is
-/// `aws.iam.PolicyDocument`. Mirrors carina-provider-aws #311 so the
-/// shared `iam_policy_document()` Struct canonicalizes identically on
-/// both providers (aws#313).
+/// `awscc.iam.PolicyDocument`.
 fn iam_policy_version() -> AttributeType {
     AttributeType::string_enum(
         "Version".to_string(),
         vec!["2012-10-17".to_string(), "2008-10-17".to_string()],
         Some(carina_core::schema::string_enum_identity(
             "Version",
-            Some("aws.iam.PolicyDocument"),
+            Some("awscc.iam.PolicyDocument"),
         )),
         vec![
             ("2012-10-17".to_string(), "2012_10_17".to_string()),
@@ -2681,6 +2677,60 @@ mod tests {
             .collect(),
         ));
         assert!(validate_iam_policy_document(&doc).is_err());
+    }
+
+    #[test]
+    fn iam_policy_document_version_identity_uses_awscc_namespace() {
+        let t = iam_policy_version();
+        let RawShape::StringEnum {
+            identity: Some(identity),
+            ..
+        } = t.raw_shape()
+        else {
+            panic!("iam_policy_version() should be a StringEnum with identity");
+        };
+
+        assert!(
+            carina_core::utils::validate_enum_namespace(
+                "awscc.iam.PolicyDocument.Version.2012_10_17",
+                identity
+            )
+            .is_ok()
+        );
+        assert!(
+            carina_core::utils::validate_enum_namespace(
+                "aws.iam.PolicyDocument.Version.2012_10_17",
+                identity
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn iam_policy_document_effect_identity_uses_awscc_namespace() {
+        let t = iam_policy_effect();
+        let RawShape::StringEnum {
+            identity: Some(identity),
+            ..
+        } = t.raw_shape()
+        else {
+            panic!("iam_policy_effect() should be a StringEnum with identity");
+        };
+
+        assert!(
+            carina_core::utils::validate_enum_namespace(
+                "awscc.iam.PolicyDocument.Effect.allow",
+                identity
+            )
+            .is_ok()
+        );
+        assert!(
+            carina_core::utils::validate_enum_namespace(
+                "aws.iam.PolicyDocument.Effect.allow",
+                identity
+            )
+            .is_err()
+        );
     }
 
     #[test]

--- a/carina-provider-awscc/src/provider/conversion.rs
+++ b/carina-provider-awscc/src/provider/conversion.rs
@@ -1237,7 +1237,7 @@ mod tests {
                 (
                     "version".to_string(),
                     Value::Concrete(ConcreteValue::EnumIdentifier(
-                        "aws.iam.PolicyDocument.Version.2012_10_17".to_string(),
+                        "awscc.iam.PolicyDocument.Version.2012_10_17".to_string(),
                     )),
                 ),
                 (

--- a/carina-provider-awscc/src/provider/normalizer.rs
+++ b/carina-provider-awscc/src/provider/normalizer.rs
@@ -347,7 +347,7 @@ mod tests {
     /// the already-fully-qualified `version` path. The desired side
     /// must resolve to the same fully-qualified DSL form that the
     /// AWS-read side produces from raw `"Allow"`
-    /// (`aws.iam.PolicyDocument.Effect.allow`), or the differ diverges.
+    /// (`awscc.iam.PolicyDocument.Effect.allow`), or the differ diverges.
     #[test]
     fn test_aws313_bare_effect_desired_resolves_to_namespaced() {
         use indexmap::IndexMap;
@@ -365,7 +365,7 @@ mod tests {
         policy.insert(
             "version".to_string(),
             Value::Concrete(ConcreteValue::String(
-                "aws.iam.PolicyDocument.Version.2012_10_17".to_string(),
+                "awscc.iam.PolicyDocument.Version.2012_10_17".to_string(),
             )),
         );
         policy.insert(
@@ -397,7 +397,7 @@ mod tests {
         assert_eq!(
             s0.get("effect"),
             Some(&Value::Concrete(ConcreteValue::String(
-                "aws.iam.PolicyDocument.Effect.allow".to_string()
+                "awscc.iam.PolicyDocument.Effect.allow".to_string()
             ))),
             "bare `effect = allow` desired must resolve to the same \
              fully-qualified form the read side produces from \"Allow\""

--- a/carina-provider-awscc/src/schemas/mod.rs
+++ b/carina-provider-awscc/src/schemas/mod.rs
@@ -168,6 +168,16 @@ mod tests {
                     collector.stack.remove(&ptr);
                     return;
                 }
+                // This invariant catches distinct generated enum fields that collapse
+                // to one identity. These IAM identities come from the single
+                // hand-written iam_policy_document() helper and are intentionally
+                // reused across all policy-document fields.
+                if identity == "awscc.iam.PolicyDocument.Version"
+                    || identity == "awscc.iam.PolicyDocument.Effect"
+                {
+                    collector.stack.remove(&ptr);
+                    return;
+                }
                 let occurrence = EnumIdentityOccurrence {
                     defining_site: defining_site.to_string(),
                 };


### PR DESCRIPTION
Closes carina-rs/carina#3384

## Problem

`awscc.iam.Role` / `awscc.iam.RolePolicy` — and every awscc resource with a `policy_document` field (e.g. `awscc.ec2.VpcEndpoint`) — required their policy-document `version` / `effect` enum fields to be written with **`aws.`-provider** type identities:

```crn
awscc.iam.RolePolicy {
  policy_document = {
    version = aws.iam.PolicyDocument.Version.2012_10_17   # aws.* inside an awscc.* resource
    statement { effect = aws.iam.PolicyDocument.Effect.allow ... }
  }
}
```

A user authoring an `awscc.*` resource was forced to spell a type identity that reads as belonging to a different provider — a surprising cross-provider boundary crossing, and a hidden authoring-time dependency on the `aws` provider's type definitions.

## Root cause

`iam_policy_effect()` and `iam_policy_version()` in `carina-aws-types/src/lib.rs` hardcoded the enum identity namespace as `"aws.iam.PolicyDocument"`. `string_enum_identity` turns that into a `TypeIdentity` whose `provider` is `aws`, and carina-core's `validate_enum_namespace` builds the accepted fully-qualified prefix from `identity.to_string()`.

Flipping the constant to `"awscc.iam.PolicyDocument"` is the single upstream change that makes the awscc resource accept `awscc.iam.PolicyDocument.{Version,Effect}.*` and reject the `aws.*` form. Because the same identity also drives the AWS-read canonicalization side, the validate and read directions flip together — one constant, no per-site filter.

## Change

- `carina-aws-types/src/lib.rs`: `iam_policy_effect()` / `iam_policy_version()` namespace `aws.iam.PolicyDocument` → `awscc.iam.PolicyDocument`; doc comments updated (the prior "shared identically on both providers" claim is intentionally removed — awscc now has its own identity).
- New tests assert via the real `validate_enum_namespace` path that `awscc.iam.PolicyDocument.{Version,Effect}.*` validates and `aws.*` is rejected; bare-value (`version = 2012_10_17`, `effect = allow`) still validates.
- Acceptance fixtures and provider unit tests updated to the `awscc.*` spelling (IAM Role/RolePolicy, EC2 VpcEndpoint, flow-log roles).
- `carina-provider-awscc/src/schemas/mod.rs`: the duplicate-identity invariant test previously skipped these (they were `aws.`-namespaced). Now `awscc.`-namespaced, they legitimately appear at multiple defining sites because the single shared `iam_policy_document()` helper is wired into every policy-document field — excluded as shared-by-design, not a generator collision.

## Verification

- `cargo nextest run` — 510 passed
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `cargo test --doc` — clean
- `generate-schemas.sh --from-cache-only` — no generated diff (codegen-check)
- `check-carina-pin.sh`, `check-docs-drift.sh` — pass
- `cargo build -p carina-provider-awscc --target wasm32-wasip2 --release` — pass