### PR TITLE
Adopt data-driven DslTransform enum from carina#3414 (closes awscc#331)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,9 +637,10 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=6fe9d3f220c3f3011fa5607e9dd321d63f049064#6fe9d3f220c3f3011fa5607e9dd321d63f049064"
+source = "git+https://github.com/carina-rs/carina?rev=31f62d0140e754fcf6867b67d7c1e1aab008acf7#31f62d0140e754fcf6867b67d7c1e1aab008acf7"
 dependencies = [
  "argon2",
+ "carina-provider-protocol",
  "futures",
  "indexmap",
  "pest",
@@ -656,7 +657,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=6fe9d3f220c3f3011fa5607e9dd321d63f049064#6fe9d3f220c3f3011fa5607e9dd321d63f049064"
+source = "git+https://github.com/carina-rs/carina?rev=31f62d0140e754fcf6867b67d7c1e1aab008acf7#31f62d0140e754fcf6867b67d7c1e1aab008acf7"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -704,7 +705,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=6fe9d3f220c3f3011fa5607e9dd321d63f049064#6fe9d3f220c3f3011fa5607e9dd321d63f049064"
+source = "git+https://github.com/carina-rs/carina?rev=31f62d0140e754fcf6867b67d7c1e1aab008acf7#31f62d0140e754fcf6867b67d7c1e1aab008acf7"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-aws-types/Cargo.toml
+++ b/carina-aws-types/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "6fe9d3f220c3f3011fa5607e9dd321d63f049064" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "31f62d0140e754fcf6867b67d7c1e1aab008acf7" }

--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -23,10 +23,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "6fe9d3f220c3f3011fa5607e9dd321d63f049064" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "31f62d0140e754fcf6867b67d7c1e1aab008acf7" }
 carina-aws-types = { path = "../carina-aws-types" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "6fe9d3f220c3f3011fa5607e9dd321d63f049064" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "6fe9d3f220c3f3011fa5607e9dd321d63f049064" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "31f62d0140e754fcf6867b67d7c1e1aab008acf7" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "31f62d0140e754fcf6867b67d7c1e1aab008acf7" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }

--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -4636,7 +4636,9 @@ fn resource_type_overrides() -> &'static HashMap<(&'static str, &'static str), T
             // Route 53 HostedZone Name: AWS returns FQDN with trailing dot
             m.insert(
                 ("AWS::Route53::HostedZone", "Name"),
-                TypeOverride::ToDsl(r#"Some(crate::strip_trailing_dot)"#),
+                TypeOverride::ToDsl(
+                    r#"Some(carina_core::schema::DslTransform::StripSuffix(".".to_string()))"#,
+                ),
             );
 
             m

--- a/carina-provider-awscc/src/convert.rs
+++ b/carina-provider-awscc/src/convert.rs
@@ -4,7 +4,7 @@
 //! needed because carina-plugin-host depends on wasmtime which cannot
 //! compile to wasm32-wasip2.
 
-use std::{collections::HashMap, sync::LazyLock};
+use std::collections::HashMap;
 
 use carina_core::provider::{
     PatchOp as CorePatchOp, PatchOpKind as CorePatchOpKind, ProviderError as CoreProviderError,
@@ -292,16 +292,13 @@ fn proto_attr_type_to_core(t: &ProtoAttributeType) -> CoreAttributeType {
         } => {
             let identity = carina_core::schema::enum_identity(name, Some(namespace.as_str()));
             let base = proto_attr_type_to_core(base);
-            let to_dsl = dsl_transform
-                .as_deref()
-                .and_then(carina_core::schema::dsl_transform_for);
             if matches!(base.raw_shape(), CoreRawShape::String) {
                 CoreAttributeType::enum_(
                     identity,
                     None,
                     vec![],
                     Some(legacy_validator(|_| Ok(()))),
-                    to_dsl,
+                    dsl_transform.clone(),
                 )
             } else {
                 CoreAttributeType::enum_with_base(
@@ -310,7 +307,7 @@ fn proto_attr_type_to_core(t: &ProtoAttributeType) -> CoreAttributeType {
                     None,
                     vec![],
                     Some(legacy_validator(|_| Ok(()))),
-                    to_dsl,
+                    dsl_transform.clone(),
                 )
             }
         }
@@ -442,7 +439,7 @@ fn core_to_proto_attribute_type(t: &CoreAttributeType) -> ProtoAttributeType {
                     name: identity.kind.clone(),
                     base: Box::new(core_to_proto_attribute_type(base)),
                     namespace: identity.dotted_prefix().unwrap_or_default(),
-                    dsl_transform: enum_dsl_transform_name(identity, to_dsl).map(str::to_string),
+                    dsl_transform: to_dsl.cloned(),
                 }
             }
         }
@@ -481,32 +478,6 @@ fn core_to_proto_attribute_type(t: &CoreAttributeType) -> ProtoAttributeType {
             name: name.to_string(),
         },
     }
-}
-
-type DslTransformFn = fn(&str) -> String;
-
-fn enum_dsl_transform_name(
-    _identity: &carina_core::schema::TypeIdentity,
-    to_dsl: Option<DslTransformFn>,
-) -> Option<&'static str> {
-    static TRANSFORM_NAMES: LazyLock<HashMap<DslTransformFn, &'static str>> = LazyLock::new(|| {
-        HashMap::from([
-            (
-                carina_provider_awscc::strip_trailing_dot as DslTransformFn,
-                carina_provider_awscc::STRIP_TRAILING_DOT_TRANSFORM,
-            ),
-            (
-                carina_provider_awscc::hyphen_to_underscore as DslTransformFn,
-                carina_provider_awscc::HYPHEN_TO_UNDERSCORE_TRANSFORM,
-            ),
-            (
-                carina_provider_awscc::ip_protocol_all_to_dsl as DslTransformFn,
-                carina_provider_awscc::IP_PROTOCOL_ALL_TRANSFORM,
-            ),
-        ])
-    });
-
-    to_dsl.and_then(|f| TRANSFORM_NAMES.get(&(f as DslTransformFn)).copied())
 }
 
 fn core_to_proto_struct_field(f: &CoreStructField) -> ProtoStructField {
@@ -637,6 +608,8 @@ pub fn core_to_proto_provider_error(e: CoreProviderError) -> ProtoProviderError 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use carina_core::schema::DslTransform;
+    use carina_provider_protocol::types::DslTransform as ProtoDslTransform;
 
     fn test_enum(
         name: &str,
@@ -835,19 +808,12 @@ mod tests {
     }
 
     #[test]
-    fn custom_enum_dsl_transform_name_lifts_state_value() {
-        carina_provider_awscc::register_dsl_transforms();
-        let registered = carina_core::schema::dsl_transform_for(
-            carina_provider_awscc::STRIP_TRAILING_DOT_TRANSFORM,
-        )
-        .expect("strip_trailing_dot should be registered");
-        assert_eq!(registered("example.com."), "example.com");
-
+    fn custom_enum_dsl_transform_data_lifts_state_value() {
         let proto_type = ProtoAttributeType::CustomEnum {
             name: "DnsName".to_string(),
             base: Box::new(ProtoAttributeType::String),
             namespace: "awscc.route53.HostedZone".to_string(),
-            dsl_transform: Some(carina_provider_awscc::STRIP_TRAILING_DOT_TRANSFORM.to_string()),
+            dsl_transform: Some(ProtoDslTransform::StripSuffix(".".to_string())),
         };
         let core_type = proto_attr_type_to_core(&proto_type);
         let lifted = carina_core::utils::lift_enum_leaves(
@@ -865,7 +831,6 @@ mod tests {
 
     #[test]
     fn dns_name_substring_identity_does_not_get_strip_trailing_dot_transform() {
-        carina_provider_awscc::register_dsl_transforms();
         let core_type = CoreAttributeType::enum_(
             carina_core::schema::enum_identity(
                 "HostnameType",
@@ -874,15 +839,15 @@ mod tests {
             None,
             vec![],
             None,
-            Some(carina_provider_awscc::hyphen_to_underscore),
+            Some(DslTransform::HyphenToUnderscore),
         );
 
         let proto_type = core_to_proto_attribute_type(&core_type);
         match &proto_type {
             ProtoAttributeType::CustomEnum { dsl_transform, .. } => {
                 assert_eq!(
-                    dsl_transform.as_deref(),
-                    Some(carina_provider_awscc::HYPHEN_TO_UNDERSCORE_TRANSFORM)
+                    dsl_transform.as_ref(),
+                    Some(&ProtoDslTransform::HyphenToUnderscore)
                 );
             }
             other => panic!("Expected CustomEnum, got {other:?}"),

--- a/carina-provider-awscc/src/lib.rs
+++ b/carina-provider-awscc/src/lib.rs
@@ -98,7 +98,6 @@ impl ProviderFactory for AwsccProviderFactory {
     fn provider_config_attribute_types(
         &self,
     ) -> HashMap<String, carina_core::schema::AttributeType> {
-        register_dsl_transforms();
         use carina_core::schema::AttributeType;
         let mut types = HashMap::new();
         types.insert(
@@ -129,7 +128,6 @@ impl ProviderFactory for AwsccProviderFactory {
     }
 
     fn validate_config(&self, attributes: &IndexMap<String, Value>) -> Result<(), String> {
-        register_dsl_transforms();
         // Cross-account guardrail: when `assume_role.role_arn` parses to
         // an account id that is not in `allowed_account_ids` (when that
         // list is configured), refuse the configuration. Avoids the
@@ -149,7 +147,6 @@ impl ProviderFactory for AwsccProviderFactory {
         identity: &carina_core::schema::TypeIdentity,
         value: &str,
     ) -> Result<(), String> {
-        register_dsl_transforms();
         use carina_core::parser::ValidatorFn;
         use std::sync::OnceLock;
         static VALIDATORS: OnceLock<HashMap<String, ValidatorFn>> = OnceLock::new();
@@ -167,7 +164,6 @@ impl ProviderFactory for AwsccProviderFactory {
     }
 
     fn extract_region(&self, attributes: &IndexMap<String, Value>) -> String {
-        register_dsl_transforms();
         if let Some(Value::Concrete(ConcreteValue::String(region))) = attributes.get("region") {
             return carina_core::utils::convert_region_value(region);
         }
@@ -179,7 +175,6 @@ impl ProviderFactory for AwsccProviderFactory {
         _binding: Option<&str>,
         attributes: &IndexMap<String, Value>,
     ) -> BoxFuture<'_, Result<Box<dyn Provider>, carina_core::provider::ProviderError>> {
-        register_dsl_transforms();
         // `_binding` is intentionally unused: the AWS Cloud Control
         // factory does not cache instances, so each call already
         // produces an independent `AwsccProvider`. The host uses the
@@ -197,12 +192,10 @@ impl ProviderFactory for AwsccProviderFactory {
         _binding: Option<&str>,
         _attributes: &IndexMap<String, Value>,
     ) -> BoxFuture<'_, Box<dyn ProviderNormalizer>> {
-        register_dsl_transforms();
         Box::pin(async { Box::new(AwsccNormalizer) as Box<dyn ProviderNormalizer> })
     }
 
     fn schemas(&self) -> Vec<carina_core::schema::ResourceSchema> {
-        register_dsl_transforms();
         schemas::all_schemas()
     }
 
@@ -213,7 +206,6 @@ impl ProviderFactory for AwsccProviderFactory {
     fn config_completions(
         &self,
     ) -> std::collections::HashMap<String, Vec<carina_core::schema::CompletionValue>> {
-        register_dsl_transforms();
         std::collections::HashMap::from([(
             "region".to_string(),
             carina_aws_types::region_completions("awscc"),
@@ -226,34 +218,6 @@ impl ProviderFactory for AwsccProviderFactory {
     // exhaustive `dsl_aliases` table on each StringEnum. The legacy
     // string-keyed dispatch (`(resource_type, attr_name)`) was
     // removed in awscc#223 / awscc#220.
-}
-
-pub const STRIP_TRAILING_DOT_TRANSFORM: &str = "strip_trailing_dot";
-pub const IP_PROTOCOL_ALL_TRANSFORM: &str = "ip_protocol_all";
-pub const HYPHEN_TO_UNDERSCORE_TRANSFORM: &str = "hyphen_to_underscore";
-
-pub fn strip_trailing_dot(s: &str) -> String {
-    s.strip_suffix('.').unwrap_or(s).to_string()
-}
-
-pub fn hyphen_to_underscore(s: &str) -> String {
-    s.replace('-', "_")
-}
-
-pub fn ip_protocol_all_to_dsl(s: &str) -> String {
-    match s {
-        "-1" => "all".to_string(),
-        _ => s.to_string(),
-    }
-}
-
-pub fn register_dsl_transforms() {
-    carina_core::schema::register_dsl_transform(STRIP_TRAILING_DOT_TRANSFORM, strip_trailing_dot);
-    carina_core::schema::register_dsl_transform(
-        HYPHEN_TO_UNDERSCORE_TRANSFORM,
-        hyphen_to_underscore,
-    );
-    carina_core::schema::register_dsl_transform(IP_PROTOCOL_ALL_TRANSFORM, ip_protocol_all_to_dsl);
 }
 
 // =============================================================================

--- a/carina-provider-awscc/src/main.rs
+++ b/carina-provider-awscc/src/main.rs
@@ -143,7 +143,7 @@ impl CarinaProvider for AwsccProcessProvider {
         let region = if let Some(CoreValue::Concrete(ConcreteValue::String(region))) =
             core_attrs.get("region")
         {
-            carina_core::utils::convert_region_value(region)
+            carina_core::utils::convert_region_value(region.as_str())
         } else {
             "ap-northeast-1".to_string()
         };

--- a/carina-provider-awscc/src/provider/normalizer.rs
+++ b/carina-provider-awscc/src/provider/normalizer.rs
@@ -7,7 +7,9 @@ use indexmap::IndexMap;
 use std::collections::HashMap;
 
 use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
-use carina_core::schema::{AttributeType, ResourceSchema, Shape, ShapeWalkBudget, StructField};
+use carina_core::schema::{
+    AttributeType, RawShape, ResourceSchema, Shape, ShapeWalkBudget, StructField,
+};
 
 /// Resolve enum identifiers in resources to their fully-qualified DSL format.
 ///
@@ -174,6 +176,13 @@ pub fn normalize_state_enums_impl(current_states: &mut HashMap<ResourceId, State
         let mut resolved_attrs = HashMap::new();
         for (key, value) in &state.attributes {
             if let Some(attr_schema) = config.schema.attributes.get(key.as_str())
+                && let Some(transformed) = apply_enum_dsl_transform(value, &attr_schema.attr_type)
+            {
+                resolved_attrs.insert(key.clone(), transformed);
+                continue;
+            }
+
+            if let Some(attr_schema) = config.schema.attributes.get(key.as_str())
                 && let Some(parts) = attr_schema.attr_type.enum_parts()
             {
                 // AWSCC state normalization: only resolve bare values (no dots)
@@ -200,6 +209,21 @@ pub fn normalize_state_enums_impl(current_states: &mut HashMap<ResourceId, State
         }
         state.attributes = resolved_attrs;
     }
+}
+
+fn apply_enum_dsl_transform(value: &Value, attr_type: &AttributeType) -> Option<Value> {
+    let RawShape::Enum {
+        to_dsl: Some(transform),
+        ..
+    } = attr_type.raw_shape()
+    else {
+        return None;
+    };
+    let Value::Concrete(ConcreteValue::String(s)) = value else {
+        return None;
+    };
+    let transformed = transform.apply(s);
+    (transformed != *s).then(|| Value::Concrete(ConcreteValue::String(transformed)))
 }
 
 /// Canonicalize attributes of every awscc state whose declared schema
@@ -564,6 +588,44 @@ mod tests {
     }
 
     #[test]
+    fn route53_hosted_zone_name_trailing_dot_has_no_diff_without_registration() {
+        let config = crate::schemas::generated::get_config_by_type("route53.HostedZone")
+            .expect("route53.HostedZone schema should exist");
+        let desired = Resource::with_provider("awscc", "route53.HostedZone", "example", None)
+            .with_attribute(
+                "name",
+                Value::Concrete(ConcreteValue::String("example.com".to_string())),
+            );
+        let mut current_states = HashMap::from([(
+            desired.id.clone(),
+            State::existing(
+                desired.id.clone(),
+                HashMap::from([(
+                    "name".to_string(),
+                    Value::Concrete(ConcreteValue::String("example.com.".to_string())),
+                )]),
+            ),
+        )]);
+
+        normalize_state_enums_impl(&mut current_states);
+
+        let current = current_states
+            .get(&desired.id)
+            .expect("normalized state should still exist");
+        assert_eq!(
+            current.attributes.get("name"),
+            Some(&Value::Concrete(ConcreteValue::String(
+                "example.com".to_string()
+            )))
+        );
+        let diff = carina_core::differ::diff(&desired, current, None, None, Some(&config.schema));
+        assert!(
+            matches!(diff, carina_core::differ::Diff::NoChange(_)),
+            "expected no diff for Route53 HostedZone name with trailing dot, got {diff:?}"
+        );
+    }
+
+    #[test]
     fn test_resolve_enum_identifiers_ip_protocol_all_alias() {
         let mut resource =
             Resource::with_provider("awscc", "ec2.SecurityGroupEgress", "test", None);
@@ -623,7 +685,10 @@ mod tests {
                     None,
                     vec![],
                     Some(legacy_validator(|_| Ok(()))),
-                    Some(crate::ip_protocol_all_to_dsl),
+                    Some(carina_core::schema::DslTransform::ReplaceTable(vec![(
+                        "-1".to_string(),
+                        "all".to_string(),
+                    )])),
                 ),
             )
             .with_provider_name("IpProtocol"),

--- a/carina-provider-awscc/src/schemas/awscc_types.rs
+++ b/carina-provider-awscc/src/schemas/awscc_types.rs
@@ -166,7 +166,7 @@ pub fn awscc_region() -> AttributeType {
                 Err("Expected string".to_string())
             }
         })),
-        Some(crate::hyphen_to_underscore),
+        Some(carina_core::schema::DslTransform::HyphenToUnderscore),
     )
 }
 
@@ -190,7 +190,7 @@ pub fn availability_zone() -> AttributeType {
                 Err("Expected string".to_string())
             }
         })),
-        Some(crate::hyphen_to_underscore),
+        Some(carina_core::schema::DslTransform::HyphenToUnderscore),
     )
 }
 
@@ -277,9 +277,9 @@ mod tests {
         // path), not a structural Custom.
         let t = availability_zone();
         if let carina_core::schema::RawShape::Enum { to_dsl, .. } = t.raw_shape() {
-            let f = to_dsl.unwrap();
-            assert_eq!(f("us-east-1a"), "us_east_1a");
-            assert_eq!(f("ap-northeast-1c"), "ap_northeast_1c");
+            let transform = to_dsl.unwrap();
+            assert_eq!(transform.apply("us-east-1a"), "us_east_1a");
+            assert_eq!(transform.apply("ap-northeast-1c"), "ap_northeast_1c");
         } else {
             panic!("Expected Enum type");
         }

--- a/carina-provider-awscc/src/schemas/generated/route53/hosted_zone.rs
+++ b/carina-provider-awscc/src/schemas/generated/route53/hosted_zone.rs
@@ -69,7 +69,7 @@ pub fn route53_hosted_zone_config() -> AwsccSchemaConfig {
                 .with_provider_name("Id"),
         )
         .attribute(
-            AttributeSchema::new("name", AttributeType::enum_(carina_core::schema::enum_identity("Name", Some("awscc.route53.HostedZone")), None, vec![], None, Some(crate::strip_trailing_dot)))
+            AttributeSchema::new("name", AttributeType::enum_(carina_core::schema::enum_identity("Name", Some("awscc.route53.HostedZone")), None, vec![], None, Some(carina_core::schema::DslTransform::StripSuffix(".".to_string()))))
                 .create_only()
                 .with_description("The name of the domain. Specify a fully qualified domain name, for example, *www.example.com*. The trailing dot is optional; Amazon Route 53 assumes that the domain name is fully qualified. This means that Route 53 treats *www.example.com* (without a trailing dot) and *www.example.com.* (with a trailing dot) as identical. If you're creating a public hosted zone, this is the name you have registered with your DNS registrar. If your domain name is registered with a registrar other than Route 53, change the name servers for your domain to the set of ``NameServers`` that are returned by the ``Fn::GetAtt`` intrinsic function.")
                 .with_provider_name("Name"),


### PR DESCRIPTION
## Summary

Adopts the data-driven `DslTransform` enum from `carina-rs/carina#3414` (PR `carina-rs/carina#3416` merged 2026-06-07). Closes awscc#331 by construction: the host-side gap that produced the spurious `forces_replacement` on `Route53::HostedZone.name` is no longer reachable now that the transform travels as data on the wire.

## Changes

- Dep bump `carina-core` git rev to `31f62d0140e754fcf6867b67d7c1e1aab008acf7`.
- Drop the entire `register_dsl_transform` / `register_dsl_transforms` / fn-pointer registry scaffolding that PR #330 added (8 call sites + the `pub fn register_dsl_transforms` definition + 3 transform-name constants + the fn-pointer mapping `HashMap<DslTransformFn, &str>`).
- Replace fn-pointer constructions with data variants:
  - `crate::hyphen_to_underscore` → `DslTransform::HyphenToUnderscore`
  - `crate::strip_trailing_dot` → `DslTransform::StripSuffix(".".to_string())`
  - `crate::ip_protocol_all_to_dsl` → `DslTransform::ReplaceTable(vec![("-1", "all")])`
- Codegen template emits the data variant directly. `route53/hosted_zone.rs` regenerated.

## Why this closes awscc#331 by construction

In carina#3412 the transform crossed the WASM boundary as a string name resolved through a host-side `LazyLock<RwLock<HashMap>>` registry. A provider plugin calling `register_dsl_transform` inside the WASM component never reached the host process registry, so `strip_trailing_dot` arrived at the host as an unknown name and the transform was silently skipped. That gap is what produced the spurious `forces_replacement` reported by awscc#331.

With carina#3414's data-driven enum, the transform IS the data crossing the wire. The host evaluates `transform.apply(s)` directly with no name lookup. The whole class of "schema names a transform that the host doesn't know" is unrepresentable.

## Verification

- `cargo check --workspace --all-targets` clean
- `cargo nextest run --workspace --all-features` → 550 passed, 0 failed
- `cargo test --workspace --doc` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `bash scripts/check-*.sh` (carina-pin / docs-drift) all OK
- Dead-name sweep `rg 'register_dsl_transform|dsl_transform_for|DslTransformFn|hyphen_to_underscore|strip_trailing_dot|ip_protocol_all_to_dsl'` → test names / comments only

## Regression test

`provider::normalizer::tests::route53_hosted_zone_name_trailing_dot_has_no_diff_without_registration` loads the real generated `route53.HostedZone` schema, runs the real `normalize_state_enums_impl`, and runs the real differ over a state value containing the trailing dot. Asserts zero diff. The function name encodes "without registration" — the production path no longer depends on any provider-init registration call.

## Cross-repo

Parent: `carina-rs/carina#3414` (PR carina-rs/carina#3416, merged).
Sibling: carina-rs/carina-provider-aws#412 (in parallel).

Closes #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)
