### PR TITLE
test(awscc): assert full CFN-schema-shaped read state for shaping-enabled resources

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,53 +76,70 @@ Every new resource must get an integration test under
 that drives the real `Provider` trait (`Provider::create` then
 `Provider::read`) against an in-process winterbaume CloudControl mock
 (`winterbaume_core::MockAws` + `winterbaume_cloudcontrol::CloudControlService`).
-Mirror the existing `dynamodb_table_cloudcontrol_roundtrip.rs`.
 
-The mock returns the desired (create) state **verbatim**. So the test
-proves only what the mock can prove: that create -> read *wiring*
-round-trips the resource's **structured** fields through CloudControl
-serialization — list-of-string and list-of-struct fields survive as
-structured `List`/`Map` values instead of being flattened or
-stringified. Scope the assertions to that. Do **not** assert full-field
-equality as if every create field comes back unchanged on real AWS — that
-is a mock artifact, not real AWS behaviour (see below). State this
-limitation in the test's module doc comment.
+winterbaume-cloudcontrol shapes the `GetResource` read model **per registered
+CloudFormation resource type**. As of winterbaume-cloudcontrol 1.0.0, the
+registered set is exactly:
 
-### 2. Reconcile mock behaviour with real AWS, and file a winterbaume issue **per resource**
+- `AWS::KMS::Key` - winterbaume #6, closed/shaped
+- `AWS::DynamoDB::Table` - winterbaume #7, closed/shaped
+- `AWS::ECS::Cluster` - winterbaume #8, closed/shaped
 
-The generic winterbaume mock does **not** reproduce real AWS CloudControl
-behaviours that the CloudFormation resource-type schema drives:
-write-only field stripping, read-only field synthesis (e.g. `Arn`),
-schema-default fill-in, and value normalization. For each new resource,
-verify the actual AWS behaviour by creating it on a live account and
-capturing the real `GetResource` output, then compare it to what the mock
-returns.
+Registered types reproduce the real AWS CloudControl schema shaping:
+write-only field stripping, read-only field synthesis (for example `Arn`), and
+schema-default fill-in. Unregistered types fall back to returning the
+create-time `DesiredState` verbatim, which is the old mock behaviour.
 
-File a **separate winterbaume issue for each new resource** — do **not**
-fold it into a single umbrella issue. Even though every case shares the
-same root cause (the CloudControl layer returns the create-time
-`DesiredState` verbatim without consulting any CFN schema), *which*
-read-only and default properties real AWS fills in is **different for
-every resource type**, so the fix can only be verified against a
-concrete, resource-specific `DesiredState → real GetResource` diff. This
-is the precedent the existing reports already follow: winterbaume #6
-(`AWS::KMS::Key`) and #7 (`AWS::DynamoDB::Table`) are separate issues for
-the same root cause, each carrying its own captured diff. A new resource
-gets its own issue, cross-linked to the existing ones (e.g. "same root
-cause as #6 / #7"), not a comment on them.
+The round-trip test's assertions therefore depend on whether the resource is in
+that shaping registry.
 
-When filing, follow winterbaume's own agent skill —
-`skills/winterbaume-bug/SKILL.md` in that repo — **verbatim**. It mandates
-a fixed `### Affected AWS service / Summary / Reproduction / Expected /
-Actual / version` layout that an auto-label GitHub Action parses; a
-free-form body silently breaks labelling. The skill also requires a real,
-actually-executed reproduction (run it and paste the output — never invent
-one), a reported duplicate search, and `git rev-parse HEAD` for the
-version field. winterbaume is **not** a `carina-rs` repository, so the
-external-repo rule in `CLAUDE.local.md` also applies: draft the issue per
-that skill, then get explicit confirmation before `gh issue create`. The
-AWS-specific behaviours themselves must be verified against live AWS, not
-asserted in the mock round-trip test.
+For a **registered** resource, assert the full CFN-schema-shaped read state
+exhaustively. Build the expected attribute map from the real `GetResource`
+shape and compare the whole map so missing keys, extra keys, wrong defaults,
+and incorrectly preserved write-only fields all fail. Use
+`kms_key_cloudcontrol_roundtrip.rs` (including its generated-UUID `arn` /
+`key_id` handling) and `ecs_cluster_cloudcontrol_roundtrip.rs` as the
+templates. To prove the test really exercises shaping, and is not passing by
+accident, it must fail against the pre-shaping verbatim mock and pass against
+the shaping mock.
+
+For an **unregistered** resource, the mock still returns the create-time
+`DesiredState` verbatim. Assert only structural preservation: list-of-string
+and list-of-struct fields survive as structured `List`/`Map` values instead of
+being flattened or stringified. Do **not** assert full shaped equality for an
+unregistered resource, because that would lock in a mock artifact rather than
+real AWS behaviour. State this limitation in the test's module doc comment.
+The ELBv2 round-trip tests are the templates for this case; winterbaume #9,
+#10, and #11 track those ELBv2 resources and are still open/unshaped.
+
+### 2. For unregistered resources, reconcile with real AWS and file a winterbaume issue **per resource**
+
+For an unregistered new resource, verify the actual AWS behaviour by creating
+it on a live account, capturing the real `GetResource` output, and comparing
+that to the mock's verbatim read state. Then file a **separate winterbaume issue
+for each resource** so the resource can get a shaper. Do **not** fold multiple
+resources into a single umbrella issue. Which read-only and default properties
+real AWS fills in differs per resource type, so each fix needs its own captured
+`DesiredState` -> real `GetResource` diff. Cross-link to the existing examples:
+#6 (`AWS::KMS::Key`), #7 (`AWS::DynamoDB::Table`), and #8
+(`AWS::ECS::Cluster`) are closed/shaped; #9/#10/#11 are the open/unshaped ELBv2
+follow-ups.
+
+When filing, follow winterbaume's own agent skill,
+`skills/winterbaume-bug/SKILL.md` in that repo, **verbatim**. It mandates a
+fixed `### Affected AWS service / Summary / Reproduction / Expected / Actual /
+version` layout that an auto-label GitHub Action parses; a free-form body
+silently breaks labelling. The skill also requires a real, actually-executed
+reproduction (run it and paste the output; never invent one), a reported
+duplicate search, and `git rev-parse HEAD` for the version field. winterbaume
+is **not** a `carina-rs` repository, so the external-repo rule in
+`CLAUDE.local.md` also applies: draft the issue per that skill, then get
+explicit confirmation before `gh issue create`.
+
+Once winterbaume registers the resource and releases it, upgrade that
+resource's round-trip test from structural-only assertions to full shaped
+equality. The dependency bump plus the KMS, DynamoDB, and ECS test
+strengthening in the winterbaume 1.0.0 work is the model for that upgrade.
 
 ## Git Workflow
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2617,9 +2617,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winterbaume-cloudcontrol"
-version = "0.2.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f523567ebf224c464d7064b47ef241a642942db50871fb8944d138da7db691fa"
+checksum = "d1e180b012bf8d8825361a931ef11a163b2ae8069ba12ba9fcc9e89effb92e2b"
 dependencies = [
  "bytes",
  "chrono",

--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -51,7 +51,7 @@ tokio = { version = "1", features = ["full"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 winterbaume-core = "0.2"
-winterbaume-cloudcontrol = "0.2"
+winterbaume-cloudcontrol = "1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tokio = { version = "1", default-features = false, features = ["rt", "macros", "time", "sync"] }

--- a/carina-provider-awscc/tests/dynamodb_table_cloudcontrol_roundtrip.rs
+++ b/carina-provider-awscc/tests/dynamodb_table_cloudcontrol_roundtrip.rs
@@ -1,19 +1,15 @@
 //! Integration coverage for the awscc provider's real Provider-trait apply path
 //! against an in-process winterbaume CloudControl mock.
 //!
-//! This test proves that create -> read wiring round-trips DynamoDB table
-//! list-of-struct serialization through CloudControl. In particular,
-//! `key_schema`, whose generated type is selected through oneOf resolution,
-//! survives the real apply path as a structured list of maps instead of being
-//! flattened into a string.
+//! winterbaume-cloudcontrol 1.0.0 fixes moriyoshi/winterbaume issue #7: the
+//! mock now reproduces CloudFormation-schema shaping, including write-only
+//! stripping, read-only synthesis, and schema-default fill-in. This test sends
+//! one create request and asserts the full CFN-schema-shaped read state
+//! round-trips through the awscc provider's serialization and conversion.
 //!
-//! This test deliberately does not assert write-only stripping, read-only
-//! synthesis, or schema-default fill-in. Those are real AWS CloudControl
-//! behaviours driven by the CloudFormation resource-type schema; the generic
-//! winterbaume mock returns the desired state verbatim and does not reproduce
-//! them because it does not consult CFN schemas. That winterbaume behavior is
-//! tracked upstream as moriyoshi/winterbaume issue #6. The AWS behaviours
-//! should be verified separately against live AWS, not here.
+//! In particular, `key_schema`, whose generated type is selected through oneOf
+//! resolution, survives the real apply path as a structured list of maps instead
+//! of being flattened into a string.
 
 use aws_config::{BehaviorVersion, Region};
 use carina_core::provider::{CreateRequest, Provider, ReadRequest};
@@ -29,7 +25,6 @@ fn string(value: &str) -> Value {
     Value::Concrete(ConcreteValue::String(value.to_string()))
 }
 
-#[allow(dead_code)]
 fn int(value: i64) -> Value {
     Value::Concrete(ConcreteValue::Int(value))
 }
@@ -94,35 +89,11 @@ async fn winterbaume_provider() -> AwsccProvider {
     AwsccProvider::from_sdk_config(config, &AwsccProviderConfig::default()).await
 }
 
-fn assert_single_map_list(
-    attributes: &HashMap<String, Value>,
-    attribute_name: &str,
-    expected_entries: &[(&str, Value)],
-) {
-    let value = attributes
-        .get(attribute_name)
-        .unwrap_or_else(|| panic!("read-back state must include {attribute_name}"));
-    let items = match value {
-        Value::Concrete(ConcreteValue::List(items)) => items,
-        other => panic!("{attribute_name} must round-trip as List(Map), got {other:?}"),
-    };
-    assert_eq!(
-        items.len(),
-        1,
-        "{attribute_name} must contain one structured element"
-    );
-    let item = match &items[0] {
-        Value::Concrete(ConcreteValue::Map(item)) => item,
-        other => panic!("{attribute_name}[0] must round-trip as Map, got {other:?}"),
-    };
-
-    for (key, expected_value) in expected_entries {
-        assert_eq!(
-            item.get(*key),
-            Some(expected_value),
-            "{attribute_name}[0].{key} must round-trip"
-        );
-    }
+fn attributes(entries: impl IntoIterator<Item = (&'static str, Value)>) -> HashMap<String, Value> {
+    entries
+        .into_iter()
+        .map(|(key, value)| (key.to_string(), value))
+        .collect()
 }
 
 #[tokio::test]
@@ -145,32 +116,54 @@ async fn dynamodb_table_create_then_read_round_trips_list_of_struct_fields() {
 
     assert!(read.exists, "read-back state must exist");
     assert_eq!(read.identifier.as_deref(), Some(identifier));
+    let expected = attributes([
+        ("table_name", string("jti-store")),
+        ("billing_mode", string("PAY_PER_REQUEST")),
+        (
+            "attribute_definitions",
+            list([map([
+                ("attribute_name", string("jti")),
+                ("attribute_type", string("S")),
+            ])]),
+        ),
+        (
+            "key_schema",
+            list([map([
+                ("attribute_name", string("jti")),
+                ("key_type", string("HASH")),
+            ])]),
+        ),
+        (
+            "time_to_live_specification",
+            map([("attribute_name", string("ttl")), ("enabled", bool_(true))]),
+        ),
+        (
+            "point_in_time_recovery_specification",
+            map([("point_in_time_recovery_enabled", bool_(true))]),
+        ),
+        ("tags", map([("Environment", string("test"))])),
+        ("sse_specification", map([("sse_enabled", bool_(false))])),
+        (
+            "contributor_insights_specification",
+            map([("enabled", bool_(false))]),
+        ),
+        ("deletion_protection_enabled", bool_(false)),
+        ("local_secondary_indexes", list([])),
+        ("global_secondary_indexes", list([])),
+        (
+            "warm_throughput",
+            map([
+                ("read_units_per_second", int(12000)),
+                ("write_units_per_second", int(4000)),
+            ]),
+        ),
+        (
+            "arn",
+            string("arn:aws:dynamodb:us-east-1:123456789012:table/jti-store"),
+        ),
+    ]);
     assert_eq!(
-        read.attributes.get("table_name"),
-        Some(&string("jti-store"))
-    );
-    assert_eq!(
-        read.attributes.get("billing_mode"),
-        Some(&string("PAY_PER_REQUEST"))
-    );
-    assert_single_map_list(
-        &read.attributes,
-        "key_schema",
-        &[
-            ("attribute_name", string("jti")),
-            ("key_type", string("HASH")),
-        ],
-    );
-    assert_single_map_list(
-        &read.attributes,
-        "attribute_definitions",
-        &[
-            ("attribute_name", string("jti")),
-            ("attribute_type", string("S")),
-        ],
-    );
-    assert_eq!(
-        read.attributes.get("tags"),
-        Some(&map([("Environment", string("test"))]))
+        &read.attributes, &expected,
+        "read-back attributes must exactly match the full shaped DynamoDB table state"
     );
 }

--- a/carina-provider-awscc/tests/ecs_cluster_cloudcontrol_roundtrip.rs
+++ b/carina-provider-awscc/tests/ecs_cluster_cloudcontrol_roundtrip.rs
@@ -1,18 +1,15 @@
 //! Integration coverage for the awscc provider's real Provider-trait apply path
 //! against an in-process winterbaume CloudControl mock.
 //!
-//! This test proves that create -> read wiring round-trips ECS cluster
-//! structured list serialization through CloudControl. In particular,
-//! `capacity_providers` survives as a list of strings and `cluster_settings`
-//! survives as a list of maps instead of being flattened into a string.
+//! winterbaume-cloudcontrol 1.0.0 fixes moriyoshi/winterbaume issue #8: the
+//! mock now reproduces CloudFormation-schema shaping, including write-only
+//! stripping, read-only synthesis, and schema-default fill-in. This test sends
+//! one create request and asserts the full CFN-schema-shaped read state
+//! round-trips through the awscc provider's serialization and conversion.
 //!
-//! This test deliberately does not assert write-only stripping, read-only
-//! synthesis such as `arn`, schema-default fill-in, or normalization. Those are
-//! real AWS CloudControl behaviours driven by the CloudFormation resource-type
-//! schema; the generic winterbaume mock returns the desired state verbatim and
-//! does not reproduce them because it does not consult CFN schemas. That
-//! winterbaume behavior is tracked upstream as moriyoshi/winterbaume issue #6.
-//! The AWS behaviours should be verified separately against live AWS, not here.
+//! In particular, `capacity_providers` survives as a list of strings and
+//! `cluster_settings` survives as a list of maps instead of being flattened into
+//! a string.
 
 use aws_config::{BehaviorVersion, Region};
 use carina_core::provider::{CreateRequest, Provider, ReadRequest};
@@ -78,58 +75,11 @@ async fn winterbaume_provider() -> AwsccProvider {
     AwsccProvider::from_sdk_config(config, &AwsccProviderConfig::default()).await
 }
 
-fn assert_single_map_list(
-    attributes: &HashMap<String, Value>,
-    attribute_name: &str,
-    expected_entries: &[(&str, Value)],
-) {
-    let value = attributes
-        .get(attribute_name)
-        .unwrap_or_else(|| panic!("read-back state must include {attribute_name}"));
-    let items = match value {
-        Value::Concrete(ConcreteValue::List(items)) => items,
-        other => panic!("{attribute_name} must round-trip as List(Map), got {other:?}"),
-    };
-    assert_eq!(
-        items.len(),
-        1,
-        "{attribute_name} must contain one structured element"
-    );
-    let item = match &items[0] {
-        Value::Concrete(ConcreteValue::Map(item)) => item,
-        other => panic!("{attribute_name}[0] must round-trip as Map, got {other:?}"),
-    };
-
-    for (key, expected_value) in expected_entries {
-        assert_eq!(
-            item.get(*key),
-            Some(expected_value),
-            "{attribute_name}[0].{key} must round-trip"
-        );
-    }
-}
-
-fn assert_string_list(attributes: &HashMap<String, Value>, attribute_name: &str, expected: Value) {
-    let value = attributes
-        .get(attribute_name)
-        .unwrap_or_else(|| panic!("read-back state must include {attribute_name}"));
-    let items = match value {
-        Value::Concrete(ConcreteValue::List(items)) => items,
-        other => panic!("{attribute_name} must round-trip as List(String), got {other:?}"),
-    };
-
-    assert_eq!(
-        items.len(),
-        2,
-        "{attribute_name} must contain two structured string elements"
-    );
-    assert_eq!(value, &expected);
-    assert!(
-        items
-            .iter()
-            .all(|item| matches!(item, Value::Concrete(ConcreteValue::String(_)))),
-        "{attribute_name} must contain only string elements"
-    );
+fn attributes(entries: impl IntoIterator<Item = (&'static str, Value)>) -> HashMap<String, Value> {
+    entries
+        .into_iter()
+        .map(|(key, value)| (key.to_string(), value))
+        .collect()
 }
 
 #[tokio::test]
@@ -152,29 +102,34 @@ async fn ecs_cluster_create_then_read_round_trips_structured_list_fields() {
 
     assert!(read.exists, "read-back state must exist");
     assert_eq!(read.identifier.as_deref(), Some(identifier));
+    let expected = attributes([
+        ("cluster_name", string("registry-fargate")),
+        (
+            "capacity_providers",
+            list([string("FARGATE"), string("FARGATE_SPOT")]),
+        ),
+        (
+            "cluster_settings",
+            list([map([
+                ("name", string("containerInsights")),
+                ("value", string("enabled")),
+            ])]),
+        ),
+        (
+            "tags",
+            map([
+                ("Environment", string("test")),
+                ("Workload", string("registry")),
+            ]),
+        ),
+        ("default_capacity_provider_strategy", list([])),
+        (
+            "arn",
+            string("arn:aws:ecs:us-east-1:123456789012:cluster/registry-fargate"),
+        ),
+    ]);
     assert_eq!(
-        read.attributes.get("cluster_name"),
-        Some(&string("registry-fargate"))
-    );
-    let expected_capacity_providers = list([string("FARGATE"), string("FARGATE_SPOT")]);
-    assert_string_list(
-        &read.attributes,
-        "capacity_providers",
-        expected_capacity_providers,
-    );
-    assert_single_map_list(
-        &read.attributes,
-        "cluster_settings",
-        &[
-            ("name", string("containerInsights")),
-            ("value", string("enabled")),
-        ],
-    );
-    assert_eq!(
-        read.attributes.get("tags"),
-        Some(&map([
-            ("Environment", string("test")),
-            ("Workload", string("registry")),
-        ]))
+        &read.attributes, &expected,
+        "read-back attributes must exactly match the full shaped ECS cluster state"
     );
 }

--- a/carina-provider-awscc/tests/kms_key_cloudcontrol_roundtrip.rs
+++ b/carina-provider-awscc/tests/kms_key_cloudcontrol_roundtrip.rs
@@ -1,18 +1,14 @@
 //! Integration coverage for the awscc provider's real Provider-trait apply path
 //! against an in-process winterbaume CloudControl mock.
 //!
-//! This test proves that create -> read wiring round-trips the provider's
-//! serialization and conversion with no network. In particular, `key_policy`
-//! survives as a structured policy document, which is PR #313's core
-//! `key_policy` = `iam_policy_document` design.
+//! winterbaume-cloudcontrol 1.0.0 fixes moriyoshi/winterbaume issue #6: the
+//! mock now reproduces CloudFormation-schema shaping, including write-only
+//! stripping, read-only synthesis, and schema-default fill-in. This test sends
+//! one create request and asserts the full CFN-schema-shaped read state
+//! round-trips through the awscc provider's serialization and conversion.
 //!
-//! This test deliberately does not assert write-only stripping, read-only
-//! synthesis, or schema-default fill-in. Those are real AWS CloudControl
-//! behaviours driven by the CloudFormation resource-type schema; the generic
-//! winterbaume mock returns the desired state verbatim and does not reproduce
-//! them because it does not consult CFN schemas. That winterbaume behavior is
-//! tracked upstream as moriyoshi/winterbaume issue #6. The AWS behaviours were
-//! verified separately against live AWS, not here.
+//! In particular, `key_policy` survives as a structured policy document, which
+//! is PR #313's core `key_policy` = `iam_policy_document` design.
 
 use aws_config::{BehaviorVersion, Region};
 use carina_core::provider::{CreateRequest, Provider, ReadRequest};
@@ -20,6 +16,7 @@ use carina_core::resource::{ConcreteValue, Resource, Value};
 use carina_provider_awscc::AwsccProvider;
 use carina_provider_awscc::provider::AwsccProviderConfig;
 use indexmap::IndexMap;
+use std::collections::HashMap;
 use winterbaume_cloudcontrol::CloudControlService;
 use winterbaume_core::MockAws;
 
@@ -92,16 +89,40 @@ async fn winterbaume_provider() -> AwsccProvider {
     AwsccProvider::from_sdk_config(config, &AwsccProviderConfig::default()).await
 }
 
+fn attributes(entries: impl IntoIterator<Item = (&'static str, Value)>) -> HashMap<String, Value> {
+    entries
+        .into_iter()
+        .map(|(key, value)| (key.to_string(), value))
+        .collect()
+}
+
+fn concrete_string_attribute<'a>(
+    attributes: &'a HashMap<String, Value>,
+    attribute_name: &str,
+) -> &'a str {
+    match attributes.get(attribute_name) {
+        Some(Value::Concrete(ConcreteValue::String(value))) => value,
+        other => panic!("{attribute_name} must be a String, got {other:?}"),
+    }
+}
+
+fn is_uuidish(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    value.len() == 36
+        && [8, 13, 18, 23]
+            .into_iter()
+            .all(|index| bytes[index] == b'-')
+        && value
+            .chars()
+            .enumerate()
+            .all(|(index, ch)| [8, 13, 18, 23].contains(&index) || ch.is_ascii_hexdigit())
+}
+
 #[tokio::test]
 async fn kms_key_create_then_read_round_trips_structured_key_policy() {
     let provider = winterbaume_provider().await;
     let resource = kms_key_resource();
     let id = resource.id.clone();
-    let desired_policy = resource
-        .attributes
-        .get("key_policy")
-        .expect("test resource has key_policy")
-        .clone();
 
     let created = Provider::create(&provider, &id, CreateRequest { resource })
         .await
@@ -117,32 +138,42 @@ async fn kms_key_create_then_read_round_trips_structured_key_policy() {
 
     assert!(read.exists, "read-back state must exist");
     assert_eq!(read.identifier.as_deref(), Some(identifier));
-    assert_eq!(
-        read.attributes.get("description"),
-        Some(&string("Winterbaume signing key"))
+    assert!(
+        !read.attributes.contains_key("pending_window_in_days"),
+        "write-only pending_window_in_days must be stripped"
     );
+    let key_id = concrete_string_attribute(&read.attributes, "key_id");
+    assert!(is_uuidish(key_id), "key_id must be uuid-shaped: {key_id}");
     assert_eq!(
-        read.attributes.get("key_usage"),
-        Some(&string("SIGN_VERIFY"))
+        concrete_string_attribute(&read.attributes, "arn"),
+        format!("arn:aws:kms:us-east-1:123456789012:key/{key_id}")
     );
+
+    let expected = attributes([
+        ("description", string("Winterbaume signing key")),
+        ("key_usage", string("SIGN_VERIFY")),
+        ("key_spec", string("ECC_NIST_P256")),
+        ("enable_key_rotation", bool_(false)),
+        ("enabled", bool_(true)),
+        ("multi_region", bool_(false)),
+        ("origin", string("AWS_KMS")),
+        ("key_policy", key_policy()),
+        ("tags", map([("Environment", string("test"))])),
+        ("key_id", string(key_id)),
+        (
+            "arn",
+            string(&format!("arn:aws:kms:us-east-1:123456789012:key/{key_id}")),
+        ),
+    ]);
     assert_eq!(
-        read.attributes.get("key_spec"),
-        Some(&string("ECC_NIST_P256"))
+        &read.attributes, &expected,
+        "read-back attributes must exactly match the full shaped KMS key state"
     );
-    assert_eq!(
-        read.attributes.get("enable_key_rotation"),
-        Some(&bool_(false))
-    );
-    assert_eq!(read.attributes.get("key_policy"), Some(&desired_policy));
     assert!(
         matches!(
             read.attributes.get("key_policy"),
             Some(Value::Concrete(ConcreteValue::Map(_)))
         ),
         "key_policy must remain a structured policy document"
-    );
-    assert_eq!(
-        read.attributes.get("tags"),
-        Some(&map([("Environment", string("test"))]))
     );
 }


### PR DESCRIPTION
## Summary

winterbaume-cloudcontrol 1.0.0 reproduces real AWS CloudControl `GetResource` shaping — write-only stripping, read-only synthesis (e.g. `Arn`), schema-default fill-in — but only for the resource types it registers a CFN-schema shaper for. As published in 1.0.0 that set is exactly three: `AWS::KMS::Key` (winterbaume #6), `AWS::DynamoDB::Table` (#7), `AWS::ECS::Cluster` (#8). Unregistered types still return the create-time `DesiredState` verbatim.

This PR:

- Bumps `winterbaume-cloudcontrol` to `1`.
- Rewrites the **three registered resources'** CloudControl round-trip tests (`kms_key`, `dynamodb_table`, `ecs_cluster`) to assert the **full shaped read state exhaustively**, instead of only spot-checking structural preservation as they did against the old verbatim mock. Each builds the expected attribute map from the real `GetResource` shape and compares the whole map, so a missing key, extra key, wrong default, or wrongly-preserved write-only field all fail. KMS additionally checks the generated-UUID `key_id` / `arn` and that the write-only `pending_window_in_days` is stripped.
- Leaves the **ELBv2** round-trip tests (TargetGroup / LoadBalancer / Listener) as structure-preservation-only. winterbaume does not register shapers for them in 1.0.0 (issues #9/#10/#11 still open), so a shaped-equality assertion there would lock in a mock artifact, not real AWS behaviour.
- Updates `CLAUDE.md` "Adding a Resource: Required Tests" to branch on whether a resource is in winterbaume's shaping registry: registered → full shaped-equality assertions; unregistered → structural-only plus a per-resource winterbaume issue so it eventually gets a shaper.

## Why this is correct, not a mock artifact

The three strengthened assertions **fail against the pre-shaping 0.2.0 verbatim mock and pass against 1.0.0** — verified by temporarily downgrading the pin. That proves they exercise shaping rather than passing by accident. The ELBv2 tests, by contrast, pass under both 0.2.0 and 1.0.0 (no shaper exists), which is exactly why they are *not* converted to shaped-equality here.

## Test

- `cargo nextest run -p carina-provider-awscc --test {kms_key,dynamodb_table,ecs_cluster,elbv2_*}_cloudcontrol_roundtrip` → 6 passed
- `cargo clippy -p carina-provider-awscc --tests -- -D warnings` → clean
- `cargo test -p carina-provider-awscc --doc` → ok
- `scripts/check-carina-pin.sh`, `scripts/check-docs-drift.sh` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)