### PR TITLE
provider: async-lift initialize/CRUD to BoxFuture for carina#3400

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,7 +637,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=bbcc5ac2d801e2e3f056e446407b095a74569f54#bbcc5ac2d801e2e3f056e446407b095a74569f54"
+source = "git+https://github.com/carina-rs/carina?rev=387d64b5614391132da1bd10aebf040dba0f82cb#387d64b5614391132da1bd10aebf040dba0f82cb"
 dependencies = [
  "argon2",
  "futures",
@@ -656,11 +656,13 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=bbcc5ac2d801e2e3f056e446407b095a74569f54#bbcc5ac2d801e2e3f056e446407b095a74569f54"
+source = "git+https://github.com/carina-rs/carina?rev=387d64b5614391132da1bd10aebf040dba0f82cb#387d64b5614391132da1bd10aebf040dba0f82cb"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "carina-provider-protocol",
+ "futures-executor",
+ "futures-util",
  "http 1.4.0",
  "serde",
  "serde_json",
@@ -704,7 +706,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=bbcc5ac2d801e2e3f056e446407b095a74569f54#bbcc5ac2d801e2e3f056e446407b095a74569f54"
+source = "git+https://github.com/carina-rs/carina?rev=387d64b5614391132da1bd10aebf040dba0f82cb#387d64b5614391132da1bd10aebf040dba0f82cb"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,7 +637,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=387d64b5614391132da1bd10aebf040dba0f82cb#387d64b5614391132da1bd10aebf040dba0f82cb"
+source = "git+https://github.com/carina-rs/carina?rev=0b1bdcd35479617c60ddcd2c84b336f36b92b9b8#0b1bdcd35479617c60ddcd2c84b336f36b92b9b8"
 dependencies = [
  "argon2",
  "futures",
@@ -656,7 +656,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=387d64b5614391132da1bd10aebf040dba0f82cb#387d64b5614391132da1bd10aebf040dba0f82cb"
+source = "git+https://github.com/carina-rs/carina?rev=0b1bdcd35479617c60ddcd2c84b336f36b92b9b8#0b1bdcd35479617c60ddcd2c84b336f36b92b9b8"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -706,7 +706,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=387d64b5614391132da1bd10aebf040dba0f82cb#387d64b5614391132da1bd10aebf040dba0f82cb"
+source = "git+https://github.com/carina-rs/carina?rev=0b1bdcd35479617c60ddcd2c84b336f36b92b9b8#0b1bdcd35479617c60ddcd2c84b336f36b92b9b8"
 dependencies = [
  "serde",
  "serde_json",
@@ -924,7 +924,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "bbcc5ac2d801e2e3f056e446407b095a74569f54" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "387d64b5614391132da1bd10aebf040dba0f82cb" }

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "387d64b5614391132da1bd10aebf040dba0f82cb" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "0b1bdcd35479617c60ddcd2c84b336f36b92b9b8" }

--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -23,10 +23,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "387d64b5614391132da1bd10aebf040dba0f82cb" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "0b1bdcd35479617c60ddcd2c84b336f36b92b9b8" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "387d64b5614391132da1bd10aebf040dba0f82cb" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "387d64b5614391132da1bd10aebf040dba0f82cb" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "0b1bdcd35479617c60ddcd2c84b336f36b92b9b8" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "0b1bdcd35479617c60ddcd2c84b336f36b92b9b8" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }
@@ -55,5 +55,5 @@ winterbaume-cloudcontrol = "1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tokio = { version = "1", default-features = false, features = ["rt", "macros", "time", "sync"] }
-wit-bindgen = { version = "0.54", default-features = false, features = ["macros"] }
+wit-bindgen = { version = "0.54", default-features = false, features = ["macros", "async"] }
 wasi = "0.14"

--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -23,10 +23,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "bbcc5ac2d801e2e3f056e446407b095a74569f54" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "387d64b5614391132da1bd10aebf040dba0f82cb" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "bbcc5ac2d801e2e3f056e446407b095a74569f54" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "bbcc5ac2d801e2e3f056e446407b095a74569f54" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "387d64b5614391132da1bd10aebf040dba0f82cb" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "387d64b5614391132da1bd10aebf040dba0f82cb" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }

--- a/carina-provider-awscc/src/main.rs
+++ b/carina-provider-awscc/src/main.rs
@@ -1,26 +1,23 @@
 use std::collections::HashMap;
 
 mod convert;
-use carina_plugin_sdk::CarinaProvider;
+use carina_plugin_sdk::{BoxFuture, CarinaProvider};
 use carina_provider_protocol::types as proto;
 
 use carina_core::provider::{
     CreateRequest as CoreCreateRequest, DeleteRequest as CoreDeleteRequest, Provider,
-    ProviderError as CoreProviderError, ProviderNormalizer, ReadRequest as CoreReadRequest,
-    SavedAttrs, UpdateRequest as CoreUpdateRequest,
+    ProviderError as CoreProviderError, ReadRequest as CoreReadRequest, SavedAttrs,
+    UpdateRequest as CoreUpdateRequest, merge_default_tags_for_provider,
 };
 use carina_core::resource::{
     ConcreteValue, ResourceId as CoreResourceId, State as CoreState, Value as CoreValue,
 };
 
-use carina_provider_awscc::AwsccNormalizer;
 use carina_provider_awscc::provider::{AwsccProvider, AwsccProviderConfig};
 use carina_provider_awscc::schemas;
 
 struct AwsccProcessProvider {
-    runtime: tokio::runtime::Runtime,
     provider: Option<AwsccProvider>,
-    normalizer: AwsccNormalizer,
 }
 
 impl Default for AwsccProcessProvider {
@@ -31,18 +28,7 @@ impl Default for AwsccProcessProvider {
 
 impl AwsccProcessProvider {
     fn new() -> Self {
-        #[cfg(not(target_arch = "wasm32"))]
-        let runtime = tokio::runtime::Runtime::new().expect("Failed to create tokio runtime");
-        #[cfg(target_arch = "wasm32")]
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_time()
-            .build()
-            .expect("Failed to create tokio runtime");
-        Self {
-            runtime,
-            provider: None,
-            normalizer: AwsccNormalizer,
-        }
+        Self { provider: None }
     }
 
     fn convert_error(e: CoreProviderError) -> proto::ProviderError {
@@ -138,7 +124,10 @@ impl CarinaProvider for AwsccProcessProvider {
         Ok(())
     }
 
-    fn initialize(&mut self, attrs: &HashMap<String, proto::Value>) -> Result<(), String> {
+    fn initialize<'a>(
+        &'a mut self,
+        attrs: &'a HashMap<String, proto::Value>,
+    ) -> BoxFuture<'a, Result<(), String>> {
         let core_attrs = convert::proto_to_core_value_map(attrs);
         let region = if let Some(CoreValue::Concrete(ConcreteValue::String(region))) =
             core_attrs.get("region")
@@ -147,19 +136,19 @@ impl CarinaProvider for AwsccProcessProvider {
         } else {
             "ap-northeast-1".to_string()
         };
-        let cfg = extract_account_guard_config(&core_attrs)?;
-        let provider = self
-            .runtime
-            .block_on(AwsccProvider::new_with_config(&region, &cfg));
-        // Surface the account-guard rejection eagerly: if the caller's
-        // AWS account violates allowed_account_ids / forbidden_account_ids,
-        // initialize() must fail so the host aborts before any plan,
-        // refresh, or apply step.
-        if let Some(err) = provider.init_error() {
-            return Err(err.to_string());
-        }
-        self.provider = Some(provider);
-        Ok(())
+        Box::pin(async move {
+            let cfg = extract_account_guard_config(&core_attrs)?;
+            let provider = AwsccProvider::new_with_config(&region, &cfg).await;
+            // Surface the account-guard rejection eagerly: if the caller's
+            // AWS account violates allowed_account_ids / forbidden_account_ids,
+            // initialize() must fail so the host aborts before any plan,
+            // refresh, or apply step.
+            if let Some(err) = provider.init_error() {
+                return Err(err.to_string());
+            }
+            self.provider = Some(provider);
+            Ok(())
+        })
     }
 
     fn config_completions(&self) -> HashMap<String, Vec<proto::CompletionValue>> {
@@ -210,48 +199,57 @@ impl CarinaProvider for AwsccProcessProvider {
         id: &proto::ResourceId,
         identifier: Option<&str>,
         _request: proto::ReadRequest,
-    ) -> Result<proto::State, proto::ProviderError> {
+    ) -> BoxFuture<'_, Result<proto::State, proto::ProviderError>> {
         let core_id = convert::proto_to_core_resource_id(id);
-        let result =
-            self.runtime
-                .block_on(self.provider().read(&core_id, identifier, CoreReadRequest));
-        match result {
-            Ok(state) => Ok(convert::core_to_proto_state(&state)),
-            Err(e) => Err(Self::convert_error(e)),
-        }
+        let identifier = identifier.map(str::to_string);
+        Box::pin(async move {
+            let result = self
+                .provider()
+                .read(&core_id, identifier.as_deref(), CoreReadRequest)
+                .await;
+            match result {
+                Ok(state) => Ok(convert::core_to_proto_state(&state)),
+                Err(e) => Err(Self::convert_error(e)),
+            }
+        })
     }
 
     fn read_data_source(
         &self,
         resource: &proto::Resource,
-    ) -> Result<proto::State, proto::ProviderError> {
+    ) -> BoxFuture<'_, Result<proto::State, proto::ProviderError>> {
         let core_data_source = convert::proto_to_core_data_source(resource);
-        let result = self
-            .runtime
-            .block_on(self.provider().read_data_source(&core_data_source));
-        match result {
-            Ok(state) => Ok(convert::core_to_proto_state(&state)),
-            Err(e) => Err(Self::convert_error(e)),
-        }
+        Box::pin(async move {
+            let result = self.provider().read_data_source(&core_data_source).await;
+            match result {
+                Ok(state) => Ok(convert::core_to_proto_state(&state)),
+                Err(e) => Err(Self::convert_error(e)),
+            }
+        })
     }
 
     fn create(
         &self,
         id: &proto::ResourceId,
         request: proto::CreateRequest,
-    ) -> Result<proto::State, proto::ProviderError> {
+    ) -> BoxFuture<'_, Result<proto::State, proto::ProviderError>> {
         let core_id = convert::proto_to_core_resource_id(id);
         let core_resource = convert::proto_to_core_resource(&request.resource);
-        let result = self.runtime.block_on(self.provider().create(
-            &core_id,
-            CoreCreateRequest {
-                resource: core_resource,
-            },
-        ));
-        match result {
-            Ok(state) => Ok(convert::core_to_proto_state(&state)),
-            Err(e) => Err(Self::convert_error(e)),
-        }
+        Box::pin(async move {
+            let result = self
+                .provider()
+                .create(
+                    &core_id,
+                    CoreCreateRequest {
+                        resource: core_resource,
+                    },
+                )
+                .await;
+            match result {
+                Ok(state) => Ok(convert::core_to_proto_state(&state)),
+                Err(e) => Err(Self::convert_error(e)),
+            }
+        })
     }
 
     fn update(
@@ -259,22 +257,28 @@ impl CarinaProvider for AwsccProcessProvider {
         id: &proto::ResourceId,
         identifier: &str,
         request: proto::UpdateRequest,
-    ) -> Result<proto::State, proto::ProviderError> {
+    ) -> BoxFuture<'_, Result<proto::State, proto::ProviderError>> {
         let core_id = convert::proto_to_core_resource_id(id);
+        let identifier = identifier.to_string();
         let core_from = convert::proto_to_core_state(&request.from);
         let core_patch = convert::proto_to_core_update_patch(&request.patch);
-        let result = self.runtime.block_on(self.provider().update(
-            &core_id,
-            identifier,
-            CoreUpdateRequest {
-                from: core_from,
-                patch: core_patch,
-            },
-        ));
-        match result {
-            Ok(state) => Ok(convert::core_to_proto_state(&state)),
-            Err(e) => Err(Self::convert_error(e)),
-        }
+        Box::pin(async move {
+            let result = self
+                .provider()
+                .update(
+                    &core_id,
+                    &identifier,
+                    CoreUpdateRequest {
+                        from: core_from,
+                        patch: core_patch,
+                    },
+                )
+                .await;
+            match result {
+                Ok(state) => Ok(convert::core_to_proto_state(&state)),
+                Err(e) => Err(Self::convert_error(e)),
+            }
+        })
     }
 
     fn delete(
@@ -282,8 +286,9 @@ impl CarinaProvider for AwsccProcessProvider {
         id: &proto::ResourceId,
         identifier: &str,
         request: proto::DeleteRequest,
-    ) -> Result<(), proto::ProviderError> {
+    ) -> BoxFuture<'_, Result<(), proto::ProviderError>> {
         let core_id = convert::proto_to_core_resource_id(id);
+        let identifier = identifier.to_string();
         let core_directives = carina_core::resource::Directives {
             force_delete: request.directives.force_delete,
             create_before_destroy: request.directives.create_before_destroy,
@@ -291,17 +296,22 @@ impl CarinaProvider for AwsccProcessProvider {
             depends_on: Vec::new(),
             provider_instance: None,
         };
-        let result = self.runtime.block_on(self.provider().delete(
-            &core_id,
-            identifier,
-            CoreDeleteRequest {
-                directives: core_directives,
-            },
-        ));
-        match result {
-            Ok(()) => Ok(()),
-            Err(e) => Err(Self::convert_error(e)),
-        }
+        Box::pin(async move {
+            let result = self
+                .provider()
+                .delete(
+                    &core_id,
+                    &identifier,
+                    CoreDeleteRequest {
+                        directives: core_directives,
+                    },
+                )
+                .await;
+            match result {
+                Ok(()) => Ok(()),
+                Err(e) => Err(Self::convert_error(e)),
+            }
+        })
     }
 
     fn normalize_desired(&self, resources: Vec<proto::Resource>) -> Vec<proto::Resource> {
@@ -309,12 +319,7 @@ impl CarinaProvider for AwsccProcessProvider {
             .iter()
             .map(convert::proto_to_core_resource)
             .collect();
-        // Guest-side: drive the now-async normalizer on the guest's own
-        // outermost runtime — same pattern as the guest's `Provider`
-        // CRUD methods. Not a nested runtime: the host drives the WASM
-        // call, the guest drives its internal async (carina#3112).
-        self.runtime
-            .block_on(self.normalizer.normalize_desired(&mut core_resources));
+        carina_provider_awscc::provider::resolve_enum_identifiers_impl(&mut core_resources);
         core_resources
             .iter()
             .map(convert::core_to_proto_resource)
@@ -332,8 +337,8 @@ impl CarinaProvider for AwsccProcessProvider {
                 (core_state.id.clone(), core_state)
             })
             .collect();
-        self.runtime
-            .block_on(self.normalizer.normalize_state(&mut core_states));
+        carina_provider_awscc::provider::normalize_state_enums_impl(&mut core_states);
+        carina_provider_awscc::provider::canonicalize_string_or_list_states_impl(&mut core_states);
         core_states
             .iter()
             .map(|(id, state)| (id.to_string(), convert::core_to_proto_state(state)))
@@ -366,9 +371,9 @@ impl CarinaProvider for AwsccProcessProvider {
                 Some((id, attrs))
             })
             .collect();
-        self.runtime.block_on(
-            self.normalizer
-                .hydrate_read_state(&mut core_states, &core_saved),
+        carina_provider_awscc::provider::restore_unreturned_attrs_impl(
+            &mut core_states,
+            &core_saved,
         );
         *states = core_states
             .iter()
@@ -394,11 +399,7 @@ impl CarinaProvider for AwsccProcessProvider {
         for s in proto_schemas {
             registry.insert("awscc", convert::proto_to_core_schema(s));
         }
-        self.runtime.block_on(self.normalizer.merge_default_tags(
-            &mut core_resources,
-            &core_tags,
-            &registry,
-        ));
+        merge_default_tags_for_provider("awscc", &mut core_resources, &core_tags, &registry);
         *resources = core_resources
             .iter()
             .map(convert::core_to_proto_resource)


### PR DESCRIPTION
## Summary

Re-pins carina-plugin-sdk / carina-core / carina-provider-protocol to carina@387d64b5 (which contains carina#3401's WIT async lift). The `AwsccProcessProvider` drops its embedded `tokio::runtime::Runtime` and `block_on` layer; `initialize`, `read`, `read_data_source`, `create`, `update`, `delete` return `BoxFuture` and await the existing async core provider futures directly.

## Cross-repo dependency

This PR pairs with:
- carina-rs/carina#3401 (already merged) — WIT + SDK + host + mock change.
- carina-rs/carina-provider-aws PR (parallel) — same conversion for the AWS provider.

The user-visible hang in `carina-rs/infra/envs/registry/dev/infra` is cured only after this PR + the aws PR + an `infra` lock refresh.

## Test plan

- [x] `cargo check --workspace` PASS
- [x] `cargo build -p carina-provider-awscc --target wasm32-wasip2 --release` PASS
- [x] `cargo nextest run --workspace` 547/547 PASS
- [x] `cargo clippy --workspace --all-targets -- -D warnings` PASS
- [x] `scripts/check-*.sh` PASS
- [ ] Real-infra `carina plan` once all three PRs merge and lock refreshes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)