### PR TITLE
Release v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,7 +670,7 @@ dependencies = [
 
 [[package]]
 name = "carina-provider-awscc"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,4 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"


### PR DESCRIPTION
Bump workspace version 0.5.0 → 0.6.0 ahead of cutting the v0.6.0 tag.

Carries the per-resource ARN newtypes + DSL namespace migration that landed in #324 (carina#3392 + carina#3256). Pairs with the parallel aws release; `carina-rs/infra` consumes both v0.6.0 tags once they are published.