### PR TITLE
docs: CODEGEN.md cfn-schema-cache is committed, not gitignored

### DIFF
--- a/CODEGEN.md
+++ b/CODEGEN.md
@@ -139,7 +139,7 @@ String types are inferred from property names (e.g., `SubnetId` maps to `subnet_
 
 ## Schema Cache
 
-Downloaded CloudFormation schemas are cached in `carina-provider-awscc/cfn-schema-cache/` with filenames like `AWS__EC2__VPC.json`. This directory is gitignored. Use `--refresh-cache` to force re-download.
+Downloaded CloudFormation schemas are cached in `carina-provider-awscc/cfn-schema-cache/` with filenames like `AWS__EC2__VPC.json`. This directory is committed to the repository so codegen is reproducible without AWS access. Use `--refresh-cache` to force re-download.
 
 ## Generating Documentation
 


### PR DESCRIPTION
## What

The Schema Cache section of `CODEGEN.md` claimed `cfn-schema-cache/` is
gitignored. That is stale:

- The directory is **tracked in git** (40 schema JSONs + `NOTICE.md`).
- `.gitignore` only lists `/target` and `.cargo/` — `cfn-schema-cache`
  is not ignored.

The cache was originally ignored but is now committed so codegen is
reproducible without AWS access. Correct the wording.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)