### PR TITLE
refactor(types): rename pre-namespacing IAM struct type names (carina#3385)

### DIFF
--- a/acceptance-tests/create_before_destroy/iam_role_step1.crn
+++ b/acceptance-tests/create_before_destroy/iam_role_step1.crn
@@ -15,7 +15,7 @@ awscc.iam.Role {
   assume_role_policy_document = {
     version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = awscc.iam.PolicyDocument.Effect.allow
+      effect = awscc.iam.PolicyDocument.Statement.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/create_before_destroy/iam_role_step2.crn
+++ b/acceptance-tests/create_before_destroy/iam_role_step2.crn
@@ -22,7 +22,7 @@ awscc.iam.Role {
   assume_role_policy_document = {
     version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = awscc.iam.PolicyDocument.Effect.allow
+      effect = awscc.iam.PolicyDocument.Statement.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/ec2_flow_log/cloudwatch.crn
+++ b/acceptance-tests/ec2_flow_log/cloudwatch.crn
@@ -22,7 +22,7 @@ let flow_log_role = awscc.iam.Role {
   assume_role_policy_document = {
     version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = awscc.iam.PolicyDocument.Effect.allow
+      effect = awscc.iam.PolicyDocument.Statement.Effect.allow
 
       principal = {
         service = 'vpc-flow-logs.amazonaws.com'

--- a/acceptance-tests/ec2_vpc_endpoint/gateway.crn
+++ b/acceptance-tests/ec2_vpc_endpoint/gateway.crn
@@ -23,7 +23,7 @@ awscc.ec2.VpcEndpoint {
   policy_document = {
     version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect    = awscc.iam.PolicyDocument.Effect.allow
+      effect    = awscc.iam.PolicyDocument.Statement.Effect.allow
       principal = '*'
       action    = 's3:GetObject'
       resource  = 'arn:aws:s3:::*'

--- a/acceptance-tests/iam_role/managed_policy.crn
+++ b/acceptance-tests/iam_role/managed_policy.crn
@@ -12,7 +12,7 @@ awscc.iam.Role {
   assume_role_policy_document = {
     version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = awscc.iam.PolicyDocument.Effect.allow
+      effect = awscc.iam.PolicyDocument.Statement.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/iam_role/prefix.crn
+++ b/acceptance-tests/iam_role/prefix.crn
@@ -14,7 +14,7 @@ awscc.iam.Role {
   assume_role_policy_document = {
     version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = awscc.iam.PolicyDocument.Effect.allow
+      effect = awscc.iam.PolicyDocument.Statement.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/iam_role/with_path.crn
+++ b/acceptance-tests/iam_role/with_path.crn
@@ -13,7 +13,7 @@ awscc.iam.Role {
   assume_role_policy_document = {
     version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = awscc.iam.PolicyDocument.Effect.allow
+      effect = awscc.iam.PolicyDocument.Statement.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/iam_role/with_policy.crn
+++ b/acceptance-tests/iam_role/with_policy.crn
@@ -15,7 +15,7 @@ awscc.iam.Role {
   assume_role_policy_document = {
     version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = awscc.iam.PolicyDocument.Effect.allow
+      effect = awscc.iam.PolicyDocument.Statement.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'
@@ -31,7 +31,7 @@ awscc.iam.Role {
     policy_document = {
       version = awscc.iam.PolicyDocument.Version.2012_10_17
       statement {
-        effect   = awscc.iam.PolicyDocument.Effect.allow
+        effect   = awscc.iam.PolicyDocument.Statement.Effect.allow
         action   = 'logs:CreateLogGroup'
         resource = '*'
       }

--- a/acceptance-tests/in_place_update/ec2_flow_log_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_flow_log_step1.crn
@@ -21,7 +21,7 @@ let flow_log_role = awscc.iam.Role {
   assume_role_policy_document = {
     version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = awscc.iam.PolicyDocument.Effect.allow
+      effect = awscc.iam.PolicyDocument.Statement.Effect.allow
 
       principal = {
         service = 'vpc-flow-logs.amazonaws.com'

--- a/acceptance-tests/in_place_update/ec2_flow_log_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_flow_log_step2.crn
@@ -21,7 +21,7 @@ let flow_log_role = awscc.iam.Role {
   assume_role_policy_document = {
     version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = awscc.iam.PolicyDocument.Effect.allow
+      effect = awscc.iam.PolicyDocument.Statement.Effect.allow
 
       principal = {
         service = 'vpc-flow-logs.amazonaws.com'

--- a/acceptance-tests/in_place_update/iam_role_step1.crn
+++ b/acceptance-tests/in_place_update/iam_role_step1.crn
@@ -12,7 +12,7 @@ awscc.iam.Role {
   assume_role_policy_document = {
     version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = awscc.iam.PolicyDocument.Effect.allow
+      effect = awscc.iam.PolicyDocument.Statement.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/in_place_update/iam_role_step2.crn
+++ b/acceptance-tests/in_place_update/iam_role_step2.crn
@@ -12,7 +12,7 @@ awscc.iam.Role {
   assume_role_policy_document = {
     version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = awscc.iam.PolicyDocument.Effect.allow
+      effect = awscc.iam.PolicyDocument.Statement.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/tag_deletion/iam_role_step1.crn
+++ b/acceptance-tests/tag_deletion/iam_role_step1.crn
@@ -13,7 +13,7 @@ awscc.iam.Role {
   assume_role_policy_document = {
     version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = awscc.iam.PolicyDocument.Effect.allow
+      effect = awscc.iam.PolicyDocument.Statement.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/tag_deletion/iam_role_step2.crn
+++ b/acceptance-tests/tag_deletion/iam_role_step2.crn
@@ -14,7 +14,7 @@ awscc.iam.Role {
   assume_role_policy_document = {
     version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = awscc.iam.PolicyDocument.Effect.allow
+      effect = awscc.iam.PolicyDocument.Statement.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/tag_deletion/iam_role_step3.crn
+++ b/acceptance-tests/tag_deletion/iam_role_step3.crn
@@ -14,7 +14,7 @@ awscc.iam.Role {
   assume_role_policy_document = {
     version = awscc.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = awscc.iam.PolicyDocument.Effect.allow
+      effect = awscc.iam.PolicyDocument.Statement.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/carina-aws-types/src/lib.rs
+++ b/carina-aws-types/src/lib.rs
@@ -1409,7 +1409,7 @@ fn string_or_principal_struct() -> AttributeType {
     // Value::Map against String incorrectly.
     AttributeType::union(vec![
         AttributeType::struct_(
-            "IamPolicyPrincipal".to_string(),
+            "Principal".to_string(),
             vec![
                 StructField::new("service", string_or_list_of_strings())
                     .with_provider_name("Service"),
@@ -1427,17 +1427,17 @@ fn string_or_principal_struct() -> AttributeType {
 /// users can write `effect = allow` as a bare identifier, matching the
 /// bare-identifier convention used by every other enum field in the
 /// same `.crn` file. The namespace also makes the fully-qualified form
-/// `awscc.iam.PolicyDocument.Effect.allow` parse and resolve: the
+/// `awscc.iam.PolicyDocument.Statement.Effect.allow` parse and resolve: the
 /// resolver's canonical shape is namespace then type_name then value,
 /// so `type_name` is the trailing `Effect` segment and `namespace` is
-/// `awscc.iam.PolicyDocument`.
+/// `awscc.iam.PolicyDocument.Statement`.
 fn iam_policy_effect() -> AttributeType {
     AttributeType::string_enum(
         "Effect".to_string(),
         vec!["Allow".to_string(), "Deny".to_string()],
         Some(carina_core::schema::string_enum_identity(
             "Effect",
-            Some("awscc.iam.PolicyDocument"),
+            Some("awscc.iam.PolicyDocument.Statement"),
         )),
         vec![
             ("Allow".to_string(), "allow".to_string()),
@@ -1494,7 +1494,7 @@ fn condition_type() -> AttributeType {
 /// IAM Policy Statement struct type
 fn iam_policy_statement() -> AttributeType {
     AttributeType::struct_(
-        "IamPolicyStatement".to_string(),
+        "Statement".to_string(),
         vec![
             StructField::new("sid", AttributeType::string()).with_provider_name("Sid"),
             StructField::new("effect", iam_policy_effect()).with_provider_name("Effect"),
@@ -1522,7 +1522,7 @@ fn iam_policy_statement() -> AttributeType {
 /// (e.g., `version` <-> `Version`, `statement` <-> `Statement`).
 pub fn iam_policy_document() -> AttributeType {
     AttributeType::struct_(
-        "IamPolicyDocument".to_string(),
+        "PolicyDocument".to_string(),
         vec![
             StructField::new("version", iam_policy_version()).with_provider_name("Version"),
             StructField::new("id", AttributeType::string()).with_provider_name("Id"),
@@ -2717,20 +2717,83 @@ mod tests {
             panic!("iam_policy_effect() should be a StringEnum with identity");
         };
 
+        assert_eq!(
+            identity.to_string(),
+            "awscc.iam.PolicyDocument.Statement.Effect"
+        );
         assert!(
             carina_core::utils::validate_enum_namespace(
-                "awscc.iam.PolicyDocument.Effect.allow",
+                "awscc.iam.PolicyDocument.Statement.Effect.allow",
                 identity
             )
             .is_ok()
         );
         assert!(
             carina_core::utils::validate_enum_namespace(
-                "aws.iam.PolicyDocument.Effect.allow",
+                "awscc.iam.PolicyDocument.Effect.allow",
                 identity
             )
             .is_err()
         );
+        assert!(
+            carina_core::utils::validate_enum_namespace(
+                "aws.iam.PolicyDocument.Statement.Effect.allow",
+                identity
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn iam_policy_document_struct_type_names_use_plain_structural_names() {
+        let doc = iam_policy_document();
+        let RawShape::Struct {
+            name: doc_name,
+            fields,
+        } = doc.raw_shape()
+        else {
+            panic!("iam_policy_document() should be a Struct");
+        };
+        assert_eq!(doc_name, "PolicyDocument");
+
+        let statement = fields
+            .iter()
+            .find(|field| field.name == "statement")
+            .expect("policy document must include statement field");
+        let RawShape::List {
+            inner: element_type,
+            ..
+        } = statement.field_type.raw_shape()
+        else {
+            panic!("statement field should be a List");
+        };
+        let RawShape::Struct {
+            name: statement_name,
+            fields,
+        } = element_type.raw_shape()
+        else {
+            panic!("statement list element should be a Struct");
+        };
+        assert_eq!(statement_name, "Statement");
+
+        let principal = fields
+            .iter()
+            .find(|field| field.name == "principal")
+            .expect("statement must include principal field");
+        let RawShape::Union(variants) = principal.field_type.raw_shape() else {
+            panic!("principal field should be a Union");
+        };
+        let RawShape::Struct {
+            name: principal_name,
+            ..
+        } = variants
+            .first()
+            .expect("principal union should include struct variant")
+            .raw_shape()
+        else {
+            panic!("principal union first variant should be a Struct");
+        };
+        assert_eq!(principal_name, "Principal");
     }
 
     #[test]

--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -921,7 +921,7 @@ fn type_display_string(
         match prop.prop_type.as_ref().and_then(|t| t.as_str()) {
             Some("string") => {
                 if prop_name.ends_with("PolicyDocument") {
-                    "IamPolicyDocument".to_string()
+                    "PolicyDocument".to_string()
                 } else {
                     let base = infer_string_type_display(prop_name, &schema.type_name);
                     if base != "String" {
@@ -1094,7 +1094,7 @@ fn type_display_string(
                 {
                     format!("[Struct({})](#{})", prop_name, prop_name.to_lowercase())
                 } else if prop_name.ends_with("PolicyDocument") {
-                    "IamPolicyDocument".to_string()
+                    "PolicyDocument".to_string()
                 } else {
                     "`Map<String, String>`".to_string()
                 }

--- a/carina-provider-awscc/src/provider/normalizer.rs
+++ b/carina-provider-awscc/src/provider/normalizer.rs
@@ -347,7 +347,7 @@ mod tests {
     /// the already-fully-qualified `version` path. The desired side
     /// must resolve to the same fully-qualified DSL form that the
     /// AWS-read side produces from raw `"Allow"`
-    /// (`awscc.iam.PolicyDocument.Effect.allow`), or the differ diverges.
+    /// (`awscc.iam.PolicyDocument.Statement.Effect.allow`), or the differ diverges.
     #[test]
     fn test_aws313_bare_effect_desired_resolves_to_namespaced() {
         use indexmap::IndexMap;
@@ -397,7 +397,7 @@ mod tests {
         assert_eq!(
             s0.get("effect"),
             Some(&Value::Concrete(ConcreteValue::String(
-                "awscc.iam.PolicyDocument.Effect.allow".to_string()
+                "awscc.iam.PolicyDocument.Statement.Effect.allow".to_string()
             ))),
             "bare `effect = allow` desired must resolve to the same \
              fully-qualified form the read side produces from \"Allow\""

--- a/carina-provider-awscc/src/schemas/mod.rs
+++ b/carina-provider-awscc/src/schemas/mod.rs
@@ -173,7 +173,7 @@ mod tests {
                 // hand-written iam_policy_document() helper and are intentionally
                 // reused across all policy-document fields.
                 if identity == "awscc.iam.PolicyDocument.Version"
-                    || identity == "awscc.iam.PolicyDocument.Effect"
+                    || identity == "awscc.iam.PolicyDocument.Statement.Effect"
                 {
                     collector.stack.remove(&ptr);
                     return;

--- a/generated-docs/awscc/ec2/vpc_endpoint.md
+++ b/generated-docs/awscc/ec2/vpc_endpoint.md
@@ -68,7 +68,7 @@ The supported IP address types.
 
 ### `policy_document`
 
-- **Type:** IamPolicyDocument
+- **Type:** PolicyDocument
 - **Required:** No
 
 An endpoint policy, which controls access to the service from the VPC. The default endpoint policy allows full access to the service. Endpoint policies are supported only for gateway and interface endpoints. For CloudFormation templates in YAML, you can provide the policy in JSON or YAML format. For example, if you have a JSON policy, you can convert it to YAML before including it in the YAML template, and CFNlong converts the policy to JSON format before calling the API actions for privatelink. Alternatively, you can include the JSON directly in the YAML, as shown in the following ``Properties`` section: ``Properties: VpcEndpointType: 'Interface' ServiceName: !Sub 'com.amazonaws.${AWS::Region}.logs' PolicyDocument: '{ "Version":"2012-10-17", "Statement": [{ "Effect":"Allow", "Principal":"*", "Action":["logs:Describe*","logs:Get*","logs:List*","logs:FilterLogEvents"], "Resource":"*" }] }'``

--- a/generated-docs/awscc/iam/role.md
+++ b/generated-docs/awscc/iam/role.md
@@ -38,7 +38,7 @@ awscc.iam.Role {
 
 ### `assume_role_policy_document`
 
-- **Type:** IamPolicyDocument
+- **Type:** PolicyDocument
 - **Required:** Yes
 
 The trust policy that is associated with this role. Trust policies define which entities can assume the role. You can associate only one trust policy with a role. For an example of a policy that can be used to assume a role, see [Template Examples](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html#aws-resource-iam-role--examples). For more information about the elements that you can use in an IAM policy, see [Policy Elements Reference](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html) in the *User Guide*.
@@ -108,7 +108,7 @@ A list of tags that are attached to the role. For more information about tagging
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `policy_document` | IamPolicyDocument | Yes | The entire contents of the policy that defines permissions. For more information, see [Overview of JSON policies](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#access_policies-json). |
+| `policy_document` | PolicyDocument | Yes | The entire contents of the policy that defines permissions. For more information, see [Overview of JSON policies](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#access_policies-json). |
 | `policy_name` | String | Yes | The friendly name (not ARN) identifying the policy. |
 
 ## Attribute Reference

--- a/generated-docs/awscc/iam/role_policy.md
+++ b/generated-docs/awscc/iam/role_policy.md
@@ -15,7 +15,7 @@ Adds or updates an inline policy document that is embedded in the specified IAM 
 
 ### `policy_document`
 
-- **Type:** IamPolicyDocument
+- **Type:** PolicyDocument
 - **Required:** No
 
 The policy document. You must provide policies in JSON format in IAM. However, for CFN templates formatted in YAML, you can provide the policy in JSON or YAML format. CFN always converts a YAML policy to JSON format before submitting it to IAM. The [regex pattern](https://docs.aws.amazon.com/http://wikipedia.org/wiki/regex) used to validate this parameter is a string of characters consisting of the following: + Any printable ASCII character ranging from the space character (``\u0020``) through the end of the ASCII character range + The printable characters in the Basic Latin and Latin-1 Supplement character set (through ``\u00FF``) + The special characters tab (``\u0009``), line feed (``\u000A``), and carriage return (``\u000D``)

--- a/generated-docs/awscc/logs/log_group.md
+++ b/generated-docs/awscc/logs/log_group.md
@@ -74,7 +74,7 @@ The name of the log group. If you don't specify a name, CFNlong generates a uniq
 
 ### `resource_policy_document`
 
-- **Type:** IamPolicyDocument
+- **Type:** PolicyDocument
 - **Required:** No
 
 Creates or updates a resource policy for the specified log group that allows other services to put log events to this account. A LogGroup can have 1 resource policy.

--- a/generated-docs/awscc/s3/bucket_policy.md
+++ b/generated-docs/awscc/s3/bucket_policy.md
@@ -29,7 +29,7 @@ The name of the Amazon S3 bucket to which the policy applies.
 
 ### `policy_document`
 
-- **Type:** IamPolicyDocument
+- **Type:** PolicyDocument
 - **Required:** Yes
 
 A policy document containing permissions to add to the specified bucket. In IAM, you must provide policy documents in JSON format. However, in CloudFormation you can provide the policy in JSON or YAML format because CloudFormation converts YAML to JSON before submitting it to IAM. For more information, see the AWS::IAM::Policy [PolicyDocument](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-policydocument) resource description in this guide and [Access Policy Language Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/access-policy-language-overview.html) in the *Amazon S3 User Guide*.


### PR DESCRIPTION
Part of carina-rs/carina#3385 (IAM PolicyDocument enum structural identity).

## Root cause

Since carina#3378, hand-written struct type names are emitted **verbatim** into
enum canonical identities (and shown in `TypeMismatch` diagnostics + generated
docs). The IAM struct types carry a redundant `IamPolicy` prefix that duplicates
the `awscc.iam.PolicyDocument` namespace — pre-namespacing leftovers,
inconsistent with the plain-structural-name convention. awscc#305 (carina#3384)
fixed the provider prefix (`aws.*` -> `awscc.*`) but left the Effect identity
**flat** AND the struct names verbose.

## Fix — rename the struct types

```
IamPolicyStatement -> Statement
IamPolicyDocument  -> PolicyDocument
IamPolicyPrincipal -> Principal
```

The Effect identity gains its structural `Statement` segment naturally:

```
awscc.iam.PolicyDocument.Effect            (flat, before)
awscc.iam.PolicyDocument.Statement.Effect  (structural, after)
```

`Version` is a direct field of `PolicyDocument` and stays
`awscc.iam.PolicyDocument.Version`.

## Changes

- `carina-aws-types/src/lib.rs`: 3 struct renames; Effect identity namespace; identity + struct-name tests (accepts structural form, rejects flat + wrong-provider).
- `carina-provider-awscc/src/bin/codegen.rs`: doc Type labels `IamPolicyDocument` -> `PolicyDocument`.
- `carina-provider-awscc/src/schemas/mod.rs`: structural-collision allowlist `.Statement.Effect`.
- `carina-provider-awscc/src/provider/normalizer.rs`: aws#313 bare-effect regression expectation.
- 16 acceptance `.crn` references.
- `generated-docs/awscc/**` (5 md files) regenerated — `IamPolicyDocument` -> `PolicyDocument`.

## Verify

`cargo nextest run -p carina-aws-types -p carina-provider-awscc` (511), doctests, `cargo clippy --workspace --all-targets -- -D warnings`, fmt, `scripts/check-docs-drift.sh` (OK: 38 resources in sync), codegen `--from-cache-only` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)