### PR TITLE
fix(types): IAM PolicyDocument enum identity carries Statement segment (carina#3385)

### DIFF
--- a/acceptance-tests/create_before_destroy/iam_role_step1.crn
+++ b/acceptance-tests/create_before_destroy/iam_role_step1.crn
@@ -15,7 +15,7 @@ awscc.iam.Role {
   assume_role_policy_document = {
     version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = awscc.iam.PolicyDocument.Effect.allow
+      effect = awscc.iam.PolicyDocument.Statement.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/create_before_destroy/iam_role_step2.crn
+++ b/acceptance-tests/create_before_destroy/iam_role_step2.crn
@@ -22,7 +22,7 @@ awscc.iam.Role {
   assume_role_policy_document = {
     version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = awscc.iam.PolicyDocument.Effect.allow
+      effect = awscc.iam.PolicyDocument.Statement.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/ec2_flow_log/cloudwatch.crn
+++ b/acceptance-tests/ec2_flow_log/cloudwatch.crn
@@ -22,7 +22,7 @@ let flow_log_role = awscc.iam.Role {
   assume_role_policy_document = {
     version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = awscc.iam.PolicyDocument.Effect.allow
+      effect = awscc.iam.PolicyDocument.Statement.Effect.allow
 
       principal = {
         service = 'vpc-flow-logs.amazonaws.com'

--- a/acceptance-tests/ec2_vpc_endpoint/gateway.crn
+++ b/acceptance-tests/ec2_vpc_endpoint/gateway.crn
@@ -23,7 +23,7 @@ awscc.ec2.VpcEndpoint {
   policy_document = {
     version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect    = awscc.iam.PolicyDocument.Effect.allow
+      effect    = awscc.iam.PolicyDocument.Statement.Effect.allow
       principal = '*'
       action    = 's3:GetObject'
       resource  = 'arn:aws:s3:::*'

--- a/acceptance-tests/iam_role/managed_policy.crn
+++ b/acceptance-tests/iam_role/managed_policy.crn
@@ -12,7 +12,7 @@ awscc.iam.Role {
   assume_role_policy_document = {
     version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = awscc.iam.PolicyDocument.Effect.allow
+      effect = awscc.iam.PolicyDocument.Statement.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/iam_role/prefix.crn
+++ b/acceptance-tests/iam_role/prefix.crn
@@ -14,7 +14,7 @@ awscc.iam.Role {
   assume_role_policy_document = {
     version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = awscc.iam.PolicyDocument.Effect.allow
+      effect = awscc.iam.PolicyDocument.Statement.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/iam_role/with_path.crn
+++ b/acceptance-tests/iam_role/with_path.crn
@@ -13,7 +13,7 @@ awscc.iam.Role {
   assume_role_policy_document = {
     version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = awscc.iam.PolicyDocument.Effect.allow
+      effect = awscc.iam.PolicyDocument.Statement.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/iam_role/with_policy.crn
+++ b/acceptance-tests/iam_role/with_policy.crn
@@ -15,7 +15,7 @@ awscc.iam.Role {
   assume_role_policy_document = {
     version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = awscc.iam.PolicyDocument.Effect.allow
+      effect = awscc.iam.PolicyDocument.Statement.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'
@@ -31,7 +31,7 @@ awscc.iam.Role {
     policy_document = {
       version = awscc.iam.PolicyDocument.Version.2012_10_17
       statement {
-        effect   = awscc.iam.PolicyDocument.Effect.allow
+        effect   = awscc.iam.PolicyDocument.Statement.Effect.allow
         action   = 'logs:CreateLogGroup'
         resource = '*'
       }

--- a/acceptance-tests/in_place_update/ec2_flow_log_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_flow_log_step1.crn
@@ -21,7 +21,7 @@ let flow_log_role = awscc.iam.Role {
   assume_role_policy_document = {
     version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = awscc.iam.PolicyDocument.Effect.allow
+      effect = awscc.iam.PolicyDocument.Statement.Effect.allow
 
       principal = {
         service = 'vpc-flow-logs.amazonaws.com'

--- a/acceptance-tests/in_place_update/ec2_flow_log_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_flow_log_step2.crn
@@ -21,7 +21,7 @@ let flow_log_role = awscc.iam.Role {
   assume_role_policy_document = {
     version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = awscc.iam.PolicyDocument.Effect.allow
+      effect = awscc.iam.PolicyDocument.Statement.Effect.allow
 
       principal = {
         service = 'vpc-flow-logs.amazonaws.com'

--- a/acceptance-tests/in_place_update/iam_role_step1.crn
+++ b/acceptance-tests/in_place_update/iam_role_step1.crn
@@ -12,7 +12,7 @@ awscc.iam.Role {
   assume_role_policy_document = {
     version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = awscc.iam.PolicyDocument.Effect.allow
+      effect = awscc.iam.PolicyDocument.Statement.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/in_place_update/iam_role_step2.crn
+++ b/acceptance-tests/in_place_update/iam_role_step2.crn
@@ -12,7 +12,7 @@ awscc.iam.Role {
   assume_role_policy_document = {
     version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = awscc.iam.PolicyDocument.Effect.allow
+      effect = awscc.iam.PolicyDocument.Statement.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/tag_deletion/iam_role_step1.crn
+++ b/acceptance-tests/tag_deletion/iam_role_step1.crn
@@ -13,7 +13,7 @@ awscc.iam.Role {
   assume_role_policy_document = {
     version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = awscc.iam.PolicyDocument.Effect.allow
+      effect = awscc.iam.PolicyDocument.Statement.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/tag_deletion/iam_role_step2.crn
+++ b/acceptance-tests/tag_deletion/iam_role_step2.crn
@@ -14,7 +14,7 @@ awscc.iam.Role {
   assume_role_policy_document = {
     version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = awscc.iam.PolicyDocument.Effect.allow
+      effect = awscc.iam.PolicyDocument.Statement.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/tag_deletion/iam_role_step3.crn
+++ b/acceptance-tests/tag_deletion/iam_role_step3.crn
@@ -14,7 +14,7 @@ awscc.iam.Role {
   assume_role_policy_document = {
     version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = awscc.iam.PolicyDocument.Effect.allow
+      effect = awscc.iam.PolicyDocument.Statement.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -1427,17 +1427,17 @@ fn string_or_principal_struct() -> AttributeType {
 /// users can write `effect = allow` as a bare identifier, matching the
 /// bare-identifier convention used by every other enum field in the
 /// same `.crn` file. The namespace also makes the fully-qualified form
-/// `awscc.iam.PolicyDocument.Effect.allow` parse and resolve: the
+/// `awscc.iam.PolicyDocument.Statement.Effect.allow` parse and resolve: the
 /// resolver's canonical shape is namespace then type_name then value,
 /// so `type_name` is the trailing `Effect` segment and `namespace` is
-/// `awscc.iam.PolicyDocument`.
+/// `awscc.iam.PolicyDocument.Statement`.
 fn iam_policy_effect() -> AttributeType {
     AttributeType::string_enum(
         "Effect".to_string(),
         vec!["Allow".to_string(), "Deny".to_string()],
         Some(carina_core::schema::string_enum_identity(
             "Effect",
-            Some("awscc.iam.PolicyDocument"),
+            Some("awscc.iam.PolicyDocument.Statement"),
         )),
         vec![
             ("Allow".to_string(), "allow".to_string()),
@@ -2717,16 +2717,27 @@ mod tests {
             panic!("iam_policy_effect() should be a StringEnum with identity");
         };
 
+        assert_eq!(
+            identity.to_string(),
+            "awscc.iam.PolicyDocument.Statement.Effect"
+        );
         assert!(
             carina_core::utils::validate_enum_namespace(
-                "awscc.iam.PolicyDocument.Effect.allow",
+                "awscc.iam.PolicyDocument.Statement.Effect.allow",
                 identity
             )
             .is_ok()
         );
         assert!(
             carina_core::utils::validate_enum_namespace(
-                "aws.iam.PolicyDocument.Effect.allow",
+                "awscc.iam.PolicyDocument.Effect.allow",
+                identity
+            )
+            .is_err()
+        );
+        assert!(
+            carina_core::utils::validate_enum_namespace(
+                "aws.iam.PolicyDocument.Statement.Effect.allow",
                 identity
             )
             .is_err()

--- a/carina-provider-awscc/src/provider/normalizer.rs
+++ b/carina-provider-awscc/src/provider/normalizer.rs
@@ -347,7 +347,7 @@ mod tests {
     /// the already-fully-qualified `version` path. The desired side
     /// must resolve to the same fully-qualified DSL form that the
     /// AWS-read side produces from raw `"Allow"`
-    /// (`awscc.iam.PolicyDocument.Effect.allow`), or the differ diverges.
+    /// (`awscc.iam.PolicyDocument.Statement.Effect.allow`), or the differ diverges.
     #[test]
     fn test_aws313_bare_effect_desired_resolves_to_namespaced() {
         use indexmap::IndexMap;
@@ -397,7 +397,7 @@ mod tests {
         assert_eq!(
             s0.get("effect"),
             Some(&Value::Concrete(ConcreteValue::String(
-                "awscc.iam.PolicyDocument.Effect.allow".to_string()
+                "awscc.iam.PolicyDocument.Statement.Effect.allow".to_string()
             ))),
             "bare `effect = allow` desired must resolve to the same \
              fully-qualified form the read side produces from \"Allow\""

--- a/carina-provider-awscc/src/schemas/mod.rs
+++ b/carina-provider-awscc/src/schemas/mod.rs
@@ -173,7 +173,7 @@ mod tests {
                 // hand-written iam_policy_document() helper and are intentionally
                 // reused across all policy-document fields.
                 if identity == "awscc.iam.PolicyDocument.Version"
-                    || identity == "awscc.iam.PolicyDocument.Effect"
+                    || identity == "awscc.iam.PolicyDocument.Statement.Effect"
                 {
                     collector.stack.remove(&ptr);
                     return;


### PR DESCRIPTION
Part of carina-rs/carina#3385 (IAM PolicyDocument enum structural identity).

## Problem

carina#3378 established that enum canonical identities carry intermediate
**structural** segments. awscc#305 (carina#3384) fixed the *provider prefix* of
awscc's hand-written IAM PolicyDocument enums (`aws.*` -> `awscc.*`) but left the
`Effect` identity **flat**, missing the structural segment:

```
awscc.iam.PolicyDocument.Effect        (flat, before)
```

## Fix

The structural path follows the DSL field names: the existing top type
`awscc.iam.PolicyDocument`, then the `Statement` field, then the `Effect` enum:

```
awscc.iam.PolicyDocument.Statement.Effect   (structural, after)
```

The identity is a hand-passed string literal independent of the Rust struct
type, so the `IamPolicyStatement` Rust type is untouched. `Version` is a direct
field of `PolicyDocument` and stays `awscc.iam.PolicyDocument.Version` (already
structurally correct).

## Changes

- `carina-aws-types/src/lib.rs`: `Effect` identity gains the `.Statement` segment; identity test asserts the structural form is accepted and the flat + wrong-provider forms are rejected.
- `carina-provider-awscc/src/schemas/mod.rs`: structural-collision allowlist updated to the new `Statement.Effect` spelling (Version branch unchanged).
- `carina-provider-awscc/src/provider/normalizer.rs`: aws#313 bare-`effect` regression test now expects the structural form.
- 16 acceptance-test `.crn` full-path references updated.

Verify: `cargo nextest run -p carina-aws-types -p carina-provider-awscc` (510+98 passed), doctests, clippy, fmt — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)