### PR TITLE
Add AWS::DynamoDB::Table resource

### DIFF
--- a/carina-provider-awscc/scripts/generate-schemas.sh
+++ b/carina-provider-awscc/scripts/generate-schemas.sh
@@ -79,6 +79,7 @@ RESOURCE_TYPES=(
     "AWS::CloudFront::OriginAccessControl"
     "AWS::WAFv2::WebACL"
     "AWS::KMS::Key"
+    "AWS::DynamoDB::Table"
 )
 
 echo "Generating awscc provider schemas..."

--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -261,10 +261,10 @@ struct CfnSchema {
     tagging: Option<CfnTagging>,
     /// Top-level oneOf variants (mutually exclusive required field groups)
     #[serde(default, rename = "oneOf")]
-    one_of: Vec<CfnOneOfVariant>,
+    one_of: Vec<CfnProperty>,
     /// Top-level anyOf variants
     #[serde(default, rename = "anyOf")]
-    any_of: Vec<CfnOneOfVariant>,
+    any_of: Vec<CfnProperty>,
     /// Cloud Control handlers (create/read/update/delete/list).
     /// Absent or empty means the type is NON_PROVISIONABLE and cannot be
     /// managed via Cloud Control API.
@@ -376,15 +376,12 @@ struct CfnProperty {
     /// Format constraint (e.g., "int64", "uri", "double")
     #[serde(default)]
     format: Option<String>,
-}
-
-#[derive(Debug, Clone, Default, Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[allow(dead_code)]
-struct CfnOneOfVariant {
-    properties: Option<BTreeMap<String, CfnProperty>>,
+    /// Property-level oneOf variants (union types)
+    #[serde(default, rename = "oneOf")]
+    one_of: Vec<CfnProperty>,
     #[serde(default)]
-    required: Vec<String>,
+    #[serde(rename = "anyOf")]
+    any_of: Vec<CfnProperty>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -398,7 +395,7 @@ struct CfnDefinition {
     required: Vec<String>,
     /// oneOf variants (union types)
     #[serde(default, rename = "oneOf")]
-    one_of: Vec<CfnOneOfVariant>,
+    one_of: Vec<CfnProperty>,
     /// Array item schema (for array-typed definitions)
     items: Option<Box<CfnProperty>>,
     /// Enum values (for enum-only definitions)
@@ -903,6 +900,31 @@ fn type_display_string(
         }
     } else if prop_name == "Tags" {
         "`Map<String, String>`".to_string()
+    } else if !prop.one_of.is_empty() {
+        if let Some(array_variant) = prop
+            .one_of
+            .iter()
+            .find(|variant| property_resolves_to_array(variant, schema))
+        {
+            return type_display_string(prop_name, array_variant, schema, enums);
+        }
+
+        let has_mergeable_object_variant = prop.one_of.iter().any(|variant| {
+            variant
+                .properties
+                .as_ref()
+                .is_some_and(|props| !props.is_empty())
+        });
+        if !has_mergeable_object_variant {
+            let variant_types: Vec<Vec<String>> =
+                prop.one_of.iter().map(property_type_values).collect();
+            panic!(
+                "unresolved oneOf for {}.{}: variants {:?}",
+                schema.type_name, prop_name, variant_types
+            );
+        }
+
+        "String".to_string()
     } else if let Some(ref_path) = &prop.ref_path {
         if ref_path.contains("/Tag") {
             "`Map<String, String>`".to_string()
@@ -3244,7 +3266,7 @@ enum ResolvedDef<'a> {
         required: &'a [String],
     },
     /// `oneOf` union of variants.
-    OneOf { variants: &'a [CfnOneOfVariant] },
+    OneOf { variants: &'a [CfnProperty] },
     /// Enum-only def (a fixed list of values, no properties). Takes
     /// precedence over `Scalar` so an integer-typed enum (e.g. WAFv2
     /// `EvaluationWindowSec`) is treated as an enum, matching the canonical
@@ -4776,6 +4798,31 @@ fn cfn_type_to_carina_type_with_enum(
     )
 }
 
+fn property_type_values(prop: &CfnProperty) -> Vec<String> {
+    let mut values = match &prop.prop_type {
+        Some(TypeValue::Single(value)) => vec![value.clone()],
+        Some(TypeValue::Multiple(values)) => values.clone(),
+        None => Vec::new(),
+    };
+
+    if let Some(ref_path) = &prop.ref_path {
+        values.push(format!("$ref:{ref_path}"));
+    }
+
+    values
+}
+
+fn property_resolves_to_array(prop: &CfnProperty, schema: &CfnSchema) -> bool {
+    if property_type_values(prop).iter().any(|ty| ty == "array") {
+        return true;
+    }
+
+    prop.ref_path
+        .as_deref()
+        .and_then(|ref_path| resolve_ref_classified(schema, ref_path))
+        .is_some_and(|resolved| matches!(resolved, ResolvedDef::Array { .. }))
+}
+
 fn cfn_type_to_carina_type_with_enum_with_struct_path(
     prop: &CfnProperty,
     prop_name: &str,
@@ -4801,6 +4848,38 @@ fn cfn_type_to_carina_type_with_enum_with_struct_path(
             values: vec![value_str],
         };
         return ("/* enum */".to_string(), Some(enum_info));
+    }
+
+    if !prop.one_of.is_empty() {
+        if let Some(array_variant) = prop
+            .one_of
+            .iter()
+            .find(|variant| property_resolves_to_array(variant, schema))
+        {
+            return cfn_type_to_carina_type_with_enum_with_struct_path(
+                array_variant,
+                prop_name,
+                schema,
+                namespace,
+                enums,
+                struct_path,
+            );
+        }
+
+        let has_mergeable_object_variant = prop.one_of.iter().any(|variant| {
+            variant
+                .properties
+                .as_ref()
+                .is_some_and(|props| !props.is_empty())
+        });
+        if !has_mergeable_object_variant {
+            let variant_types: Vec<Vec<String>> =
+                prop.one_of.iter().map(property_type_values).collect();
+            panic!(
+                "unresolved oneOf for {}.{}: variants {:?}",
+                schema.type_name, prop_name, variant_types
+            );
+        }
     }
 
     // Handle $ref
@@ -5484,7 +5563,7 @@ mod tests {
     fn def(
         def_type: Option<&str>,
         properties: Option<BTreeMap<String, CfnProperty>>,
-        one_of: Vec<CfnOneOfVariant>,
+        one_of: Vec<CfnProperty>,
         enum_values: Option<Vec<EnumValue>>,
         items: Option<CfnProperty>,
         pattern: Option<&str>,
@@ -5569,7 +5648,7 @@ mod tests {
             classify_def(&def(
                 Some("object"),
                 Some(one_prop()),
-                vec![CfnOneOfVariant::default()],
+                vec![CfnProperty::default()],
                 Some(vec![EnumValue::Str("x".into())]),
                 None,
                 None,
@@ -5582,7 +5661,7 @@ mod tests {
             classify_def(&def(
                 Some("object"),
                 None,
-                vec![CfnOneOfVariant::default()],
+                vec![CfnProperty::default()],
                 Some(vec![EnumValue::Str("x".into())]),
                 None,
                 None,
@@ -6021,6 +6100,7 @@ mod tests {
             min_length: None,
             max_length: None,
             format: None,
+            ..Default::default()
         };
         let schema = CfnSchema {
             type_name: "AWS::EC2::SecurityGroupIngress".to_string(),
@@ -6098,6 +6178,7 @@ mod tests {
             min_length: None,
             max_length: None,
             format: None,
+            ..Default::default()
         };
         let schema = CfnSchema {
             type_name: "AWS::CloudFront::Distribution".to_string(),
@@ -6221,6 +6302,7 @@ mod tests {
             min_length: None,
             max_length: None,
             format: None,
+            ..Default::default()
         };
         let schema = CfnSchema {
             type_name: "AWS::EC2::SecurityGroupIngress".to_string(),
@@ -6268,6 +6350,7 @@ mod tests {
             min_length: None,
             max_length: None,
             format: None,
+            ..Default::default()
         };
         let schema = CfnSchema {
             type_name: "AWS::EC2::SecurityGroupIngress".to_string(),
@@ -6315,6 +6398,7 @@ mod tests {
             min_length: None,
             max_length: None,
             format: None,
+            ..Default::default()
         };
         let schema = CfnSchema {
             type_name: "AWS::EC2::NatGateway".to_string(),
@@ -6367,6 +6451,7 @@ mod tests {
             min_length: None,
             max_length: None,
             format: None,
+            ..Default::default()
         };
         let schema = CfnSchema {
             type_name: "AWS::EC2::EIP".to_string(),
@@ -6414,6 +6499,7 @@ mod tests {
             min_length: None,
             max_length: None,
             format: None,
+            ..Default::default()
         };
         let schema = CfnSchema {
             type_name: "AWS::EC2::NatGateway".to_string(),
@@ -6465,6 +6551,7 @@ mod tests {
             min_length: None,
             max_length: None,
             format: None,
+            ..Default::default()
         };
         let schema = CfnSchema {
             type_name: "AWS::EC2::Subnet".to_string(),
@@ -6573,6 +6660,7 @@ mod tests {
             min_length: None,
             max_length: None,
             format: None,
+            ..Default::default()
         };
         assert_eq!(
             list_element_type_display(&prop, "GenericProp", ""),
@@ -6600,6 +6688,7 @@ mod tests {
             min_length: None,
             max_length: None,
             format: None,
+            ..Default::default()
         };
         assert_eq!(
             list_element_type_display(&prop, "GenericProp", ""),
@@ -6627,6 +6716,7 @@ mod tests {
             min_length: None,
             max_length: None,
             format: None,
+            ..Default::default()
         };
         assert_eq!(
             list_element_type_display(&prop, "GenericProp", ""),
@@ -6654,6 +6744,7 @@ mod tests {
             min_length: None,
             max_length: None,
             format: None,
+            ..Default::default()
         };
         assert_eq!(
             list_element_type_display(&prop, "GenericProp", ""),
@@ -6683,6 +6774,7 @@ mod tests {
             min_length: None,
             max_length: None,
             format: None,
+            ..Default::default()
         };
         assert_eq!(
             list_element_type_display(&prop, "SubnetIds", ""),
@@ -6753,6 +6845,7 @@ mod tests {
                 min_length: None,
                 max_length: None,
                 format: None,
+                ..Default::default()
             })),
             ref_path: None,
             insertion_order: None,
@@ -6769,6 +6862,7 @@ mod tests {
             min_length: None,
             max_length: None,
             format: None,
+            ..Default::default()
         };
         let schema = CfnSchema {
             type_name: "AWS::EC2::VPC".to_string(),
@@ -6819,6 +6913,7 @@ mod tests {
                 min_length: None,
                 max_length: None,
                 format: None,
+                ..Default::default()
             })),
             ref_path: None,
             insertion_order: None,
@@ -6835,6 +6930,7 @@ mod tests {
             min_length: None,
             max_length: None,
             format: None,
+            ..Default::default()
         };
         let schema = CfnSchema {
             type_name: "AWS::EC2::VPC".to_string(),
@@ -6966,6 +7062,7 @@ mod tests {
             min_length: None,
             max_length: None,
             format: None,
+            ..Default::default()
         };
         let schema = CfnSchema {
             type_name: "AWS::EC2::VPC".to_string(),
@@ -7023,6 +7120,7 @@ mod tests {
                 min_length: None,
                 max_length: None,
                 format: None,
+                ..Default::default()
             };
             let result = list_element_type_display(&prop, "GenericProp", "");
             assert!(
@@ -7076,6 +7174,7 @@ mod tests {
             min_length: None,
             max_length: None,
             format: None,
+            ..Default::default()
         };
         let result = type_display_string("Prop1", &prop, &schema, &enums);
         assert_ne!(
@@ -7108,6 +7207,7 @@ mod tests {
                 min_length: None,
                 max_length: None,
                 format: None,
+                ..Default::default()
             })),
             ref_path: None,
             insertion_order: None,
@@ -7124,6 +7224,7 @@ mod tests {
             min_length: None,
             max_length: None,
             format: None,
+            ..Default::default()
         };
         let result = type_display_string("Prop2", &prop, &schema, &enums);
         assert_ne!(
@@ -7156,6 +7257,7 @@ mod tests {
                 min_length: None,
                 max_length: None,
                 format: None,
+                ..Default::default()
             })),
             ref_path: None,
             insertion_order: None,
@@ -7172,6 +7274,7 @@ mod tests {
             min_length: None,
             max_length: None,
             format: None,
+            ..Default::default()
         };
         let result = type_display_string("Prop3", &prop, &schema, &enums);
         assert_ne!(
@@ -7204,6 +7307,7 @@ mod tests {
                 min_length: None,
                 max_length: None,
                 format: None,
+                ..Default::default()
             })),
             ref_path: None,
             insertion_order: None,
@@ -7220,6 +7324,7 @@ mod tests {
             min_length: None,
             max_length: None,
             format: None,
+            ..Default::default()
         };
         let result = type_display_string("Prop4", &prop, &schema, &enums);
         assert_ne!(
@@ -7250,6 +7355,7 @@ mod tests {
             min_length: None,
             max_length: None,
             format: None,
+            ..Default::default()
         };
         let schema = CfnSchema {
             type_name: "AWS::EC2::VPC".to_string(),
@@ -7312,6 +7418,7 @@ mod tests {
             min_length: None,
             max_length: None,
             format: None,
+            ..Default::default()
         };
         let schema = CfnSchema {
             type_name: "AWS::EC2::VPC".to_string(),
@@ -7356,6 +7463,7 @@ mod tests {
             min_length: None,
             max_length: None,
             format: None,
+            ..Default::default()
         };
         let schema = CfnSchema {
             type_name: "AWS::EC2::VPC".to_string(),
@@ -7409,6 +7517,7 @@ mod tests {
             min_length: None,
             max_length: None,
             format: None,
+            ..Default::default()
         };
         let schema = CfnSchema {
             type_name: "AWS::EC2::VPC".to_string(),
@@ -7468,6 +7577,7 @@ mod tests {
             min_length: None,
             max_length: None,
             format: None,
+            ..Default::default()
         };
         let schema = CfnSchema {
             type_name: "AWS::Logs::LogGroup".to_string(),
@@ -7530,6 +7640,7 @@ mod tests {
             min_length: None,
             max_length: None,
             format: None,
+            ..Default::default()
         };
         let schema = CfnSchema {
             type_name: "AWS::EC2::NatGateway".to_string(),
@@ -7578,6 +7689,7 @@ mod tests {
             min_length: None,
             max_length: None,
             format: None,
+            ..Default::default()
         };
         let schema = CfnSchema {
             type_name: "AWS::SomeService::Resource".to_string(),
@@ -7626,6 +7738,7 @@ mod tests {
             min_length: None,
             max_length: None,
             format: None,
+            ..Default::default()
         };
         let schema = CfnSchema {
             type_name: "AWS::Logs::LogGroup".to_string(),
@@ -7673,6 +7786,7 @@ mod tests {
             min_length: None,
             max_length: None,
             format: None,
+            ..Default::default()
         };
         let schema = CfnSchema {
             type_name: "AWS::EC2::VPC".to_string(),
@@ -7754,6 +7868,7 @@ mod tests {
             min_length: None,
             max_length: None,
             format: None,
+            ..Default::default()
         };
         let schema = CfnSchema {
             type_name: "AWS::EC2::VPC".to_string(),
@@ -7803,6 +7918,7 @@ mod tests {
             min_length: None,
             max_length: None,
             format: None,
+            ..Default::default()
         };
         let schema = CfnSchema {
             type_name: "AWS::EC2::SecurityGroupIngress".to_string(),
@@ -7856,6 +7972,7 @@ mod tests {
             min_length: None,
             max_length: None,
             format: None,
+            ..Default::default()
         };
         let schema = CfnSchema {
             type_name: "AWS::S3::Bucket".to_string(),
@@ -7917,6 +8034,7 @@ mod tests {
             min_length: None,
             max_length: None,
             format: None,
+            ..Default::default()
         };
         let schema = CfnSchema {
             type_name: "AWS::EC2::SecurityGroupIngress".to_string(),
@@ -8404,6 +8522,130 @@ mod tests {
     }
 
     #[test]
+    fn test_property_oneof_array_ref_maps_to_list_of_struct() {
+        let mut key_schema_props = BTreeMap::new();
+        key_schema_props.insert(
+            "AttributeName".to_string(),
+            CfnProperty {
+                prop_type: Some(TypeValue::Single("string".to_string())),
+                ..Default::default()
+            },
+        );
+        key_schema_props.insert(
+            "KeyType".to_string(),
+            CfnProperty {
+                prop_type: Some(TypeValue::Single("string".to_string())),
+                enum_values: Some(vec![
+                    EnumValue::Str("HASH".to_string()),
+                    EnumValue::Str("RANGE".to_string()),
+                ]),
+                ..Default::default()
+            },
+        );
+
+        let mut definitions = BTreeMap::new();
+        definitions.insert(
+            "KeySchema".to_string(),
+            CfnDefinition {
+                def_type: Some("object".to_string()),
+                properties: Some(key_schema_props),
+                required: vec!["AttributeName".to_string(), "KeyType".to_string()],
+                ..Default::default()
+            },
+        );
+
+        let prop = CfnProperty {
+            one_of: vec![
+                CfnProperty {
+                    prop_type: Some(TypeValue::Single("array".to_string())),
+                    items: Some(Box::new(CfnProperty {
+                        ref_path: Some("#/definitions/KeySchema".to_string()),
+                        ..Default::default()
+                    })),
+                    ..Default::default()
+                },
+                CfnProperty {
+                    prop_type: Some(TypeValue::Single("object".to_string())),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+        let schema = CfnSchema {
+            type_name: "AWS::DynamoDB::Table".to_string(),
+            description: None,
+            properties: BTreeMap::new(),
+            required: vec![],
+            read_only_properties: vec![],
+            create_only_properties: vec![],
+            write_only_properties: vec![],
+            primary_identifier: None,
+            definitions: Some(definitions),
+            tagging: None,
+            one_of: vec![],
+            any_of: vec![],
+            handlers: BTreeMap::new(),
+        };
+
+        let (carina_type, enum_info) = cfn_type_to_carina_type_with_enum_with_struct_path(
+            &prop,
+            "KeySchema",
+            &schema,
+            "",
+            &BTreeMap::new(),
+            &[],
+        );
+
+        assert!(enum_info.is_none());
+        assert!(carina_type.contains("AttributeType::list("));
+        assert!(carina_type.contains(r#"AttributeType::struct_("KeySchema""#));
+        assert!(carina_type.contains("attribute_name"));
+        assert!(carina_type.contains("key_type"));
+    }
+
+    #[test]
+    #[should_panic(expected = "unresolved oneOf")]
+    fn test_property_oneof_unhandled_scalar_union_panics() {
+        let prop = CfnProperty {
+            one_of: vec![
+                CfnProperty {
+                    prop_type: Some(TypeValue::Single("string".to_string())),
+                    ..Default::default()
+                },
+                CfnProperty {
+                    prop_type: Some(TypeValue::Single("integer".to_string())),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+        let schema = CfnSchema {
+            type_name: "AWS::Test::Resource".to_string(),
+            description: None,
+            properties: BTreeMap::new(),
+            required: vec![],
+            read_only_properties: vec![],
+            create_only_properties: vec![],
+            write_only_properties: vec![],
+            primary_identifier: None,
+            definitions: None,
+            tagging: None,
+            one_of: vec![],
+            any_of: vec![],
+            handlers: BTreeMap::new(),
+        };
+
+        let _ = cfn_type_to_carina_type_with_enum_with_struct_path(
+            &prop,
+            "UnionProperty",
+            &schema,
+            "",
+            &BTreeMap::new(),
+            &[],
+        );
+    }
+
+    #[test]
     fn test_iam_oidc_provider_arn_override() {
         // IAM OIDCProvider's Arn should use iam_oidc_provider_arn(), not generic arn
         assert_eq!(
@@ -8699,6 +8941,7 @@ mod tests {
                 min_length: None,
                 max_length: None,
                 format: None,
+                ..Default::default()
             },
         );
 
@@ -8767,6 +9010,7 @@ mod tests {
                 min_length: None,
                 max_length: None,
                 format: None,
+                ..Default::default()
             },
         );
 
@@ -8812,6 +9056,7 @@ mod tests {
                 min_length: None,
                 max_length: None,
                 format: None,
+                ..Default::default()
             },
         );
 
@@ -12065,13 +12310,13 @@ mod tests {
     fn test_detect_exclusive_from_oneof_two_variants() {
         let mut schema = make_schema_with_props(BTreeMap::new());
         schema.one_of = vec![
-            CfnOneOfVariant {
-                properties: None,
+            CfnProperty {
                 required: vec!["FieldA".to_string()],
+                ..Default::default()
             },
-            CfnOneOfVariant {
-                properties: None,
+            CfnProperty {
                 required: vec!["FieldB".to_string()],
+                ..Default::default()
             },
         ];
         let groups = detect_exclusive_from_oneof(&schema);
@@ -12085,17 +12330,17 @@ mod tests {
     fn test_detect_exclusive_from_oneof_three_variants() {
         let mut schema = make_schema_with_props(BTreeMap::new());
         schema.one_of = vec![
-            CfnOneOfVariant {
-                properties: None,
+            CfnProperty {
                 required: vec!["A".to_string()],
+                ..Default::default()
             },
-            CfnOneOfVariant {
-                properties: None,
+            CfnProperty {
                 required: vec!["B".to_string()],
+                ..Default::default()
             },
-            CfnOneOfVariant {
-                properties: None,
+            CfnProperty {
                 required: vec!["C".to_string()],
+                ..Default::default()
             },
         ];
         let groups = detect_exclusive_from_oneof(&schema);
@@ -12110,13 +12355,13 @@ mod tests {
         // Variants with multiple required fields are not simple exclusive groups
         let mut schema = make_schema_with_props(BTreeMap::new());
         schema.one_of = vec![
-            CfnOneOfVariant {
-                properties: None,
+            CfnProperty {
                 required: vec!["A".to_string(), "B".to_string()],
+                ..Default::default()
             },
-            CfnOneOfVariant {
-                properties: None,
+            CfnProperty {
                 required: vec!["C".to_string()],
+                ..Default::default()
             },
         ];
         let groups = detect_exclusive_from_oneof(&schema);
@@ -12134,13 +12379,13 @@ mod tests {
     fn test_detect_exclusive_from_anyof() {
         let mut schema = make_schema_with_props(BTreeMap::new());
         schema.any_of = vec![
-            CfnOneOfVariant {
-                properties: None,
+            CfnProperty {
                 required: vec!["X".to_string()],
+                ..Default::default()
             },
-            CfnOneOfVariant {
-                properties: None,
+            CfnProperty {
                 required: vec!["Y".to_string()],
+                ..Default::default()
             },
         ];
         let groups = detect_exclusive_from_oneof(&schema);
@@ -12255,13 +12500,13 @@ mod tests {
         let mut schema = make_schema_with_props(props);
         // Also add oneOf that detects the same group
         schema.one_of = vec![
-            CfnOneOfVariant {
-                properties: None,
+            CfnProperty {
                 required: vec!["FieldA".to_string()],
+                ..Default::default()
             },
-            CfnOneOfVariant {
-                properties: None,
+            CfnProperty {
                 required: vec!["FieldB".to_string()],
+                ..Default::default()
             },
         ];
         let groups = detect_exclusive_fields(&schema, "AWS::Test::Resource");
@@ -12677,6 +12922,7 @@ mod tests {
                 min_length: None,
                 max_length: None,
                 format: None,
+                ..Default::default()
             },
         );
         let schema = CfnSchema {
@@ -12751,6 +12997,7 @@ mod tests {
                 min_length: None,
                 max_length: None,
                 format: None,
+                ..Default::default()
             },
         );
         let schema = CfnSchema {
@@ -12806,6 +13053,7 @@ mod tests {
                 min_length: None,
                 max_length: None,
                 format: None,
+                ..Default::default()
             },
         );
         let schema = CfnSchema {
@@ -12881,6 +13129,7 @@ mod tests {
                 min_length: None,
                 max_length: None,
                 format: None,
+                ..Default::default()
             },
         );
         let schema = CfnSchema {
@@ -13015,6 +13264,7 @@ mod tests {
                 min_length: None,
                 max_length: None,
                 format: None,
+                ..Default::default()
             },
         );
         let schema = CfnSchema {
@@ -13128,6 +13378,7 @@ mod tests {
                 min_length: None,
                 max_length: None,
                 format: None,
+                ..Default::default()
             },
         );
         let mut definitions = BTreeMap::new();
@@ -13162,6 +13413,7 @@ mod tests {
                 min_length: None,
                 max_length: None,
                 format: None,
+                ..Default::default()
             },
         );
         let schema = CfnSchema {
@@ -13235,6 +13487,7 @@ mod tests {
                     min_length: None,
                     max_length: None,
                     format: None,
+                    ..Default::default()
                 })),
                 ref_path: None,
                 insertion_order: None,
@@ -13251,6 +13504,7 @@ mod tests {
                 min_length: None,
                 max_length: None,
                 format: None,
+                ..Default::default()
             },
         );
         let mut definitions = BTreeMap::new();
@@ -13285,6 +13539,7 @@ mod tests {
                 min_length: None,
                 max_length: None,
                 format: None,
+                ..Default::default()
             },
         );
         let schema = CfnSchema {

--- a/carina-provider-awscc/src/schemas/generated/dynamodb/mod.rs
+++ b/carina-provider-awscc/src/schemas/generated/dynamodb/mod.rs
@@ -1,0 +1,9 @@
+//! Auto-generated — DO NOT EDIT MANUALLY
+//!
+//! Regenerate with:
+//!   aws-vault exec <profile> -- ./carina-provider-awscc/scripts/generate-schemas.sh
+
+// Re-export parent types so resource modules can use `super::` to access them.
+pub use super::*;
+
+pub mod table;

--- a/carina-provider-awscc/src/schemas/generated/dynamodb/table.rs
+++ b/carina-provider-awscc/src/schemas/generated/dynamodb/table.rs
@@ -1,0 +1,329 @@
+//! table schema definition for AWS Cloud Control
+//!
+//! Auto-generated from CloudFormation schema: AWS::DynamoDB::Table
+//!
+//! DO NOT EDIT MANUALLY - regenerate with carina-codegen
+
+use super::AwsccSchemaConfig;
+use super::tags_type;
+use super::validate_tags_map;
+use carina_core::resource::{ConcreteValue, Value};
+use carina_core::schema::{
+    AttributeSchema, AttributeType, ResourceSchema, StructField, legacy_validator,
+};
+
+const VALID_ATTRIBUTE_DEFINITION_ATTRIBUTE_TYPE: &[&str] = &["S", "N", "B"];
+
+const VALID_BILLING_MODE: &[&str] = &["PAY_PER_REQUEST", "PROVISIONED"];
+
+const VALID_CONTRIBUTOR_INSIGHTS_SPECIFICATION_MODE: &[&str] =
+    &["ACCESSED_AND_THROTTLED_KEYS", "THROTTLED_KEYS"];
+
+const VALID_IMPORT_SOURCE_SPECIFICATION_INPUT_FORMAT: &[&str] = &["CSV", "DYNAMODB_JSON", "ION"];
+
+const VALID_KEY_SCHEMA_KEY_TYPE: &[&str] = &["HASH", "RANGE"];
+
+const VALID_KINESIS_STREAM_SPECIFICATION_APPROXIMATE_CREATION_DATE_TIME_PRECISION: &[&str] =
+    &["MICROSECOND", "MILLISECOND"];
+
+const VALID_PROJECTION_PROJECTION_TYPE: &[&str] = &["KEYS_ONLY", "INCLUDE", "ALL"];
+
+const VALID_STREAM_SPECIFICATION_STREAM_VIEW_TYPE: &[&str] =
+    &["KEYS_ONLY", "NEW_IMAGE", "OLD_IMAGE", "NEW_AND_OLD_IMAGES"];
+
+const VALID_TABLE_CLASS: &[&str] = &["STANDARD", "STANDARD_INFREQUENT_ACCESS"];
+
+fn validate_max_read_request_units_range(value: &Value) -> Result<(), String> {
+    if let Value::Concrete(ConcreteValue::Int(n)) = value {
+        if *n < 1 {
+            Err(format!("Value {} is out of range 1..", n))
+        } else {
+            Ok(())
+        }
+    } else {
+        Err("Expected integer".to_string())
+    }
+}
+
+fn validate_max_write_request_units_range(value: &Value) -> Result<(), String> {
+    if let Value::Concrete(ConcreteValue::Int(n)) = value {
+        if *n < 1 {
+            Err(format!("Value {} is out of range 1..", n))
+        } else {
+            Ok(())
+        }
+    } else {
+        Err("Expected integer".to_string())
+    }
+}
+
+fn validate_read_units_per_second_range(value: &Value) -> Result<(), String> {
+    if let Value::Concrete(ConcreteValue::Int(n)) = value {
+        if *n < 1 {
+            Err(format!("Value {} is out of range 1..", n))
+        } else {
+            Ok(())
+        }
+    } else {
+        Err("Expected integer".to_string())
+    }
+}
+
+fn validate_recovery_period_in_days_range(value: &Value) -> Result<(), String> {
+    if let Value::Concrete(ConcreteValue::Int(n)) = value {
+        if *n < 1 || *n > 35 {
+            Err(format!("Value {} is out of range 1..=35", n))
+        } else {
+            Ok(())
+        }
+    } else {
+        Err("Expected integer".to_string())
+    }
+}
+
+fn validate_write_units_per_second_range(value: &Value) -> Result<(), String> {
+    if let Value::Concrete(ConcreteValue::Int(n)) = value {
+        if *n < 1 {
+            Err(format!("Value {} is out of range 1..", n))
+        } else {
+            Ok(())
+        }
+    } else {
+        Err("Expected integer".to_string())
+    }
+}
+
+/// Returns the schema config for dynamodb_table (AWS::DynamoDB::Table)
+pub fn dynamodb_table_config() -> AwsccSchemaConfig {
+    AwsccSchemaConfig {
+        aws_type_name: "AWS::DynamoDB::Table",
+        resource_type_name: "dynamodb.Table",
+        has_tags: true,
+        schema: ResourceSchema::new("dynamodb.Table")
+        .with_description("The ``AWS::DynamoDB::Table`` resource creates a DDB table. For more information, see [CreateTable](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_CreateTable.html) in the *API Reference*.  You should be aware of the following behaviors when working with DDB tables:   +  CFNlong typically creates DDB tables in parallel. However, if your template includes multiple DDB tables with indexes, you must declare dependencies so that the tables are created sequentially. DDBlong limits the number of tables with secondary indexes that are in the creating state. If you create multiple tables with indexes at the same time, DDB returns an error and the stack operation fails. For an example, see [DynamoDB Table with a DependsOn Attribute](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#aws-resource-dynamodb-table--examples--DynamoDB_Table_with_a_DependsOn_Attribute).       Our guidance is to use the latest schema documented for your CFNlong templates. This schema supports the provisioning of all table settings below. When using this schema in your CFNlong templates, please ensure that your Identity and Access Management (IAM) policies are updated with appropriate permissions to allow for the authorization of these setting changes.")
+        .attribute(
+            AttributeSchema::new("arn", super::arn())
+                .read_only()
+                .with_description(" (read-only)")
+                .with_provider_name("Arn"),
+        )
+        .attribute(
+            AttributeSchema::new("attribute_definitions", AttributeType::list(AttributeType::struct_("AttributeDefinition".to_string(), vec![StructField::new("attribute_name", AttributeType::string()).required().with_description("A name for the attribute.").with_provider_name("AttributeName"),
+                    StructField::new("attribute_type", AttributeType::string_enum("AttributeType".to_string(), vec!["S".to_string(), "N".to_string(), "B".to_string()], Some(carina_core::schema::string_enum_identity("AttributeType", Some("awscc.dynamodb.Table.AttributeDefinition"))), vec![("S".to_string(), "s".to_string()), ("N".to_string(), "n".to_string()), ("B".to_string(), "b".to_string())])).required().with_description("The data type for the attribute, where: + ``S`` - the attribute is of type String + ``N`` - the attribute is of type Number + ``B`` - the attribute is of type Binary").with_provider_name("AttributeType")])))
+                .with_description("A list of attributes that describe the key schema for the table and indexes. This property is required to create a DDB table. Update requires: [Some interruptions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-some-interrupt). Replacement if you edit an existing AttributeDefinition.")
+                .with_provider_name("AttributeDefinitions")
+                .with_block_name("attribute_definition"),
+        )
+        .attribute(
+            AttributeSchema::new("billing_mode", AttributeType::string_enum("BillingMode".to_string(), vec!["PAY_PER_REQUEST".to_string(), "PROVISIONED".to_string()], Some(carina_core::schema::string_enum_identity("BillingMode", Some("awscc.dynamodb.Table"))), vec![("PAY_PER_REQUEST".to_string(), "pay_per_request".to_string()), ("PROVISIONED".to_string(), "provisioned".to_string())]))
+                .with_description("Specify how you are charged for read and write throughput and how you manage capacity. Valid values include: + ``PAY_PER_REQUEST`` - We recommend using ``PAY_PER_REQUEST`` for most DynamoDB workloads. ``PAY_PER_REQUEST`` sets the billing mode to [On-demand capacity mode](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/on-demand-capacity-mode.html). + ``PROVISIONED`` - We recommend using ``PROVISIONED`` for steady workloads with predictable growth where capacity requirements can be reliably forecasted. ``PROVISIONED`` sets the billing mode to [Provisioned capacity mode](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/provisioned-capacity-mode.html). If not specified, the default is ``PROVISIONED``.")
+                .with_provider_name("BillingMode"),
+        )
+        .attribute(
+            AttributeSchema::new("contributor_insights_specification", AttributeType::struct_("ContributorInsightsSpecification".to_string(), vec![StructField::new("enabled", AttributeType::bool()).required().with_description("Indicates whether CloudWatch Contributor Insights are to be enabled (true) or disabled (false).").with_provider_name("Enabled"),
+                    StructField::new("mode", AttributeType::string_enum("Mode".to_string(), vec!["ACCESSED_AND_THROTTLED_KEYS".to_string(), "THROTTLED_KEYS".to_string()], Some(carina_core::schema::string_enum_identity("Mode", Some("awscc.dynamodb.Table.ContributorInsightsSpecification"))), vec![("ACCESSED_AND_THROTTLED_KEYS".to_string(), "accessed_and_throttled_keys".to_string()), ("THROTTLED_KEYS".to_string(), "throttled_keys".to_string())])).with_description("Specifies the CloudWatch Contributor Insights mode for a table. Valid values are ``ACCESSED_AND_THROTTLED_KEYS`` (tracks all access and throttled events) or ``THROTTLED_KEYS`` (tracks only throttled events). This setting determines what type of contributor insights data is collected for the table.").with_provider_name("Mode")]))
+                .with_description("The settings used to specify whether to enable CloudWatch Contributor Insights for the table and define which events to monitor.")
+                .with_provider_name("ContributorInsightsSpecification"),
+        )
+        .attribute(
+            AttributeSchema::new("deletion_protection_enabled", AttributeType::bool())
+                .with_description("Determines if a table is protected from deletion. When enabled, the table cannot be deleted by any user or process. This setting is disabled by default. For more information, see [Using deletion protection](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/WorkingWithTables.Basics.html#WorkingWithTables.Basics.DeletionProtection) in the *Developer Guide*.")
+                .with_provider_name("DeletionProtectionEnabled"),
+        )
+        .attribute(
+            AttributeSchema::new("global_secondary_indexes", AttributeType::list(AttributeType::struct_("GlobalSecondaryIndex".to_string(), vec![StructField::new("contributor_insights_specification", AttributeType::ref_("ContributorInsightsSpecification".to_string())).with_description("The settings used to specify whether to enable CloudWatch Contributor Insights for the global table and define which events to monitor.").with_provider_name("ContributorInsightsSpecification"),
+                    StructField::new("index_name", AttributeType::string()).required().with_description("The name of the global secondary index. The name must be unique among all other indexes on this table.").with_provider_name("IndexName"),
+                    StructField::new("key_schema", AttributeType::list(AttributeType::struct_("KeySchema".to_string(), vec![StructField::new("attribute_name", AttributeType::string()).required().with_description("The name of a key attribute.").with_provider_name("AttributeName"),
+                    StructField::new("key_type", AttributeType::string_enum("KeyType".to_string(), vec!["HASH".to_string(), "RANGE".to_string()], Some(carina_core::schema::string_enum_identity("KeyType", Some("awscc.dynamodb.Table.GlobalSecondaryIndex.KeySchema"))), vec![("HASH".to_string(), "hash".to_string()), ("RANGE".to_string(), "range".to_string())])).required().with_description("The role that this key attribute will assume: + ``HASH`` - partition key + ``RANGE`` - sort key The partition key of an item is also known as its *hash attribute*. The term \"hash attribute\" derives from DynamoDB's usage of an internal hash function to evenly distribute data items across partitions, based on their partition key values. The sort key of an item is also known as its *range attribute*. The term \"range attribute\" derives from the way DynamoDB stores items with the same partition key physically close together, in sorted order by the sort key value.").with_provider_name("KeyType")]))).required().with_description("The complete key schema for a global secondary index, which consists of one or more pairs of attribute names and key types: + ``HASH`` - partition key + ``RANGE`` - sort key The partition key of an item is also known as its *hash attribute*. The term \"hash attribute\" derives from DynamoDB's usage of an internal hash function to evenly distribute data items across partitions, based on their partition key values. The sort key of an item is also known as its *range attribute*. The term \"range attribute\" derives from the way DynamoDB stores items with the same partition key physically close together, in sorted order by the sort key value.").with_provider_name("KeySchema").with_block_name("key_schema"),
+                    StructField::new("on_demand_throughput", AttributeType::struct_("OnDemandThroughput".to_string(), vec![StructField::new("max_read_request_units", AttributeType::custom(None, AttributeType::int(), None, None, legacy_validator(validate_max_read_request_units_range), None)).with_description("Maximum number of read request units for the specified table. To specify a maximum ``OnDemandThroughput`` on your table, set the value of ``MaxReadRequestUnits`` as greater than or equal to 1. To remove the maximum ``OnDemandThroughput`` that is currently set on your table, set the value of ``MaxReadRequestUnits`` to -1.").with_provider_name("MaxReadRequestUnits"),
+                    StructField::new("max_write_request_units", AttributeType::custom(None, AttributeType::int(), None, None, legacy_validator(validate_max_write_request_units_range), None)).with_description("Maximum number of write request units for the specified table. To specify a maximum ``OnDemandThroughput`` on your table, set the value of ``MaxWriteRequestUnits`` as greater than or equal to 1. To remove the maximum ``OnDemandThroughput`` that is currently set on your table, set the value of ``MaxWriteRequestUnits`` to -1.").with_provider_name("MaxWriteRequestUnits")])).with_description("The maximum number of read and write units for the specified global secondary index. If you use this parameter, you must specify ``MaxReadRequestUnits``, ``MaxWriteRequestUnits``, or both. You must use either ``OnDemandThroughput`` or ``ProvisionedThroughput`` based on your table's capacity mode.").with_provider_name("OnDemandThroughput"),
+                    StructField::new("projection", AttributeType::struct_("Projection".to_string(), vec![StructField::new("non_key_attributes", AttributeType::list(AttributeType::string())).with_description("Represents the non-key attribute names which will be projected into the index. For global and local secondary indexes, the total count of ``NonKeyAttributes`` summed across all of the secondary indexes, must not exceed 100. If you project the same attribute into two different indexes, this counts as two distinct attributes when determining the total. This limit only applies when you specify the ProjectionType of ``INCLUDE``. You still can specify the ProjectionType of ``ALL`` to project all attributes from the source table, even if the table has more than 100 attributes.").with_provider_name("NonKeyAttributes"),
+                    StructField::new("projection_type", AttributeType::string_enum("ProjectionType".to_string(), vec!["KEYS_ONLY".to_string(), "INCLUDE".to_string(), "ALL".to_string()], Some(carina_core::schema::string_enum_identity("ProjectionType", Some("awscc.dynamodb.Table.GlobalSecondaryIndex.Projection"))), vec![("KEYS_ONLY".to_string(), "keys_only".to_string()), ("INCLUDE".to_string(), "include".to_string()), ("ALL".to_string(), "all".to_string())])).with_description("The set of attributes that are projected into the index: + ``KEYS_ONLY`` - Only the index and primary keys are projected into the index. + ``INCLUDE`` - In addition to the attributes described in ``KEYS_ONLY``, the secondary index will include other non-key attributes that you specify. + ``ALL`` - All of the table attributes are projected into the index. When using the DynamoDB console, ``ALL`` is selected by default.").with_provider_name("ProjectionType")])).required().with_description("Represents attributes that are copied (projected) from the table into the global secondary index. These are in addition to the primary key attributes and index key attributes, which are automatically projected.").with_provider_name("Projection"),
+                    StructField::new("provisioned_throughput", AttributeType::struct_("ProvisionedThroughput".to_string(), vec![StructField::new("read_capacity_units", AttributeType::int()).required().with_description("The maximum number of strongly consistent reads consumed per second before DynamoDB returns a ``ThrottlingException``. For more information, see [Specifying Read and Write Requirements](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughput.html) in the *Amazon DynamoDB Developer Guide*. If read/write capacity mode is ``PAY_PER_REQUEST`` the value is set to 0.").with_provider_name("ReadCapacityUnits"),
+                    StructField::new("write_capacity_units", AttributeType::int()).required().with_description("The maximum number of writes consumed per second before DynamoDB returns a ``ThrottlingException``. For more information, see [Specifying Read and Write Requirements](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughput.html) in the *Amazon DynamoDB Developer Guide*. If read/write capacity mode is ``PAY_PER_REQUEST`` the value is set to 0.").with_provider_name("WriteCapacityUnits")])).with_description("Represents the provisioned throughput settings for the specified global secondary index. You must use either ``OnDemandThroughput`` or ``ProvisionedThroughput`` based on your table's capacity mode. For current minimum and maximum provisioned throughput values, see [Service, Account, and Table Quotas](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html) in the *Amazon DynamoDB Developer Guide*.").with_provider_name("ProvisionedThroughput"),
+                    StructField::new("warm_throughput", AttributeType::struct_("WarmThroughput".to_string(), vec![StructField::new("read_units_per_second", AttributeType::custom(None, AttributeType::int(), None, None, legacy_validator(validate_read_units_per_second_range), None)).with_description("Represents the number of read operations your base table can instantaneously support.").with_provider_name("ReadUnitsPerSecond"),
+                    StructField::new("write_units_per_second", AttributeType::custom(None, AttributeType::int(), None, None, legacy_validator(validate_write_units_per_second_range), None)).with_description("Represents the number of write operations your base table can instantaneously support.").with_provider_name("WriteUnitsPerSecond")])).with_description("Represents the warm throughput value (in read units per second and write units per second) for the specified secondary index. If you use this parameter, you must specify ``ReadUnitsPerSecond``, ``WriteUnitsPerSecond``, or both.").with_provider_name("WarmThroughput")])))
+                .with_description("Global secondary indexes to be created on the table. You can create up to 20 global secondary indexes. If you update a table to include a new global secondary index, CFNlong initiates the index creation and then proceeds with the stack update. CFNlong doesn't wait for the index to complete creation because the backfilling phase can take a long time, depending on the size of the table. You can't use the index or update the table until the index's status is ``ACTIVE``. You can track its status by using the DynamoDB [DescribeTable](https://docs.aws.amazon.com/cli/latest/reference/dynamodb/describe-table.html) command. If you add or delete an index during an update, we recommend that you don't update any other resources. If your stack fails to update and is rolled back while adding a new index, you must manually delete the index. Updates are not supported. The following are exceptions: + If you update either the contributor insights specification or the provisioned throughput values of global secondary indexes, you can update the table without interruption. + You can delete or add one global secondary index without interruption. If you do both in the same update (for example, by changing the index's logical ID), the update fails.")
+                .with_provider_name("GlobalSecondaryIndexes")
+                .with_block_name("global_secondary_index"),
+        )
+        .attribute(
+            AttributeSchema::new("import_source_specification", AttributeType::struct_("ImportSourceSpecification".to_string(), vec![StructField::new("input_compression_type", AttributeType::string()).with_description("Type of compression to be used on the input coming from the imported table.").with_provider_name("InputCompressionType"),
+                    StructField::new("input_format", AttributeType::string_enum("InputFormat".to_string(), vec!["CSV".to_string(), "DYNAMODB_JSON".to_string(), "ION".to_string()], Some(carina_core::schema::string_enum_identity("InputFormat", Some("awscc.dynamodb.Table.ImportSourceSpecification"))), vec![("CSV".to_string(), "csv".to_string()), ("DYNAMODB_JSON".to_string(), "dynamodb_json".to_string()), ("ION".to_string(), "ion".to_string())])).required().with_description("The format of the source data. Valid values for ``ImportFormat`` are ``CSV``, ``DYNAMODB_JSON`` or ``ION``.").with_provider_name("InputFormat"),
+                    StructField::new("input_format_options", AttributeType::struct_("InputFormatOptions".to_string(), vec![StructField::new("csv", AttributeType::struct_("Csv".to_string(), vec![StructField::new("delimiter", AttributeType::string()).with_description("The delimiter used for separating items in the CSV file being imported.").with_provider_name("Delimiter"),
+                    StructField::new("header_list", AttributeType::list(AttributeType::string())).with_description("List of the headers used to specify a common header for all source CSV files being imported. If this field is specified then the first line of each CSV file is treated as data instead of the header. If this field is not specified the the first line of each CSV file is treated as the header.").with_provider_name("HeaderList")])).with_description("The options for imported source files in CSV format. The values are Delimiter and HeaderList.").with_provider_name("Csv")])).with_description("Additional properties that specify how the input is formatted,").with_provider_name("InputFormatOptions"),
+                    StructField::new("s3_bucket_source", AttributeType::struct_("S3BucketSource".to_string(), vec![StructField::new("s3_bucket", AttributeType::string()).required().with_description("The S3 bucket that is being imported from.").with_provider_name("S3Bucket"),
+                    StructField::new("s3_bucket_owner", AttributeType::string()).with_description("The account number of the S3 bucket that is being imported from. If the bucket is owned by the requester this is optional.").with_provider_name("S3BucketOwner"),
+                    StructField::new("s3_key_prefix", AttributeType::string()).with_description("The key prefix shared by all S3 Objects that are being imported.").with_provider_name("S3KeyPrefix")])).required().with_description("The S3 bucket that provides the source for the import.").with_provider_name("S3BucketSource")]))
+                .create_only()
+                .write_only()
+                .with_description("Specifies the properties of data being imported from the S3 bucket source to the\" table. If you specify the ``ImportSourceSpecification`` property, and also specify either the ``StreamSpecification``, the ``TableClass`` property, the ``DeletionProtectionEnabled`` property, or the ``WarmThroughput`` property, the IAM entity creating/updating stack must have ``UpdateTable`` permission.")
+                .with_provider_name("ImportSourceSpecification"),
+        )
+        .attribute(
+            AttributeSchema::new("key_schema", AttributeType::list(AttributeType::struct_("KeySchema".to_string(), vec![StructField::new("attribute_name", AttributeType::string()).required().with_description("The name of a key attribute.").with_provider_name("AttributeName"),
+                    StructField::new("key_type", AttributeType::string_enum("KeyType".to_string(), vec!["HASH".to_string(), "RANGE".to_string()], Some(carina_core::schema::string_enum_identity("KeyType", Some("awscc.dynamodb.Table.KeySchema"))), vec![("HASH".to_string(), "hash".to_string()), ("RANGE".to_string(), "range".to_string())])).required().with_description("The role that this key attribute will assume: + ``HASH`` - partition key + ``RANGE`` - sort key The partition key of an item is also known as its *hash attribute*. The term \"hash attribute\" derives from DynamoDB's usage of an internal hash function to evenly distribute data items across partitions, based on their partition key values. The sort key of an item is also known as its *range attribute*. The term \"range attribute\" derives from the way DynamoDB stores items with the same partition key physically close together, in sorted order by the sort key value.").with_provider_name("KeyType")])))
+                .required()
+                .with_description("Specifies the attributes that make up the primary key for the table. The attributes in the ``KeySchema`` property must also be defined in the ``AttributeDefinitions`` property.")
+                .with_provider_name("KeySchema")
+                .with_block_name("key_schema"),
+        )
+        .attribute(
+            AttributeSchema::new("kinesis_stream_specification", AttributeType::struct_("KinesisStreamSpecification".to_string(), vec![StructField::new("approximate_creation_date_time_precision", AttributeType::string_enum("ApproximateCreationDateTimePrecision".to_string(), vec!["MICROSECOND".to_string(), "MILLISECOND".to_string()], Some(carina_core::schema::string_enum_identity("ApproximateCreationDateTimePrecision", Some("awscc.dynamodb.Table.KinesisStreamSpecification"))), vec![("MICROSECOND".to_string(), "microsecond".to_string()), ("MILLISECOND".to_string(), "millisecond".to_string())])).with_description("The precision for the time and date that the stream was created.").with_provider_name("ApproximateCreationDateTimePrecision"),
+                    StructField::new("stream_arn", super::arn()).required().with_description("The ARN for a specific Kinesis data stream. Length Constraints: Minimum length of 37. Maximum length of 1024.").with_provider_name("StreamArn")]))
+                .with_description("The Kinesis Data Streams configuration for the specified table.")
+                .with_provider_name("KinesisStreamSpecification"),
+        )
+        .attribute(
+            AttributeSchema::new("local_secondary_indexes", AttributeType::list(AttributeType::struct_("LocalSecondaryIndex".to_string(), vec![StructField::new("index_name", AttributeType::string()).required().with_description("The name of the local secondary index. The name must be unique among all other indexes on this table.").with_provider_name("IndexName"),
+                    StructField::new("key_schema", AttributeType::list(AttributeType::struct_("KeySchema".to_string(), vec![StructField::new("attribute_name", AttributeType::string()).required().with_description("The name of a key attribute.").with_provider_name("AttributeName"),
+                    StructField::new("key_type", AttributeType::string_enum("KeyType".to_string(), vec!["HASH".to_string(), "RANGE".to_string()], Some(carina_core::schema::string_enum_identity("KeyType", Some("awscc.dynamodb.Table.LocalSecondaryIndex.KeySchema"))), vec![("HASH".to_string(), "hash".to_string()), ("RANGE".to_string(), "range".to_string())])).required().with_description("The role that this key attribute will assume: + ``HASH`` - partition key + ``RANGE`` - sort key The partition key of an item is also known as its *hash attribute*. The term \"hash attribute\" derives from DynamoDB's usage of an internal hash function to evenly distribute data items across partitions, based on their partition key values. The sort key of an item is also known as its *range attribute*. The term \"range attribute\" derives from the way DynamoDB stores items with the same partition key physically close together, in sorted order by the sort key value.").with_provider_name("KeyType")]))).required().with_description("The complete key schema for the local secondary index, consisting of one or more pairs of attribute names and key types: + ``HASH`` - partition key + ``RANGE`` - sort key The partition key of an item is also known as its *hash attribute*. The term \"hash attribute\" derives from DynamoDB's usage of an internal hash function to evenly distribute data items across partitions, based on their partition key values. The sort key of an item is also known as its *range attribute*. The term \"range attribute\" derives from the way DynamoDB stores items with the same partition key physically close together, in sorted order by the sort key value.").with_provider_name("KeySchema").with_block_name("key_schema"),
+                    StructField::new("projection", AttributeType::ref_("Projection".to_string())).required().with_description("Represents attributes that are copied (projected) from the table into the local secondary index. These are in addition to the primary key attributes and index key attributes, which are automatically projected.").with_provider_name("Projection")])))
+                .with_description("Local secondary indexes to be created on the table. You can create up to 5 local secondary indexes. Each index is scoped to a given hash key value. The size of each hash key can be up to 10 gigabytes.")
+                .with_provider_name("LocalSecondaryIndexes")
+                .with_block_name("local_secondary_index"),
+        )
+        .attribute(
+            AttributeSchema::new("on_demand_throughput", AttributeType::ref_("OnDemandThroughput".to_string()))
+                .with_description("Sets the maximum number of read and write units for the specified on-demand table. If you use this property, you must specify ``MaxReadRequestUnits``, ``MaxWriteRequestUnits``, or both.")
+                .with_provider_name("OnDemandThroughput"),
+        )
+        .attribute(
+            AttributeSchema::new("point_in_time_recovery_specification", AttributeType::struct_("PointInTimeRecoverySpecification".to_string(), vec![StructField::new("point_in_time_recovery_enabled", AttributeType::bool()).with_description("Indicates whether point in time recovery is enabled (true) or disabled (false) on the table.").with_provider_name("PointInTimeRecoveryEnabled"),
+                    StructField::new("recovery_period_in_days", AttributeType::custom(None, AttributeType::int(), None, None, legacy_validator(validate_recovery_period_in_days_range), None)).with_description("The number of preceding days for which continuous backups are taken and maintained. Your table data is only recoverable to any point-in-time from within the configured recovery period. This parameter is optional. If no value is provided, the value will default to 35.").with_provider_name("RecoveryPeriodInDays")]))
+                .with_description("The settings used to enable point in time recovery.")
+                .with_provider_name("PointInTimeRecoverySpecification"),
+        )
+        .attribute(
+            AttributeSchema::new("provisioned_throughput", AttributeType::ref_("ProvisionedThroughput".to_string()))
+                .with_description("Throughput for the specified table, which consists of values for ``ReadCapacityUnits`` and ``WriteCapacityUnits``. For more information about the contents of a provisioned throughput structure, see [Amazon DynamoDB Table ProvisionedThroughput](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ProvisionedThroughput.html). If you set ``BillingMode`` as ``PROVISIONED``, you must specify this property. If you set ``BillingMode`` as ``PAY_PER_REQUEST``, you cannot specify this property.")
+                .with_provider_name("ProvisionedThroughput"),
+        )
+        .attribute(
+            AttributeSchema::new("resource_policy", AttributeType::struct_("ResourcePolicy".to_string(), vec![StructField::new("policy_document", super::iam_policy_document()).required().with_description("A resource-based policy document that contains permissions to add to the specified DDB table, index, or both. In a CFNshort template, you can provide the policy in JSON or YAML format because CFNshort converts YAML to JSON before submitting it to DDB. For more information about resource-based policies, see [Using resource-based policies for](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/access-control-resource-based.html) and [Resource-based policy examples](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/rbac-examples.html).").with_provider_name("PolicyDocument")]))
+                .with_description("An AWS resource-based policy document in JSON format that will be attached to the table. When you attach a resource-based policy while creating a table, the policy application is *strongly consistent*. The maximum size supported for a resource-based policy document is 20 KB. DynamoDB counts whitespaces when calculating the size of a policy against this limit. For a full list of all considerations that apply for resource-based policies, see [Resource-based policy considerations](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/rbac-considerations.html). You need to specify the ``CreateTable`` and ``PutResourcePolicy`` IAM actions for authorizing a user to create a table with a resource-based policy.")
+                .with_provider_name("ResourcePolicy"),
+        )
+        .attribute(
+            AttributeSchema::new("sse_specification", AttributeType::struct_("SSESpecification".to_string(), vec![StructField::new("kms_master_key_id", AttributeType::string()).with_description("The KMS key that should be used for the KMS encryption. To specify a key, use its key ID, Amazon Resource Name (ARN), alias name, or alias ARN. Note that you should only provide this parameter if the key is different from the default DynamoDB key ``alias/aws/dynamodb``.").with_provider_name("KMSMasterKeyId"),
+                    StructField::new("sse_enabled", AttributeType::bool()).required().with_description("Indicates whether server-side encryption is done using an AWS managed key or an AWS owned key. If enabled (true), server-side encryption type is set to ``KMS`` and an AWS managed key is used (KMS charges apply). If disabled (false) or not specified, server-side encryption is set to AWS owned key.").with_provider_name("SSEEnabled"),
+                    StructField::new("sse_type", AttributeType::string()).with_description("Server-side encryption type. The only supported value is: + ``KMS`` - Server-side encryption that uses KMSlong. The key is stored in your account and is managed by KMS (KMS charges apply).").with_provider_name("SSEType")]))
+                .with_description("Specifies the settings to enable server-side encryption.")
+                .with_provider_name("SSESpecification"),
+        )
+        .attribute(
+            AttributeSchema::new("stream_arn", super::arn())
+                .read_only()
+                .with_description(" (read-only)")
+                .with_provider_name("StreamArn"),
+        )
+        .attribute(
+            AttributeSchema::new("stream_specification", AttributeType::struct_("StreamSpecification".to_string(), vec![StructField::new("resource_policy", AttributeType::ref_("ResourcePolicy".to_string())).with_description("Creates or updates a resource-based policy document that contains the permissions for DDB resources, such as a table's streams. Resource-based policies let you define access permissions by specifying who has access to each resource, and the actions they are allowed to perform on each resource. When you remove the ``StreamSpecification`` property from the template, DynamoDB disables the stream but retains any attached resource policy until the stream is deleted after 24 hours. When you modify the ``StreamViewType`` property, DynamoDB creates a new stream and retains the old stream's resource policy. The old stream and its resource policy are deleted after the 24-hour retention period. In a CFNshort template, you can provide the policy in JSON or YAML format because CFNshort converts YAML to JSON before submitting it to DDB. For more information about resource-based policies, see [Using resource-based policies for](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/access-control-resource-based.html) and [Resource-based policy examples](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/rbac-examples.html).").with_provider_name("ResourcePolicy"),
+                    StructField::new("stream_view_type", AttributeType::string_enum("StreamViewType".to_string(), vec!["KEYS_ONLY".to_string(), "NEW_IMAGE".to_string(), "OLD_IMAGE".to_string(), "NEW_AND_OLD_IMAGES".to_string()], Some(carina_core::schema::string_enum_identity("StreamViewType", Some("awscc.dynamodb.Table.StreamSpecification"))), vec![("KEYS_ONLY".to_string(), "keys_only".to_string()), ("NEW_IMAGE".to_string(), "new_image".to_string()), ("OLD_IMAGE".to_string(), "old_image".to_string()), ("NEW_AND_OLD_IMAGES".to_string(), "new_and_old_images".to_string())])).required().with_description("When an item in the table is modified, ``StreamViewType`` determines what information is written to the stream for this table. Valid values for ``StreamViewType`` are: + ``KEYS_ONLY`` - Only the key attributes of the modified item are written to the stream. + ``NEW_IMAGE`` - The entire item, as it appears after it was modified, is written to the stream. + ``OLD_IMAGE`` - The entire item, as it appeared before it was modified, is written to the stream. + ``NEW_AND_OLD_IMAGES`` - Both the new and the old item images of the item are written to the stream.").with_provider_name("StreamViewType")]))
+                .with_description("The settings for the DDB table stream, which captures changes to items stored in the table. Including this property in your CFNlong template automatically enables streaming.")
+                .with_provider_name("StreamSpecification"),
+        )
+        .attribute(
+            AttributeSchema::new("table_class", AttributeType::string_enum("TableClass".to_string(), vec!["STANDARD".to_string(), "STANDARD_INFREQUENT_ACCESS".to_string()], Some(carina_core::schema::string_enum_identity("TableClass", Some("awscc.dynamodb.Table"))), vec![("STANDARD".to_string(), "standard".to_string()), ("STANDARD_INFREQUENT_ACCESS".to_string(), "standard_infrequent_access".to_string())]))
+                .with_description("The table class of the new table. Valid values are ``STANDARD`` and ``STANDARD_INFREQUENT_ACCESS``.")
+                .with_provider_name("TableClass"),
+        )
+        .attribute(
+            AttributeSchema::new("table_name", AttributeType::string())
+                .create_only()
+                .with_description("A name for the table. If you don't specify a name, CFNlong generates a unique physical ID and uses that ID for the table name. For more information, see [Name Type](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-name.html). If you specify a name, you cannot perform updates that require replacement of this resource. You can perform updates that require no or some interruption. If you must replace the resource, specify a new name.")
+                .with_provider_name("TableName"),
+        )
+        .attribute(
+            AttributeSchema::new("tags", tags_type())
+                .with_description("An array of key-value pairs to apply to this resource. For more information, see [Tag](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html).")
+                .with_provider_name("Tags")
+                .with_block_name("tag"),
+        )
+        .attribute(
+            AttributeSchema::new("time_to_live_specification", AttributeType::struct_("TimeToLiveSpecification".to_string(), vec![StructField::new("attribute_name", AttributeType::string()).with_description("The name of the TTL attribute used to store the expiration time for items in the table. + The ``AttributeName`` property is required when enabling the TTL, or when TTL is already enabled. + To update this property, you must first disable TTL and then enable TTL with the new attribute name.").with_provider_name("AttributeName"),
+                    StructField::new("enabled", AttributeType::bool()).required().with_description("Indicates whether TTL is to be enabled (true) or disabled (false) on the table.").with_provider_name("Enabled")]))
+                .with_description("Specifies the Time to Live (TTL) settings for the table. For detailed information about the limits in DynamoDB, see [Limits in Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html) in the Amazon DynamoDB Developer Guide.")
+                .with_provider_name("TimeToLiveSpecification"),
+        )
+        .attribute(
+            AttributeSchema::new("warm_throughput", AttributeType::ref_("WarmThroughput".to_string()))
+                .with_description("Represents the warm throughput (in read units per second and write units per second) for creating a table.")
+                .with_provider_name("WarmThroughput"),
+        )
+        .with_name_attribute("table_name")
+        .with_validator(|attrs| {
+            let mut errors = Vec::new();
+            if let Err(mut e) = validate_tags_map(attrs) {
+                errors.append(&mut e);
+            }
+            if errors.is_empty() { Ok(()) } else { Err(errors) }
+        })
+        .with_def("ContributorInsightsSpecification", AttributeType::struct_("ContributorInsightsSpecification".to_string(), vec![StructField::new("enabled", AttributeType::bool()).required().with_description("Indicates whether CloudWatch Contributor Insights are to be enabled (true) or disabled (false).").with_provider_name("Enabled"),
+                    StructField::new("mode", AttributeType::string_enum("Mode".to_string(), vec!["ACCESSED_AND_THROTTLED_KEYS".to_string(), "THROTTLED_KEYS".to_string()], Some(carina_core::schema::string_enum_identity("Mode", Some("awscc.dynamodb.Table.ContributorInsightsSpecification"))), vec![("ACCESSED_AND_THROTTLED_KEYS".to_string(), "accessed_and_throttled_keys".to_string()), ("THROTTLED_KEYS".to_string(), "throttled_keys".to_string())])).with_description("Specifies the CloudWatch Contributor Insights mode for a table. Valid values are ``ACCESSED_AND_THROTTLED_KEYS`` (tracks all access and throttled events) or ``THROTTLED_KEYS`` (tracks only throttled events). This setting determines what type of contributor insights data is collected for the table.").with_provider_name("Mode")]))
+        .with_def("Csv", AttributeType::struct_("Csv".to_string(), vec![StructField::new("delimiter", AttributeType::string()).with_description("The delimiter used for separating items in the CSV file being imported.").with_provider_name("Delimiter"),
+                    StructField::new("header_list", AttributeType::list(AttributeType::string())).with_description("List of the headers used to specify a common header for all source CSV files being imported. If this field is specified then the first line of each CSV file is treated as data instead of the header. If this field is not specified the the first line of each CSV file is treated as the header.").with_provider_name("HeaderList")]))
+        .with_def("ImportSourceSpecification", AttributeType::struct_("ImportSourceSpecification".to_string(), vec![StructField::new("input_compression_type", AttributeType::string()).with_description("Type of compression to be used on the input coming from the imported table.").with_provider_name("InputCompressionType"),
+                    StructField::new("input_format", AttributeType::string_enum("InputFormat".to_string(), vec!["CSV".to_string(), "DYNAMODB_JSON".to_string(), "ION".to_string()], Some(carina_core::schema::string_enum_identity("InputFormat", Some("awscc.dynamodb.Table.ImportSourceSpecification"))), vec![("CSV".to_string(), "csv".to_string()), ("DYNAMODB_JSON".to_string(), "dynamodb_json".to_string()), ("ION".to_string(), "ion".to_string())])).required().with_description("The format of the source data. Valid values for ``ImportFormat`` are ``CSV``, ``DYNAMODB_JSON`` or ``ION``.").with_provider_name("InputFormat"),
+                    StructField::new("input_format_options", AttributeType::struct_("InputFormatOptions".to_string(), vec![StructField::new("csv", AttributeType::struct_("Csv".to_string(), vec![StructField::new("delimiter", AttributeType::string()).with_description("The delimiter used for separating items in the CSV file being imported.").with_provider_name("Delimiter"),
+                    StructField::new("header_list", AttributeType::list(AttributeType::string())).with_description("List of the headers used to specify a common header for all source CSV files being imported. If this field is specified then the first line of each CSV file is treated as data instead of the header. If this field is not specified the the first line of each CSV file is treated as the header.").with_provider_name("HeaderList")])).with_description("The options for imported source files in CSV format. The values are Delimiter and HeaderList.").with_provider_name("Csv")])).with_description("Additional properties that specify how the input is formatted,").with_provider_name("InputFormatOptions"),
+                    StructField::new("s3_bucket_source", AttributeType::struct_("S3BucketSource".to_string(), vec![StructField::new("s3_bucket", AttributeType::string()).required().with_description("The S3 bucket that is being imported from.").with_provider_name("S3Bucket"),
+                    StructField::new("s3_bucket_owner", AttributeType::string()).with_description("The account number of the S3 bucket that is being imported from. If the bucket is owned by the requester this is optional.").with_provider_name("S3BucketOwner"),
+                    StructField::new("s3_key_prefix", AttributeType::string()).with_description("The key prefix shared by all S3 Objects that are being imported.").with_provider_name("S3KeyPrefix")])).required().with_description("The S3 bucket that provides the source for the import.").with_provider_name("S3BucketSource")]))
+        .with_def("InputFormatOptions", AttributeType::struct_("InputFormatOptions".to_string(), vec![StructField::new("csv", AttributeType::struct_("Csv".to_string(), vec![StructField::new("delimiter", AttributeType::string()).with_description("The delimiter used for separating items in the CSV file being imported.").with_provider_name("Delimiter"),
+                    StructField::new("header_list", AttributeType::list(AttributeType::string())).with_description("List of the headers used to specify a common header for all source CSV files being imported. If this field is specified then the first line of each CSV file is treated as data instead of the header. If this field is not specified the the first line of each CSV file is treated as the header.").with_provider_name("HeaderList")])).with_description("The options for imported source files in CSV format. The values are Delimiter and HeaderList.").with_provider_name("Csv")]))
+        .with_def("KinesisStreamSpecification", AttributeType::struct_("KinesisStreamSpecification".to_string(), vec![StructField::new("approximate_creation_date_time_precision", AttributeType::string_enum("ApproximateCreationDateTimePrecision".to_string(), vec!["MICROSECOND".to_string(), "MILLISECOND".to_string()], Some(carina_core::schema::string_enum_identity("ApproximateCreationDateTimePrecision", Some("awscc.dynamodb.Table.KinesisStreamSpecification"))), vec![("MICROSECOND".to_string(), "microsecond".to_string()), ("MILLISECOND".to_string(), "millisecond".to_string())])).with_description("The precision for the time and date that the stream was created.").with_provider_name("ApproximateCreationDateTimePrecision"),
+                    StructField::new("stream_arn", super::arn()).required().with_description("The ARN for a specific Kinesis data stream. Length Constraints: Minimum length of 37. Maximum length of 1024.").with_provider_name("StreamArn")]))
+        .with_def("OnDemandThroughput", AttributeType::struct_("OnDemandThroughput".to_string(), vec![StructField::new("max_read_request_units", AttributeType::custom(None, AttributeType::int(), None, None, legacy_validator(validate_max_read_request_units_range), None)).with_description("Maximum number of read request units for the specified table. To specify a maximum ``OnDemandThroughput`` on your table, set the value of ``MaxReadRequestUnits`` as greater than or equal to 1. To remove the maximum ``OnDemandThroughput`` that is currently set on your table, set the value of ``MaxReadRequestUnits`` to -1.").with_provider_name("MaxReadRequestUnits"),
+                    StructField::new("max_write_request_units", AttributeType::custom(None, AttributeType::int(), None, None, legacy_validator(validate_max_write_request_units_range), None)).with_description("Maximum number of write request units for the specified table. To specify a maximum ``OnDemandThroughput`` on your table, set the value of ``MaxWriteRequestUnits`` as greater than or equal to 1. To remove the maximum ``OnDemandThroughput`` that is currently set on your table, set the value of ``MaxWriteRequestUnits`` to -1.").with_provider_name("MaxWriteRequestUnits")]))
+        .with_def("PointInTimeRecoverySpecification", AttributeType::struct_("PointInTimeRecoverySpecification".to_string(), vec![StructField::new("point_in_time_recovery_enabled", AttributeType::bool()).with_description("Indicates whether point in time recovery is enabled (true) or disabled (false) on the table.").with_provider_name("PointInTimeRecoveryEnabled"),
+                    StructField::new("recovery_period_in_days", AttributeType::custom(None, AttributeType::int(), None, None, legacy_validator(validate_recovery_period_in_days_range), None)).with_description("The number of preceding days for which continuous backups are taken and maintained. Your table data is only recoverable to any point-in-time from within the configured recovery period. This parameter is optional. If no value is provided, the value will default to 35.").with_provider_name("RecoveryPeriodInDays")]))
+        .with_def("Projection", AttributeType::struct_("Projection".to_string(), vec![StructField::new("non_key_attributes", AttributeType::list(AttributeType::string())).with_description("Represents the non-key attribute names which will be projected into the index. For global and local secondary indexes, the total count of ``NonKeyAttributes`` summed across all of the secondary indexes, must not exceed 100. If you project the same attribute into two different indexes, this counts as two distinct attributes when determining the total. This limit only applies when you specify the ProjectionType of ``INCLUDE``. You still can specify the ProjectionType of ``ALL`` to project all attributes from the source table, even if the table has more than 100 attributes.").with_provider_name("NonKeyAttributes"),
+                    StructField::new("projection_type", AttributeType::string_enum("ProjectionType".to_string(), vec!["KEYS_ONLY".to_string(), "INCLUDE".to_string(), "ALL".to_string()], Some(carina_core::schema::string_enum_identity("ProjectionType", Some("awscc.dynamodb.Table.GlobalSecondaryIndex.Projection"))), vec![("KEYS_ONLY".to_string(), "keys_only".to_string()), ("INCLUDE".to_string(), "include".to_string()), ("ALL".to_string(), "all".to_string())])).with_description("The set of attributes that are projected into the index: + ``KEYS_ONLY`` - Only the index and primary keys are projected into the index. + ``INCLUDE`` - In addition to the attributes described in ``KEYS_ONLY``, the secondary index will include other non-key attributes that you specify. + ``ALL`` - All of the table attributes are projected into the index. When using the DynamoDB console, ``ALL`` is selected by default.").with_provider_name("ProjectionType")]))
+        .with_def("ProvisionedThroughput", AttributeType::struct_("ProvisionedThroughput".to_string(), vec![StructField::new("read_capacity_units", AttributeType::int()).required().with_description("The maximum number of strongly consistent reads consumed per second before DynamoDB returns a ``ThrottlingException``. For more information, see [Specifying Read and Write Requirements](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughput.html) in the *Amazon DynamoDB Developer Guide*. If read/write capacity mode is ``PAY_PER_REQUEST`` the value is set to 0.").with_provider_name("ReadCapacityUnits"),
+                    StructField::new("write_capacity_units", AttributeType::int()).required().with_description("The maximum number of writes consumed per second before DynamoDB returns a ``ThrottlingException``. For more information, see [Specifying Read and Write Requirements](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughput.html) in the *Amazon DynamoDB Developer Guide*. If read/write capacity mode is ``PAY_PER_REQUEST`` the value is set to 0.").with_provider_name("WriteCapacityUnits")]))
+        .with_def("ResourcePolicy", AttributeType::struct_("ResourcePolicy".to_string(), vec![StructField::new("policy_document", super::iam_policy_document()).required().with_description("A resource-based policy document that contains permissions to add to the specified DDB table, index, or both. In a CFNshort template, you can provide the policy in JSON or YAML format because CFNshort converts YAML to JSON before submitting it to DDB. For more information about resource-based policies, see [Using resource-based policies for](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/access-control-resource-based.html) and [Resource-based policy examples](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/rbac-examples.html).").with_provider_name("PolicyDocument")]))
+        .with_def("S3BucketSource", AttributeType::struct_("S3BucketSource".to_string(), vec![StructField::new("s3_bucket", AttributeType::string()).required().with_description("The S3 bucket that is being imported from.").with_provider_name("S3Bucket"),
+                    StructField::new("s3_bucket_owner", AttributeType::string()).with_description("The account number of the S3 bucket that is being imported from. If the bucket is owned by the requester this is optional.").with_provider_name("S3BucketOwner"),
+                    StructField::new("s3_key_prefix", AttributeType::string()).with_description("The key prefix shared by all S3 Objects that are being imported.").with_provider_name("S3KeyPrefix")]))
+        .with_def("SSESpecification", AttributeType::struct_("SSESpecification".to_string(), vec![StructField::new("kms_master_key_id", AttributeType::string()).with_description("The KMS key that should be used for the KMS encryption. To specify a key, use its key ID, Amazon Resource Name (ARN), alias name, or alias ARN. Note that you should only provide this parameter if the key is different from the default DynamoDB key ``alias/aws/dynamodb``.").with_provider_name("KMSMasterKeyId"),
+                    StructField::new("sse_enabled", AttributeType::bool()).required().with_description("Indicates whether server-side encryption is done using an AWS managed key or an AWS owned key. If enabled (true), server-side encryption type is set to ``KMS`` and an AWS managed key is used (KMS charges apply). If disabled (false) or not specified, server-side encryption is set to AWS owned key.").with_provider_name("SSEEnabled"),
+                    StructField::new("sse_type", AttributeType::string()).with_description("Server-side encryption type. The only supported value is: + ``KMS`` - Server-side encryption that uses KMSlong. The key is stored in your account and is managed by KMS (KMS charges apply).").with_provider_name("SSEType")]))
+        .with_def("StreamSpecification", AttributeType::struct_("StreamSpecification".to_string(), vec![StructField::new("resource_policy", AttributeType::ref_("ResourcePolicy".to_string())).with_description("Creates or updates a resource-based policy document that contains the permissions for DDB resources, such as a table's streams. Resource-based policies let you define access permissions by specifying who has access to each resource, and the actions they are allowed to perform on each resource. When you remove the ``StreamSpecification`` property from the template, DynamoDB disables the stream but retains any attached resource policy until the stream is deleted after 24 hours. When you modify the ``StreamViewType`` property, DynamoDB creates a new stream and retains the old stream's resource policy. The old stream and its resource policy are deleted after the 24-hour retention period. In a CFNshort template, you can provide the policy in JSON or YAML format because CFNshort converts YAML to JSON before submitting it to DDB. For more information about resource-based policies, see [Using resource-based policies for](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/access-control-resource-based.html) and [Resource-based policy examples](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/rbac-examples.html).").with_provider_name("ResourcePolicy"),
+                    StructField::new("stream_view_type", AttributeType::string_enum("StreamViewType".to_string(), vec!["KEYS_ONLY".to_string(), "NEW_IMAGE".to_string(), "OLD_IMAGE".to_string(), "NEW_AND_OLD_IMAGES".to_string()], Some(carina_core::schema::string_enum_identity("StreamViewType", Some("awscc.dynamodb.Table.StreamSpecification"))), vec![("KEYS_ONLY".to_string(), "keys_only".to_string()), ("NEW_IMAGE".to_string(), "new_image".to_string()), ("OLD_IMAGE".to_string(), "old_image".to_string()), ("NEW_AND_OLD_IMAGES".to_string(), "new_and_old_images".to_string())])).required().with_description("When an item in the table is modified, ``StreamViewType`` determines what information is written to the stream for this table. Valid values for ``StreamViewType`` are: + ``KEYS_ONLY`` - Only the key attributes of the modified item are written to the stream. + ``NEW_IMAGE`` - The entire item, as it appears after it was modified, is written to the stream. + ``OLD_IMAGE`` - The entire item, as it appeared before it was modified, is written to the stream. + ``NEW_AND_OLD_IMAGES`` - Both the new and the old item images of the item are written to the stream.").with_provider_name("StreamViewType")]))
+        .with_def("TimeToLiveSpecification", AttributeType::struct_("TimeToLiveSpecification".to_string(), vec![StructField::new("attribute_name", AttributeType::string()).with_description("The name of the TTL attribute used to store the expiration time for items in the table. + The ``AttributeName`` property is required when enabling the TTL, or when TTL is already enabled. + To update this property, you must first disable TTL and then enable TTL with the new attribute name.").with_provider_name("AttributeName"),
+                    StructField::new("enabled", AttributeType::bool()).required().with_description("Indicates whether TTL is to be enabled (true) or disabled (false) on the table.").with_provider_name("Enabled")]))
+        .with_def("WarmThroughput", AttributeType::struct_("WarmThroughput".to_string(), vec![StructField::new("read_units_per_second", AttributeType::custom(None, AttributeType::int(), None, None, legacy_validator(validate_read_units_per_second_range), None)).with_description("Represents the number of read operations your base table can instantaneously support.").with_provider_name("ReadUnitsPerSecond"),
+                    StructField::new("write_units_per_second", AttributeType::custom(None, AttributeType::int(), None, None, legacy_validator(validate_write_units_per_second_range), None)).with_description("Represents the number of write operations your base table can instantaneously support.").with_provider_name("WriteUnitsPerSecond")]))
+    }
+}
+
+/// Returns the resource type name and all enum valid values for this module
+pub fn enum_valid_values() -> (
+    &'static str,
+    &'static [(&'static str, &'static [&'static str])],
+) {
+    (
+        "dynamodb.Table",
+        &[
+            ("attribute_type", VALID_ATTRIBUTE_DEFINITION_ATTRIBUTE_TYPE),
+            ("billing_mode", VALID_BILLING_MODE),
+            ("mode", VALID_CONTRIBUTOR_INSIGHTS_SPECIFICATION_MODE),
+            (
+                "input_format",
+                VALID_IMPORT_SOURCE_SPECIFICATION_INPUT_FORMAT,
+            ),
+            ("key_type", VALID_KEY_SCHEMA_KEY_TYPE),
+            (
+                "approximate_creation_date_time_precision",
+                VALID_KINESIS_STREAM_SPECIFICATION_APPROXIMATE_CREATION_DATE_TIME_PRECISION,
+            ),
+            ("projection_type", VALID_PROJECTION_PROJECTION_TYPE),
+            (
+                "stream_view_type",
+                VALID_STREAM_SPECIFICATION_STREAM_VIEW_TYPE,
+            ),
+            ("table_class", VALID_TABLE_CLASS),
+        ],
+    )
+}

--- a/carina-provider-awscc/src/schemas/generated/mod.rs
+++ b/carina-provider-awscc/src/schemas/generated/mod.rs
@@ -11,6 +11,7 @@ use std::sync::LazyLock;
 pub use super::awscc_types::*;
 
 pub mod cloudfront;
+pub mod dynamodb;
 pub mod ec2;
 pub mod iam;
 pub mod identitystore;
@@ -79,6 +80,7 @@ static ENUM_VALID_VALUES: LazyLock<
         cloudfront::origin_access_control::enum_valid_values(),
         wafv2::web_acl::enum_valid_values(),
         kms::key::enum_valid_values(),
+        dynamodb::table::enum_valid_values(),
     ];
     let mut map: HashMap<&str, HashMap<&str, &[&str]>> = HashMap::new();
     for (rt, attrs) in modules {
@@ -132,6 +134,7 @@ fn build_configs() -> Vec<AwsccSchemaConfig> {
         cloudfront::origin_access_control::cloudfront_origin_access_control_config(),
         wafv2::web_acl::wafv2_web_acl_config(),
         kms::key::kms_key_config(),
+        dynamodb::table::dynamodb_table_config(),
     ]
 }
 

--- a/carina-provider-awscc/tests/dynamodb_table_cloudcontrol_roundtrip.rs
+++ b/carina-provider-awscc/tests/dynamodb_table_cloudcontrol_roundtrip.rs
@@ -1,0 +1,176 @@
+//! Integration coverage for the awscc provider's real Provider-trait apply path
+//! against an in-process winterbaume CloudControl mock.
+//!
+//! This test proves that create -> read wiring round-trips DynamoDB table
+//! list-of-struct serialization through CloudControl. In particular,
+//! `key_schema`, whose generated type is selected through oneOf resolution,
+//! survives the real apply path as a structured list of maps instead of being
+//! flattened into a string.
+//!
+//! This test deliberately does not assert write-only stripping, read-only
+//! synthesis, or schema-default fill-in. Those are real AWS CloudControl
+//! behaviours driven by the CloudFormation resource-type schema; the generic
+//! winterbaume mock returns the desired state verbatim and does not reproduce
+//! them because it does not consult CFN schemas. That winterbaume behavior is
+//! tracked upstream as moriyoshi/winterbaume issue #6. The AWS behaviours
+//! should be verified separately against live AWS, not here.
+
+use aws_config::{BehaviorVersion, Region};
+use carina_core::provider::{CreateRequest, Provider, ReadRequest};
+use carina_core::resource::{ConcreteValue, Resource, Value};
+use carina_provider_awscc::AwsccProvider;
+use carina_provider_awscc::provider::AwsccProviderConfig;
+use indexmap::IndexMap;
+use std::collections::HashMap;
+use winterbaume_cloudcontrol::CloudControlService;
+use winterbaume_core::MockAws;
+
+fn string(value: &str) -> Value {
+    Value::Concrete(ConcreteValue::String(value.to_string()))
+}
+
+#[allow(dead_code)]
+fn int(value: i64) -> Value {
+    Value::Concrete(ConcreteValue::Int(value))
+}
+
+fn bool_(value: bool) -> Value {
+    Value::Concrete(ConcreteValue::Bool(value))
+}
+
+fn map(entries: impl IntoIterator<Item = (&'static str, Value)>) -> Value {
+    Value::Concrete(ConcreteValue::Map(
+        entries
+            .into_iter()
+            .map(|(key, value)| (key.to_string(), value))
+            .collect::<IndexMap<_, _>>(),
+    ))
+}
+
+fn list(items: impl IntoIterator<Item = Value>) -> Value {
+    Value::Concrete(ConcreteValue::List(items.into_iter().collect()))
+}
+
+fn dynamodb_table_resource() -> Resource {
+    Resource::with_provider("awscc", "dynamodb.Table", "jti_store", None)
+        .with_attribute("table_name", string("jti-store"))
+        .with_attribute("billing_mode", string("PAY_PER_REQUEST"))
+        .with_attribute(
+            "attribute_definitions",
+            list([map([
+                ("attribute_name", string("jti")),
+                ("attribute_type", string("S")),
+            ])]),
+        )
+        .with_attribute(
+            "key_schema",
+            list([map([
+                ("attribute_name", string("jti")),
+                ("key_type", string("HASH")),
+            ])]),
+        )
+        .with_attribute(
+            "time_to_live_specification",
+            map([("enabled", bool_(true)), ("attribute_name", string("ttl"))]),
+        )
+        .with_attribute(
+            "point_in_time_recovery_specification",
+            map([("point_in_time_recovery_enabled", bool_(true))]),
+        )
+        .with_attribute("tags", map([("Environment", string("test"))]))
+}
+
+async fn winterbaume_provider() -> AwsccProvider {
+    let mock = MockAws::builder()
+        .with_service(CloudControlService::new())
+        .build();
+    let config = aws_config::defaults(BehaviorVersion::latest())
+        .http_client(mock.http_client())
+        .credentials_provider(mock.credentials_provider())
+        .region(Region::new("us-east-1"))
+        .load()
+        .await;
+
+    AwsccProvider::from_sdk_config(config, &AwsccProviderConfig::default()).await
+}
+
+fn assert_single_map_list(
+    attributes: &HashMap<String, Value>,
+    attribute_name: &str,
+    expected_entries: &[(&str, Value)],
+) {
+    let value = attributes
+        .get(attribute_name)
+        .unwrap_or_else(|| panic!("read-back state must include {attribute_name}"));
+    let items = match value {
+        Value::Concrete(ConcreteValue::List(items)) => items,
+        other => panic!("{attribute_name} must round-trip as List(Map), got {other:?}"),
+    };
+    assert_eq!(
+        items.len(),
+        1,
+        "{attribute_name} must contain one structured element"
+    );
+    let item = match &items[0] {
+        Value::Concrete(ConcreteValue::Map(item)) => item,
+        other => panic!("{attribute_name}[0] must round-trip as Map, got {other:?}"),
+    };
+
+    for (key, expected_value) in expected_entries {
+        assert_eq!(
+            item.get(*key),
+            Some(expected_value),
+            "{attribute_name}[0].{key} must round-trip"
+        );
+    }
+}
+
+#[tokio::test]
+async fn dynamodb_table_create_then_read_round_trips_list_of_struct_fields() {
+    let provider = winterbaume_provider().await;
+    let resource = dynamodb_table_resource();
+    let id = resource.id.clone();
+
+    let created = Provider::create(&provider, &id, CreateRequest { resource })
+        .await
+        .expect("dynamodb.Table create through Provider::create should succeed");
+    let identifier = created
+        .identifier
+        .as_deref()
+        .expect("CloudControl create must return a stable identifier");
+
+    let read = Provider::read(&provider, &id, Some(identifier), ReadRequest)
+        .await
+        .expect("dynamodb.Table read through Provider::read should succeed");
+
+    assert!(read.exists, "read-back state must exist");
+    assert_eq!(read.identifier.as_deref(), Some(identifier));
+    assert_eq!(
+        read.attributes.get("table_name"),
+        Some(&string("jti-store"))
+    );
+    assert_eq!(
+        read.attributes.get("billing_mode"),
+        Some(&string("PAY_PER_REQUEST"))
+    );
+    assert_single_map_list(
+        &read.attributes,
+        "key_schema",
+        &[
+            ("attribute_name", string("jti")),
+            ("key_type", string("HASH")),
+        ],
+    );
+    assert_single_map_list(
+        &read.attributes,
+        "attribute_definitions",
+        &[
+            ("attribute_name", string("jti")),
+            ("attribute_type", string("S")),
+        ],
+    );
+    assert_eq!(
+        read.attributes.get("tags"),
+        Some(&map([("Environment", string("test"))]))
+    );
+}

--- a/cfn-schema-cache/AWS__DynamoDB__Table.json
+++ b/cfn-schema-cache/AWS__DynamoDB__Table.json
@@ -1,0 +1,672 @@
+{
+    "tagging": {
+        "permissions": [
+            "dynamodb:TagResource",
+            "dynamodb:UntagResource",
+            "dynamodb:ListTagsOfResource"
+        ],
+        "taggable": true,
+        "tagOnCreate": true,
+        "tagUpdatable": true,
+        "tagProperty": "/properties/Tags",
+        "cloudFormationSystemTags": false
+    },
+    "typeName": "AWS::DynamoDB::Table",
+    "readOnlyProperties": [
+        "/properties/Arn",
+        "/properties/StreamArn"
+    ],
+    "description": "The ``AWS::DynamoDB::Table`` resource creates a DDB table. For more information, see [CreateTable](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_CreateTable.html) in the *API Reference*.\n You should be aware of the following behaviors when working with DDB tables:\n  +  CFNlong typically creates DDB tables in parallel. However, if your template includes multiple DDB tables with indexes, you must declare dependencies so that the tables are created sequentially. DDBlong limits the number of tables with secondary indexes that are in the creating state. If you create multiple tables with indexes at the same time, DDB returns an error and the stack operation fails. For an example, see [DynamoDB Table with a DependsOn Attribute](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#aws-resource-dynamodb-table--examples--DynamoDB_Table_with_a_DependsOn_Attribute).\n  \n   Our guidance is to use the latest schema documented for your CFNlong templates. This schema supports the provisioning of all table settings below. When using this schema in your CFNlong templates, please ensure that your Identity and Access Management (IAM) policies are updated with appropriate permissions to allow for the authorization of these setting changes.",
+    "createOnlyProperties": [
+        "/properties/TableName",
+        "/properties/ImportSourceSpecification"
+    ],
+    "primaryIdentifier": ["/properties/TableName"],
+    "required": ["KeySchema"],
+    "conditionalCreateOnlyProperties": ["/properties/KeySchema"],
+    "propertyTransform": {"/properties/SSESpecification/KMSMasterKeyId": "$join([\"arn:aws(-[a-z]{1,4}){0,2}:kms:[a-z]{2,4}(-[a-z]{1,4})?-[a-z]{1,10}-[0-9]:[0-9]{12}:key\\/\", SSESpecification.KMSMasterKeyId]) $OR $join([\"arn:aws(-[a-z]{1,4}){0,2}:kms:[a-z]{2,4}(-[a-z]{1,4})?-[a-z]{1,10}-[0-9]:[0-9]{12}:key\\/\", KMSMasterKeyId])"},
+    "handlers": {
+        "read": {"permissions": [
+            "dynamodb:DescribeTable",
+            "dynamodb:DescribeContinuousBackups",
+            "dynamodb:DescribeContributorInsights",
+            "dynamodb:DescribeKinesisStreamingDestination",
+            "dynamodb:ListTagsOfResource",
+            "dynamodb:GetResourcePolicy",
+            "dynamodb:DescribeTimeToLive"
+        ]},
+        "create": {
+            "permissions": [
+                "dynamodb:CreateTable",
+                "dynamodb:DescribeImport",
+                "dynamodb:DescribeTable",
+                "dynamodb:DescribeTimeToLive",
+                "dynamodb:UpdateTimeToLive",
+                "dynamodb:UpdateContributorInsights",
+                "dynamodb:UpdateContinuousBackups",
+                "dynamodb:DescribeContinuousBackups",
+                "dynamodb:DescribeContributorInsights",
+                "dynamodb:EnableKinesisStreamingDestination",
+                "dynamodb:DisableKinesisStreamingDestination",
+                "dynamodb:DescribeKinesisStreamingDestination",
+                "dynamodb:ImportTable",
+                "dynamodb:ListTagsOfResource",
+                "dynamodb:TagResource",
+                "dynamodb:UpdateTable",
+                "dynamodb:GetResourcePolicy",
+                "dynamodb:PutResourcePolicy",
+                "dynamodb:CreateTableReplica",
+                "dynamodb:Scan",
+                "dynamodb:Query",
+                "dynamodb:UpdateItem",
+                "dynamodb:PutItem",
+                "dynamodb:GetItem",
+                "dynamodb:DeleteItem",
+                "dynamodb:BatchWriteItem",
+                "dynamodb:AssociateTableReplica",
+                "kinesis:DescribeStream",
+                "kinesis:PutRecords",
+                "iam:CreateServiceLinkedRole",
+                "kms:CreateGrant",
+                "kms:Decrypt",
+                "kms:DescribeKey",
+                "kms:ListAliases",
+                "kms:Encrypt",
+                "kms:RevokeGrant",
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:DescribeLogGroups",
+                "logs:DescribeLogStreams",
+                "logs:PutLogEvents",
+                "logs:PutRetentionPolicy",
+                "s3:GetObject",
+                "s3:GetObjectMetadata",
+                "s3:ListBucket"
+            ],
+            "timeoutInMinutes": 720
+        },
+        "update": {
+            "permissions": [
+                "dynamodb:UpdateTable",
+                "dynamodb:DescribeTable",
+                "dynamodb:DescribeTimeToLive",
+                "dynamodb:UpdateTimeToLive",
+                "dynamodb:UpdateContinuousBackups",
+                "dynamodb:UpdateContributorInsights",
+                "dynamodb:UpdateKinesisStreamingDestination",
+                "dynamodb:DescribeContinuousBackups",
+                "dynamodb:DescribeKinesisStreamingDestination",
+                "dynamodb:ListTagsOfResource",
+                "dynamodb:TagResource",
+                "dynamodb:UntagResource",
+                "dynamodb:DescribeContributorInsights",
+                "dynamodb:EnableKinesisStreamingDestination",
+                "dynamodb:DisableKinesisStreamingDestination",
+                "dynamodb:GetResourcePolicy",
+                "dynamodb:PutResourcePolicy",
+                "dynamodb:DeleteResourcePolicy",
+                "dynamodb:CreateTable",
+                "dynamodb:CreateTableReplica",
+                "dynamodb:Scan",
+                "dynamodb:Query",
+                "dynamodb:UpdateItem",
+                "dynamodb:PutItem",
+                "dynamodb:GetItem",
+                "dynamodb:DeleteItem",
+                "dynamodb:BatchWriteItem",
+                "dynamodb:AssociateTableReplica",
+                "kinesis:DescribeStream",
+                "kinesis:PutRecords",
+                "iam:CreateServiceLinkedRole",
+                "kms:CreateGrant",
+                "kms:DescribeKey",
+                "kms:ListAliases",
+                "kms:RevokeGrant"
+            ],
+            "timeoutInMinutes": 720
+        },
+        "list": {"permissions": ["dynamodb:ListTables"]},
+        "delete": {
+            "permissions": [
+                "dynamodb:DeleteTable",
+                "dynamodb:DescribeTable"
+            ],
+            "timeoutInMinutes": 720
+        }
+    },
+    "writeOnlyProperties": ["/properties/ImportSourceSpecification"],
+    "additionalProperties": false,
+    "definitions": {
+        "OnDemandThroughput": {
+            "description": "Sets the maximum number of read and write units for the specified on-demand table. If you use this property, you must specify ``MaxReadRequestUnits``, ``MaxWriteRequestUnits``, or both.",
+            "additionalProperties": false,
+            "type": "object",
+            "properties": {
+                "MaxReadRequestUnits": {
+                    "description": "Maximum number of read request units for the specified table.\n To specify a maximum ``OnDemandThroughput`` on your table, set the value of ``MaxReadRequestUnits`` as greater than or equal to 1. To remove the maximum ``OnDemandThroughput`` that is currently set on your table, set the value of ``MaxReadRequestUnits`` to -1.",
+                    "type": "integer",
+                    "minimum": 1
+                },
+                "MaxWriteRequestUnits": {
+                    "description": "Maximum number of write request units for the specified table.\n To specify a maximum ``OnDemandThroughput`` on your table, set the value of ``MaxWriteRequestUnits`` as greater than or equal to 1. To remove the maximum ``OnDemandThroughput`` that is currently set on your table, set the value of ``MaxWriteRequestUnits`` to -1.",
+                    "type": "integer",
+                    "minimum": 1
+                }
+            }
+        },
+        "LocalSecondaryIndex": {
+            "description": "Represents the properties of a local secondary index. A local secondary index can only be created when its parent table is created.",
+            "additionalProperties": false,
+            "type": "object",
+            "properties": {
+                "IndexName": {
+                    "description": "The name of the local secondary index. The name must be unique among all other indexes on this table.",
+                    "type": "string"
+                },
+                "Projection": {
+                    "description": "Represents attributes that are copied (projected) from the table into the local secondary index. These are in addition to the primary key attributes and index key attributes, which are automatically projected.",
+                    "$ref": "#/definitions/Projection"
+                },
+                "KeySchema": {
+                    "uniqueItems": true,
+                    "description": "The complete key schema for the local secondary index, consisting of one or more pairs of attribute names and key types:\n  +  ``HASH`` - partition key\n  +  ``RANGE`` - sort key\n  \n  The partition key of an item is also known as its *hash attribute*. The term \"hash attribute\" derives from DynamoDB's usage of an internal hash function to evenly distribute data items across partitions, based on their partition key values.\n The sort key of an item is also known as its *range attribute*. The term \"range attribute\" derives from the way DynamoDB stores items with the same partition key physically close together, in sorted order by the sort key value.",
+                    "type": "array",
+                    "items": {"$ref": "#/definitions/KeySchema"}
+                }
+            },
+            "required": [
+                "IndexName",
+                "Projection",
+                "KeySchema"
+            ]
+        },
+        "SSESpecification": {
+            "description": "Represents the settings used to enable server-side encryption.",
+            "additionalProperties": false,
+            "type": "object",
+            "properties": {
+                "SSEEnabled": {
+                    "description": "Indicates whether server-side encryption is done using an AWS managed key or an AWS owned key. If enabled (true), server-side encryption type is set to ``KMS`` and an AWS managed key is used (KMS charges apply). If disabled (false) or not specified, server-side encryption is set to AWS owned key.",
+                    "type": "boolean"
+                },
+                "SSEType": {
+                    "description": "Server-side encryption type. The only supported value is:\n  +  ``KMS`` - Server-side encryption that uses KMSlong. The key is stored in your account and is managed by KMS (KMS charges apply).",
+                    "type": "string"
+                },
+                "KMSMasterKeyId": {
+                    "anyOf": [
+                        {"relationshipRef": {
+                            "typeName": "AWS::KMS::Key",
+                            "propertyPath": "/properties/Arn"
+                        }},
+                        {"relationshipRef": {
+                            "typeName": "AWS::KMS::Key",
+                            "propertyPath": "/properties/KeyId"
+                        }},
+                        {"relationshipRef": {
+                            "typeName": "AWS::KMS::Alias",
+                            "propertyPath": "/properties/AliasName"
+                        }}
+                    ],
+                    "description": "The KMS key that should be used for the KMS encryption. To specify a key, use its key ID, Amazon Resource Name (ARN), alias name, or alias ARN. Note that you should only provide this parameter if the key is different from the default DynamoDB key ``alias/aws/dynamodb``.",
+                    "type": "string"
+                }
+            },
+            "required": ["SSEEnabled"]
+        },
+        "KinesisStreamSpecification": {
+            "description": "The Kinesis Data Streams configuration for the specified table.",
+            "additionalProperties": false,
+            "type": "object",
+            "properties": {
+                "ApproximateCreationDateTimePrecision": {
+                    "description": "The precision for the time and date that the stream was created.",
+                    "type": "string",
+                    "enum": [
+                        "MICROSECOND",
+                        "MILLISECOND"
+                    ]
+                },
+                "StreamArn": {
+                    "description": "The ARN for a specific Kinesis data stream.\n Length Constraints: Minimum length of 37. Maximum length of 1024.",
+                    "type": "string"
+                }
+            },
+            "required": ["StreamArn"]
+        },
+        "StreamSpecification": {
+            "description": "Represents the DynamoDB Streams configuration for a table in DynamoDB.",
+            "additionalProperties": false,
+            "type": "object",
+            "properties": {
+                "StreamViewType": {
+                    "description": "When an item in the table is modified, ``StreamViewType`` determines what information is written to the stream for this table. Valid values for ``StreamViewType`` are:\n  +  ``KEYS_ONLY`` - Only the key attributes of the modified item are written to the stream.\n  +  ``NEW_IMAGE`` - The entire item, as it appears after it was modified, is written to the stream.\n  +  ``OLD_IMAGE`` - The entire item, as it appeared before it was modified, is written to the stream.\n  +  ``NEW_AND_OLD_IMAGES`` - Both the new and the old item images of the item are written to the stream.",
+                    "type": "string"
+                },
+                "ResourcePolicy": {
+                    "description": "Creates or updates a resource-based policy document that contains the permissions for DDB resources, such as a table's streams. Resource-based policies let you define access permissions by specifying who has access to each resource, and the actions they are allowed to perform on each resource.\n  When you remove the ``StreamSpecification`` property from the template, DynamoDB disables the stream but retains any attached resource policy until the stream is deleted after 24 hours. When you modify the ``StreamViewType`` property, DynamoDB creates a new stream and retains the old stream's resource policy. The old stream and its resource policy are deleted after the 24-hour retention period.\n  In a CFNshort template, you can provide the policy in JSON or YAML format because CFNshort converts YAML to JSON before submitting it to DDB. For more information about resource-based policies, see [Using resource-based policies for](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/access-control-resource-based.html) and [Resource-based policy examples](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/rbac-examples.html).",
+                    "$ref": "#/definitions/ResourcePolicy"
+                }
+            },
+            "required": ["StreamViewType"]
+        },
+        "ContributorInsightsSpecification": {
+            "description": "Configures contributor insights settings for a table or one of its indexes.",
+            "additionalProperties": false,
+            "type": "object",
+            "properties": {
+                "Mode": {
+                    "description": "Specifies the CloudWatch Contributor Insights mode for a table. Valid values are ``ACCESSED_AND_THROTTLED_KEYS`` (tracks all access and throttled events) or ``THROTTLED_KEYS`` (tracks only throttled events). This setting determines what type of contributor insights data is collected for the table.",
+                    "type": "string",
+                    "enum": [
+                        "ACCESSED_AND_THROTTLED_KEYS",
+                        "THROTTLED_KEYS"
+                    ]
+                },
+                "Enabled": {
+                    "description": "Indicates whether CloudWatch Contributor Insights are to be enabled (true) or disabled (false).",
+                    "type": "boolean"
+                }
+            },
+            "required": ["Enabled"]
+        },
+        "InputFormatOptions": {
+            "description": "The format options for the data that was imported into the target table. There is one value, CsvOption.",
+            "additionalProperties": false,
+            "type": "object",
+            "properties": {"Csv": {
+                "description": "The options for imported source files in CSV format. The values are Delimiter and HeaderList.",
+                "$ref": "#/definitions/Csv"
+            }}
+        },
+        "Csv": {
+            "description": "The options for imported source files in CSV format. The values are Delimiter and HeaderList.",
+            "additionalProperties": false,
+            "type": "object",
+            "properties": {
+                "Delimiter": {
+                    "description": "The delimiter used for separating items in the CSV file being imported.",
+                    "type": "string"
+                },
+                "HeaderList": {
+                    "uniqueItems": true,
+                    "description": "List of the headers used to specify a common header for all source CSV files being imported. If this field is specified then the first line of each CSV file is treated as data instead of the header. If this field is not specified the the first line of each CSV file is treated as the header.",
+                    "type": "array",
+                    "items": {"type": "string"}
+                }
+            }
+        },
+        "ImportSourceSpecification": {
+            "description": "Specifies the properties of data being imported from the S3 bucket source to the table.",
+            "additionalProperties": false,
+            "type": "object",
+            "properties": {
+                "S3BucketSource": {
+                    "description": "The S3 bucket that provides the source for the import.",
+                    "$ref": "#/definitions/S3BucketSource"
+                },
+                "InputFormat": {
+                    "description": "The format of the source data. Valid values for ``ImportFormat`` are ``CSV``, ``DYNAMODB_JSON`` or ``ION``.",
+                    "type": "string"
+                },
+                "InputFormatOptions": {
+                    "description": "Additional properties that specify how the input is formatted,",
+                    "$ref": "#/definitions/InputFormatOptions"
+                },
+                "InputCompressionType": {
+                    "description": "Type of compression to be used on the input coming from the imported table.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "S3BucketSource",
+                "InputFormat"
+            ]
+        },
+        "AttributeDefinition": {
+            "description": "Represents an attribute for describing the schema for the table and indexes.",
+            "additionalProperties": false,
+            "type": "object",
+            "properties": {
+                "AttributeType": {
+                    "description": "The data type for the attribute, where:\n  +  ``S`` - the attribute is of type String\n  +  ``N`` - the attribute is of type Number\n  +  ``B`` - the attribute is of type Binary",
+                    "type": "string"
+                },
+                "AttributeName": {
+                    "description": "A name for the attribute.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "AttributeName",
+                "AttributeType"
+            ]
+        },
+        "Projection": {
+            "description": "Represents attributes that are copied (projected) from the table into an index. These are in addition to the primary key attributes and index key attributes, which are automatically projected.",
+            "additionalProperties": false,
+            "type": "object",
+            "properties": {
+                "NonKeyAttributes": {
+                    "uniqueItems": false,
+                    "description": "Represents the non-key attribute names which will be projected into the index.\n For global and local secondary indexes, the total count of ``NonKeyAttributes`` summed across all of the secondary indexes, must not exceed 100. If you project the same attribute into two different indexes, this counts as two distinct attributes when determining the total. This limit only applies when you specify the ProjectionType of ``INCLUDE``. You still can specify the ProjectionType of ``ALL`` to project all attributes from the source table, even if the table has more than 100 attributes.",
+                    "type": "array",
+                    "items": {"type": "string"}
+                },
+                "ProjectionType": {
+                    "description": "The set of attributes that are projected into the index:\n  +  ``KEYS_ONLY`` - Only the index and primary keys are projected into the index.\n  +  ``INCLUDE`` - In addition to the attributes described in ``KEYS_ONLY``, the secondary index will include other non-key attributes that you specify.\n  +  ``ALL`` - All of the table attributes are projected into the index.\n  \n When using the DynamoDB console, ``ALL`` is selected by default.",
+                    "type": "string"
+                }
+            }
+        },
+        "PointInTimeRecoverySpecification": {
+            "description": "The settings used to enable point in time recovery.",
+            "additionalProperties": false,
+            "type": "object",
+            "properties": {
+                "PointInTimeRecoveryEnabled": {
+                    "description": "Indicates whether point in time recovery is enabled (true) or disabled (false) on the table.",
+                    "type": "boolean"
+                },
+                "RecoveryPeriodInDays": {
+                    "maximum": 35,
+                    "description": "The number of preceding days for which continuous backups are taken and maintained. Your table data is only recoverable to any point-in-time from within the configured recovery period. This parameter is optional. If no value is provided, the value will default to 35.",
+                    "type": "integer",
+                    "minimum": 1
+                }
+            },
+            "dependencies": {"RecoveryPeriodInDays": ["PointInTimeRecoveryEnabled"]}
+        },
+        "ProvisionedThroughput": {
+            "description": "Throughput for the specified table, which consists of values for ``ReadCapacityUnits`` and ``WriteCapacityUnits``. For more information about the contents of a provisioned throughput structure, see [Table ProvisionedThroughput](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ProvisionedThroughput.html).",
+            "additionalProperties": false,
+            "type": "object",
+            "properties": {
+                "WriteCapacityUnits": {
+                    "description": "The maximum number of writes consumed per second before DynamoDB returns a ``ThrottlingException``. For more information, see [Specifying Read and Write Requirements](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughput.html) in the *Amazon DynamoDB Developer Guide*.\n If read/write capacity mode is ``PAY_PER_REQUEST`` the value is set to 0.",
+                    "type": "integer"
+                },
+                "ReadCapacityUnits": {
+                    "description": "The maximum number of strongly consistent reads consumed per second before DynamoDB returns a ``ThrottlingException``. For more information, see [Specifying Read and Write Requirements](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughput.html) in the *Amazon DynamoDB Developer Guide*.\n If read/write capacity mode is ``PAY_PER_REQUEST`` the value is set to 0.",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "WriteCapacityUnits",
+                "ReadCapacityUnits"
+            ]
+        },
+        "WarmThroughput": {
+            "anyOf": [
+                {"required": ["ReadUnitsPerSecond"]},
+                {"required": ["WriteUnitsPerSecond"]}
+            ],
+            "description": "Provides visibility into the number of read and write operations your table or secondary index can instantaneously support. The settings can be modified using the ``UpdateTable`` operation to meet the throughput requirements of an upcoming peak event.",
+            "additionalProperties": false,
+            "type": "object",
+            "properties": {
+                "ReadUnitsPerSecond": {
+                    "description": "Represents the number of read operations your base table can instantaneously support.",
+                    "type": "integer",
+                    "minimum": 1
+                },
+                "WriteUnitsPerSecond": {
+                    "description": "Represents the number of write operations your base table can instantaneously support.",
+                    "type": "integer",
+                    "minimum": 1
+                }
+            }
+        },
+        "GlobalSecondaryIndex": {
+            "description": "Represents the properties of a global secondary index.",
+            "additionalProperties": false,
+            "type": "object",
+            "properties": {
+                "IndexName": {
+                    "description": "The name of the global secondary index. The name must be unique among all other indexes on this table.",
+                    "type": "string"
+                },
+                "OnDemandThroughput": {
+                    "description": "The maximum number of read and write units for the specified global secondary index. If you use this parameter, you must specify ``MaxReadRequestUnits``, ``MaxWriteRequestUnits``, or both. You must use either ``OnDemandThroughput`` or ``ProvisionedThroughput`` based on your table's capacity mode.",
+                    "$ref": "#/definitions/OnDemandThroughput"
+                },
+                "ContributorInsightsSpecification": {
+                    "description": "The settings used to specify whether to enable CloudWatch Contributor Insights for the global table and define which events to monitor.",
+                    "$ref": "#/definitions/ContributorInsightsSpecification"
+                },
+                "Projection": {
+                    "description": "Represents attributes that are copied (projected) from the table into the global secondary index. These are in addition to the primary key attributes and index key attributes, which are automatically projected.",
+                    "$ref": "#/definitions/Projection"
+                },
+                "ProvisionedThroughput": {
+                    "description": "Represents the provisioned throughput settings for the specified global secondary index. You must use either ``OnDemandThroughput`` or ``ProvisionedThroughput`` based on your table's capacity mode.\n For current minimum and maximum provisioned throughput values, see [Service, Account, and Table Quotas](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html) in the *Amazon DynamoDB Developer Guide*.",
+                    "$ref": "#/definitions/ProvisionedThroughput"
+                },
+                "KeySchema": {
+                    "uniqueItems": true,
+                    "description": "The complete key schema for a global secondary index, which consists of one or more pairs of attribute names and key types:\n  +  ``HASH`` - partition key\n  +  ``RANGE`` - sort key\n  \n  The partition key of an item is also known as its *hash attribute*. The term \"hash attribute\" derives from DynamoDB's usage of an internal hash function to evenly distribute data items across partitions, based on their partition key values.\n The sort key of an item is also known as its *range attribute*. The term \"range attribute\" derives from the way DynamoDB stores items with the same partition key physically close together, in sorted order by the sort key value.",
+                    "type": "array",
+                    "items": {"$ref": "#/definitions/KeySchema"}
+                },
+                "WarmThroughput": {
+                    "description": "Represents the warm throughput value (in read units per second and write units per second) for the specified secondary index. If you use this parameter, you must specify ``ReadUnitsPerSecond``, ``WriteUnitsPerSecond``, or both.",
+                    "$ref": "#/definitions/WarmThroughput"
+                }
+            },
+            "required": [
+                "IndexName",
+                "Projection",
+                "KeySchema"
+            ]
+        },
+        "S3BucketSource": {
+            "description": "The S3 bucket that is being imported from.",
+            "additionalProperties": false,
+            "type": "object",
+            "properties": {
+                "S3Bucket": {
+                    "description": "The S3 bucket that is being imported from.",
+                    "type": "string"
+                },
+                "S3KeyPrefix": {
+                    "description": "The key prefix shared by all S3 Objects that are being imported.",
+                    "type": "string"
+                },
+                "S3BucketOwner": {
+                    "description": "The account number of the S3 bucket that is being imported from. If the bucket is owned by the requester this is optional.",
+                    "type": "string"
+                }
+            },
+            "required": ["S3Bucket"]
+        },
+        "ResourcePolicy": {
+            "description": "Creates or updates a resource-based policy document that contains the permissions for DDB resources, such as a table, its indexes, and stream. Resource-based policies let you define access permissions by specifying who has access to each resource, and the actions they are allowed to perform on each resource.\n In a CFNshort template, you can provide the policy in JSON or YAML format because CFNshort converts YAML to JSON before submitting it to DDB. For more information about resource-based policies, see [Using resource-based policies for](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/access-control-resource-based.html) and [Resource-based policy examples](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/rbac-examples.html).\n While defining resource-based policies in your CFNshort templates, the following considerations apply:\n  +  The maximum size supported for a resource-based policy document in JSON format is 20 KB. DDB counts whitespaces when calculating the size of a policy against this limit. \n  +  Resource-based policies don't support [drift detection](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-stack-drift.html#). If you update a policy outside of the CFNshort stack template, you'll need to update the CFNshort stack with the changes.\n  +  Resource-based policies don't support out-of-band changes. If you add, update, or delete a policy outside of the CFNshort template, the change won't be overwritten if there are no changes to the policy within the template.\n For example, say that your template contains a resource-based policy, which you later update outside of the template. If you don't make any changes to the policy in the template, the updated policy in DDB won\u2019t be synced with the policy in the template.\n Conversely, say that your template doesn\u2019t contain a resource-based policy, but you add a policy outside of the template. This policy won\u2019t be removed from DDB as long as you don\u2019t add it to the template. When you add a policy to the template and update the stack, the existing policy in DDB will be updated to match the one defined in the template.\n  \n For a full list of all considerations, see [Resource-based policy considerations](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/rbac-considerations.html).",
+            "additionalProperties": false,
+            "type": "object",
+            "properties": {"PolicyDocument": {
+                "description": "A resource-based policy document that contains permissions to add to the specified DDB table, index, or both. In a CFNshort template, you can provide the policy in JSON or YAML format because CFNshort converts YAML to JSON before submitting it to DDB. For more information about resource-based policies, see [Using resource-based policies for](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/access-control-resource-based.html) and [Resource-based policy examples](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/rbac-examples.html).",
+                "type": "object"
+            }},
+            "required": ["PolicyDocument"]
+        },
+        "DeprecatedKeySchema": {
+            "description": "",
+            "additionalProperties": false,
+            "type": "object",
+            "properties": {"HashKeyElement": {"$ref": "#/definitions/DeprecatedHashKeyElement"}},
+            "required": ["HashKeyElement"]
+        },
+        "KeySchema": {
+            "description": "Represents *a single element* of a key schema. A key schema specifies the attributes that make up the primary key of a table, or the key attributes of an index.\n A ``KeySchemaElement`` represents exactly one attribute of the primary key. For example, a simple primary key would be represented by one ``KeySchemaElement`` (for the partition key). A composite primary key would require one ``KeySchemaElement`` for the partition key, and another ``KeySchemaElement`` for the sort key.\n A ``KeySchemaElement`` must be a scalar, top-level attribute (not a nested attribute). The data type must be one of String, Number, or Binary. The attribute cannot be nested within a List or a Map.",
+            "additionalProperties": false,
+            "type": "object",
+            "properties": {
+                "KeyType": {
+                    "description": "The role that this key attribute will assume:\n  +  ``HASH`` - partition key\n  +  ``RANGE`` - sort key\n  \n  The partition key of an item is also known as its *hash attribute*. The term \"hash attribute\" derives from DynamoDB's usage of an internal hash function to evenly distribute data items across partitions, based on their partition key values.\n The sort key of an item is also known as its *range attribute*. The term \"range attribute\" derives from the way DynamoDB stores items with the same partition key physically close together, in sorted order by the sort key value.",
+                    "type": "string"
+                },
+                "AttributeName": {
+                    "description": "The name of a key attribute.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "KeyType",
+                "AttributeName"
+            ]
+        },
+        "Tag": {
+            "description": "Describes a tag. A tag is a key-value pair. You can add up to 50 tags to a single DynamoDB table. \n AWS-assigned tag names and values are automatically assigned the ``aws:`` prefix, which the user cannot assign. AWS-assigned tag names do not count towards the tag limit of 50. User-assigned tag names have the prefix ``user:`` in the Cost Allocation Report. You cannot backdate the application of a tag.\n For an overview on tagging DynamoDB resources, see [Tagging for DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tagging.html) in the *Amazon DynamoDB Developer Guide*.",
+            "additionalProperties": false,
+            "type": "object",
+            "properties": {
+                "Value": {
+                    "description": "The value of the tag. Tag values are case-sensitive and can be null.",
+                    "type": "string"
+                },
+                "Key": {
+                    "description": "The key of the tag. Tag keys are case sensitive. Each DynamoDB table can only have up to one tag with the same key. If you try to add an existing tag (same key), the existing tag value will be updated to the new value.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Value",
+                "Key"
+            ]
+        },
+        "DeprecatedHashKeyElement": {
+            "description": "",
+            "additionalProperties": false,
+            "type": "object",
+            "properties": {
+                "AttributeType": {"type": "string"},
+                "AttributeName": {"type": "string"}
+            },
+            "required": [
+                "AttributeType",
+                "AttributeName"
+            ]
+        },
+        "TimeToLiveSpecification": {
+            "description": "Represents the settings used to enable or disable Time to Live (TTL) for the specified table.",
+            "additionalProperties": false,
+            "type": "object",
+            "properties": {
+                "Enabled": {
+                    "description": "Indicates whether TTL is to be enabled (true) or disabled (false) on the table.",
+                    "type": "boolean"
+                },
+                "AttributeName": {
+                    "description": "The name of the TTL attribute used to store the expiration time for items in the table.\n   +  The ``AttributeName`` property is required when enabling the TTL, or when TTL is already enabled.\n  +  To update this property, you must first disable TTL and then enable TTL with the new attribute name.",
+                    "type": "string"
+                }
+            },
+            "required": ["Enabled"]
+        }
+    },
+    "properties": {
+        "OnDemandThroughput": {
+            "description": "Sets the maximum number of read and write units for the specified on-demand table. If you use this property, you must specify ``MaxReadRequestUnits``, ``MaxWriteRequestUnits``, or both.",
+            "$ref": "#/definitions/OnDemandThroughput"
+        },
+        "SSESpecification": {
+            "description": "Specifies the settings to enable server-side encryption.",
+            "$ref": "#/definitions/SSESpecification"
+        },
+        "KinesisStreamSpecification": {
+            "description": "The Kinesis Data Streams configuration for the specified table.",
+            "$ref": "#/definitions/KinesisStreamSpecification"
+        },
+        "StreamSpecification": {
+            "description": "The settings for the DDB table stream, which captures changes to items stored in the table. Including this property in your CFNlong template automatically enables streaming.",
+            "$ref": "#/definitions/StreamSpecification"
+        },
+        "ContributorInsightsSpecification": {
+            "description": "The settings used to specify whether to enable CloudWatch Contributor Insights for the table and define which events to monitor.",
+            "$ref": "#/definitions/ContributorInsightsSpecification"
+        },
+        "ImportSourceSpecification": {
+            "description": "Specifies the properties of data being imported from the S3 bucket source to the\" table.\n  If you specify the ``ImportSourceSpecification`` property, and also specify either the ``StreamSpecification``, the ``TableClass`` property, the ``DeletionProtectionEnabled`` property, or the ``WarmThroughput`` property, the IAM entity creating/updating stack must have ``UpdateTable`` permission.",
+            "$ref": "#/definitions/ImportSourceSpecification"
+        },
+        "PointInTimeRecoverySpecification": {
+            "description": "The settings used to enable point in time recovery.",
+            "$ref": "#/definitions/PointInTimeRecoverySpecification"
+        },
+        "ProvisionedThroughput": {
+            "description": "Throughput for the specified table, which consists of values for ``ReadCapacityUnits`` and ``WriteCapacityUnits``. For more information about the contents of a provisioned throughput structure, see [Amazon DynamoDB Table ProvisionedThroughput](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ProvisionedThroughput.html). \n If you set ``BillingMode`` as ``PROVISIONED``, you must specify this property. If you set ``BillingMode`` as ``PAY_PER_REQUEST``, you cannot specify this property.",
+            "$ref": "#/definitions/ProvisionedThroughput"
+        },
+        "WarmThroughput": {
+            "description": "Represents the warm throughput (in read units per second and write units per second) for creating a table.",
+            "$ref": "#/definitions/WarmThroughput"
+        },
+        "TableName": {
+            "description": "A name for the table. If you don't specify a name, CFNlong generates a unique physical ID and uses that ID for the table name. For more information, see [Name Type](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-name.html).\n  If you specify a name, you cannot perform updates that require replacement of this resource. You can perform updates that require no or some interruption. If you must replace the resource, specify a new name.",
+            "type": "string"
+        },
+        "AttributeDefinitions": {
+            "uniqueItems": true,
+            "description": "A list of attributes that describe the key schema for the table and indexes.\n This property is required to create a DDB table.\n Update requires: [Some interruptions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-some-interrupt). Replacement if you edit an existing AttributeDefinition.",
+            "type": "array",
+            "items": {"$ref": "#/definitions/AttributeDefinition"}
+        },
+        "GlobalSecondaryIndexes": {
+            "uniqueItems": false,
+            "description": "Global secondary indexes to be created on the table. You can create up to 20 global secondary indexes.\n  If you update a table to include a new global secondary index, CFNlong initiates the index creation and then proceeds with the stack update. CFNlong doesn't wait for the index to complete creation because the backfilling phase can take a long time, depending on the size of the table. You can't use the index or update the table until the index's status is ``ACTIVE``. You can track its status by using the DynamoDB [DescribeTable](https://docs.aws.amazon.com/cli/latest/reference/dynamodb/describe-table.html) command.\n If you add or delete an index during an update, we recommend that you don't update any other resources. If your stack fails to update and is rolled back while adding a new index, you must manually delete the index. \n Updates are not supported. The following are exceptions:\n  +  If you update either the contributor insights specification or the provisioned throughput values of global secondary indexes, you can update the table without interruption.\n  +  You can delete or add one global secondary index without interruption. If you do both in the same update (for example, by changing the index's logical ID), the update fails.",
+            "type": "array",
+            "items": {"$ref": "#/definitions/GlobalSecondaryIndex"}
+        },
+        "BillingMode": {
+            "description": "Specify how you are charged for read and write throughput and how you manage capacity.\n Valid values include:\n  +  ``PAY_PER_REQUEST`` - We recommend using ``PAY_PER_REQUEST`` for most DynamoDB workloads. ``PAY_PER_REQUEST`` sets the billing mode to [On-demand capacity mode](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/on-demand-capacity-mode.html). \n  +  ``PROVISIONED`` - We recommend using ``PROVISIONED`` for steady workloads with predictable growth where capacity requirements can be reliably forecasted. ``PROVISIONED`` sets the billing mode to [Provisioned capacity mode](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/provisioned-capacity-mode.html).\n  \n If not specified, the default is ``PROVISIONED``.",
+            "type": "string"
+        },
+        "ResourcePolicy": {
+            "description": "An AWS resource-based policy document in JSON format that will be attached to the table.\n When you attach a resource-based policy while creating a table, the policy application is *strongly consistent*.\n The maximum size supported for a resource-based policy document is 20 KB. DynamoDB counts whitespaces when calculating the size of a policy against this limit. For a full list of all considerations that apply for resource-based policies, see [Resource-based policy considerations](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/rbac-considerations.html).\n  You need to specify the ``CreateTable`` and ``PutResourcePolicy`` IAM actions for authorizing a user to create a table with a resource-based policy.",
+            "$ref": "#/definitions/ResourcePolicy"
+        },
+        "LocalSecondaryIndexes": {
+            "uniqueItems": false,
+            "description": "Local secondary indexes to be created on the table. You can create up to 5 local secondary indexes. Each index is scoped to a given hash key value. The size of each hash key can be up to 10 gigabytes.",
+            "type": "array",
+            "items": {"$ref": "#/definitions/LocalSecondaryIndex"}
+        },
+        "KeySchema": {
+            "oneOf": [
+                {
+                    "uniqueItems": true,
+                    "type": "array",
+                    "items": {"$ref": "#/definitions/KeySchema"}
+                },
+                {"type": "object"}
+            ],
+            "description": "Specifies the attributes that make up the primary key for the table. The attributes in the ``KeySchema`` property must also be defined in the ``AttributeDefinitions`` property."
+        },
+        "Arn": {
+            "description": "",
+            "type": "string"
+        },
+        "StreamArn": {
+            "description": "",
+            "type": "string"
+        },
+        "DeletionProtectionEnabled": {
+            "description": "Determines if a table is protected from deletion. When enabled, the table cannot be deleted by any user or process. This setting is disabled by default. For more information, see [Using deletion protection](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/WorkingWithTables.Basics.html#WorkingWithTables.Basics.DeletionProtection) in the *Developer Guide*.",
+            "type": "boolean"
+        },
+        "TableClass": {
+            "description": "The table class of the new table. Valid values are ``STANDARD`` and ``STANDARD_INFREQUENT_ACCESS``.",
+            "type": "string"
+        },
+        "Tags": {
+            "uniqueItems": false,
+            "description": "An array of key-value pairs to apply to this resource.\n For more information, see [Tag](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html).",
+            "type": "array",
+            "items": {"$ref": "#/definitions/Tag"}
+        },
+        "TimeToLiveSpecification": {
+            "description": "Specifies the Time to Live (TTL) settings for the table.\n  For detailed information about the limits in DynamoDB, see [Limits in Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html) in the Amazon DynamoDB Developer Guide.",
+            "$ref": "#/definitions/TimeToLiveSpecification"
+        }
+    }
+}

--- a/examples/dynamodb_table/main.crn
+++ b/examples/dynamodb_table/main.crn
@@ -1,0 +1,36 @@
+# DynamoDB Table Example
+#
+# Creates an on-demand table for storing registry JWT IDs with TTL enabled.
+
+provider awscc {
+  region = awscc.Region.ap_northeast_1
+}
+
+awscc.dynamodb.Table {
+  table_name   = 'jti-store'
+  billing_mode = awscc.dynamodb.Table.BillingMode.pay_per_request
+
+  attribute_definition {
+    attribute_name = 'jti'
+    attribute_type = s
+  }
+
+  key_schema {
+    attribute_name = 'jti'
+    key_type       = hash
+  }
+
+  time_to_live_specification = {
+    enabled        = true
+    attribute_name = 'ttl'
+  }
+
+  point_in_time_recovery_specification = {
+    point_in_time_recovery_enabled = true
+  }
+
+  tags = {
+    Environment = 'example'
+    Workload    = 'registry'
+  }
+}

--- a/generated-docs/awscc/dynamodb/table.md
+++ b/generated-docs/awscc/dynamodb/table.md
@@ -1,0 +1,404 @@
+---
+title: "awscc.dynamodb.Table"
+description: "AWSCC DYNAMODB Table resource reference"
+---
+
+
+CloudFormation Type: `AWS::DynamoDB::Table`
+
+The ``AWS::DynamoDB::Table`` resource creates a DDB table. For more information, see [CreateTable](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_CreateTable.html) in the *API Reference*.
+ You should be aware of the following behaviors when working with DDB tables:
+  +  CFNlong typically creates DDB tables in parallel. However, if your template includes multiple DDB tables with indexes, you must declare dependencies so that the tables are created sequentially. DDBlong limits the number of tables with secondary indexes that are in the creating state. If you create multiple tables with indexes at the same time, DDB returns an error and the stack operation fails. For an example, see [DynamoDB Table with a DependsOn Attribute](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html#aws-resource-dynamodb-table--examples--DynamoDB_Table_with_a_DependsOn_Attribute).
+  
+   Our guidance is to use the latest schema documented for your CFNlong templates. This schema supports the provisioning of all table settings below. When using this schema in your CFNlong templates, please ensure that your Identity and Access Management (IAM) policies are updated with appropriate permissions to allow for the authorization of these setting changes.
+
+## Argument Reference
+
+### `attribute_definitions`
+
+- **Type:** [List\<AttributeDefinition\>](#attributedefinition)
+- **Required:** No
+
+A list of attributes that describe the key schema for the table and indexes. This property is required to create a DDB table. Update requires: [Some interruptions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-some-interrupt). Replacement if you edit an existing AttributeDefinition.
+
+### `billing_mode`
+
+- **Type:** [Enum (BillingMode)](#billing_mode-billingmode)
+- **Required:** No
+
+Specify how you are charged for read and write throughput and how you manage capacity. Valid values include: + ``PAY_PER_REQUEST`` - We recommend using ``PAY_PER_REQUEST`` for most DynamoDB workloads. ``PAY_PER_REQUEST`` sets the billing mode to [On-demand capacity mode](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/on-demand-capacity-mode.html). + ``PROVISIONED`` - We recommend using ``PROVISIONED`` for steady workloads with predictable growth where capacity requirements can be reliably forecasted. ``PROVISIONED`` sets the billing mode to [Provisioned capacity mode](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/provisioned-capacity-mode.html). If not specified, the default is ``PROVISIONED``.
+
+### `contributor_insights_specification`
+
+- **Type:** [Struct(ContributorInsightsSpecification)](#contributorinsightsspecification)
+- **Required:** No
+
+The settings used to specify whether to enable CloudWatch Contributor Insights for the table and define which events to monitor.
+
+### `deletion_protection_enabled`
+
+- **Type:** Bool
+- **Required:** No
+
+Determines if a table is protected from deletion. When enabled, the table cannot be deleted by any user or process. This setting is disabled by default. For more information, see [Using deletion protection](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/WorkingWithTables.Basics.html#WorkingWithTables.Basics.DeletionProtection) in the *Developer Guide*.
+
+### `global_secondary_indexes`
+
+- **Type:** [List\<GlobalSecondaryIndex\>](#globalsecondaryindex)
+- **Required:** No
+
+Global secondary indexes to be created on the table. You can create up to 20 global secondary indexes. If you update a table to include a new global secondary index, CFNlong initiates the index creation and then proceeds with the stack update. CFNlong doesn't wait for the index to complete creation because the backfilling phase can take a long time, depending on the size of the table. You can't use the index or update the table until the index's status is ``ACTIVE``. You can track its status by using the DynamoDB [DescribeTable](https://docs.aws.amazon.com/cli/latest/reference/dynamodb/describe-table.html) command. If you add or delete an index during an update, we recommend that you don't update any other resources. If your stack fails to update and is rolled back while adding a new index, you must manually delete the index. Updates are not supported. The following are exceptions: + If you update either the contributor insights specification or the provisioned throughput values of global secondary indexes, you can update the table without interruption. + You can delete or add one global secondary index without interruption. If you do both in the same update (for example, by changing the index's logical ID), the update fails.
+
+### `import_source_specification`
+
+- **Type:** [Struct(ImportSourceSpecification)](#importsourcespecification)
+- **Required:** No
+- **Create-only:** Yes
+- **Write-only:** Yes
+
+Specifies the properties of data being imported from the S3 bucket source to the" table. If you specify the ``ImportSourceSpecification`` property, and also specify either the ``StreamSpecification``, the ``TableClass`` property, the ``DeletionProtectionEnabled`` property, or the ``WarmThroughput`` property, the IAM entity creating/updating stack must have ``UpdateTable`` permission.
+
+### `key_schema`
+
+- **Type:** [List\<KeySchema\>](#keyschema)
+- **Required:** Yes
+
+Specifies the attributes that make up the primary key for the table. The attributes in the ``KeySchema`` property must also be defined in the ``AttributeDefinitions`` property.
+
+### `kinesis_stream_specification`
+
+- **Type:** [Struct(KinesisStreamSpecification)](#kinesisstreamspecification)
+- **Required:** No
+
+The Kinesis Data Streams configuration for the specified table.
+
+### `local_secondary_indexes`
+
+- **Type:** [List\<LocalSecondaryIndex\>](#localsecondaryindex)
+- **Required:** No
+
+Local secondary indexes to be created on the table. You can create up to 5 local secondary indexes. Each index is scoped to a given hash key value. The size of each hash key can be up to 10 gigabytes.
+
+### `on_demand_throughput`
+
+- **Type:** [Struct(OnDemandThroughput)](#ondemandthroughput)
+- **Required:** No
+
+Sets the maximum number of read and write units for the specified on-demand table. If you use this property, you must specify ``MaxReadRequestUnits``, ``MaxWriteRequestUnits``, or both.
+
+### `point_in_time_recovery_specification`
+
+- **Type:** [Struct(PointInTimeRecoverySpecification)](#pointintimerecoveryspecification)
+- **Required:** No
+
+The settings used to enable point in time recovery.
+
+### `provisioned_throughput`
+
+- **Type:** [Struct(ProvisionedThroughput)](#provisionedthroughput)
+- **Required:** No
+
+Throughput for the specified table, which consists of values for ``ReadCapacityUnits`` and ``WriteCapacityUnits``. For more information about the contents of a provisioned throughput structure, see [Amazon DynamoDB Table ProvisionedThroughput](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ProvisionedThroughput.html). If you set ``BillingMode`` as ``PROVISIONED``, you must specify this property. If you set ``BillingMode`` as ``PAY_PER_REQUEST``, you cannot specify this property.
+
+### `resource_policy`
+
+- **Type:** [Struct(ResourcePolicy)](#resourcepolicy)
+- **Required:** No
+
+An AWS resource-based policy document in JSON format that will be attached to the table. When you attach a resource-based policy while creating a table, the policy application is *strongly consistent*. The maximum size supported for a resource-based policy document is 20 KB. DynamoDB counts whitespaces when calculating the size of a policy against this limit. For a full list of all considerations that apply for resource-based policies, see [Resource-based policy considerations](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/rbac-considerations.html). You need to specify the ``CreateTable`` and ``PutResourcePolicy`` IAM actions for authorizing a user to create a table with a resource-based policy.
+
+### `sse_specification`
+
+- **Type:** [Struct(SSESpecification)](#ssespecification)
+- **Required:** No
+
+Specifies the settings to enable server-side encryption.
+
+### `stream_specification`
+
+- **Type:** [Struct(StreamSpecification)](#streamspecification)
+- **Required:** No
+
+The settings for the DDB table stream, which captures changes to items stored in the table. Including this property in your CFNlong template automatically enables streaming.
+
+### `table_class`
+
+- **Type:** [Enum (TableClass)](#table_class-tableclass)
+- **Required:** No
+
+The table class of the new table. Valid values are ``STANDARD`` and ``STANDARD_INFREQUENT_ACCESS``.
+
+### `table_name`
+
+- **Type:** String
+- **Required:** No
+- **Create-only:** Yes
+
+A name for the table. If you don't specify a name, CFNlong generates a unique physical ID and uses that ID for the table name. For more information, see [Name Type](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-name.html). If you specify a name, you cannot perform updates that require replacement of this resource. You can perform updates that require no or some interruption. If you must replace the resource, specify a new name.
+
+### `tags`
+
+- **Type:** `Map<String, String>`
+- **Required:** No
+
+An array of key-value pairs to apply to this resource. For more information, see [Tag](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html).
+
+### `time_to_live_specification`
+
+- **Type:** [Struct(TimeToLiveSpecification)](#timetolivespecification)
+- **Required:** No
+
+Specifies the Time to Live (TTL) settings for the table. For detailed information about the limits in DynamoDB, see [Limits in Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html) in the Amazon DynamoDB Developer Guide.
+
+### `warm_throughput`
+
+- **Type:** [Struct(WarmThroughput)](#warmthroughput)
+- **Required:** No
+
+Represents the warm throughput (in read units per second and write units per second) for creating a table.
+
+## Enum Values
+
+### attribute_type (AttributeType)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `S` | `awscc.dynamodb.Table.AttributeDefinition.AttributeType.s` |
+| `N` | `awscc.dynamodb.Table.AttributeDefinition.AttributeType.n` |
+| `B` | `awscc.dynamodb.Table.AttributeDefinition.AttributeType.b` |
+
+Shorthand formats: `s` or `AttributeType.s`
+
+### billing_mode (BillingMode)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `PAY_PER_REQUEST` | `awscc.dynamodb.Table.BillingMode.pay_per_request` |
+| `PROVISIONED` | `awscc.dynamodb.Table.BillingMode.provisioned` |
+
+Shorthand formats: `pay_per_request` or `BillingMode.pay_per_request`
+
+### mode (Mode)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `ACCESSED_AND_THROTTLED_KEYS` | `awscc.dynamodb.Table.ContributorInsightsSpecification.Mode.accessed_and_throttled_keys` |
+| `THROTTLED_KEYS` | `awscc.dynamodb.Table.ContributorInsightsSpecification.Mode.throttled_keys` |
+
+Shorthand formats: `accessed_and_throttled_keys` or `Mode.accessed_and_throttled_keys`
+
+### input_format (InputFormat)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `CSV` | `awscc.dynamodb.Table.ImportSourceSpecification.InputFormat.csv` |
+| `DYNAMODB_JSON` | `awscc.dynamodb.Table.ImportSourceSpecification.InputFormat.dynamodb_json` |
+| `ION` | `awscc.dynamodb.Table.ImportSourceSpecification.InputFormat.ion` |
+
+Shorthand formats: `csv` or `InputFormat.csv`
+
+### key_type (KeyType)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `HASH` | `awscc.dynamodb.Table.GlobalSecondaryIndex.KeySchema.KeyType.hash` |
+| `RANGE` | `awscc.dynamodb.Table.GlobalSecondaryIndex.KeySchema.KeyType.range` |
+
+Shorthand formats: `hash` or `KeyType.hash`
+
+### approximate_creation_date_time_precision (ApproximateCreationDateTimePrecision)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `MICROSECOND` | `awscc.dynamodb.Table.KinesisStreamSpecification.ApproximateCreationDateTimePrecision.microsecond` |
+| `MILLISECOND` | `awscc.dynamodb.Table.KinesisStreamSpecification.ApproximateCreationDateTimePrecision.millisecond` |
+
+Shorthand formats: `microsecond` or `ApproximateCreationDateTimePrecision.microsecond`
+
+### projection_type (ProjectionType)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `KEYS_ONLY` | `awscc.dynamodb.Table.GlobalSecondaryIndex.Projection.ProjectionType.keys_only` |
+| `INCLUDE` | `awscc.dynamodb.Table.GlobalSecondaryIndex.Projection.ProjectionType.include` |
+| `ALL` | `awscc.dynamodb.Table.GlobalSecondaryIndex.Projection.ProjectionType.all` |
+
+Shorthand formats: `keys_only` or `ProjectionType.keys_only`
+
+### stream_view_type (StreamViewType)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `KEYS_ONLY` | `awscc.dynamodb.Table.StreamSpecification.StreamViewType.keys_only` |
+| `NEW_IMAGE` | `awscc.dynamodb.Table.StreamSpecification.StreamViewType.new_image` |
+| `OLD_IMAGE` | `awscc.dynamodb.Table.StreamSpecification.StreamViewType.old_image` |
+| `NEW_AND_OLD_IMAGES` | `awscc.dynamodb.Table.StreamSpecification.StreamViewType.new_and_old_images` |
+
+Shorthand formats: `keys_only` or `StreamViewType.keys_only`
+
+### table_class (TableClass)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `STANDARD` | `awscc.dynamodb.Table.TableClass.standard` |
+| `STANDARD_INFREQUENT_ACCESS` | `awscc.dynamodb.Table.TableClass.standard_infrequent_access` |
+
+Shorthand formats: `standard` or `TableClass.standard`
+
+## Struct Definitions
+
+### AttributeDefinition
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `attribute_name` | String | Yes | A name for the attribute. |
+| `attribute_type` | [Enum (AttributeType)](#attribute_type-attributetype) | Yes | The data type for the attribute, where: + ``S`` - the attribute is of type String + ``N`` - the attribute is of type Number + ``B`` - the attribute is of type Binary |
+
+### ContributorInsightsSpecification
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `enabled` | Bool | Yes | Indicates whether CloudWatch Contributor Insights are to be enabled (true) or disabled (false). |
+| `mode` | [Enum (Mode)](#mode-mode) | No | Specifies the CloudWatch Contributor Insights mode for a table. Valid values are ``ACCESSED_AND_THROTTLED_KEYS`` (tracks all access and throttled events) or ``THROTTLED_KEYS`` (tracks only throttled events). This setting determines what type of contributor insights data is collected for the table. |
+
+### Csv
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `delimiter` | String | No | The delimiter used for separating items in the CSV file being imported. |
+| `header_list` | `List<String>` | No | List of the headers used to specify a common header for all source CSV files being imported. If this field is specified then the first line of each CSV file is treated as data instead of the header. If this field is not specified the the first line of each CSV file is treated as the header. |
+
+### GlobalSecondaryIndex
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `contributor_insights_specification` | [Struct(ContributorInsightsSpecification)](#contributorinsightsspecification) | No | The settings used to specify whether to enable CloudWatch Contributor Insights for the global table and define which events to monitor. |
+| `index_name` | String | Yes | The name of the global secondary index. The name must be unique among all other indexes on this table. |
+| `key_schema` | [List\<KeySchema\>](#keyschema) | Yes | The complete key schema for a global secondary index, which consists of one or more pairs of attribute names and key types: + ``HASH`` - partition key + ``RANGE`` - sort key The partition key of an item is also known as its *hash attribute*. The term "hash attribute" derives from DynamoDB's usage of an internal hash function to evenly distribute data items across partitions, based on their partition key values. The sort key of an item is also known as its *range attribute*. The term "range attribute" derives from the way DynamoDB stores items with the same partition key physically close together, in sorted order by the sort key value. |
+| `on_demand_throughput` | [Struct(OnDemandThroughput)](#ondemandthroughput) | No | The maximum number of read and write units for the specified global secondary index. If you use this parameter, you must specify ``MaxReadRequestUnits``, ``MaxWriteRequestUnits``, or both. You must use either ``OnDemandThroughput`` or ``ProvisionedThroughput`` based on your table's capacity mode. |
+| `projection` | [Struct(Projection)](#projection) | Yes | Represents attributes that are copied (projected) from the table into the global secondary index. These are in addition to the primary key attributes and index key attributes, which are automatically projected. |
+| `provisioned_throughput` | [Struct(ProvisionedThroughput)](#provisionedthroughput) | No | Represents the provisioned throughput settings for the specified global secondary index. You must use either ``OnDemandThroughput`` or ``ProvisionedThroughput`` based on your table's capacity mode. For current minimum and maximum provisioned throughput values, see [Service, Account, and Table Quotas](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html) in the *Amazon DynamoDB Developer Guide*. |
+| `warm_throughput` | [Struct(WarmThroughput)](#warmthroughput) | No | Represents the warm throughput value (in read units per second and write units per second) for the specified secondary index. If you use this parameter, you must specify ``ReadUnitsPerSecond``, ``WriteUnitsPerSecond``, or both. |
+
+### ImportSourceSpecification
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `input_compression_type` | String | No | Type of compression to be used on the input coming from the imported table. |
+| `input_format` | [Enum (InputFormat)](#input_format-inputformat) | Yes | The format of the source data. Valid values for ``ImportFormat`` are ``CSV``, ``DYNAMODB_JSON`` or ``ION``. |
+| `input_format_options` | [Struct(InputFormatOptions)](#inputformatoptions) | No | Additional properties that specify how the input is formatted, |
+| `s3_bucket_source` | [Struct(S3BucketSource)](#s3bucketsource) | Yes | The S3 bucket that provides the source for the import. |
+
+### InputFormatOptions
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `csv` | [Struct(Csv)](#csv) | No | The options for imported source files in CSV format. The values are Delimiter and HeaderList. |
+
+### KeySchema
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `attribute_name` | String | Yes | The name of a key attribute. |
+| `key_type` | [Enum (KeyType)](#key_type-keytype) | Yes | The role that this key attribute will assume: + ``HASH`` - partition key + ``RANGE`` - sort key The partition key of an item is also known as its *hash attribute*. The term "hash attribute" derives from DynamoDB's usage of an internal hash function to evenly distribute data items across partitions, based on their partition key values. The sort key of an item is also known as its *range attribute*. The term "range attribute" derives from the way DynamoDB stores items with the same partition key physically close together, in sorted order by the sort key value. |
+
+### KinesisStreamSpecification
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `approximate_creation_date_time_precision` | [Enum (ApproximateCreationDateTimePrecision)](#approximate_creation_date_time_precision-approximatecreationdatetimeprecision) | No | The precision for the time and date that the stream was created. |
+| `stream_arn` | Arn | Yes | The ARN for a specific Kinesis data stream. Length Constraints: Minimum length of 37. Maximum length of 1024. |
+
+### LocalSecondaryIndex
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `index_name` | String | Yes | The name of the local secondary index. The name must be unique among all other indexes on this table. |
+| `key_schema` | [List\<KeySchema\>](#keyschema) | Yes | The complete key schema for the local secondary index, consisting of one or more pairs of attribute names and key types: + ``HASH`` - partition key + ``RANGE`` - sort key The partition key of an item is also known as its *hash attribute*. The term "hash attribute" derives from DynamoDB's usage of an internal hash function to evenly distribute data items across partitions, based on their partition key values. The sort key of an item is also known as its *range attribute*. The term "range attribute" derives from the way DynamoDB stores items with the same partition key physically close together, in sorted order by the sort key value. |
+| `projection` | [Struct(Projection)](#projection) | Yes | Represents attributes that are copied (projected) from the table into the local secondary index. These are in addition to the primary key attributes and index key attributes, which are automatically projected. |
+
+### OnDemandThroughput
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `max_read_request_units` | Int(1..) | No | Maximum number of read request units for the specified table. To specify a maximum ``OnDemandThroughput`` on your table, set the value of ``MaxReadRequestUnits`` as greater than or equal to 1. To remove the maximum ``OnDemandThroughput`` that is currently set on your table, set the value of ``MaxReadRequestUnits`` to -1. |
+| `max_write_request_units` | Int(1..) | No | Maximum number of write request units for the specified table. To specify a maximum ``OnDemandThroughput`` on your table, set the value of ``MaxWriteRequestUnits`` as greater than or equal to 1. To remove the maximum ``OnDemandThroughput`` that is currently set on your table, set the value of ``MaxWriteRequestUnits`` to -1. |
+
+### PointInTimeRecoverySpecification
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `point_in_time_recovery_enabled` | Bool | No | Indicates whether point in time recovery is enabled (true) or disabled (false) on the table. |
+| `recovery_period_in_days` | Int(1..=35) | No | The number of preceding days for which continuous backups are taken and maintained. Your table data is only recoverable to any point-in-time from within the configured recovery period. This parameter is optional. If no value is provided, the value will default to 35. |
+
+### Projection
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `non_key_attributes` | `List<String>` | No | Represents the non-key attribute names which will be projected into the index. For global and local secondary indexes, the total count of ``NonKeyAttributes`` summed across all of the secondary indexes, must not exceed 100. If you project the same attribute into two different indexes, this counts as two distinct attributes when determining the total. This limit only applies when you specify the ProjectionType of ``INCLUDE``. You still can specify the ProjectionType of ``ALL`` to project all attributes from the source table, even if the table has more than 100 attributes. |
+| `projection_type` | [Enum (ProjectionType)](#projection_type-projectiontype) | No | The set of attributes that are projected into the index: + ``KEYS_ONLY`` - Only the index and primary keys are projected into the index. + ``INCLUDE`` - In addition to the attributes described in ``KEYS_ONLY``, the secondary index will include other non-key attributes that you specify. + ``ALL`` - All of the table attributes are projected into the index. When using the DynamoDB console, ``ALL`` is selected by default. |
+
+### ProvisionedThroughput
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `read_capacity_units` | Int | Yes | The maximum number of strongly consistent reads consumed per second before DynamoDB returns a ``ThrottlingException``. For more information, see [Specifying Read and Write Requirements](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughput.html) in the *Amazon DynamoDB Developer Guide*. If read/write capacity mode is ``PAY_PER_REQUEST`` the value is set to 0. |
+| `write_capacity_units` | Int | Yes | The maximum number of writes consumed per second before DynamoDB returns a ``ThrottlingException``. For more information, see [Specifying Read and Write Requirements](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughput.html) in the *Amazon DynamoDB Developer Guide*. If read/write capacity mode is ``PAY_PER_REQUEST`` the value is set to 0. |
+
+### ResourcePolicy
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `policy_document` | PolicyDocument | Yes | A resource-based policy document that contains permissions to add to the specified DDB table, index, or both. In a CFNshort template, you can provide the policy in JSON or YAML format because CFNshort converts YAML to JSON before submitting it to DDB. For more information about resource-based policies, see [Using resource-based policies for](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/access-control-resource-based.html) and [Resource-based policy examples](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/rbac-examples.html). |
+
+### S3BucketSource
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `s3_bucket` | String | Yes | The S3 bucket that is being imported from. |
+| `s3_bucket_owner` | String | No | The account number of the S3 bucket that is being imported from. If the bucket is owned by the requester this is optional. |
+| `s3_key_prefix` | String | No | The key prefix shared by all S3 Objects that are being imported. |
+
+### SSESpecification
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `kms_master_key_id` | String | No | The KMS key that should be used for the KMS encryption. To specify a key, use its key ID, Amazon Resource Name (ARN), alias name, or alias ARN. Note that you should only provide this parameter if the key is different from the default DynamoDB key ``alias/aws/dynamodb``. |
+| `sse_enabled` | Bool | Yes | Indicates whether server-side encryption is done using an AWS managed key or an AWS owned key. If enabled (true), server-side encryption type is set to ``KMS`` and an AWS managed key is used (KMS charges apply). If disabled (false) or not specified, server-side encryption is set to AWS owned key. |
+| `sse_type` | String | No | Server-side encryption type. The only supported value is: + ``KMS`` - Server-side encryption that uses KMSlong. The key is stored in your account and is managed by KMS (KMS charges apply). |
+
+### StreamSpecification
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `resource_policy` | [Struct(ResourcePolicy)](#resourcepolicy) | No | Creates or updates a resource-based policy document that contains the permissions for DDB resources, such as a table's streams. Resource-based policies let you define access permissions by specifying who has access to each resource, and the actions they are allowed to perform on each resource. When you remove the ``StreamSpecification`` property from the template, DynamoDB disables the stream but retains any attached resource policy until the stream is deleted after 24 hours. When you modify the ``StreamViewType`` property, DynamoDB creates a new stream and retains the old stream's resource policy. The old stream and its resource policy are deleted after the 24-hour retention period. In a CFNshort template, you can provide the policy in JSON or YAML format because CFNshort converts YAML to JSON before submitting it to DDB. For more information about resource-based policies, see [Using resource-based policies for](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/access-control-resource-based.html) and [Resource-based policy examples](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/rbac-examples.html). |
+| `stream_view_type` | [Enum (StreamViewType)](#stream_view_type-streamviewtype) | Yes | When an item in the table is modified, ``StreamViewType`` determines what information is written to the stream for this table. Valid values for ``StreamViewType`` are: + ``KEYS_ONLY`` - Only the key attributes of the modified item are written to the stream. + ``NEW_IMAGE`` - The entire item, as it appears after it was modified, is written to the stream. + ``OLD_IMAGE`` - The entire item, as it appeared before it was modified, is written to the stream. + ``NEW_AND_OLD_IMAGES`` - Both the new and the old item images of the item are written to the stream. |
+
+### TimeToLiveSpecification
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `attribute_name` | String | No | The name of the TTL attribute used to store the expiration time for items in the table. + The ``AttributeName`` property is required when enabling the TTL, or when TTL is already enabled. + To update this property, you must first disable TTL and then enable TTL with the new attribute name. |
+| `enabled` | Bool | Yes | Indicates whether TTL is to be enabled (true) or disabled (false) on the table. |
+
+### WarmThroughput
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `read_units_per_second` | Int(1..) | No | Represents the number of read operations your base table can instantaneously support. |
+| `write_units_per_second` | Int(1..) | No | Represents the number of write operations your base table can instantaneously support. |
+
+## Attribute Reference
+
+### `arn`
+
+- **Type:** Arn
+
+
+
+### `stream_arn`
+
+- **Type:** Arn
+
+
+


### PR DESCRIPTION
## Summary

Adds `dynamodb.Table` via the Cloud Control codegen pipeline, required for the Publish API write-plane (carina-rs/registry#4 — the publish-policy / owner-binding / jti-store tables).

Adding the resource surfaced one root-cause codegen gap, fixed at the upstream seam.

## Root-cause fix: property-level `oneOf` resolution

`KeySchema` (a required field) is declared in the CFN schema as `oneOf: [ {array of #/definitions/KeySchema}, {object} ]`. codegen degraded it to `AttributeType::string()` — real AWS returns it as `[{AttributeName, KeyType}]` (verified live via `cloudcontrol get-resource`). Two layers were broken:

1. **Parser**: `CfnOneOfVariant` carried only `properties`/`required`, so an array/`$ref`/`items` variant was dropped at deserialization. Replaced `CfnOneOfVariant` with `CfnProperty` (which already carries `type`/`items`/`$ref`/`properties`/nested `oneOf`), and deleted `CfnOneOfVariant` — so a second schema DTO can't drift out of sync again.
2. **Type mapper**: never inspected `prop.one_of`. Added property-level `oneOf` handling to both the Rust mapper and the markdown display mapper, with identical precedence: if a variant resolves to an array, recurse into it through the existing array path (the same one `AttributeDefinitions` uses — no parallel mapper); else fall through to object-merge; else **panic** with `unresolved oneOf for {resource}.{prop}`.

The panic converts the old silent `string()` fallback into a loud codegen-time failure, so a future unhandled union is caught at generation, not shipped as a wrong type. Confirmed no existing cached resource trips it.

Result: `key_schema` becomes `list(struct("KeySchema", [attribute_name (required), key_type enum HASH/RANGE (required)]))`, matching real AWS. `resource_policy.policy_document` correctly maps to `iam_policy_document()` (the #308 lesson holds via the `$ref` struct path).

## Behavior-preserving

`generate-schemas.sh --from-cache-only` produces **zero** diff on the 39 existing resources — only the new DynamoDB files appear. The parser/mapper change affects no other resource's output.

## Tests

- `test_property_oneof_array_ref_maps_to_list_of_struct` — oneOf[array of $ref, object] becomes list(struct) (RED then GREEN).
- `test_property_oneof_unhandled_scalar_union_panics` — an unresolvable scalar union panics (covers the type-safety net itself).

## Resource + example

All 22 CFN properties generated; readOnly (`arn`/`stream_arn`), createOnly (`table_name`/`import_source_specification`), writeOnly (`import_source_specification`) correctly marked. Example `examples/dynamodb_table/main.crn` mirrors the registry jti-store: PAY_PER_REQUEST table, HASH key, TTL, PITR, tags.

## Verify

`cargo test` (217 codegen + package + integration), `cargo clippy --workspace --all-targets -D warnings`, `cargo fmt --check`, `cargo build --target wasm32-wasip2 --release`, `check-carina-pin.sh`, `check-docs-drift.sh` (40 resources), and the `generate-schemas.sh --from-cache-only` zero-diff gate all pass.

Closes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)
