### PR TITLE
Add AWS::KMS::Key resource

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,7 +62,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -64,7 +73,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -86,6 +95,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,6 +114,8 @@ checksum = "11493b0bad143270fb8ad284a096dd529ba91924c5409adeac856cc1bf047dbc"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
  "aws-sdk-sts",
  "aws-smithy-async",
  "aws-smithy-http",
@@ -109,11 +126,14 @@ dependencies = [
  "aws-types",
  "bytes",
  "fastrand",
+ "hex",
  "http 1.4.0",
+ "sha1",
  "time",
  "tokio",
  "tracing",
  "url",
+ "zeroize",
 ]
 
 [[package]]
@@ -126,6 +146,28 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "zeroize",
+]
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
 ]
 
 [[package]]
@@ -213,6 +255,54 @@ dependencies = [
  "sha2",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.97.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aadc669e184501caaa6beafb28c6267fc1baef0810fb58f9b205485ca3f2567"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.99.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1342a7db8f358d3de0aed2007a0b54e875458e39848d54cc1d46700b2bfcb0a8"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
 ]
 
 [[package]]
@@ -329,6 +419,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-http-client"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2",
+ "http 1.4.0",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tracing",
+]
+
+[[package]]
 name = "aws-smithy-json"
 version = "0.62.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,6 +478,7 @@ checksum = "028999056d2d2fd58a697232f9eec4a643cf73a71cf327690a7edad1d2af2110"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
+ "aws-smithy-http-client",
  "aws-smithy-observability",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -442,6 +557,12 @@ dependencies = [
  "rustc_version",
  "tracing",
 ]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64-simd"
@@ -575,6 +696,8 @@ dependencies = [
  "thiserror",
  "tokio",
  "wasi 0.14.7+wasi-0.2.4",
+ "winterbaume-cloudcontrol",
+ "winterbaume-core",
  "wit-bindgen 0.54.0",
 ]
 
@@ -588,10 +711,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.2.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -634,10 +781,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -726,6 +898,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -744,7 +922,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -752,6 +930,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fnv"
@@ -779,6 +963,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -880,15 +1070,57 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.4.0",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -991,6 +1223,96 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http 1.4.0",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1115,6 +1437,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1125,6 +1453,16 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -1202,7 +1540,7 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1240,6 +1578,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "outref"
@@ -1387,6 +1731,12 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -1442,12 +1792,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1463,10 +1874,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -1540,6 +1983,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1568,7 +2017,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1691,7 +2140,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1704,6 +2153,51 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -1737,6 +2231,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1759,6 +2259,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -1796,7 +2302,7 @@ version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
- "getrandom",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -1812,6 +2318,15 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -1960,10 +2475,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1972,6 +2549,108 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winterbaume-cloudcontrol"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f523567ebf224c464d7064b47ef241a642942db50871fb8944d138da7db691fa"
+dependencies = [
+ "bytes",
+ "chrono",
+ "http 1.4.0",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "uuid",
+ "winterbaume-core",
+]
+
+[[package]]
+name = "winterbaume-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9135da905ed2cbe0f7464134bf88feb0e1b1f3ce3315536805b4505db6abd4"
+dependencies = [
+ "aws-config",
+ "aws-credential-types",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "http 1.4.0",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -49,6 +49,10 @@ http = "1"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1", features = ["full"] }
 
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+winterbaume-core = "0.2"
+winterbaume-cloudcontrol = "0.2"
+
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tokio = { version = "1", default-features = false, features = ["rt", "macros", "time", "sync"] }
 wit-bindgen = { version = "0.54", default-features = false, features = ["macros"] }

--- a/carina-provider-awscc/scripts/generate-schemas.sh
+++ b/carina-provider-awscc/scripts/generate-schemas.sh
@@ -78,6 +78,7 @@ RESOURCE_TYPES=(
     "AWS::CloudFront::Distribution"
     "AWS::CloudFront::OriginAccessControl"
     "AWS::WAFv2::WebACL"
+    "AWS::KMS::Key"
 )
 
 echo "Generating awscc provider schemas..."

--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -2067,11 +2067,6 @@ fn generate_schema_code(schema: &CfnSchema, type_name: &str) -> Result<String> {
     let has_ranged_lists = !ranged_lists.is_empty();
     let has_patterns = !patterns.is_empty();
     let has_ranged_strings = !ranged_strings.is_empty();
-    let has_defaults = schema.properties.values().any(|p| {
-        p.default_value
-            .as_ref()
-            .is_some_and(|v| json_default_to_value_code(v).is_some())
-    });
     // Enums use AttributeType::Custom with AttributeType::String base
     if has_enums {
         needs_attribute_type = true;
@@ -2505,9 +2500,14 @@ pub fn {}() -> AwsccSchemaConfig {{
             prop_name
         ));
 
-        // Add default value if defined in CloudFormation schema
+        // Add default value if defined in CloudFormation schema. A CFN JSON scalar
+        // default whose shape does not match the resolved Carina type (for example
+        // a JSON-string default on a structured policy document) would cause a
+        // perpetual phantom diff. Policy document fields follow the IAM Role
+        // convention: omit the Carina default and let AWS apply its server default.
         if let Some(default_val) = &prop.default_value
             && let Some(default_code) = json_default_to_value_code(default_val)
+            && attr_type_accepts_scalar_default(&attr_type)
         {
             attr_code.push_str(&format!(
                 "\n                .with_default({})",
@@ -2898,6 +2898,7 @@ use super::AwsccSchemaConfig;
 "#,
         resource, type_name, schema_imports_str
     ));
+    let has_defaults = body.contains(".with_default(");
     if has_ranged_ints
         || has_ranged_floats
         || has_int_enums
@@ -2998,6 +2999,12 @@ fn looks_like_enum_value(s: &str) -> bool {
         return false;
     }
     if s.contains(' ') {
+        return false;
+    }
+    // Real enum identifiers always include at least one ASCII alphanumeric
+    // character. Backticked punctuation in CFN descriptions is usually an
+    // allowed-character list, not an enum member.
+    if !s.chars().any(|c| c.is_ascii_alphanumeric()) {
         return false;
     }
     // CFN descriptions use double-backticks for both enum members and code-style
@@ -3934,6 +3941,11 @@ fn resource_type_overrides() -> &'static HashMap<(&'static str, &'static str), T
             m.insert(
                 ("AWS::IAM::Role", "RoleId"),
                 TypeOverride::StringType("super::iam_role_id()"),
+            );
+            // KMS KeyPolicy is an IAM policy document, though CFN types it object|string.
+            m.insert(
+                ("AWS::KMS::Key", "KeyPolicy"),
+                TypeOverride::StringType("super::iam_policy_document()"),
             );
             // EC2 Route's GatewayId accepts both igw-* and vgw-*
             m.insert(
@@ -5258,6 +5270,14 @@ fn cfn_type_to_carina_type_with_enum_with_struct_path(
             }
         }
         Some("object") => {
+            // Check known string type overrides first, mirroring the string branch
+            // for CFN union types whose first type is object.
+            let res_override =
+                resource_type_overrides().get(&(schema.type_name.as_str(), prop_name));
+            if let Some(TypeOverride::StringType(override_type)) = res_override {
+                return (override_type.to_string(), None);
+            }
+
             // Check if this object has inline properties -> Struct
             if let Some(props) = &prop.properties
                 && !props.is_empty()
@@ -5329,6 +5349,19 @@ fn json_default_to_value_code(val: &serde_json::Value) -> Option<String> {
         }
         _ => None,
     }
+}
+
+fn attr_type_accepts_scalar_default(attr_type: &str) -> bool {
+    ![
+        "iam_policy_document",
+        "struct_",
+        "::map(",
+        "::map (",
+        "list(",
+        "ref_(",
+    ]
+    .iter()
+    .any(|non_scalar| attr_type.contains(non_scalar))
 }
 
 /// Convert a JSON default value to a display string for markdown documentation.
@@ -5666,6 +5699,19 @@ mod tests {
     }
 
     #[test]
+    fn test_looks_like_enum_value_rejects_lone_punctuation() {
+        for value in ["_", "=", "+", "@", "-", "\""] {
+            assert!(
+                !looks_like_enum_value(value),
+                "lone punctuation token {value:?} must not be treated as an enum value"
+            );
+        }
+
+        assert!(looks_like_enum_value("ENCRYPT_DECRYPT"));
+        assert!(looks_like_enum_value("SIGN_VERIFY"));
+    }
+
+    #[test]
     fn test_extract_enum_from_description_instance_tenancy() {
         let description = r#"The allowed tenancy of instances launched into the VPC.
   +  ``default``: An instance launched into the VPC runs on shared hardware by default.
@@ -5677,6 +5723,26 @@ mod tests {
         assert!(result.is_some());
         let values = result.unwrap();
         assert_eq!(values, vec!["default", "dedicated", "host"]);
+    }
+
+    #[test]
+    fn test_extract_enum_from_description_rejects_kms_tag_allowed_punctuation() {
+        let description = r#"The key of the tag. The allowed characters are Unicode letters,
+            digits, whitespace, ``_``, ``.``, ``:``, ``/``, ``=``, ``+``, ``@``, ``-``,
+            and ``"``."#;
+        let result = extract_enum_from_description(description);
+        if let Some(values) = &result {
+            assert!(
+                !values
+                    .iter()
+                    .any(|v| matches!(v.as_str(), "\"" | "_" | "=")),
+                "KMS tag punctuation must not be extracted as enum values (got {values:?})"
+            );
+        }
+        assert!(
+            result.is_none() || result.as_ref().is_some_and(|values| values.is_empty()),
+            "KMS tag allowed-character punctuation must not form an enum (got {result:?})"
+        );
     }
 
     #[test]
@@ -8216,6 +8282,44 @@ mod tests {
     }
 
     #[test]
+    fn test_kms_key_policy_object_string_uses_iam_policy_document_override() {
+        let prop = CfnProperty {
+            prop_type: Some(TypeValue::Multiple(vec![
+                "object".to_string(),
+                "string".to_string(),
+            ])),
+            ..Default::default()
+        };
+        let schema = CfnSchema {
+            type_name: "AWS::KMS::Key".to_string(),
+            description: None,
+            properties: BTreeMap::new(),
+            required: vec![],
+            read_only_properties: vec![],
+            create_only_properties: vec![],
+            write_only_properties: vec![],
+            primary_identifier: None,
+            definitions: None,
+            tagging: None,
+            one_of: vec![],
+            any_of: vec![],
+            handlers: BTreeMap::new(),
+        };
+
+        let (carina_type, enum_info) = cfn_type_to_carina_type_with_enum_with_struct_path(
+            &prop,
+            "KeyPolicy",
+            &schema,
+            "",
+            &BTreeMap::new(),
+            &[],
+        );
+
+        assert_eq!(carina_type, "super::iam_policy_document()");
+        assert!(enum_info.is_none());
+    }
+
+    #[test]
     fn test_iam_oidc_provider_arn_override() {
         // IAM OIDCProvider's Arn should use iam_oidc_provider_arn(), not generic arn
         assert_eq!(
@@ -9821,6 +9925,88 @@ mod tests {
         assert!(
             generated.contains(".with_default(Value::Concrete(ConcreteValue::Int(3)))"),
             "Should emit .with_default() for integer default value: {generated}"
+        );
+    }
+
+    #[test]
+    fn test_attr_type_accepts_scalar_default() {
+        assert!(attr_type_accepts_scalar_default("AttributeType::bool()"));
+        assert!(attr_type_accepts_scalar_default("AttributeType::int()"));
+        assert!(attr_type_accepts_scalar_default("AttributeType::float()"));
+        assert!(attr_type_accepts_scalar_default(
+            "AttributeType::string_enum(VALID_KEY_USAGE)"
+        ));
+        assert!(
+            attr_type_accepts_scalar_default("super::prefix_list_id()"),
+            "scalar string types whose name merely contains 'list' must still accept defaults"
+        );
+        assert!(attr_type_accepts_scalar_default(
+            "AttributeType::custom(None, AttributeType::int(), None, None, legacy_validator(f), None)"
+        ));
+        assert!(attr_type_accepts_scalar_default("super::arn()"));
+        assert!(!attr_type_accepts_scalar_default(
+            "super::iam_policy_document()"
+        ));
+        assert!(!attr_type_accepts_scalar_default(
+            "AttributeType::struct_(\"Config\")"
+        ));
+        assert!(!attr_type_accepts_scalar_default(
+            "AttributeType::unordered_list(AttributeType::string())"
+        ));
+        assert!(!attr_type_accepts_scalar_default(
+            "AttributeType::map(AttributeType::string())"
+        ));
+        assert!(!attr_type_accepts_scalar_default(
+            "AttributeType::list(AttributeType::string())"
+        ));
+        assert!(!attr_type_accepts_scalar_default(
+            "AttributeType::ref_(\"Other\")"
+        ));
+    }
+
+    #[test]
+    fn test_generate_schema_code_suppresses_default_for_iam_policy_document() {
+        let mut properties = BTreeMap::new();
+        properties.insert(
+            "KeyPolicy".to_string(),
+            CfnProperty {
+                prop_type: Some(TypeValue::Multiple(vec![
+                    "object".to_string(),
+                    "string".to_string(),
+                ])),
+                default_value: Some(serde_json::Value::String(
+                    r#"{"Version":"2012-10-17","Statement":[]}"#.to_string(),
+                )),
+                ..Default::default()
+            },
+        );
+
+        let schema = CfnSchema {
+            type_name: "AWS::KMS::Key".to_string(),
+            description: None,
+            properties,
+            required: vec![],
+            read_only_properties: vec![],
+            create_only_properties: vec![],
+            write_only_properties: vec![],
+            primary_identifier: None,
+            definitions: None,
+            tagging: None,
+            one_of: vec![],
+            any_of: vec![],
+            handlers: BTreeMap::new(),
+        };
+
+        let generated = generate_schema_code(&schema, "AWS::KMS::Key").unwrap();
+
+        assert!(
+            generated
+                .contains(r#"AttributeSchema::new("key_policy", super::iam_policy_document())"#),
+            "Should resolve KeyPolicy to iam_policy_document: {generated}"
+        );
+        assert!(
+            !generated.contains(".with_default("),
+            "Should not emit scalar JSON defaults for structured policy documents: {generated}"
         );
     }
 

--- a/carina-provider-awscc/src/provider/mod.rs
+++ b/carina-provider-awscc/src/provider/mod.rs
@@ -109,7 +109,11 @@ impl AwsccProvider {
     /// CloudControl call.
     pub async fn new_with_config(region: &str, cfg: &AwsccProviderConfig) -> Self {
         let config = Self::build_config(region, cfg.assume_role.as_ref()).await;
+        Self::from_sdk_config(config, cfg).await
+    }
 
+    /// Create a new AwsccProvider from a prebuilt AWS SDK configuration.
+    pub async fn from_sdk_config(config: aws_config::SdkConfig, cfg: &AwsccProviderConfig) -> Self {
         let init_error =
             if cfg.allowed_account_ids.is_empty() && cfg.forbidden_account_ids.is_empty() {
                 None

--- a/carina-provider-awscc/src/schemas/generated/kms/key.rs
+++ b/carina-provider-awscc/src/schemas/generated/kms/key.rs
@@ -1,0 +1,192 @@
+//! key schema definition for AWS Cloud Control
+//!
+//! Auto-generated from CloudFormation schema: AWS::KMS::Key
+//!
+//! DO NOT EDIT MANUALLY - regenerate with carina-codegen
+
+use super::AwsccSchemaConfig;
+use super::tags_type;
+use super::validate_tags_map;
+use carina_core::resource::{ConcreteValue, Value};
+use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, legacy_validator};
+
+const VALID_KEY_SPEC: &[&str] = &[
+    "SYMMETRIC_DEFAULT",
+    "RSA_2048",
+    "RSA_3072",
+    "RSA_4096",
+    "ECC_NIST_P256",
+    "ECC_NIST_P384",
+    "ECC_NIST_P521",
+    "ECC_SECG_P256K1",
+    "HMAC_224",
+    "HMAC_256",
+    "HMAC_384",
+    "HMAC_512",
+    "SM2",
+    "ML_DSA_44",
+    "ML_DSA_65",
+    "ML_DSA_87",
+    "ECC_NIST_EDWARDS25519",
+];
+
+const VALID_KEY_USAGE: &[&str] = &[
+    "ENCRYPT_DECRYPT",
+    "SIGN_VERIFY",
+    "GENERATE_VERIFY_MAC",
+    "KEY_AGREEMENT",
+];
+
+const VALID_ORIGIN: &[&str] = &["AWS_KMS", "EXTERNAL"];
+
+fn validate_pending_window_in_days_range(value: &Value) -> Result<(), String> {
+    if let Value::Concrete(ConcreteValue::Int(n)) = value {
+        if *n < 7 || *n > 30 {
+            Err(format!("Value {} is out of range 7..=30", n))
+        } else {
+            Ok(())
+        }
+    } else {
+        Err("Expected integer".to_string())
+    }
+}
+
+fn validate_rotation_period_in_days_range(value: &Value) -> Result<(), String> {
+    if let Value::Concrete(ConcreteValue::Int(n)) = value {
+        if *n < 90 || *n > 2560 {
+            Err(format!("Value {} is out of range 90..=2560", n))
+        } else {
+            Ok(())
+        }
+    } else {
+        Err("Expected integer".to_string())
+    }
+}
+
+fn validate_string_length_max_8192(value: &Value) -> Result<(), String> {
+    if let Value::Concrete(ConcreteValue::String(s)) = value {
+        let len = s.chars().count();
+        if len > 8192 {
+            Err(format!("String length {} is out of range ..=8192", len))
+        } else {
+            Ok(())
+        }
+    } else {
+        Ok(())
+    }
+}
+
+/// Returns the schema config for kms_key (AWS::KMS::Key)
+pub fn kms_key_config() -> AwsccSchemaConfig {
+    AwsccSchemaConfig {
+        aws_type_name: "AWS::KMS::Key",
+        resource_type_name: "kms.Key",
+        has_tags: true,
+        schema: ResourceSchema::new("kms.Key")
+        .with_description("The ``AWS::KMS::Key`` resource specifies an [KMS key](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#kms_keys) in KMSlong. You can use this resource to create symmetric encryption KMS keys, asymmetric KMS keys for encryption or signing, and symmetric HMAC KMS keys. You can use ``AWS::KMS::Key`` to create [multi-Region primary keys](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html#mrk-primary-key) of all supported types. To replicate a multi-Region key, use the ``AWS::KMS::ReplicaKey`` resource.   If you change the value of the ``KeySpec``, ``KeyUsage``, ``Origin``, or ``MultiRegion`` properties of an existing KMS key, the update request fails, regardless of the value of the [UpdateReplacePolicy attribute](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html). This prevents you from accidentally deleting a KMS key by changing any of its immutable property values.    KMS replaced the term *customer master key (CMK)* with ** and *KMS key*. The concept has not changed. To prevent breaking changes, KMS is keeping some variations of this term.   You can use symmetric encryption KMS keys to encrypt and decrypt small amounts of data, but they are more commonly used to generate data keys and data key pairs. You can also use a symmetric encryption KMS key to encrypt data stored in AWS services that are [integrated with](https://docs.aws.amazon.com//kms/features/#AWS_Service_Integration). For more information, see [Symmetric encryption KMS keys](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#symmetric-cmks) in the *Developer Guide*.  You can use asymmetric KMS keys to encrypt and decrypt data or sign messages and verify signatures. To create an asymmetric key, you must specify an asymmetric ``KeySpec`` value and a ``KeyUsage`` value. For details, see [Asymmetric keys in](https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html) in the *Developer Guide*.  You can use HMAC KMS keys (which are also symmetric keys) to generate and verify hash-based message authentication codes. To create an HMAC key, you must specify an HMAC ``KeySpec`` value and a ``KeyUsage`` value of ``GENERATE_VERIFY_MAC``. For details, see [HMAC keys in](https://docs.aws.amazon.com/kms/latest/developerguide/hmac.html) in the *Developer Guide*.  You can also create symmetric encryption, asymmetric, and HMAC multi-Region primary keys. To create a multi-Region primary key, set the ``MultiRegion`` property to ``true``. For information about multi-Region keys, see [Multi-Region keys in](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html) in the *Developer Guide*.  You cannot use the ``AWS::KMS::Key`` resource to specify a KMS key with [imported key material](https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html) or a KMS key in a [custom key store](https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html).   *Regions*   KMS CloudFormation resources are available in all Regions in which KMS and CFN are supported. You can use the ``AWS::KMS::Key`` resource to create and manage all KMS key types that are supported in a Region.")
+        .attribute(
+            AttributeSchema::new("arn", super::arn())
+                .read_only()
+                .with_description(" (read-only)")
+                .with_provider_name("Arn"),
+        )
+        .attribute(
+            AttributeSchema::new("bypass_policy_lockout_safety_check", AttributeType::bool())
+                .write_only()
+                .with_description("Skips (\"bypasses\") the key policy lockout safety check. The default value is false. Setting this value to true increases the risk that the KMS key becomes unmanageable. Do not set this value to true indiscriminately. For more information, see [Default key policy](https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html#prevent-unmanageable-key) in the *Developer Guide*. Use this parameter only when you intend to prevent the principal that is making the request from making a subsequent [PutKeyPolicy](https://docs.aws.amazon.com/kms/latest/APIReference/API_PutKeyPolicy.html) request on the KMS key.")
+                .with_provider_name("BypassPolicyLockoutSafetyCheck")
+                .with_default(Value::Concrete(ConcreteValue::Bool(false))),
+        )
+        .attribute(
+            AttributeSchema::new("description", AttributeType::custom(None, AttributeType::string(), None, Some((None, Some(8192))), legacy_validator(validate_string_length_max_8192), None))
+                .with_description("A description of the KMS key. Use a description that helps you to distinguish this KMS key from others in the account, such as its intended use.")
+                .with_provider_name("Description"),
+        )
+        .attribute(
+            AttributeSchema::new("enable_key_rotation", AttributeType::bool())
+                .with_description("Enables automatic rotation of the key material for the specified KMS key. By default, automatic key rotation is not enabled. KMS supports automatic rotation only for symmetric encryption KMS keys (``KeySpec`` = ``SYMMETRIC_DEFAULT``). For asymmetric KMS keys, HMAC KMS keys, and KMS keys with Origin ``EXTERNAL``, omit the ``EnableKeyRotation`` property or set it to ``false``. To enable automatic key rotation of the key material for a multi-Region KMS key, set ``EnableKeyRotation`` to ``true`` on the primary key (created by using ``AWS::KMS::Key``). KMS copies the rotation status to all replica keys. For details, see [Rotating multi-Region keys](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-manage.html#multi-region-rotate) in the *Developer Guide*. When you enable automatic rotation, KMS automatically creates new key material for the KMS key one year after the enable date and every year thereafter. KMS retains all key material until you delete the KMS key. For detailed information about automatic key rotation, see [Rotating KMS keys](https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html) in the *Developer Guide*.")
+                .with_provider_name("EnableKeyRotation"),
+        )
+        .attribute(
+            AttributeSchema::new("enabled", AttributeType::bool())
+                .with_description("Specifies whether the KMS key is enabled. Disabled KMS keys cannot be used in cryptographic operations. When ``Enabled`` is ``true``, the *key state* of the KMS key is ``Enabled``. When ``Enabled`` is ``false``, the key state of the KMS key is ``Disabled``. The default value is ``true``. The actual key state of the KMS key might be affected by actions taken outside of CloudFormation, such as running the [EnableKey](https://docs.aws.amazon.com/kms/latest/APIReference/API_EnableKey.html), [DisableKey](https://docs.aws.amazon.com/kms/latest/APIReference/API_DisableKey.html), or [ScheduleKeyDeletion](https://docs.aws.amazon.com/kms/latest/APIReference/API_ScheduleKeyDeletion.html) operations. For information about the key states of a KMS key, see [Key state: Effect on your KMS key](https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html) in the *Developer Guide*.")
+                .with_provider_name("Enabled"),
+        )
+        .attribute(
+            AttributeSchema::new("key_id", AttributeType::string())
+                .read_only()
+                .with_description(" (read-only)")
+                .with_provider_name("KeyId"),
+        )
+        .attribute(
+            AttributeSchema::new("key_policy", super::iam_policy_document())
+                .with_description("The key policy to attach to the KMS key. If you provide a key policy, it must meet the following criteria: + The key policy must allow the caller to make a subsequent [PutKeyPolicy](https://docs.aws.amazon.com/kms/latest/APIReference/API_PutKeyPolicy.html) request on the KMS key. This reduces the risk that the KMS key becomes unmanageable. For more information, see [Default key policy](https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam) in the *Developer Guide*. (To omit this condition, set ``BypassPolicyLockoutSafetyCheck`` to true.) + Each statement in the key policy must contain one or more principals. The principals in the key policy must exist and be visible to KMS. When you create a new AWS principal (for example, an IAM user or role), you might need to enforce a delay before including the new principal in a key policy because the new principal might not be immediately visible to KMS. For more information, see [Changes that I make are not always immediately visible](https://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_general.html#troubleshoot_general_eventual-consistency) in the *User Guide*. If you do not provide a key policy, KMS attaches a default key policy to the KMS key. For more information, see [Default key policy](https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default) in the *Developer Guide*. A key policy document can include only the following characters: + Printable ASCII characters + Printable characters in the Basic Latin and Latin-1 Supplement character set + The tab (``\\u0009``), line feed (``\\u000A``), and carriage return (``\\u000D``) special characters *Minimum*: ``1`` *Maximum*: ``32768``")
+                .with_provider_name("KeyPolicy"),
+        )
+        .attribute(
+            AttributeSchema::new("key_spec", AttributeType::string_enum("KeySpec".to_string(), vec!["SYMMETRIC_DEFAULT".to_string(), "RSA_2048".to_string(), "RSA_3072".to_string(), "RSA_4096".to_string(), "ECC_NIST_P256".to_string(), "ECC_NIST_P384".to_string(), "ECC_NIST_P521".to_string(), "ECC_SECG_P256K1".to_string(), "HMAC_224".to_string(), "HMAC_256".to_string(), "HMAC_384".to_string(), "HMAC_512".to_string(), "SM2".to_string(), "ML_DSA_44".to_string(), "ML_DSA_65".to_string(), "ML_DSA_87".to_string(), "ECC_NIST_EDWARDS25519".to_string()], Some(carina_core::schema::string_enum_identity("KeySpec", Some("awscc.kms.Key"))), vec![("SYMMETRIC_DEFAULT".to_string(), "symmetric_default".to_string()), ("RSA_2048".to_string(), "rsa_2048".to_string()), ("RSA_3072".to_string(), "rsa_3072".to_string()), ("RSA_4096".to_string(), "rsa_4096".to_string()), ("ECC_NIST_P256".to_string(), "ecc_nist_p256".to_string()), ("ECC_NIST_P384".to_string(), "ecc_nist_p384".to_string()), ("ECC_NIST_P521".to_string(), "ecc_nist_p521".to_string()), ("ECC_SECG_P256K1".to_string(), "ecc_secg_p256k1".to_string()), ("HMAC_224".to_string(), "hmac_224".to_string()), ("HMAC_256".to_string(), "hmac_256".to_string()), ("HMAC_384".to_string(), "hmac_384".to_string()), ("HMAC_512".to_string(), "hmac_512".to_string()), ("SM2".to_string(), "sm2".to_string()), ("ML_DSA_44".to_string(), "ml_dsa_44".to_string()), ("ML_DSA_65".to_string(), "ml_dsa_65".to_string()), ("ML_DSA_87".to_string(), "ml_dsa_87".to_string()), ("ECC_NIST_EDWARDS25519".to_string(), "ecc_nist_edwards25519".to_string())]))
+                .with_description("Specifies the type of KMS key to create. The default value, ``SYMMETRIC_DEFAULT``, creates a KMS key with a 256-bit symmetric key for encryption and decryption. In China Regions, ``SYMMETRIC_DEFAULT`` creates a 128-bit symmetric key that uses SM4 encryption. You can't change the ``KeySpec`` value after the KMS key is created. For help choosing a key spec for your KMS key, see [Choosing a KMS key type](https://docs.aws.amazon.com/kms/latest/developerguide/symm-asymm-choose.html) in the *Developer Guide*. The ``KeySpec`` property determines the type of key material in the KMS key and the algorithms that the KMS key supports. To further restrict the algorithms that can be used with the KMS key, use a condition key in its key policy or IAM policy. For more information, see [condition keys](https://docs.aws.amazon.com/kms/latest/developerguide/policy-conditions.html#conditions-kms) in the *Developer Guide*. If you change the value of the ``KeySpec`` property on an existing KMS key, the update request fails, regardless of the value of the [UpdateReplacePolicy attribute](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html). This prevents you from accidentally deleting a KMS key by changing an immutable property value. [services that are integrated with](https://docs.aws.amazon.com/kms/features/#AWS_Service_Integration) use symmetric encryption KMS keys to protect your data. These services do not support encryption with asymmetric KMS keys. For help determining whether a KMS key is asymmetric, see [Identifying asymmetric KMS keys](https://docs.aws.amazon.com/kms/latest/developerguide/find-symm-asymm.html) in the *Developer Guide*. KMS supports the following key specs for KMS keys: + Symmetric encryption key (default) + ``SYMMETRIC_DEFAULT`` (AES-256-GCM) + HMAC keys (symmetric) + ``HMAC_224`` + ``HMAC_256`` + ``HMAC_384`` + ``HMAC_512`` + Asymmetric RSA key pairs (encryption and decryption *or* signing and verification) + ``RSA_2048`` + ``RSA_3072`` + ``RSA_4096`` + Asymmetric NIST-recommended elliptic curve key pairs (signing and verification *or* deriving shared secrets) + ``ECC_NIST_P256`` (secp256r1) + ``ECC_NIST_P384`` (secp384r1) + ``ECC_NIST_P521`` (secp521r1) + ``ECC_NIST_EDWARDS25519`` (ed25519) - signing and verification only + *Note:* For ECC_NIST_EDWARDS25519 KMS keys, the ED25519_SHA_512 signing algorithm requires [MessageType:RAW](https://docs.aws.amazon.com/kms/latest/APIReference/API_Sign.html#KMS-Sign-request-MessageType), while ED25519_PH_SHA_512 requires [MessageType:DIGEST](https://docs.aws.amazon.com/kms/latest/APIReference/API_Sign.html#KMS-Sign-request-MessageType). These message types cannot be used interchangeably. + Other asymmetric elliptic curve key pairs (signing and verification) + ``ECC_SECG_P256K1`` (secp256k1), commonly used for cryptocurrencies. + Asymmetric ML-DSA key pairs (signing and verification) + ``ML_DSA_44`` + ``ML_DSA_65`` + ``ML_DSA_87`` + SM2 key pairs (encryption and decryption *or* signing and verification *or* deriving shared secrets) + ``SM2`` (China Regions only)")
+                .with_provider_name("KeySpec")
+                .with_default(Value::Concrete(ConcreteValue::String("SYMMETRIC_DEFAULT".to_string()))),
+        )
+        .attribute(
+            AttributeSchema::new("key_usage", AttributeType::string_enum("KeyUsage".to_string(), vec!["ENCRYPT_DECRYPT".to_string(), "SIGN_VERIFY".to_string(), "GENERATE_VERIFY_MAC".to_string(), "KEY_AGREEMENT".to_string()], Some(carina_core::schema::string_enum_identity("KeyUsage", Some("awscc.kms.Key"))), vec![("ENCRYPT_DECRYPT".to_string(), "encrypt_decrypt".to_string()), ("SIGN_VERIFY".to_string(), "sign_verify".to_string()), ("GENERATE_VERIFY_MAC".to_string(), "generate_verify_mac".to_string()), ("KEY_AGREEMENT".to_string(), "key_agreement".to_string())]))
+                .with_description("Determines the [cryptographic operations](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations) for which you can use the KMS key. The default value is ``ENCRYPT_DECRYPT``. This property is required for asymmetric KMS keys and HMAC KMS keys. You can't change the ``KeyUsage`` value after the KMS key is created. If you change the value of the ``KeyUsage`` property on an existing KMS key, the update request fails, regardless of the value of the [UpdateReplacePolicy attribute](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html). This prevents you from accidentally deleting a KMS key by changing an immutable property value. Select only one valid value. + For symmetric encryption KMS keys, omit the parameter or specify ``ENCRYPT_DECRYPT``. + For HMAC KMS keys (symmetric), specify ``GENERATE_VERIFY_MAC``. + For asymmetric KMS keys with RSA key pairs, specify ``ENCRYPT_DECRYPT`` or ``SIGN_VERIFY``. + For asymmetric KMS keys with NIST-recommended elliptic curve key pairs, specify ``SIGN_VERIFY`` or ``KEY_AGREEMENT``. + For asymmetric KMS keys with ``ECC_SECG_P256K1`` key pairs, specify ``SIGN_VERIFY``. + For asymmetric KMS keys with ML-DSA key pairs, specify ``SIGN_VERIFY``. + For asymmetric KMS keys with SM2 key pairs (China Regions only), specify ``ENCRYPT_DECRYPT``, ``SIGN_VERIFY``, or ``KEY_AGREEMENT``.")
+                .with_provider_name("KeyUsage")
+                .with_default(Value::Concrete(ConcreteValue::String("ENCRYPT_DECRYPT".to_string()))),
+        )
+        .attribute(
+            AttributeSchema::new("multi_region", AttributeType::bool())
+                .with_description("Creates a multi-Region primary key that you can replicate in other AWS-Regions. You can't change the ``MultiRegion`` value after the KMS key is created. For a list of AWS-Regions in which multi-Region keys are supported, see [Multi-Region keys in](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html) in the **. If you change the value of the ``MultiRegion`` property on an existing KMS key, the update request fails, regardless of the value of the [UpdateReplacePolicy attribute](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html). This prevents you from accidentally deleting a KMS key by changing an immutable property value. For a multi-Region key, set to this property to ``true``. For a single-Region key, omit this property or set it to ``false``. The default value is ``false``. *Multi-Region keys* are an KMS feature that lets you create multiple interoperable KMS keys in different AWS-Regions. Because these KMS keys have the same key ID, key material, and other metadata, you can use them to encrypt data in one AWS-Region and decrypt it in a different AWS-Region without making a cross-Region call or exposing the plaintext data. For more information, see [Multi-Region keys](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html) in the *Developer Guide*. You can create a symmetric encryption, HMAC, or asymmetric multi-Region KMS key, and you can create a multi-Region key with imported key material. However, you cannot create a multi-Region key in a custom key store. To create a replica of this primary key in a different AWS-Region , create an [AWS::KMS::ReplicaKey](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kms-replicakey.html) resource in a CloudFormation stack in the replica Region. Specify the key ARN of this primary key.")
+                .with_provider_name("MultiRegion")
+                .with_default(Value::Concrete(ConcreteValue::Bool(false))),
+        )
+        .attribute(
+            AttributeSchema::new("origin", AttributeType::string_enum("Origin".to_string(), vec!["AWS_KMS".to_string(), "EXTERNAL".to_string()], Some(carina_core::schema::string_enum_identity("Origin", Some("awscc.kms.Key"))), vec![("AWS_KMS".to_string(), "aws_kms".to_string()), ("EXTERNAL".to_string(), "external".to_string())]))
+                .with_description("The source of the key material for the KMS key. You cannot change the origin after you create the KMS key. The default is ``AWS_KMS``, which means that KMS creates the key material. To [create a KMS key with no key material](https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys-create-cmk.html) (for imported key material), set this value to ``EXTERNAL``. For more information about importing key material into KMS, see [Importing Key Material](https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html) in the *Developer Guide*. You can ignore ``ENABLED`` when Origin is ``EXTERNAL``. When a KMS key with Origin ``EXTERNAL`` is created, the key state is ``PENDING_IMPORT`` and ``ENABLED`` is ``false``. After you import the key material, ``ENABLED`` updated to ``true``. The KMS key can then be used for Cryptographic Operations. + CFN doesn't support creating an ``Origin`` parameter of the ``AWS_CLOUDHSM`` or ``EXTERNAL_KEY_STORE`` values. + ``EXTERNAL`` is not supported for ML-DSA keys.")
+                .with_provider_name("Origin")
+                .with_default(Value::Concrete(ConcreteValue::String("AWS_KMS".to_string()))),
+        )
+        .attribute(
+            AttributeSchema::new("pending_window_in_days", AttributeType::custom(None, AttributeType::int(), None, None, legacy_validator(validate_pending_window_in_days_range), None))
+                .write_only()
+                .with_description("Specifies the number of days in the waiting period before KMS deletes a KMS key that has been removed from a CloudFormation stack. Enter a value between 7 and 30 days. The default value is 30 days. When you remove a KMS key from a CloudFormation stack, KMS schedules the KMS key for deletion and starts the mandatory waiting period. The ``PendingWindowInDays`` property determines the length of waiting period. During the waiting period, the key state of KMS key is ``Pending Deletion`` or ``Pending Replica Deletion``, which prevents the KMS key from being used in cryptographic operations. When the waiting period expires, KMS permanently deletes the KMS key. KMS will not delete a [multi-Region primary key](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html) that has replica keys. If you remove a multi-Region primary key from a CloudFormation stack, its key state changes to ``PendingReplicaDeletion`` so it cannot be replicated or used in cryptographic operations. This state can persist indefinitely. When the last of its replica keys is deleted, the key state of the primary key changes to ``PendingDeletion`` and the waiting period specified by ``PendingWindowInDays`` begins. When this waiting period expires, KMS deletes the primary key. For details, see [Deleting multi-Region keys](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-delete.html) in the *Developer Guide*. You cannot use a CloudFormation template to cancel deletion of the KMS key after you remove it from the stack, regardless of the waiting period. If you specify a KMS key in your template, even one with the same name, CloudFormation creates a new KMS key. To cancel deletion of a KMS key, use the KMS console or the [CancelKeyDeletion](https://docs.aws.amazon.com/kms/latest/APIReference/API_CancelKeyDeletion.html) operation. For information about the ``Pending Deletion`` and ``Pending Replica Deletion`` key states, see [Key state: Effect on your KMS key](https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html) in the *Developer Guide*. For more information about deleting KMS keys, see the [ScheduleKeyDeletion](https://docs.aws.amazon.com/kms/latest/APIReference/API_ScheduleKeyDeletion.html) operation in the *API Reference* and [Deleting KMS keys](https://docs.aws.amazon.com/kms/latest/developerguide/deleting-keys.html) in the *Developer Guide*.")
+                .with_provider_name("PendingWindowInDays"),
+        )
+        .attribute(
+            AttributeSchema::new("rotation_period_in_days", AttributeType::custom(None, AttributeType::int(), None, None, legacy_validator(validate_rotation_period_in_days_range), None))
+                .write_only()
+                .with_description("Specifies a custom period of time between each rotation date. If no value is specified, the default value is 365 days. The rotation period defines the number of days after you enable automatic key rotation that KMS will rotate your key material, and the number of days between each automatic rotation thereafter. You can use the [kms:RotationPeriodInDays](https://docs.aws.amazon.com/kms/latest/developerguide/conditions-kms.html#conditions-kms-rotation-period-in-days) condition key to further constrain the values that principals can specify in the ``RotationPeriodInDays`` parameter. For more information about rotating KMS keys and automatic rotation, see [Rotating keys](https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html) in the *Developer Guide*.")
+                .with_provider_name("RotationPeriodInDays")
+                .with_default(Value::Concrete(ConcreteValue::Int(365))),
+        )
+        .attribute(
+            AttributeSchema::new("tags", tags_type())
+                .with_description("Assigns one or more tags to the replica key. Tagging or untagging a KMS key can allow or deny permission to the KMS key. For details, see [ABAC for](https://docs.aws.amazon.com/kms/latest/developerguide/abac.html) in the *Developer Guide*. For information about tags in KMS, see [Tagging keys](https://docs.aws.amazon.com/kms/latest/developerguide/tagging-keys.html) in the *Developer Guide*. For information about tags in CloudFormation, see [Tag](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html).")
+                .with_provider_name("Tags")
+                .with_block_name("tag"),
+        )
+        .with_validator(|attrs| {
+            let mut errors = Vec::new();
+            if let Err(mut e) = validate_tags_map(attrs) {
+                errors.append(&mut e);
+            }
+            if errors.is_empty() { Ok(()) } else { Err(errors) }
+        })
+    }
+}
+
+/// Returns the resource type name and all enum valid values for this module
+pub fn enum_valid_values() -> (
+    &'static str,
+    &'static [(&'static str, &'static [&'static str])],
+) {
+    (
+        "kms.Key",
+        &[
+            ("key_spec", VALID_KEY_SPEC),
+            ("key_usage", VALID_KEY_USAGE),
+            ("origin", VALID_ORIGIN),
+        ],
+    )
+}

--- a/carina-provider-awscc/src/schemas/generated/kms/mod.rs
+++ b/carina-provider-awscc/src/schemas/generated/kms/mod.rs
@@ -1,0 +1,9 @@
+//! Auto-generated — DO NOT EDIT MANUALLY
+//!
+//! Regenerate with:
+//!   aws-vault exec <profile> -- ./carina-provider-awscc/scripts/generate-schemas.sh
+
+// Re-export parent types so resource modules can use `super::` to access them.
+pub use super::*;
+
+pub mod key;

--- a/carina-provider-awscc/src/schemas/generated/mod.rs
+++ b/carina-provider-awscc/src/schemas/generated/mod.rs
@@ -14,6 +14,7 @@ pub mod cloudfront;
 pub mod ec2;
 pub mod iam;
 pub mod identitystore;
+pub mod kms;
 pub mod logs;
 pub mod organizations;
 pub mod route53;
@@ -77,6 +78,7 @@ static ENUM_VALID_VALUES: LazyLock<
         cloudfront::distribution::enum_valid_values(),
         cloudfront::origin_access_control::enum_valid_values(),
         wafv2::web_acl::enum_valid_values(),
+        kms::key::enum_valid_values(),
     ];
     let mut map: HashMap<&str, HashMap<&str, &[&str]>> = HashMap::new();
     for (rt, attrs) in modules {
@@ -129,6 +131,7 @@ fn build_configs() -> Vec<AwsccSchemaConfig> {
         cloudfront::distribution::cloudfront_distribution_config(),
         cloudfront::origin_access_control::cloudfront_origin_access_control_config(),
         wafv2::web_acl::wafv2_web_acl_config(),
+        kms::key::kms_key_config(),
     ]
 }
 

--- a/carina-provider-awscc/tests/kms_key_cloudcontrol_roundtrip.rs
+++ b/carina-provider-awscc/tests/kms_key_cloudcontrol_roundtrip.rs
@@ -1,0 +1,148 @@
+//! Integration coverage for the awscc provider's real Provider-trait apply path
+//! against an in-process winterbaume CloudControl mock.
+//!
+//! This test proves that create -> read wiring round-trips the provider's
+//! serialization and conversion with no network. In particular, `key_policy`
+//! survives as a structured policy document, which is PR #313's core
+//! `key_policy` = `iam_policy_document` design.
+//!
+//! This test deliberately does not assert write-only stripping, read-only
+//! synthesis, or schema-default fill-in. Those are real AWS CloudControl
+//! behaviours driven by the CloudFormation resource-type schema; the generic
+//! winterbaume mock returns the desired state verbatim and does not reproduce
+//! them because it does not consult CFN schemas. That winterbaume behavior is
+//! tracked upstream as moriyoshi/winterbaume issue #6. The AWS behaviours were
+//! verified separately against live AWS, not here.
+
+use aws_config::{BehaviorVersion, Region};
+use carina_core::provider::{CreateRequest, Provider, ReadRequest};
+use carina_core::resource::{ConcreteValue, Resource, Value};
+use carina_provider_awscc::AwsccProvider;
+use carina_provider_awscc::provider::AwsccProviderConfig;
+use indexmap::IndexMap;
+use winterbaume_cloudcontrol::CloudControlService;
+use winterbaume_core::MockAws;
+
+fn string(value: &str) -> Value {
+    Value::Concrete(ConcreteValue::String(value.to_string()))
+}
+
+fn int(value: i64) -> Value {
+    Value::Concrete(ConcreteValue::Int(value))
+}
+
+fn bool_(value: bool) -> Value {
+    Value::Concrete(ConcreteValue::Bool(value))
+}
+
+fn map(entries: impl IntoIterator<Item = (&'static str, Value)>) -> Value {
+    Value::Concrete(ConcreteValue::Map(
+        entries
+            .into_iter()
+            .map(|(key, value)| (key.to_string(), value))
+            .collect::<IndexMap<_, _>>(),
+    ))
+}
+
+fn list(items: impl IntoIterator<Item = Value>) -> Value {
+    Value::Concrete(ConcreteValue::List(items.into_iter().collect()))
+}
+
+fn key_policy() -> Value {
+    map([
+        ("version", string("2012-10-17")),
+        (
+            "statement",
+            list([map([
+                ("sid", string("AllowRootAccountAccess")),
+                ("effect", string("Allow")),
+                (
+                    "principal",
+                    map([("aws", string("arn:aws:iam::111122223333:root"))]),
+                ),
+                ("action", string("kms:*")),
+                ("resource", string("*")),
+            ])]),
+        ),
+    ])
+}
+
+fn kms_key_resource() -> Resource {
+    Resource::with_provider("awscc", "kms.Key", "signing_key", None)
+        .with_attribute("description", string("Winterbaume signing key"))
+        .with_attribute("key_policy", key_policy())
+        .with_attribute("key_usage", string("SIGN_VERIFY"))
+        .with_attribute("key_spec", string("ECC_NIST_P256"))
+        .with_attribute("enable_key_rotation", bool_(false))
+        .with_attribute("pending_window_in_days", int(7))
+        .with_attribute("tags", map([("Environment", string("test"))]))
+}
+
+async fn winterbaume_provider() -> AwsccProvider {
+    let mock = MockAws::builder()
+        .with_service(CloudControlService::new())
+        .build();
+    let config = aws_config::defaults(BehaviorVersion::latest())
+        .http_client(mock.http_client())
+        .credentials_provider(mock.credentials_provider())
+        .region(Region::new("us-east-1"))
+        .load()
+        .await;
+
+    AwsccProvider::from_sdk_config(config, &AwsccProviderConfig::default()).await
+}
+
+#[tokio::test]
+async fn kms_key_create_then_read_round_trips_structured_key_policy() {
+    let provider = winterbaume_provider().await;
+    let resource = kms_key_resource();
+    let id = resource.id.clone();
+    let desired_policy = resource
+        .attributes
+        .get("key_policy")
+        .expect("test resource has key_policy")
+        .clone();
+
+    let created = Provider::create(&provider, &id, CreateRequest { resource })
+        .await
+        .expect("kms.Key create through Provider::create should succeed");
+    let identifier = created
+        .identifier
+        .as_deref()
+        .expect("CloudControl create must return a stable identifier");
+
+    let read = Provider::read(&provider, &id, Some(identifier), ReadRequest)
+        .await
+        .expect("kms.Key read through Provider::read should succeed");
+
+    assert!(read.exists, "read-back state must exist");
+    assert_eq!(read.identifier.as_deref(), Some(identifier));
+    assert_eq!(
+        read.attributes.get("description"),
+        Some(&string("Winterbaume signing key"))
+    );
+    assert_eq!(
+        read.attributes.get("key_usage"),
+        Some(&string("SIGN_VERIFY"))
+    );
+    assert_eq!(
+        read.attributes.get("key_spec"),
+        Some(&string("ECC_NIST_P256"))
+    );
+    assert_eq!(
+        read.attributes.get("enable_key_rotation"),
+        Some(&bool_(false))
+    );
+    assert_eq!(read.attributes.get("key_policy"), Some(&desired_policy));
+    assert!(
+        matches!(
+            read.attributes.get("key_policy"),
+            Some(Value::Concrete(ConcreteValue::Map(_)))
+        ),
+        "key_policy must remain a structured policy document"
+    );
+    assert_eq!(
+        read.attributes.get("tags"),
+        Some(&map([("Environment", string("test"))]))
+    );
+}

--- a/cfn-schema-cache/AWS__KMS__Key.json
+++ b/cfn-schema-cache/AWS__KMS__Key.json
@@ -1,0 +1,136 @@
+{
+  "typeName" : "AWS::KMS::Key",
+  "description" : "The ``AWS::KMS::Key`` resource specifies an [KMS key](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#kms_keys) in KMSlong. You can use this resource to create symmetric encryption KMS keys, asymmetric KMS keys for encryption or signing, and symmetric HMAC KMS keys. You can use ``AWS::KMS::Key`` to create [multi-Region primary keys](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html#mrk-primary-key) of all supported types. To replicate a multi-Region key, use the ``AWS::KMS::ReplicaKey`` resource.\n  If you change the value of the ``KeySpec``, ``KeyUsage``, ``Origin``, or ``MultiRegion`` properties of an existing KMS key, the update request fails, regardless of the value of the [UpdateReplacePolicy attribute](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html). This prevents you from accidentally deleting a KMS key by changing any of its immutable property values.\n   KMS replaced the term *customer master key (CMK)* with ** and *KMS key*. The concept has not changed. To prevent breaking changes, KMS is keeping some variations of this term.\n  You can use symmetric encryption KMS keys to encrypt and decrypt small amounts of data, but they are more commonly used to generate data keys and data key pairs. You can also use a symmetric encryption KMS key to encrypt data stored in AWS services that are [integrated with](https://docs.aws.amazon.com//kms/features/#AWS_Service_Integration). For more information, see [Symmetric encryption KMS keys](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#symmetric-cmks) in the *Developer Guide*.\n You can use asymmetric KMS keys to encrypt and decrypt data or sign messages and verify signatures. To create an asymmetric key, you must specify an asymmetric ``KeySpec`` value and a ``KeyUsage`` value. For details, see [Asymmetric keys in](https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html) in the *Developer Guide*.\n You can use HMAC KMS keys (which are also symmetric keys) to generate and verify hash-based message authentication codes. To create an HMAC key, you must specify an HMAC ``KeySpec`` value and a ``KeyUsage`` value of ``GENERATE_VERIFY_MAC``. For details, see [HMAC keys in](https://docs.aws.amazon.com/kms/latest/developerguide/hmac.html) in the *Developer Guide*.\n You can also create symmetric encryption, asymmetric, and HMAC multi-Region primary keys. To create a multi-Region primary key, set the ``MultiRegion`` property to ``true``. For information about multi-Region keys, see [Multi-Region keys in](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html) in the *Developer Guide*.\n You cannot use the ``AWS::KMS::Key`` resource to specify a KMS key with [imported key material](https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html) or a KMS key in a [custom key store](https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html).\n  *Regions* \n KMS CloudFormation resources are available in all Regions in which KMS and CFN are supported. You can use the ``AWS::KMS::Key`` resource to create and manage all KMS key types that are supported in a Region.",
+  "sourceUrl" : "https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-kms",
+  "definitions" : {
+    "Tag" : {
+      "description" : "A key-value pair. A tag consists of a tag key and a tag value. Tag keys and tag values are both required, but tag values can be empty (null) strings.\n  Do not include confidential or sensitive information in this field. This field may be displayed in plaintext in CloudTrail logs and other output.\n  For information about the rules that apply to tag keys and tag values, see [User-Defined Tag Restrictions](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/allocation-tag-restrictions.html) in the *Billing and Cost Management User Guide*.",
+      "type" : "object",
+      "properties" : {
+        "Key" : {
+          "type" : "string",
+          "description" : "The key name of the tag. You can specify a value that's 1 to 128 Unicode characters in length and can't be prefixed with ``aws:``. digits, whitespace, ``_``, ``.``, ``:``, ``/``, ``=``, ``+``, ``@``, ``-``, and ``\"``.\n For more information, see [Tag](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html).",
+          "minLength" : 1,
+          "maxLength" : 128
+        },
+        "Value" : {
+          "type" : "string",
+          "description" : "The value for the tag. You can specify a value that's 1 to 256 characters in length. You can use any of the following characters: the set of Unicode letters, digits, whitespace, ``_``, ``.``, ``/``, ``=``, ``+``, and ``-``.\n For more information, see [Tag](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html).",
+          "minLength" : 0,
+          "maxLength" : 256
+        }
+      },
+      "additionalProperties" : false,
+      "required" : [ "Key", "Value" ]
+    }
+  },
+  "properties" : {
+    "Description" : {
+      "description" : "A description of the KMS key. Use a description that helps you to distinguish this KMS key from others in the account, such as its intended use.",
+      "type" : "string",
+      "minLength" : 0,
+      "maxLength" : 8192
+    },
+    "Enabled" : {
+      "description" : "Specifies whether the KMS key is enabled. Disabled KMS keys cannot be used in cryptographic operations.\n When ``Enabled`` is ``true``, the *key state* of the KMS key is ``Enabled``. When ``Enabled`` is ``false``, the key state of the KMS key is ``Disabled``. The default value is ``true``.\n The actual key state of the KMS key might be affected by actions taken outside of CloudFormation, such as running the [EnableKey](https://docs.aws.amazon.com/kms/latest/APIReference/API_EnableKey.html), [DisableKey](https://docs.aws.amazon.com/kms/latest/APIReference/API_DisableKey.html), or [ScheduleKeyDeletion](https://docs.aws.amazon.com/kms/latest/APIReference/API_ScheduleKeyDeletion.html) operations.\n For information about the key states of a KMS key, see [Key state: Effect on your KMS key](https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html) in the *Developer Guide*.",
+      "type" : "boolean"
+    },
+    "EnableKeyRotation" : {
+      "description" : "Enables automatic rotation of the key material for the specified KMS key. By default, automatic key rotation is not enabled.\n KMS supports automatic rotation only for symmetric encryption KMS keys (``KeySpec`` = ``SYMMETRIC_DEFAULT``). For asymmetric KMS keys, HMAC KMS keys, and KMS keys with Origin ``EXTERNAL``, omit the ``EnableKeyRotation`` property or set it to ``false``.\n To enable automatic key rotation of the key material for a multi-Region KMS key, set ``EnableKeyRotation`` to ``true`` on the primary key (created by using ``AWS::KMS::Key``). KMS copies the rotation status to all replica keys. For details, see [Rotating multi-Region keys](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-manage.html#multi-region-rotate) in the *Developer Guide*.\n When you enable automatic rotation, KMS automatically creates new key material for the KMS key one year after the enable date and every year thereafter. KMS retains all key material until you delete the KMS key. For detailed information about automatic key rotation, see [Rotating KMS keys](https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html) in the *Developer Guide*.",
+      "type" : "boolean"
+    },
+    "KeyPolicy" : {
+      "description" : "The key policy to attach to the KMS key.\n If you provide a key policy, it must meet the following criteria:\n  +  The key policy must allow the caller to make a subsequent [PutKeyPolicy](https://docs.aws.amazon.com/kms/latest/APIReference/API_PutKeyPolicy.html) request on the KMS key. This reduces the risk that the KMS key becomes unmanageable. For more information, see [Default key policy](https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam) in the *Developer Guide*. (To omit this condition, set ``BypassPolicyLockoutSafetyCheck`` to true.)\n  +  Each statement in the key policy must contain one or more principals. The principals in the key policy must exist and be visible to KMS. When you create a new AWS principal (for example, an IAM user or role), you might need to enforce a delay before including the new principal in a key policy because the new principal might not be immediately visible to KMS. For more information, see [Changes that I make are not always immediately visible](https://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_general.html#troubleshoot_general_eventual-consistency) in the *User Guide*.\n  \n If you do not provide a key policy, KMS attaches a default key policy to the KMS key. For more information, see [Default key policy](https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default) in the *Developer Guide*.\n A key policy document can include only the following characters:\n  +  Printable ASCII characters\n  +  Printable characters in the Basic Latin and Latin-1 Supplement character set\n  +  The tab (``\\u0009``), line feed (``\\u000A``), and carriage return (``\\u000D``) special characters\n  \n *Minimum*: ``1``\n *Maximum*: ``32768``",
+      "type" : [ "object", "string" ],
+      "default" : "{\n    \"Version\": \"2012-10-17\",\n    \"Id\": \"key-default\",\n    \"Statement\": [\n        {\n            \"Sid\": \"Enable IAM User Permissions\",\n            \"Effect\": \"Allow\",\n            \"Principal\": {\n                \"AWS\": \"arn:<partition>:iam::<account-id>:root\"\n            },\n            \"Action\": \"kms:*\",\n            \"Resource\": \"*\"\n        }\n    ]\n}"
+    },
+    "KeyUsage" : {
+      "description" : "Determines the [cryptographic operations](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations) for which you can use the KMS key. The default value is ``ENCRYPT_DECRYPT``. This property is required for asymmetric KMS keys and HMAC KMS keys. You can't change the ``KeyUsage`` value after the KMS key is created.\n  If you change the value of the ``KeyUsage`` property on an existing KMS key, the update request fails, regardless of the value of the [UpdateReplacePolicy attribute](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html). This prevents you from accidentally deleting a KMS key by changing an immutable property value.\n  Select only one valid value.\n  +  For symmetric encryption KMS keys, omit the parameter or specify ``ENCRYPT_DECRYPT``.\n  +  For HMAC KMS keys (symmetric), specify ``GENERATE_VERIFY_MAC``.\n  +  For asymmetric KMS keys with RSA key pairs, specify ``ENCRYPT_DECRYPT`` or ``SIGN_VERIFY``.\n  +  For asymmetric KMS keys with NIST-recommended elliptic curve key pairs, specify ``SIGN_VERIFY`` or ``KEY_AGREEMENT``.\n  +  For asymmetric KMS keys with ``ECC_SECG_P256K1`` key pairs, specify ``SIGN_VERIFY``.\n  +  For asymmetric KMS keys with ML-DSA key pairs, specify ``SIGN_VERIFY``.\n  +  For asymmetric KMS keys with SM2 key pairs (China Regions only), specify ``ENCRYPT_DECRYPT``, ``SIGN_VERIFY``, or ``KEY_AGREEMENT``.",
+      "type" : "string",
+      "default" : "ENCRYPT_DECRYPT",
+      "enum" : [ "ENCRYPT_DECRYPT", "SIGN_VERIFY", "GENERATE_VERIFY_MAC", "KEY_AGREEMENT" ]
+    },
+    "Origin" : {
+      "description" : "The source of the key material for the KMS key. You cannot change the origin after you create the KMS key. The default is ``AWS_KMS``, which means that KMS creates the key material.\n To [create a KMS key with no key material](https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys-create-cmk.html) (for imported key material), set this value to ``EXTERNAL``. For more information about importing key material into KMS, see [Importing Key Material](https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html) in the *Developer Guide*.\n You can ignore ``ENABLED`` when Origin is ``EXTERNAL``. When a KMS key with Origin ``EXTERNAL`` is created, the key state is ``PENDING_IMPORT`` and ``ENABLED`` is ``false``. After you import the key material, ``ENABLED`` updated to ``true``. The KMS key can then be used for Cryptographic Operations. \n   +  CFN doesn't support creating an ``Origin`` parameter of the ``AWS_CLOUDHSM`` or ``EXTERNAL_KEY_STORE`` values.\n  +  ``EXTERNAL`` is not supported for ML-DSA keys.",
+      "type" : "string",
+      "default" : "AWS_KMS",
+      "enum" : [ "AWS_KMS", "EXTERNAL" ]
+    },
+    "KeySpec" : {
+      "description" : "Specifies the type of KMS key to create. The default value, ``SYMMETRIC_DEFAULT``, creates a KMS key with a 256-bit symmetric key for encryption and decryption. In China Regions, ``SYMMETRIC_DEFAULT`` creates a 128-bit symmetric key that uses SM4 encryption. You can't change the ``KeySpec`` value after the KMS key is created. For help choosing a key spec for your KMS key, see [Choosing a KMS key type](https://docs.aws.amazon.com/kms/latest/developerguide/symm-asymm-choose.html) in the *Developer Guide*.\n The ``KeySpec`` property determines the type of key material in the KMS key and the algorithms that the KMS key supports. To further restrict the algorithms that can be used with the KMS key, use a condition key in its key policy or IAM policy. For more information, see [condition keys](https://docs.aws.amazon.com/kms/latest/developerguide/policy-conditions.html#conditions-kms) in the *Developer Guide*.\n  If you change the value of the ``KeySpec`` property on an existing KMS key, the update request fails, regardless of the value of the [UpdateReplacePolicy attribute](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html). This prevents you from accidentally deleting a KMS key by changing an immutable property value.\n   [services that are integrated with](https://docs.aws.amazon.com/kms/features/#AWS_Service_Integration) use symmetric encryption KMS keys to protect your data. These services do not support encryption with asymmetric KMS keys. For help determining whether a KMS key is asymmetric, see [Identifying asymmetric KMS keys](https://docs.aws.amazon.com/kms/latest/developerguide/find-symm-asymm.html) in the *Developer Guide*.\n  KMS supports the following key specs for KMS keys:\n  +  Symmetric encryption key (default)\n  +  ``SYMMETRIC_DEFAULT`` (AES-256-GCM)\n  \n  +  HMAC keys (symmetric)\n  +   ``HMAC_224`` \n  +   ``HMAC_256`` \n  +   ``HMAC_384`` \n  +   ``HMAC_512`` \n  \n  +  Asymmetric RSA key pairs (encryption and decryption *or* signing and verification)\n  +   ``RSA_2048`` \n  +   ``RSA_3072`` \n  +   ``RSA_4096`` \n  \n  +  Asymmetric NIST-recommended elliptic curve key pairs (signing and verification *or* deriving shared secrets)\n  +  ``ECC_NIST_P256`` (secp256r1)\n  +  ``ECC_NIST_P384`` (secp384r1)\n  +  ``ECC_NIST_P521`` (secp521r1)\n  +  ``ECC_NIST_EDWARDS25519`` (ed25519) - signing and verification only\n  +  *Note:* For ECC_NIST_EDWARDS25519 KMS keys, the ED25519_SHA_512 signing algorithm requires [MessageType:RAW](https://docs.aws.amazon.com/kms/latest/APIReference/API_Sign.html#KMS-Sign-request-MessageType), while ED25519_PH_SHA_512 requires [MessageType:DIGEST](https://docs.aws.amazon.com/kms/latest/APIReference/API_Sign.html#KMS-Sign-request-MessageType). These message types cannot be used interchangeably.\n  \n  \n  +  Other asymmetric elliptic curve key pairs (signing and verification)\n  +  ``ECC_SECG_P256K1`` (secp256k1), commonly used for cryptocurrencies.\n  \n  +  Asymmetric ML-DSA key pairs (signing and verification)\n  +   ``ML_DSA_44`` \n  +   ``ML_DSA_65`` \n  +   ``ML_DSA_87`` \n  \n  +  SM2 key pairs (encryption and decryption *or* signing and verification *or* deriving shared secrets)\n  +  ``SM2`` (China Regions only)",
+      "type" : "string",
+      "default" : "SYMMETRIC_DEFAULT",
+      "enum" : [ "SYMMETRIC_DEFAULT", "RSA_2048", "RSA_3072", "RSA_4096", "ECC_NIST_P256", "ECC_NIST_P384", "ECC_NIST_P521", "ECC_SECG_P256K1", "HMAC_224", "HMAC_256", "HMAC_384", "HMAC_512", "SM2", "ML_DSA_44", "ML_DSA_65", "ML_DSA_87", "ECC_NIST_EDWARDS25519" ]
+    },
+    "MultiRegion" : {
+      "description" : "Creates a multi-Region primary key that you can replicate in other AWS-Regions. You can't change the ``MultiRegion`` value after the KMS key is created.\n For a list of AWS-Regions in which multi-Region keys are supported, see [Multi-Region keys in](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html) in the **.\n  If you change the value of the ``MultiRegion`` property on an existing KMS key, the update request fails, regardless of the value of the [UpdateReplacePolicy attribute](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html). This prevents you from accidentally deleting a KMS key by changing an immutable property value.\n  For a multi-Region key, set to this property to ``true``. For a single-Region key, omit this property or set it to ``false``. The default value is ``false``.\n *Multi-Region keys* are an KMS feature that lets you create multiple interoperable KMS keys in different AWS-Regions. Because these KMS keys have the same key ID, key material, and other metadata, you can use them to encrypt data in one AWS-Region and decrypt it in a different AWS-Region without making a cross-Region call or exposing the plaintext data. For more information, see [Multi-Region keys](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html) in the *Developer Guide*.\n You can create a symmetric encryption, HMAC, or asymmetric multi-Region KMS key, and you can create a multi-Region key with imported key material. However, you cannot create a multi-Region key in a custom key store.\n To create a replica of this primary key in a different AWS-Region , create an [AWS::KMS::ReplicaKey](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kms-replicakey.html) resource in a CloudFormation stack in the replica Region. Specify the key ARN of this primary key.",
+      "type" : "boolean",
+      "default" : false
+    },
+    "PendingWindowInDays" : {
+      "description" : "Specifies the number of days in the waiting period before KMS deletes a KMS key that has been removed from a CloudFormation stack. Enter a value between 7 and 30 days. The default value is 30 days.\n When you remove a KMS key from a CloudFormation stack, KMS schedules the KMS key for deletion and starts the mandatory waiting period. The ``PendingWindowInDays`` property determines the length of waiting period. During the waiting period, the key state of KMS key is ``Pending Deletion`` or ``Pending Replica Deletion``, which prevents the KMS key from being used in cryptographic operations. When the waiting period expires, KMS permanently deletes the KMS key.\n KMS will not delete a [multi-Region primary key](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html) that has replica keys. If you remove a multi-Region primary key from a CloudFormation stack, its key state changes to ``PendingReplicaDeletion`` so it cannot be replicated or used in cryptographic operations. This state can persist indefinitely. When the last of its replica keys is deleted, the key state of the primary key changes to ``PendingDeletion`` and the waiting period specified by ``PendingWindowInDays`` begins. When this waiting period expires, KMS deletes the primary key. For details, see [Deleting multi-Region keys](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-delete.html) in the *Developer Guide*.\n You cannot use a CloudFormation template to cancel deletion of the KMS key after you remove it from the stack, regardless of the waiting period. If you specify a KMS key in your template, even one with the same name, CloudFormation creates a new KMS key. To cancel deletion of a KMS key, use the KMS console or the [CancelKeyDeletion](https://docs.aws.amazon.com/kms/latest/APIReference/API_CancelKeyDeletion.html) operation.\n For information about the ``Pending Deletion`` and ``Pending Replica Deletion`` key states, see [Key state: Effect on your KMS key](https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html) in the *Developer Guide*. For more information about deleting KMS keys, see the [ScheduleKeyDeletion](https://docs.aws.amazon.com/kms/latest/APIReference/API_ScheduleKeyDeletion.html) operation in the *API Reference* and [Deleting KMS keys](https://docs.aws.amazon.com/kms/latest/developerguide/deleting-keys.html) in the *Developer Guide*.",
+      "type" : "integer",
+      "minimum" : 7,
+      "maximum" : 30
+    },
+    "Tags" : {
+      "description" : "Assigns one or more tags to the replica key.\n  Tagging or untagging a KMS key can allow or deny permission to the KMS key. For details, see [ABAC for](https://docs.aws.amazon.com/kms/latest/developerguide/abac.html) in the *Developer Guide*.\n  For information about tags in KMS, see [Tagging keys](https://docs.aws.amazon.com/kms/latest/developerguide/tagging-keys.html) in the *Developer Guide*. For information about tags in CloudFormation, see [Tag](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html).",
+      "type" : "array",
+      "uniqueItems" : true,
+      "insertionOrder" : false,
+      "items" : {
+        "$ref" : "#/definitions/Tag"
+      }
+    },
+    "Arn" : {
+      "type" : "string",
+      "description" : ""
+    },
+    "KeyId" : {
+      "type" : "string",
+      "description" : ""
+    },
+    "BypassPolicyLockoutSafetyCheck" : {
+      "description" : "Skips (\"bypasses\") the key policy lockout safety check. The default value is false.\n  Setting this value to true increases the risk that the KMS key becomes unmanageable. Do not set this value to true indiscriminately.\n For more information, see [Default key policy](https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html#prevent-unmanageable-key) in the *Developer Guide*.\n  Use this parameter only when you intend to prevent the principal that is making the request from making a subsequent [PutKeyPolicy](https://docs.aws.amazon.com/kms/latest/APIReference/API_PutKeyPolicy.html) request on the KMS key.",
+      "type" : "boolean",
+      "default" : false
+    },
+    "RotationPeriodInDays" : {
+      "description" : "Specifies a custom period of time between each rotation date. If no value is specified, the default value is 365 days.\n The rotation period defines the number of days after you enable automatic key rotation that KMS will rotate your key material, and the number of days between each automatic rotation thereafter.\n You can use the [kms:RotationPeriodInDays](https://docs.aws.amazon.com/kms/latest/developerguide/conditions-kms.html#conditions-kms-rotation-period-in-days) condition key to further constrain the values that principals can specify in the ``RotationPeriodInDays`` parameter.\n For more information about rotating KMS keys and automatic rotation, see [Rotating keys](https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html) in the *Developer Guide*.",
+      "type" : "integer",
+      "minimum" : 90,
+      "maximum" : 2560,
+      "default" : 365
+    }
+  },
+  "additionalProperties" : false,
+  "readOnlyProperties" : [ "/properties/Arn", "/properties/KeyId" ],
+  "primaryIdentifier" : [ "/properties/KeyId" ],
+  "writeOnlyProperties" : [ "/properties/PendingWindowInDays", "/properties/BypassPolicyLockoutSafetyCheck", "/properties/RotationPeriodInDays" ],
+  "tagging" : {
+    "taggable" : true,
+    "tagOnCreate" : true,
+    "tagUpdatable" : true,
+    "cloudFormationSystemTags" : false,
+    "tagProperty" : "/properties/Tags",
+    "permissions" : [ "kms:TagResource", "kms:UntagResource", "kms:ListResourceTags" ]
+  },
+  "handlers" : {
+    "create" : {
+      "permissions" : [ "kms:CreateKey", "kms:EnableKeyRotation", "kms:DisableKey", "kms:TagResource", "kms:PutKeyPolicy" ]
+    },
+    "read" : {
+      "permissions" : [ "kms:DescribeKey", "kms:GetKeyPolicy", "kms:GetKeyRotationStatus", "kms:ListResourceTags" ]
+    },
+    "update" : {
+      "permissions" : [ "kms:DescribeKey", "kms:DisableKey", "kms:DisableKeyRotation", "kms:EnableKey", "kms:EnableKeyRotation", "kms:PutKeyPolicy", "kms:TagResource", "kms:UntagResource", "kms:UpdateKeyDescription", "kms:ListResourceTags" ]
+    },
+    "delete" : {
+      "permissions" : [ "kms:DescribeKey", "kms:ScheduleKeyDeletion" ]
+    },
+    "list" : {
+      "permissions" : [ "kms:ListKeys", "kms:DescribeKey" ]
+    }
+  }
+}
+

--- a/examples/kms_key/main.crn
+++ b/examples/kms_key/main.crn
@@ -1,0 +1,33 @@
+# KMS Key Example
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+awscc.kms.Key {
+  description = 'Example signing key'
+
+  key_policy = {
+    version = '2012-10-17'
+    statement {
+      sid    = 'AllowRootAccountAccess'
+      effect = 'Allow'
+
+      principal = {
+        aws = 'arn:aws:iam::111122223333:root'
+      }
+
+      action   = 'kms:*'
+      resource = '*'
+    }
+  }
+
+  key_usage              = awscc.kms.Key.KeyUsage.sign_verify
+  key_spec               = awscc.kms.Key.KeySpec.ecc_nist_p256
+  enable_key_rotation    = false
+  pending_window_in_days = 7
+
+  tags = {
+    Environment = 'example'
+  }
+}

--- a/generated-docs/awscc/kms/key.md
+++ b/generated-docs/awscc/kms/key.md
@@ -1,0 +1,221 @@
+---
+title: "awscc.kms.Key"
+description: "AWSCC KMS Key resource reference"
+---
+
+
+CloudFormation Type: `AWS::KMS::Key`
+
+The ``AWS::KMS::Key`` resource specifies an [KMS key](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#kms_keys) in KMSlong. You can use this resource to create symmetric encryption KMS keys, asymmetric KMS keys for encryption or signing, and symmetric HMAC KMS keys. You can use ``AWS::KMS::Key`` to create [multi-Region primary keys](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html#mrk-primary-key) of all supported types. To replicate a multi-Region key, use the ``AWS::KMS::ReplicaKey`` resource.
+  If you change the value of the ``KeySpec``, ``KeyUsage``, ``Origin``, or ``MultiRegion`` properties of an existing KMS key, the update request fails, regardless of the value of the [UpdateReplacePolicy attribute](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html). This prevents you from accidentally deleting a KMS key by changing any of its immutable property values.
+   KMS replaced the term *customer master key (CMK)* with ** and *KMS key*. The concept has not changed. To prevent breaking changes, KMS is keeping some variations of this term.
+  You can use symmetric encryption KMS keys to encrypt and decrypt small amounts of data, but they are more commonly used to generate data keys and data key pairs. You can also use a symmetric encryption KMS key to encrypt data stored in AWS services that are [integrated with](https://docs.aws.amazon.com//kms/features/#AWS_Service_Integration). For more information, see [Symmetric encryption KMS keys](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#symmetric-cmks) in the *Developer Guide*.
+ You can use asymmetric KMS keys to encrypt and decrypt data or sign messages and verify signatures. To create an asymmetric key, you must specify an asymmetric ``KeySpec`` value and a ``KeyUsage`` value. For details, see [Asymmetric keys in](https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html) in the *Developer Guide*.
+ You can use HMAC KMS keys (which are also symmetric keys) to generate and verify hash-based message authentication codes. To create an HMAC key, you must specify an HMAC ``KeySpec`` value and a ``KeyUsage`` value of ``GENERATE_VERIFY_MAC``. For details, see [HMAC keys in](https://docs.aws.amazon.com/kms/latest/developerguide/hmac.html) in the *Developer Guide*.
+ You can also create symmetric encryption, asymmetric, and HMAC multi-Region primary keys. To create a multi-Region primary key, set the ``MultiRegion`` property to ``true``. For information about multi-Region keys, see [Multi-Region keys in](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html) in the *Developer Guide*.
+ You cannot use the ``AWS::KMS::Key`` resource to specify a KMS key with [imported key material](https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html) or a KMS key in a [custom key store](https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html).
+  *Regions* 
+ KMS CloudFormation resources are available in all Regions in which KMS and CFN are supported. You can use the ``AWS::KMS::Key`` resource to create and manage all KMS key types that are supported in a Region.
+
+## Example
+
+```crn
+awscc.kms.Key {
+  description = 'Example signing key'
+
+  key_policy = {
+    version = '2012-10-17'
+    statement {
+      sid    = 'AllowRootAccountAccess'
+      effect = 'Allow'
+
+      principal = {
+        aws = 'arn:aws:iam::111122223333:root'
+      }
+
+      action   = 'kms:*'
+      resource = '*'
+    }
+  }
+
+  key_usage              = awscc.kms.Key.KeyUsage.sign_verify
+  key_spec               = awscc.kms.Key.KeySpec.ecc_nist_p256
+  enable_key_rotation    = false
+  pending_window_in_days = 7
+
+  tags = {
+    Environment = 'example'
+  }
+}
+```
+
+## Argument Reference
+
+### `bypass_policy_lockout_safety_check`
+
+- **Type:** Bool
+- **Required:** No
+- **Write-only:** Yes
+- **Default:** `false`
+
+Skips ("bypasses") the key policy lockout safety check. The default value is false. Setting this value to true increases the risk that the KMS key becomes unmanageable. Do not set this value to true indiscriminately. For more information, see [Default key policy](https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html#prevent-unmanageable-key) in the *Developer Guide*. Use this parameter only when you intend to prevent the principal that is making the request from making a subsequent [PutKeyPolicy](https://docs.aws.amazon.com/kms/latest/APIReference/API_PutKeyPolicy.html) request on the KMS key.
+
+### `description`
+
+- **Type:** String(len: ..=8192)
+- **Required:** No
+
+A description of the KMS key. Use a description that helps you to distinguish this KMS key from others in the account, such as its intended use.
+
+### `enable_key_rotation`
+
+- **Type:** Bool
+- **Required:** No
+
+Enables automatic rotation of the key material for the specified KMS key. By default, automatic key rotation is not enabled. KMS supports automatic rotation only for symmetric encryption KMS keys (``KeySpec`` = ``SYMMETRIC_DEFAULT``). For asymmetric KMS keys, HMAC KMS keys, and KMS keys with Origin ``EXTERNAL``, omit the ``EnableKeyRotation`` property or set it to ``false``. To enable automatic key rotation of the key material for a multi-Region KMS key, set ``EnableKeyRotation`` to ``true`` on the primary key (created by using ``AWS::KMS::Key``). KMS copies the rotation status to all replica keys. For details, see [Rotating multi-Region keys](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-manage.html#multi-region-rotate) in the *Developer Guide*. When you enable automatic rotation, KMS automatically creates new key material for the KMS key one year after the enable date and every year thereafter. KMS retains all key material until you delete the KMS key. For detailed information about automatic key rotation, see [Rotating KMS keys](https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html) in the *Developer Guide*.
+
+### `enabled`
+
+- **Type:** Bool
+- **Required:** No
+
+Specifies whether the KMS key is enabled. Disabled KMS keys cannot be used in cryptographic operations. When ``Enabled`` is ``true``, the *key state* of the KMS key is ``Enabled``. When ``Enabled`` is ``false``, the key state of the KMS key is ``Disabled``. The default value is ``true``. The actual key state of the KMS key might be affected by actions taken outside of CloudFormation, such as running the [EnableKey](https://docs.aws.amazon.com/kms/latest/APIReference/API_EnableKey.html), [DisableKey](https://docs.aws.amazon.com/kms/latest/APIReference/API_DisableKey.html), or [ScheduleKeyDeletion](https://docs.aws.amazon.com/kms/latest/APIReference/API_ScheduleKeyDeletion.html) operations. For information about the key states of a KMS key, see [Key state: Effect on your KMS key](https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html) in the *Developer Guide*.
+
+### `key_policy`
+
+- **Type:** `Map<String, String>`
+- **Required:** No
+- **Default:** `"{
+    "Version": "2012-10-17",
+    "Id": "key-default",
+    "Statement": [
+        {
+            "Sid": "Enable IAM User Permissions",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:<partition>:iam::<account-id>:root"
+            },
+            "Action": "kms:*",
+            "Resource": "*"
+        }
+    ]
+}"`
+
+The key policy to attach to the KMS key. If you provide a key policy, it must meet the following criteria: + The key policy must allow the caller to make a subsequent [PutKeyPolicy](https://docs.aws.amazon.com/kms/latest/APIReference/API_PutKeyPolicy.html) request on the KMS key. This reduces the risk that the KMS key becomes unmanageable. For more information, see [Default key policy](https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam) in the *Developer Guide*. (To omit this condition, set ``BypassPolicyLockoutSafetyCheck`` to true.) + Each statement in the key policy must contain one or more principals. The principals in the key policy must exist and be visible to KMS. When you create a new AWS principal (for example, an IAM user or role), you might need to enforce a delay before including the new principal in a key policy because the new principal might not be immediately visible to KMS. For more information, see [Changes that I make are not always immediately visible](https://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_general.html#troubleshoot_general_eventual-consistency) in the *User Guide*. If you do not provide a key policy, KMS attaches a default key policy to the KMS key. For more information, see [Default key policy](https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default) in the *Developer Guide*. A key policy document can include only the following characters: + Printable ASCII characters + Printable characters in the Basic Latin and Latin-1 Supplement character set + The tab (``\u0009``), line feed (``\u000A``), and carriage return (``\u000D``) special characters *Minimum*: ``1`` *Maximum*: ``32768``
+
+### `key_spec`
+
+- **Type:** [Enum (KeySpec)](#key_spec-keyspec)
+- **Required:** No
+- **Default:** `"SYMMETRIC_DEFAULT"`
+
+Specifies the type of KMS key to create. The default value, ``SYMMETRIC_DEFAULT``, creates a KMS key with a 256-bit symmetric key for encryption and decryption. In China Regions, ``SYMMETRIC_DEFAULT`` creates a 128-bit symmetric key that uses SM4 encryption. You can't change the ``KeySpec`` value after the KMS key is created. For help choosing a key spec for your KMS key, see [Choosing a KMS key type](https://docs.aws.amazon.com/kms/latest/developerguide/symm-asymm-choose.html) in the *Developer Guide*. The ``KeySpec`` property determines the type of key material in the KMS key and the algorithms that the KMS key supports. To further restrict the algorithms that can be used with the KMS key, use a condition key in its key policy or IAM policy. For more information, see [condition keys](https://docs.aws.amazon.com/kms/latest/developerguide/policy-conditions.html#conditions-kms) in the *Developer Guide*. If you change the value of the ``KeySpec`` property on an existing KMS key, the update request fails, regardless of the value of the [UpdateReplacePolicy attribute](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html). This prevents you from accidentally deleting a KMS key by changing an immutable property value. [services that are integrated with](https://docs.aws.amazon.com/kms/features/#AWS_Service_Integration) use symmetric encryption KMS keys to protect your data. These services do not support encryption with asymmetric KMS keys. For help determining whether a KMS key is asymmetric, see [Identifying asymmetric KMS keys](https://docs.aws.amazon.com/kms/latest/developerguide/find-symm-asymm.html) in the *Developer Guide*. KMS supports the following key specs for KMS keys: + Symmetric encryption key (default) + ``SYMMETRIC_DEFAULT`` (AES-256-GCM) + HMAC keys (symmetric) + ``HMAC_224`` + ``HMAC_256`` + ``HMAC_384`` + ``HMAC_512`` + Asymmetric RSA key pairs (encryption and decryption *or* signing and verification) + ``RSA_2048`` + ``RSA_3072`` + ``RSA_4096`` + Asymmetric NIST-recommended elliptic curve key pairs (signing and verification *or* deriving shared secrets) + ``ECC_NIST_P256`` (secp256r1) + ``ECC_NIST_P384`` (secp384r1) + ``ECC_NIST_P521`` (secp521r1) + ``ECC_NIST_EDWARDS25519`` (ed25519) - signing and verification only + *Note:* For ECC_NIST_EDWARDS25519 KMS keys, the ED25519_SHA_512 signing algorithm requires [MessageType:RAW](https://docs.aws.amazon.com/kms/latest/APIReference/API_Sign.html#KMS-Sign-request-MessageType), while ED25519_PH_SHA_512 requires [MessageType:DIGEST](https://docs.aws.amazon.com/kms/latest/APIReference/API_Sign.html#KMS-Sign-request-MessageType). These message types cannot be used interchangeably. + Other asymmetric elliptic curve key pairs (signing and verification) + ``ECC_SECG_P256K1`` (secp256k1), commonly used for cryptocurrencies. + Asymmetric ML-DSA key pairs (signing and verification) + ``ML_DSA_44`` + ``ML_DSA_65`` + ``ML_DSA_87`` + SM2 key pairs (encryption and decryption *or* signing and verification *or* deriving shared secrets) + ``SM2`` (China Regions only)
+
+### `key_usage`
+
+- **Type:** [Enum (KeyUsage)](#key_usage-keyusage)
+- **Required:** No
+- **Default:** `"ENCRYPT_DECRYPT"`
+
+Determines the [cryptographic operations](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations) for which you can use the KMS key. The default value is ``ENCRYPT_DECRYPT``. This property is required for asymmetric KMS keys and HMAC KMS keys. You can't change the ``KeyUsage`` value after the KMS key is created. If you change the value of the ``KeyUsage`` property on an existing KMS key, the update request fails, regardless of the value of the [UpdateReplacePolicy attribute](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html). This prevents you from accidentally deleting a KMS key by changing an immutable property value. Select only one valid value. + For symmetric encryption KMS keys, omit the parameter or specify ``ENCRYPT_DECRYPT``. + For HMAC KMS keys (symmetric), specify ``GENERATE_VERIFY_MAC``. + For asymmetric KMS keys with RSA key pairs, specify ``ENCRYPT_DECRYPT`` or ``SIGN_VERIFY``. + For asymmetric KMS keys with NIST-recommended elliptic curve key pairs, specify ``SIGN_VERIFY`` or ``KEY_AGREEMENT``. + For asymmetric KMS keys with ``ECC_SECG_P256K1`` key pairs, specify ``SIGN_VERIFY``. + For asymmetric KMS keys with ML-DSA key pairs, specify ``SIGN_VERIFY``. + For asymmetric KMS keys with SM2 key pairs (China Regions only), specify ``ENCRYPT_DECRYPT``, ``SIGN_VERIFY``, or ``KEY_AGREEMENT``.
+
+### `multi_region`
+
+- **Type:** Bool
+- **Required:** No
+- **Default:** `false`
+
+Creates a multi-Region primary key that you can replicate in other AWS-Regions. You can't change the ``MultiRegion`` value after the KMS key is created. For a list of AWS-Regions in which multi-Region keys are supported, see [Multi-Region keys in](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html) in the **. If you change the value of the ``MultiRegion`` property on an existing KMS key, the update request fails, regardless of the value of the [UpdateReplacePolicy attribute](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html). This prevents you from accidentally deleting a KMS key by changing an immutable property value. For a multi-Region key, set to this property to ``true``. For a single-Region key, omit this property or set it to ``false``. The default value is ``false``. *Multi-Region keys* are an KMS feature that lets you create multiple interoperable KMS keys in different AWS-Regions. Because these KMS keys have the same key ID, key material, and other metadata, you can use them to encrypt data in one AWS-Region and decrypt it in a different AWS-Region without making a cross-Region call or exposing the plaintext data. For more information, see [Multi-Region keys](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html) in the *Developer Guide*. You can create a symmetric encryption, HMAC, or asymmetric multi-Region KMS key, and you can create a multi-Region key with imported key material. However, you cannot create a multi-Region key in a custom key store. To create a replica of this primary key in a different AWS-Region , create an [AWS::KMS::ReplicaKey](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kms-replicakey.html) resource in a CloudFormation stack in the replica Region. Specify the key ARN of this primary key.
+
+### `origin`
+
+- **Type:** [Enum (Origin)](#origin-origin)
+- **Required:** No
+- **Default:** `"AWS_KMS"`
+
+The source of the key material for the KMS key. You cannot change the origin after you create the KMS key. The default is ``AWS_KMS``, which means that KMS creates the key material. To [create a KMS key with no key material](https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys-create-cmk.html) (for imported key material), set this value to ``EXTERNAL``. For more information about importing key material into KMS, see [Importing Key Material](https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html) in the *Developer Guide*. You can ignore ``ENABLED`` when Origin is ``EXTERNAL``. When a KMS key with Origin ``EXTERNAL`` is created, the key state is ``PENDING_IMPORT`` and ``ENABLED`` is ``false``. After you import the key material, ``ENABLED`` updated to ``true``. The KMS key can then be used for Cryptographic Operations. + CFN doesn't support creating an ``Origin`` parameter of the ``AWS_CLOUDHSM`` or ``EXTERNAL_KEY_STORE`` values. + ``EXTERNAL`` is not supported for ML-DSA keys.
+
+### `pending_window_in_days`
+
+- **Type:** Int(7..=30)
+- **Required:** No
+- **Write-only:** Yes
+
+Specifies the number of days in the waiting period before KMS deletes a KMS key that has been removed from a CloudFormation stack. Enter a value between 7 and 30 days. The default value is 30 days. When you remove a KMS key from a CloudFormation stack, KMS schedules the KMS key for deletion and starts the mandatory waiting period. The ``PendingWindowInDays`` property determines the length of waiting period. During the waiting period, the key state of KMS key is ``Pending Deletion`` or ``Pending Replica Deletion``, which prevents the KMS key from being used in cryptographic operations. When the waiting period expires, KMS permanently deletes the KMS key. KMS will not delete a [multi-Region primary key](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html) that has replica keys. If you remove a multi-Region primary key from a CloudFormation stack, its key state changes to ``PendingReplicaDeletion`` so it cannot be replicated or used in cryptographic operations. This state can persist indefinitely. When the last of its replica keys is deleted, the key state of the primary key changes to ``PendingDeletion`` and the waiting period specified by ``PendingWindowInDays`` begins. When this waiting period expires, KMS deletes the primary key. For details, see [Deleting multi-Region keys](https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-delete.html) in the *Developer Guide*. You cannot use a CloudFormation template to cancel deletion of the KMS key after you remove it from the stack, regardless of the waiting period. If you specify a KMS key in your template, even one with the same name, CloudFormation creates a new KMS key. To cancel deletion of a KMS key, use the KMS console or the [CancelKeyDeletion](https://docs.aws.amazon.com/kms/latest/APIReference/API_CancelKeyDeletion.html) operation. For information about the ``Pending Deletion`` and ``Pending Replica Deletion`` key states, see [Key state: Effect on your KMS key](https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html) in the *Developer Guide*. For more information about deleting KMS keys, see the [ScheduleKeyDeletion](https://docs.aws.amazon.com/kms/latest/APIReference/API_ScheduleKeyDeletion.html) operation in the *API Reference* and [Deleting KMS keys](https://docs.aws.amazon.com/kms/latest/developerguide/deleting-keys.html) in the *Developer Guide*.
+
+### `rotation_period_in_days`
+
+- **Type:** Int(90..=2560)
+- **Required:** No
+- **Write-only:** Yes
+- **Default:** `365`
+
+Specifies a custom period of time between each rotation date. If no value is specified, the default value is 365 days. The rotation period defines the number of days after you enable automatic key rotation that KMS will rotate your key material, and the number of days between each automatic rotation thereafter. You can use the [kms:RotationPeriodInDays](https://docs.aws.amazon.com/kms/latest/developerguide/conditions-kms.html#conditions-kms-rotation-period-in-days) condition key to further constrain the values that principals can specify in the ``RotationPeriodInDays`` parameter. For more information about rotating KMS keys and automatic rotation, see [Rotating keys](https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html) in the *Developer Guide*.
+
+### `tags`
+
+- **Type:** `Map<String, String>`
+- **Required:** No
+
+Assigns one or more tags to the replica key. Tagging or untagging a KMS key can allow or deny permission to the KMS key. For details, see [ABAC for](https://docs.aws.amazon.com/kms/latest/developerguide/abac.html) in the *Developer Guide*. For information about tags in KMS, see [Tagging keys](https://docs.aws.amazon.com/kms/latest/developerguide/tagging-keys.html) in the *Developer Guide*. For information about tags in CloudFormation, see [Tag](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html).
+
+## Enum Values
+
+### key_spec (KeySpec)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `SYMMETRIC_DEFAULT` | `awscc.kms.Key.KeySpec.symmetric_default` |
+| `RSA_2048` | `awscc.kms.Key.KeySpec.rsa_2048` |
+| `RSA_3072` | `awscc.kms.Key.KeySpec.rsa_3072` |
+| `RSA_4096` | `awscc.kms.Key.KeySpec.rsa_4096` |
+| `ECC_NIST_P256` | `awscc.kms.Key.KeySpec.ecc_nist_p256` |
+| `ECC_NIST_P384` | `awscc.kms.Key.KeySpec.ecc_nist_p384` |
+| `ECC_NIST_P521` | `awscc.kms.Key.KeySpec.ecc_nist_p521` |
+| `ECC_SECG_P256K1` | `awscc.kms.Key.KeySpec.ecc_secg_p256k1` |
+| `HMAC_224` | `awscc.kms.Key.KeySpec.hmac_224` |
+| `HMAC_256` | `awscc.kms.Key.KeySpec.hmac_256` |
+| `HMAC_384` | `awscc.kms.Key.KeySpec.hmac_384` |
+| `HMAC_512` | `awscc.kms.Key.KeySpec.hmac_512` |
+| `SM2` | `awscc.kms.Key.KeySpec.sm2` |
+| `ML_DSA_44` | `awscc.kms.Key.KeySpec.ml_dsa_44` |
+| `ML_DSA_65` | `awscc.kms.Key.KeySpec.ml_dsa_65` |
+| `ML_DSA_87` | `awscc.kms.Key.KeySpec.ml_dsa_87` |
+| `ECC_NIST_EDWARDS25519` | `awscc.kms.Key.KeySpec.ecc_nist_edwards25519` |
+
+Shorthand formats: `symmetric_default` or `KeySpec.symmetric_default`
+
+### key_usage (KeyUsage)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `ENCRYPT_DECRYPT` | `awscc.kms.Key.KeyUsage.encrypt_decrypt` |
+| `SIGN_VERIFY` | `awscc.kms.Key.KeyUsage.sign_verify` |
+| `GENERATE_VERIFY_MAC` | `awscc.kms.Key.KeyUsage.generate_verify_mac` |
+| `KEY_AGREEMENT` | `awscc.kms.Key.KeyUsage.key_agreement` |
+
+Shorthand formats: `encrypt_decrypt` or `KeyUsage.encrypt_decrypt`
+
+### origin (Origin)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `AWS_KMS` | `awscc.kms.Key.Origin.aws_kms` |
+| `EXTERNAL` | `awscc.kms.Key.Origin.external` |
+
+Shorthand formats: `aws_kms` or `Origin.aws_kms`
+
+## Attribute Reference
+
+### `arn`
+
+- **Type:** Arn
+
+
+
+### `key_id`
+
+- **Type:** String
+
+
+


### PR DESCRIPTION
## Summary

Adds `kms.Key` support via the generic Cloud Control codegen pipeline, required for the Publish API write-plane (carina-rs/registry#4). The KMS key signs short-lived internal grants; the task role gets `kms:Sign` only.

Adding the resource surfaced three upstream codegen bugs. Each is fixed at the seam, not per-symptom.

## Codegen fixes (root cause)

1. **Object-branch ignored type overrides.** The `Some("object")` arm of `cfn_type_to_carina_type_with_enum_with_struct_path` did not consult `resource_type_overrides()`, unlike the string arm. A policy-document property typed `object|string` but not named `*PolicyDocument` (KMS `KeyPolicy`) silently degraded to `Map<String>`, which breaks the policy-document apply path. The object arm now honors `StringType` overrides; `KeyPolicy` maps to `super::iam_policy_document()`, the same type IAM role's policy fields use.

2. **`looks_like_enum_value` accepted lone punctuation.** The KMS Tag key/value descriptions list allowed characters as backtick-quoted punctuation, including a literal double-quote. These were mis-extracted as a `StringEnum` and emitted an unescaped double-quote that broke the build. A real enum identifier always contains at least one ASCII alphanumeric character; the guard now requires it. Regenerating all 39 resources from cache confirms no other resource changes.

3. **Type-incoherent default on a structured attribute.** The attribute-default emitter attached `.with_default(...)` whenever the CFN schema had a default, without checking the resolved Carina type. The CFN `KeyPolicy` default is a JSON *string* but the resolved type is the structured `iam_policy_document()` — a type-incoherent default that risks a perpetual phantom diff when the user omits `key_policy`. Defaults are now suppressed for non-scalar types via `attr_type_accepts_scalar_default`, matching the `iam.Role` no-default policy-document convention (AWS applies its server-side default).

## Generated resource

`kms.Key` with all 14 CFN properties: `description`, `enabled`, `enable_key_rotation`, `key_policy` (policy document), `key_usage`/`key_spec`/`origin` (snake_case enums), `multi_region`, `pending_window_in_days` (7–30), `rotation_period_in_days` (90–2560), `bypass_policy_lockout_safety_check`, `tags`, plus read-only `arn`/`key_id`. Write-only fields are flagged so they don't appear in read-back diffs.

## Tests

Five new codegen unit tests, each a verified RED→GREEN regression guard:
- `test_kms_key_policy_object_string_uses_iam_policy_document_override`
- `test_looks_like_enum_value_rejects_lone_punctuation`
- `test_extract_enum_from_description_rejects_kms_tag_allowed_punctuation`
- `test_generate_schema_code_suppresses_default_for_iam_policy_document`
- `test_attr_type_accepts_scalar_default` (incl. a `prefix_list_id()` guard against the substring-match edge)

## Verify

`cargo test` (213 passed), `cargo clippy --workspace --all-targets -D warnings`, `cargo fmt --check`, `cargo build --target wasm32-wasip2 --release`, `check-carina-pin.sh`, `check-docs-drift.sh` (39 resources), and the `generate-schemas.sh --from-cache-only` idempotence check all pass.

## Follow-up

#312 — the enum-value emission sites still emit values without Rust string escaping. Not reachable by any real AWS enum today (fix #2 above removed the KMS trigger), filed as a separate hardening issue.

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)
