### PR TITLE
Fix stale dynamodb doc and add a docs content-drift CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,30 @@ jobs:
             exit 1
           fi
 
+  # docs-drift and docs-check cover different gaps: docs-drift verifies each
+  # schema has a tracked doc and catches missing/orphan files via a directory
+  # scan, while docs-check regenerates docs and uses git diff to catch tracked
+  # content drift.
+  docs-check:
+    name: Check Docs Content
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - uses: Swatinem/rust-cache@v2
+      - name: Run docs generation (from committed cache, no AWS calls)
+        run: ./scripts/generate-docs.sh --from-cache-only
+      - name: Verify no uncommitted changes
+        run: |
+          if ! git diff --exit-code; then
+            echo "::error::Docs generation produced uncommitted changes. Run 'aws-vault exec <profile> -- ./scripts/generate-docs.sh' locally and commit the regenerated generated-docs/."
+            exit 1
+          fi
+
   wasm-build:
     name: WASM Build
     runs-on: ubuntu-latest

--- a/generated-docs/awscc/dynamodb/table.md
+++ b/generated-docs/awscc/dynamodb/table.md
@@ -12,6 +12,39 @@ The ``AWS::DynamoDB::Table`` resource creates a DDB table. For more information,
   
    Our guidance is to use the latest schema documented for your CFNlong templates. This schema supports the provisioning of all table settings below. When using this schema in your CFNlong templates, please ensure that your Identity and Access Management (IAM) policies are updated with appropriate permissions to allow for the authorization of these setting changes.
 
+## Example
+
+```crn
+awscc.dynamodb.Table {
+  table_name   = 'jti-store'
+  billing_mode = awscc.dynamodb.Table.BillingMode.pay_per_request
+
+  attribute_definition {
+    attribute_name = 'jti'
+    attribute_type = s
+  }
+
+  key_schema {
+    attribute_name = 'jti'
+    key_type       = hash
+  }
+
+  time_to_live_specification = {
+    enabled        = true
+    attribute_name = 'ttl'
+  }
+
+  point_in_time_recovery_specification = {
+    point_in_time_recovery_enabled = true
+  }
+
+  tags = {
+    Environment = 'example'
+    Workload    = 'registry'
+  }
+}
+```
+
 ## Argument Reference
 
 ### `attribute_definitions`

--- a/scripts/generate-docs.sh
+++ b/scripts/generate-docs.sh
@@ -4,9 +4,15 @@
 # Usage (from project root):
 #   aws-vault exec <profile> -- ./scripts/generate-docs.sh
 #   aws-vault exec <profile> -- ./scripts/generate-docs.sh --refresh-cache
+#   ./scripts/generate-docs.sh --from-cache-only
 #
 # Options:
-#   --refresh-cache  Force re-download of all CloudFormation schemas
+#   --refresh-cache    Force re-download of all CloudFormation schemas
+#                      (requires AWS credentials via aws-vault).
+#   --from-cache-only  Never call AWS; require every schema to be present
+#                      in the committed cache. Fails with a clear error
+#                      if any cache file is missing. Used by CI to detect
+#                      docs drift without needing AWS credentials.
 #
 # Downloaded schemas are cached in cfn-schema-cache/.
 # Subsequent runs use cached schemas unless --refresh-cache is specified.
@@ -14,9 +20,11 @@ set -e
 
 # Parse flags
 REFRESH_CACHE=false
+FROM_CACHE_ONLY=false
 for arg in "$@"; do
     case "$arg" in
         --refresh-cache) REFRESH_CACHE=true ;;
+        --from-cache-only) FROM_CACHE_ONLY=true ;;
     esac
 done
 
@@ -103,7 +111,19 @@ for TYPE_NAME in "${RESOURCE_TYPES[@]}"; do
 
     # Cache CloudFormation schema to avoid redundant API calls
     CACHE_FILE="$CACHE_DIR/${TYPE_NAME//::/__}.json"
-    if [ "$REFRESH_CACHE" = true ] || [ ! -f "$CACHE_FILE" ]; then
+    if [ "$FROM_CACHE_ONLY" = true ]; then
+        # CI / offline mode: cache must already exist. Surface a clear
+        # error rather than silently calling AWS (which would fail with
+        # a credential error and obscure the real cause).
+        if [ ! -f "$CACHE_FILE" ]; then
+            echo "ERROR: --from-cache-only set but cache file not found:" >&2
+            echo "  $CACHE_FILE" >&2
+            echo "Run 'aws-vault exec <profile> -- $0 --refresh-cache'" >&2
+            echo "locally and commit the updated cfn-schema-cache/." >&2
+            exit 1
+        fi
+        echo "  Using cached schema (--from-cache-only)"
+    elif [ "$REFRESH_CACHE" = true ] || [ ! -f "$CACHE_FILE" ]; then
         aws cloudformation describe-type \
             --type RESOURCE \
             --type-name "$TYPE_NAME" \


### PR DESCRIPTION
Closes #320

## Problem

`generated-docs/awscc/dynamodb/table.md` was missing the `## Example` block that `scripts/generate-docs.sh` produces from `examples/dynamodb_table/main.crn`. The doc was committed (in `d731f90`) before the example existed, or without re-running docgen afterward, so the committed file diverged from deterministic generator output. Every `generate-docs.sh` run reintroduced the block, which showed up as unrelated drift in other PRs (it surfaced twice while adding the ELBv2 resources in #319 and had to be reverted to keep that PR scoped).

The **root cause of the recurrence** is that `scripts/check-docs-drift.sh` only checks doc *existence* (1:1 schema↔doc basename), so a stale doc *body* passes the gate silently.

## Fix

Fixed the same way schemas are already guarded by `codegen-check`:

1. **Data fix** — regenerated `generated-docs/awscc/dynamodb/table.md` (adds the missing `## Example` block).
2. **`--from-cache-only` flag** in `scripts/generate-docs.sh`, mirroring `carina-provider-awscc/scripts/generate-schemas.sh`: never calls AWS, errors with a clear message if a cache file is missing — so docgen runs offline in CI from the committed `cfn-schema-cache/`.
3. **`docs-check` CI job** ("Check Docs Content") mirroring `codegen-check`: regenerate docs from cache, then `git diff --exit-code`. Any future doc content drift now fails CI, for any resource.

`docs-drift` (existence) and `docs-check` (content) are **complementary, not redundant**: `git diff --exit-code` does not catch a doc that was never committed (regeneration recreates it as an untracked file), which the directory-scan existence check still catches. A comment on the new job records this so the two gates are not "consolidated" into a gap later.

## Verification

- `./scripts/generate-docs.sh --from-cache-only` runs offline (no AWS), and `git diff --exit-code` is clean against the committed state — the new gate is green on this PR.
- `--from-cache-only` error path verified: a missing cache file → clear stderr error → exit 1, no AWS call.
- `check-docs-drift.sh` — schemas and docs in sync (44 resources).
- `check-carina-pin.sh` — pass.
- Output is deterministic (codegen markdown path uses sorted `BTreeMap` iteration; per-resource files are order-independent), so the gate won't be flaky.

Scope is exactly 3 files: the regenerated doc, the script flag, and the CI job. No Rust source touched.
