### PR TITLE
test(awscc): assert full CFN-schema-shaped read state for ELBv2 resources (winterbaume v1.0.1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,12 +78,15 @@ that drives the real `Provider` trait (`Provider::create` then
 (`winterbaume_core::MockAws` + `winterbaume_cloudcontrol::CloudControlService`).
 
 winterbaume-cloudcontrol shapes the `GetResource` read model **per registered
-CloudFormation resource type**. As of winterbaume-cloudcontrol 1.0.0, the
+CloudFormation resource type**. As of winterbaume-cloudcontrol 1.0.1, the
 registered set is exactly:
 
 - `AWS::KMS::Key` - winterbaume #6, closed/shaped
 - `AWS::DynamoDB::Table` - winterbaume #7, closed/shaped
 - `AWS::ECS::Cluster` - winterbaume #8, closed/shaped
+- `AWS::ElasticLoadBalancingV2::TargetGroup` - winterbaume #9, closed/shaped
+- `AWS::ElasticLoadBalancingV2::LoadBalancer` - winterbaume #10, closed/shaped
+- `AWS::ElasticLoadBalancingV2::Listener` - winterbaume #11, closed/shaped
 
 Registered types reproduce the real AWS CloudControl schema shaping:
 write-only field stripping, read-only field synthesis (for example `Arn`), and
@@ -109,8 +112,8 @@ and list-of-struct fields survive as structured `List`/`Map` values instead of
 being flattened or stringified. Do **not** assert full shaped equality for an
 unregistered resource, because that would lock in a mock artifact rather than
 real AWS behaviour. State this limitation in the test's module doc comment.
-The ELBv2 round-trip tests are the templates for this case; winterbaume #9,
-#10, and #11 track those ELBv2 resources and are still open/unshaped.
+Use this pattern only until the resource gets a winterbaume shaper; after that,
+upgrade the test to full shaped equality.
 
 ### 2. For unregistered resources, reconcile with real AWS and file a winterbaume issue **per resource**
 
@@ -121,9 +124,10 @@ for each resource** so the resource can get a shaper. Do **not** fold multiple
 resources into a single umbrella issue. Which read-only and default properties
 real AWS fills in differs per resource type, so each fix needs its own captured
 `DesiredState` -> real `GetResource` diff. Cross-link to the existing examples:
-#6 (`AWS::KMS::Key`), #7 (`AWS::DynamoDB::Table`), and #8
-(`AWS::ECS::Cluster`) are closed/shaped; #9/#10/#11 are the open/unshaped ELBv2
-follow-ups.
+#6 (`AWS::KMS::Key`), #7 (`AWS::DynamoDB::Table`), #8
+(`AWS::ECS::Cluster`), #9 (`AWS::ElasticLoadBalancingV2::TargetGroup`), #10
+(`AWS::ElasticLoadBalancingV2::LoadBalancer`), and #11
+(`AWS::ElasticLoadBalancingV2::Listener`) are closed/shaped.
 
 When filing, follow winterbaume's own agent skill,
 `skills/winterbaume-bug/SKILL.md` in that repo, **verbatim**. It mandates a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2617,9 +2617,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winterbaume-cloudcontrol"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1e180b012bf8d8825361a931ef11a163b2ae8069ba12ba9fcc9e89effb92e2b"
+checksum = "8562a7e456a553b5c8ef0cef662adee2e0143157e49225a808c3e9169b9a0247"
 dependencies = [
  "bytes",
  "chrono",

--- a/carina-provider-awscc/tests/elasticloadbalancingv2_listener_cloudcontrol_roundtrip.rs
+++ b/carina-provider-awscc/tests/elasticloadbalancingv2_listener_cloudcontrol_roundtrip.rs
@@ -1,18 +1,13 @@
 //! Integration coverage for the awscc provider's real Provider-trait apply path
 //! against an in-process winterbaume CloudControl mock.
 //!
-//! This test proves that create -> read wiring round-trips Elastic Load
-//! Balancing v2 listener structured list serialization through CloudControl. In
-//! particular, `certificates` and `default_actions` survive as lists of maps
-//! instead of being flattened into strings.
-//!
-//! This test deliberately does not assert write-only stripping, read-only
-//! synthesis such as `arn`, schema-default fill-in, or normalization. Those are
-//! real AWS CloudControl behaviours driven by the CloudFormation resource-type
-//! schema; the generic winterbaume mock returns the desired state verbatim and
-//! does not reproduce them because it does not consult CFN schemas. That
-//! winterbaume behavior is tracked upstream as moriyoshi/winterbaume issue #6.
-//! The AWS behaviours should be verified separately against live AWS, not here.
+//! winterbaume-cloudcontrol 1.0.1 fixes moriyoshi/winterbaume issue #11: the
+//! mock now reproduces CloudFormation-schema shaping for
+//! AWS::ElasticLoadBalancingV2::Listener, including write-only stripping,
+//! read-only synthesis (for example `ListenerArn`), schema-default fill-in, and
+//! enriched sub-structures. This test sends one create request and asserts the
+//! full CFN-schema-shaped read state round-trips through the awscc provider's
+//! serialization and conversion.
 
 use aws_config::{BehaviorVersion, Region};
 use carina_core::provider::{CreateRequest, Provider, ReadRequest};
@@ -32,6 +27,10 @@ fn int(value: i64) -> Value {
     Value::Concrete(ConcreteValue::Int(value))
 }
 
+fn bool_(value: bool) -> Value {
+    Value::Concrete(ConcreteValue::Bool(value))
+}
+
 fn map(entries: impl IntoIterator<Item = (&'static str, Value)>) -> Value {
     Value::Concrete(ConcreteValue::Map(
         entries
@@ -43,6 +42,10 @@ fn map(entries: impl IntoIterator<Item = (&'static str, Value)>) -> Value {
 
 fn list(items: impl IntoIterator<Item = Value>) -> Value {
     Value::Concrete(ConcreteValue::List(items.into_iter().collect()))
+}
+
+fn key_value(key: &'static str, value: &'static str) -> Value {
+    map([("key", string(key)), ("value", string(value))])
 }
 
 fn listener_resource() -> Resource {
@@ -95,39 +98,72 @@ async fn winterbaume_provider() -> AwsccProvider {
     AwsccProvider::from_sdk_config(config, &AwsccProviderConfig::default()).await
 }
 
-fn assert_single_map_list(
-    attributes: &HashMap<String, Value>,
-    attribute_name: &str,
-    expected_entries: &[(&str, Value)],
-) {
-    let value = attributes
-        .get(attribute_name)
-        .unwrap_or_else(|| panic!("read-back state must include {attribute_name}"));
-    let items = match value {
-        Value::Concrete(ConcreteValue::List(items)) => items,
-        other => panic!("{attribute_name} must round-trip as List(Map), got {other:?}"),
-    };
-    assert_eq!(
-        items.len(),
-        1,
-        "{attribute_name} must contain one structured element"
-    );
-    let item = match &items[0] {
-        Value::Concrete(ConcreteValue::Map(item)) => item,
-        other => panic!("{attribute_name}[0] must round-trip as Map, got {other:?}"),
-    };
+fn attributes(entries: impl IntoIterator<Item = (&'static str, Value)>) -> HashMap<String, Value> {
+    entries
+        .into_iter()
+        .map(|(key, value)| (key.to_string(), value))
+        .collect()
+}
 
-    for (key, expected_value) in expected_entries {
-        assert_eq!(
-            item.get(*key),
-            Some(expected_value),
-            "{attribute_name}[0].{key} must round-trip"
-        );
+fn concrete_string_attribute<'a>(
+    attributes: &'a HashMap<String, Value>,
+    attribute_name: &str,
+) -> &'a str {
+    match attributes.get(attribute_name) {
+        Some(Value::Concrete(ConcreteValue::String(value))) => value,
+        other => panic!("{attribute_name} must be a String, got {other:?}"),
     }
 }
 
+fn is_lower_hex16(value: &str) -> bool {
+    value.len() == 16 && value.chars().all(|ch| ch.is_ascii_hexdigit())
+}
+
+fn listener_attributes() -> Value {
+    list([
+        key_value("routing.http.response.server.enabled", "true"),
+        key_value(
+            "routing.http.response.access_control_allow_headers.header_value",
+            "",
+        ),
+        key_value("routing.http.response.x_frame_options.header_value", ""),
+        key_value(
+            "routing.http.response.access_control_allow_methods.header_value",
+            "",
+        ),
+        key_value(
+            "routing.http.response.access_control_allow_origin.header_value",
+            "",
+        ),
+        key_value(
+            "routing.http.response.access_control_allow_credentials.header_value",
+            "",
+        ),
+        key_value(
+            "routing.http.response.x_content_type_options.header_value",
+            "",
+        ),
+        key_value(
+            "routing.http.response.content_security_policy.header_value",
+            "",
+        ),
+        key_value(
+            "routing.http.response.access_control_expose_headers.header_value",
+            "",
+        ),
+        key_value(
+            "routing.http.response.strict_transport_security.header_value",
+            "",
+        ),
+        key_value(
+            "routing.http.response.access_control_max_age.header_value",
+            "",
+        ),
+    ])
+}
+
 #[tokio::test]
-async fn listener_create_then_read_round_trips_structured_list_fields() {
+async fn listener_create_then_read_round_trips_full_shaped_state() {
     let provider = winterbaume_provider().await;
     let resource = listener_resource();
     let id = resource.id.clone();
@@ -146,23 +182,65 @@ async fn listener_create_then_read_round_trips_structured_list_fields() {
 
     assert!(read.exists, "read-back state must exist");
     assert_eq!(read.identifier.as_deref(), Some(identifier));
+
+    let listener_arn = concrete_string_attribute(&read.attributes, "listener_arn");
+    let suffix = listener_arn
+        .strip_prefix(
+            "arn:aws:elasticloadbalancing:ap-northeast-1:123456789012:listener/app/registry-alb/abc123/",
+        )
+        .expect("listener_arn must derive from load_balancer_arn and append a listener suffix");
+    assert!(
+        is_lower_hex16(suffix),
+        "listener_arn suffix must be 16 hex characters: {suffix}"
+    );
+
+    let target_group_arn =
+        "arn:aws:elasticloadbalancing:ap-northeast-1:123456789012:targetgroup/registry-tg/def456";
+    let expected = attributes([
+        (
+            "load_balancer_arn",
+            string(
+                "arn:aws:elasticloadbalancing:ap-northeast-1:123456789012:loadbalancer/app/registry-alb/abc123",
+            ),
+        ),
+        ("port", int(443)),
+        ("protocol", string("HTTPS")),
+        (
+            "certificates",
+            list([map([(
+                "certificate_arn",
+                string("arn:aws:acm:ap-northeast-1:123456789012:certificate/aaaa-bbbb"),
+            )])]),
+        ),
+        ("alpn_policy", list([])),
+        (
+            "default_actions",
+            list([map([
+                ("type", string("forward")),
+                ("target_group_arn", string(target_group_arn)),
+                (
+                    "forward_config",
+                    map([
+                        (
+                            "target_group_stickiness_config",
+                            map([("enabled", bool_(false))]),
+                        ),
+                        (
+                            "target_groups",
+                            list([map([
+                                ("target_group_arn", string(target_group_arn)),
+                                ("weight", int(1)),
+                            ])]),
+                        ),
+                    ]),
+                ),
+            ])]),
+        ),
+        ("listener_arn", string(listener_arn)),
+        ("listener_attributes", listener_attributes()),
+    ]);
     assert_eq!(
-        read.attributes.get("load_balancer_arn"),
-        Some(&string(
-            "arn:aws:elasticloadbalancing:ap-northeast-1:123456789012:loadbalancer/app/registry-alb/abc123",
-        ))
-    );
-    assert_single_map_list(
-        &read.attributes,
-        "certificates",
-        &[(
-            "certificate_arn",
-            string("arn:aws:acm:ap-northeast-1:123456789012:certificate/aaaa-bbbb"),
-        )],
-    );
-    assert_single_map_list(
-        &read.attributes,
-        "default_actions",
-        &[("type", string("forward"))],
+        &read.attributes, &expected,
+        "read-back attributes must exactly match the full shaped ELBv2 listener state"
     );
 }

--- a/carina-provider-awscc/tests/elasticloadbalancingv2_load_balancer_cloudcontrol_roundtrip.rs
+++ b/carina-provider-awscc/tests/elasticloadbalancingv2_load_balancer_cloudcontrol_roundtrip.rs
@@ -1,18 +1,13 @@
 //! Integration coverage for the awscc provider's real Provider-trait apply path
 //! against an in-process winterbaume CloudControl mock.
 //!
-//! This test proves that create -> read wiring round-trips Elastic Load
-//! Balancing v2 load balancer structured list serialization through
-//! CloudControl. In particular, `subnets` survives as a list of strings instead
-//! of being flattened into a string.
-//!
-//! This test deliberately does not assert write-only stripping, read-only
-//! synthesis such as `arn`, schema-default fill-in, or normalization. Those are
-//! real AWS CloudControl behaviours driven by the CloudFormation resource-type
-//! schema; the generic winterbaume mock returns the desired state verbatim and
-//! does not reproduce them because it does not consult CFN schemas. That
-//! winterbaume behavior is tracked upstream as moriyoshi/winterbaume issue #6.
-//! The AWS behaviours should be verified separately against live AWS, not here.
+//! winterbaume-cloudcontrol 1.0.1 fixes moriyoshi/winterbaume issue #10: the
+//! mock now reproduces CloudFormation-schema shaping for
+//! AWS::ElasticLoadBalancingV2::LoadBalancer, including write-only stripping,
+//! read-only synthesis (for example `LoadBalancerArn`), schema-default fill-in,
+//! and derived sub-structures. This test sends one create request and asserts
+//! the full CFN-schema-shaped read state round-trips through the awscc
+//! provider's serialization and conversion.
 
 use aws_config::{BehaviorVersion, Region};
 use carina_core::provider::{CreateRequest, Provider, ReadRequest};
@@ -39,6 +34,10 @@ fn map(entries: impl IntoIterator<Item = (&'static str, Value)>) -> Value {
 
 fn list(items: impl IntoIterator<Item = Value>) -> Value {
     Value::Concrete(ConcreteValue::List(items.into_iter().collect()))
+}
+
+fn key_value(key: &'static str, value: &'static str) -> Value {
+    map([("key", string(key)), ("value", string(value))])
 }
 
 fn load_balancer_resource() -> Resource {
@@ -79,31 +78,63 @@ async fn winterbaume_provider() -> AwsccProvider {
     AwsccProvider::from_sdk_config(config, &AwsccProviderConfig::default()).await
 }
 
-fn assert_string_list(attributes: &HashMap<String, Value>, attribute_name: &str, expected: Value) {
-    let value = attributes
-        .get(attribute_name)
-        .unwrap_or_else(|| panic!("read-back state must include {attribute_name}"));
-    let items = match value {
-        Value::Concrete(ConcreteValue::List(items)) => items,
-        other => panic!("{attribute_name} must round-trip as List(String), got {other:?}"),
-    };
+fn attributes(entries: impl IntoIterator<Item = (&'static str, Value)>) -> HashMap<String, Value> {
+    entries
+        .into_iter()
+        .map(|(key, value)| (key.to_string(), value))
+        .collect()
+}
 
-    assert_eq!(
-        items.len(),
-        2,
-        "{attribute_name} must contain two structured string elements"
-    );
-    assert_eq!(value, &expected);
-    assert!(
-        items
-            .iter()
-            .all(|item| matches!(item, Value::Concrete(ConcreteValue::String(_)))),
-        "{attribute_name} must contain only string elements"
-    );
+fn concrete_string_attribute<'a>(
+    attributes: &'a HashMap<String, Value>,
+    attribute_name: &str,
+) -> &'a str {
+    match attributes.get(attribute_name) {
+        Some(Value::Concrete(ConcreteValue::String(value))) => value,
+        other => panic!("{attribute_name} must be a String, got {other:?}"),
+    }
+}
+
+fn is_lower_hex16(value: &str) -> bool {
+    value.len() == 16 && value.chars().all(|ch| ch.is_ascii_hexdigit())
+}
+
+fn is_decimal10(value: &str) -> bool {
+    value.len() == 10 && value.chars().all(|ch| ch.is_ascii_digit())
+}
+
+fn load_balancer_attributes() -> Value {
+    list([
+        key_value("access_logs.s3.prefix", ""),
+        key_value("routing.http.xff_header_processing.mode", "append"),
+        key_value("routing.http2.enabled", "true"),
+        key_value("waf.fail_open.enabled", "false"),
+        key_value("connection_logs.s3.bucket", ""),
+        key_value("access_logs.s3.enabled", "false"),
+        key_value("zonal_shift.config.enabled", "false"),
+        key_value("routing.http.desync_mitigation_mode", "defensive"),
+        key_value("connection_logs.s3.prefix", ""),
+        key_value("health_check_logs.s3.prefix", ""),
+        key_value(
+            "routing.http.x_amzn_tls_version_and_cipher_suite.enabled",
+            "false",
+        ),
+        key_value("routing.http.preserve_host_header.enabled", "false"),
+        key_value("load_balancing.cross_zone.enabled", "true"),
+        key_value("health_check_logs.s3.enabled", "false"),
+        key_value("health_check_logs.s3.bucket", ""),
+        key_value("routing.http.xff_client_port.enabled", "false"),
+        key_value("access_logs.s3.bucket", ""),
+        key_value("deletion_protection.enabled", "false"),
+        key_value("client_keep_alive.seconds", "3600"),
+        key_value("routing.http.drop_invalid_header_fields.enabled", "false"),
+        key_value("connection_logs.s3.enabled", "false"),
+        key_value("idle_timeout.timeout_seconds", "60"),
+    ])
 }
 
 #[tokio::test]
-async fn load_balancer_create_then_read_round_trips_structured_list_fields() {
+async fn load_balancer_create_then_read_round_trips_full_shaped_state() {
     let provider = winterbaume_provider().await;
     let resource = load_balancer_resource();
     let id = resource.id.clone();
@@ -124,36 +155,68 @@ async fn load_balancer_create_then_read_round_trips_structured_list_fields() {
 
     assert!(read.exists, "read-back state must exist");
     assert_eq!(read.identifier.as_deref(), Some(identifier));
-    assert_eq!(read.attributes.get("name"), Some(&string("registry-alb")));
-    let expected_subnets = list([string("subnet-aaaa1111"), string("subnet-bbbb2222")]);
-    assert_string_list(&read.attributes, "subnets", expected_subnets);
 
-    let security_groups = read
-        .attributes
-        .get("security_groups")
-        .expect("read-back state must include security_groups");
-    let security_group_items = match security_groups {
-        Value::Concrete(ConcreteValue::List(items)) => items,
-        other => panic!("security_groups must round-trip as List(String), got {other:?}"),
-    };
-    assert_eq!(
-        security_group_items.len(),
-        1,
-        "security_groups must contain one structured string element"
-    );
-    assert_eq!(security_groups, &list([string("sg-cccc3333")]));
+    let load_balancer_arn = concrete_string_attribute(&read.attributes, "load_balancer_arn");
+    let load_balancer_full_name =
+        concrete_string_attribute(&read.attributes, "load_balancer_full_name");
+    let suffix = load_balancer_full_name
+        .strip_prefix("app/registry-alb/")
+        .expect("load_balancer_full_name must use app/<name>/<suffix>");
     assert!(
-        security_group_items
-            .iter()
-            .all(|item| matches!(item, Value::Concrete(ConcreteValue::String(_)))),
-        "security_groups must contain only string elements"
+        is_lower_hex16(suffix),
+        "load_balancer_full_name suffix must be 16 hex characters: {suffix}"
+    );
+    assert_eq!(
+        load_balancer_arn,
+        format!(
+            "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/{load_balancer_full_name}"
+        )
     );
 
+    let dns_name = concrete_string_attribute(&read.attributes, "dns_name");
+    let dns_suffix = dns_name
+        .strip_prefix("registry-alb-")
+        .and_then(|rest| rest.strip_suffix(".us-east-1.elb.amazonaws.com"))
+        .expect("dns_name must use <name>-<10digits>.<region>.elb.amazonaws.com");
+    assert!(
+        is_decimal10(dns_suffix),
+        "dns_name suffix must be 10 decimal digits: {dns_suffix}"
+    );
+
+    let expected = attributes([
+        ("name", string("registry-alb")),
+        ("type", string("application")),
+        ("scheme", string("internet-facing")),
+        (
+            "subnets",
+            list([string("subnet-aaaa1111"), string("subnet-bbbb2222")]),
+        ),
+        ("security_groups", list([string("sg-cccc3333")])),
+        (
+            "tags",
+            map([
+                ("Environment", string("test")),
+                ("Workload", string("registry")),
+            ]),
+        ),
+        ("load_balancer_name", string("registry-alb")),
+        ("load_balancer_full_name", string(load_balancer_full_name)),
+        ("load_balancer_arn", string(load_balancer_arn)),
+        ("dns_name", string(dns_name)),
+        ("canonical_hosted_zone_id", string("Z35SXDOTRQ7X7K")),
+        ("ip_address_type", string("ipv4")),
+        ("enable_prefix_for_ipv6_source_nat", string("off")),
+        ("load_balancer_attributes", load_balancer_attributes()),
+        (
+            "subnet_mappings",
+            list([
+                map([("subnet_id", string("subnet-aaaa1111"))]),
+                map([("subnet_id", string("subnet-bbbb2222"))]),
+            ]),
+        ),
+    ]);
     assert_eq!(
-        read.attributes.get("tags"),
-        Some(&map([
-            ("Environment", string("test")),
-            ("Workload", string("registry")),
-        ]))
+        &read.attributes, &expected,
+        "read-back attributes must exactly match the full shaped ELBv2 load balancer state"
     );
 }

--- a/carina-provider-awscc/tests/elasticloadbalancingv2_target_group_cloudcontrol_roundtrip.rs
+++ b/carina-provider-awscc/tests/elasticloadbalancingv2_target_group_cloudcontrol_roundtrip.rs
@@ -1,18 +1,12 @@
 //! Integration coverage for the awscc provider's real Provider-trait apply path
 //! against an in-process winterbaume CloudControl mock.
 //!
-//! This test proves that create -> read wiring round-trips Elastic Load
-//! Balancing v2 target group structured list serialization through
-//! CloudControl. In particular, `targets` survives as a list of maps instead of
-//! being flattened into a string.
-//!
-//! This test deliberately does not assert write-only stripping, read-only
-//! synthesis such as `arn`, schema-default fill-in, or normalization. Those are
-//! real AWS CloudControl behaviours driven by the CloudFormation resource-type
-//! schema; the generic winterbaume mock returns the desired state verbatim and
-//! does not reproduce them because it does not consult CFN schemas. That
-//! winterbaume behavior is tracked upstream as moriyoshi/winterbaume issue #6.
-//! The AWS behaviours should be verified separately against live AWS, not here.
+//! winterbaume-cloudcontrol 1.0.1 fixes moriyoshi/winterbaume issue #9: the
+//! mock now reproduces CloudFormation-schema shaping for
+//! AWS::ElasticLoadBalancingV2::TargetGroup, including read-only synthesis
+//! (for example `TargetGroupArn`) and schema-default fill-in. This test sends
+//! one create request and asserts the full CFN-schema-shaped read state
+//! round-trips through the awscc provider's serialization and conversion.
 
 use aws_config::{BehaviorVersion, Region};
 use carina_core::provider::{CreateRequest, Provider, ReadRequest};
@@ -32,6 +26,10 @@ fn int(value: i64) -> Value {
     Value::Concrete(ConcreteValue::Int(value))
 }
 
+fn bool_(value: bool) -> Value {
+    Value::Concrete(ConcreteValue::Bool(value))
+}
+
 fn map(entries: impl IntoIterator<Item = (&'static str, Value)>) -> Value {
     Value::Concrete(ConcreteValue::Map(
         entries
@@ -43,6 +41,10 @@ fn map(entries: impl IntoIterator<Item = (&'static str, Value)>) -> Value {
 
 fn list(items: impl IntoIterator<Item = Value>) -> Value {
     Value::Concrete(ConcreteValue::List(items.into_iter().collect()))
+}
+
+fn key_value(key: &'static str, value: &'static str) -> Value {
+    map([("key", string(key)), ("value", string(value))])
 }
 
 fn target_group_resource() -> Resource {
@@ -85,39 +87,63 @@ async fn winterbaume_provider() -> AwsccProvider {
     AwsccProvider::from_sdk_config(config, &AwsccProviderConfig::default()).await
 }
 
-fn assert_single_map_list(
-    attributes: &HashMap<String, Value>,
-    attribute_name: &str,
-    expected_entries: &[(&str, Value)],
-) {
-    let value = attributes
-        .get(attribute_name)
-        .unwrap_or_else(|| panic!("read-back state must include {attribute_name}"));
-    let items = match value {
-        Value::Concrete(ConcreteValue::List(items)) => items,
-        other => panic!("{attribute_name} must round-trip as List(Map), got {other:?}"),
-    };
-    assert_eq!(
-        items.len(),
-        1,
-        "{attribute_name} must contain one structured element"
-    );
-    let item = match &items[0] {
-        Value::Concrete(ConcreteValue::Map(item)) => item,
-        other => panic!("{attribute_name}[0] must round-trip as Map, got {other:?}"),
-    };
+fn attributes(entries: impl IntoIterator<Item = (&'static str, Value)>) -> HashMap<String, Value> {
+    entries
+        .into_iter()
+        .map(|(key, value)| (key.to_string(), value))
+        .collect()
+}
 
-    for (key, expected_value) in expected_entries {
-        assert_eq!(
-            item.get(*key),
-            Some(expected_value),
-            "{attribute_name}[0].{key} must round-trip"
-        );
+fn concrete_string_attribute<'a>(
+    attributes: &'a HashMap<String, Value>,
+    attribute_name: &str,
+) -> &'a str {
+    match attributes.get(attribute_name) {
+        Some(Value::Concrete(ConcreteValue::String(value))) => value,
+        other => panic!("{attribute_name} must be a String, got {other:?}"),
     }
 }
 
+fn is_lower_hex16(value: &str) -> bool {
+    value.len() == 16 && value.chars().all(|ch| ch.is_ascii_hexdigit())
+}
+
+fn target_group_attributes() -> Value {
+    list([
+        key_value("stickiness.type", "lb_cookie"),
+        key_value("stickiness.app_cookie.duration_seconds", "86400"),
+        key_value(
+            "target_group_health.dns_failover.minimum_healthy_targets.count",
+            "1",
+        ),
+        key_value(
+            "load_balancing.cross_zone.enabled",
+            "use_load_balancer_configuration",
+        ),
+        key_value("stickiness.lb_cookie.duration_seconds", "86400"),
+        key_value(
+            "target_group_health.dns_failover.minimum_healthy_targets.percentage",
+            "off",
+        ),
+        key_value("stickiness.enabled", "false"),
+        key_value(
+            "target_group_health.unhealthy_state_routing.minimum_healthy_targets.percentage",
+            "off",
+        ),
+        key_value("slow_start.duration_seconds", "0"),
+        key_value("deregistration_delay.timeout_seconds", "300"),
+        key_value(
+            "target_group_health.unhealthy_state_routing.minimum_healthy_targets.count",
+            "1",
+        ),
+        key_value("load_balancing.algorithm.anomaly_mitigation", "off"),
+        key_value("stickiness.app_cookie.cookie_name", ""),
+        key_value("load_balancing.algorithm.type", "round_robin"),
+    ])
+}
+
 #[tokio::test]
-async fn target_group_create_then_read_round_trips_structured_list_fields() {
+async fn target_group_create_then_read_round_trips_full_shaped_state() {
     let provider = winterbaume_provider().await;
     let resource = target_group_resource();
     let id = resource.id.clone();
@@ -138,13 +164,58 @@ async fn target_group_create_then_read_round_trips_structured_list_fields() {
 
     assert!(read.exists, "read-back state must exist");
     assert_eq!(read.identifier.as_deref(), Some(identifier));
-    assert_eq!(read.attributes.get("name"), Some(&string("registry-tg")));
-    assert_single_map_list(&read.attributes, "targets", &[("id", string("10.0.1.10"))]);
+
+    let target_group_arn = concrete_string_attribute(&read.attributes, "target_group_arn");
+    let target_group_full_name =
+        concrete_string_attribute(&read.attributes, "target_group_full_name");
+    let suffix = target_group_full_name
+        .strip_prefix("targetgroup/registry-tg/")
+        .expect("target_group_full_name must use targetgroup/<name>/<suffix>");
+    assert!(
+        is_lower_hex16(suffix),
+        "target_group_full_name suffix must be 16 hex characters: {suffix}"
+    );
     assert_eq!(
-        read.attributes.get("tags"),
-        Some(&map([
-            ("Environment", string("test")),
-            ("Workload", string("registry")),
-        ]))
+        target_group_arn,
+        format!("arn:aws:elasticloadbalancing:us-east-1:123456789012:{target_group_full_name}")
+    );
+
+    let expected = attributes([
+        ("name", string("registry-tg")),
+        ("protocol", string("HTTP")),
+        ("port", int(8080)),
+        ("vpc_id", string("vpc-dddd4444")),
+        ("target_type", string("ip")),
+        ("health_check_path", string("/health")),
+        (
+            "targets",
+            list([map([("id", string("10.0.1.10")), ("port", int(8080))])]),
+        ),
+        (
+            "tags",
+            map([
+                ("Environment", string("test")),
+                ("Workload", string("registry")),
+            ]),
+        ),
+        ("target_group_name", string("registry-tg")),
+        ("target_group_full_name", string(target_group_full_name)),
+        ("target_group_arn", string(target_group_arn)),
+        ("load_balancer_arns", list([])),
+        ("ip_address_type", string("ipv4")),
+        ("health_check_enabled", bool_(true)),
+        ("health_check_interval_seconds", int(30)),
+        ("health_check_protocol", string("HTTP")),
+        ("health_check_port", string("traffic-port")),
+        ("health_check_timeout_seconds", int(5)),
+        ("healthy_threshold_count", int(5)),
+        ("unhealthy_threshold_count", int(2)),
+        ("protocol_version", string("HTTP1")),
+        ("matcher", map([("http_code", string("200"))])),
+        ("target_group_attributes", target_group_attributes()),
+    ]);
+    assert_eq!(
+        &read.attributes, &expected,
+        "read-back attributes must exactly match the full shaped ELBv2 target group state"
     );
 }


### PR DESCRIPTION
## Summary

winterbaume-cloudcontrol 1.0.1 closes [moriyoshi/winterbaume#9](https://github.com/moriyoshi/winterbaume/issues/9), [#10](https://github.com/moriyoshi/winterbaume/issues/10), and [#11](https://github.com/moriyoshi/winterbaume/issues/11) by adding CFN-schema shaping for `AWS::ElasticLoadBalancingV2::TargetGroup` / `LoadBalancer` / `Listener` in `GetResource` responses. The shaper now synthesizes read-only fields (ARNs, `*FullName`, `DNSName`, `CanonicalHostedZoneID`), fills schema defaults (the 14/22/11-entry attribute arrays), derives `SubnetMappings` from `Subnets`, and enriches forward `DefaultActions` with a full `ForwardConfig`.

Until #322 the ELBv2 round-trip tests had to be structure-preservation-only because the mock returned `DesiredState` verbatim. With 1.0.1 they can — and must — assert full shaped equality, in the same way #322 did for KMS/DynamoDB/ECS.

This PR:

- Bumps `winterbaume-cloudcontrol` from `1.0.0` to `1.0.1` in `Cargo.lock`.
- Rewrites the three ELBv2 round-trip tests (`elasticloadbalancingv2_target_group`, `_load_balancer`, `_listener`) to assert the **full shaped read state exhaustively** instead of spot-checking structural preservation. Each builds the expected attribute map from the real `GetResource` shape and compares the whole map, so missing keys, extra keys, wrong defaults, or wrongly-preserved write-only fields all fail. Random suffixes (16-hex resource IDs, 10-decimal DNS suffix) are extracted from the read map, validated structurally, and injected back into the expected map before equality.
- Updates the repository `CLAUDE.md` "Adding a Resource: Required Tests" section so the registered shaping list now includes the three ELBv2 resources, and removes the stale "#9/#10/#11 still open/unshaped" callouts.

## Why this is correct, not a mock artifact

The strengthened assertions **fail against the pre-shaping 1.0.0 mock and pass against 1.0.1** — verified by temporarily pinning `--precise 1.0.0` and re-running the three tests:

```
Downgrading winterbaume-cloudcontrol v1.0.1 -> v1.0.0
3 tests run: 0 passed, 3 failed
  TargetGroup: target_group_arn must be a String, got None
  LoadBalancer: load_balancer_arn must be a String, got None
  Listener:    listener_arn must be a String, got None

Updating winterbaume-cloudcontrol v1.0.0 -> v1.0.1
3 tests run: 3 passed, 0 skipped
```

That proves the tests exercise shaping rather than passing by accident. Same validation pattern as #322.

## Test

- `cargo nextest run -p carina-provider-awscc` → 435 passed
- `cargo test -p carina-provider-awscc --doc` → ok
- `cargo clippy -p carina-provider-awscc --all-targets -- -D warnings` → clean
- `scripts/check-docs-drift.sh` → OK (44 resources)
- `scripts/check-carina-pin.sh` → OK