### PR TITLE
Rename aws-types to awscc-types and share canonical AWS identities (carina#3413)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code when working with the carina-provider
 
 ## Repository Overview
 
-This is the AWS Cloud Control provider for [Carina](https://github.com/carina-rs/carina), split out as a standalone repository. It uses the AWS Cloud Control API to manage resources via CloudFormation resource type schemas. It depends on carina-core, carina-plugin-sdk, and carina-provider-protocol via git dependencies from the main carina repository. `carina-aws-types` lives in this repository (a local copy, not shared from the main repo).
+This is the AWS Cloud Control provider for [Carina](https://github.com/carina-rs/carina), split out as a standalone repository. It uses the AWS Cloud Control API to manage resources via CloudFormation resource type schemas. It depends on carina-core, carina-plugin-sdk, and carina-provider-protocol via git dependencies from the main carina repository. `carina-awscc-types` (awscc-specific types) lives in this repository, and it re-exports canonical AWS identity types from `carina-aws-types` (a `git` dependency on carina-provider-aws) so cross-namespace identity values share a single TypeIdentity per carina#3413.
 
 ## Build and Test Commands
 
@@ -34,7 +34,7 @@ aws-vault exec <profile> -- cargo test
 ## Crate Structure
 
 - **carina-provider-awscc**: The AWSCC provider implementation. Includes a `codegen` binary for generating resource definitions from CloudFormation schemas. Builds as both a native binary and a WASM component.
-- **carina-aws-types**: AWS-specific type definitions. A local copy lives in this repo (the same crate is duplicated in `carina-provider-aws`; it is not shared from the main carina repository).
+- **carina-awscc-types**: AWSCC-specific type definitions. Lives in this repo. Re-exports canonical AWS identities (`aws_account_id`, `iam_role_arn`, `iam_policy_arn`, `iam_oidc_provider_arn`) from `carina-aws-types` (a `git` dependency on carina-provider-aws) per carina#3413, so awscc and aws emit the same TypeIdentity for those values.
 
 ## Dependencies on carina (main repo)
 
@@ -52,9 +52,14 @@ carina-plugin-sdk = { path = "../carina/carina-plugin-sdk" }
 carina-provider-protocol = { path = "../carina/carina-provider-protocol" }
 ```
 
-`carina-aws-types` is **not** a main-repo dependency — it is a local crate in
+`carina-awscc-types` is **not** a main-repo dependency — it is a local crate in
 this repository (`carina-provider-awscc/Cargo.toml` references it as
-`{ path = "../carina-aws-types" }`), so it needs no patch entry.
+`{ path = "../carina-awscc-types" }`), so it needs no patch entry.
+
+`carina-aws-types` is a separate `git` dependency on `carina-provider-aws` used
+for canonical AWS identity constructors. It is not patched by the
+`github.com/carina-rs/carina` block above; update its pinned `rev` in the
+awscc Cargo.toml files when changing the shared identity dependency.
 
 ## Code Generation
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,7 +629,16 @@ dependencies = [
 [[package]]
 name = "carina-aws-types"
 version = "0.4.0"
+source = "git+https://github.com/carina-rs/carina-provider-aws?rev=0883f60174b189eaef3b31256ae8bb9e0454a2fe#0883f60174b189eaef3b31256ae8bb9e0454a2fe"
 dependencies = [
+ "carina-core",
+]
+
+[[package]]
+name = "carina-awscc-types"
+version = "0.4.0"
+dependencies = [
+ "carina-aws-types",
  "carina-core",
  "indexmap",
 ]
@@ -683,6 +692,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "carina-aws-types",
+ "carina-awscc-types",
  "carina-core",
  "carina-plugin-sdk",
  "carina-provider-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = [
-    "carina-aws-types",
+    "carina-awscc-types",
     "carina-provider-awscc",
 ]
 resolver = "3"

--- a/carina-awscc-types/Cargo.toml
+++ b/carina-awscc-types/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "carina-aws-types"
+name = "carina-awscc-types"
 version = "0.4.0"
 edition = "2024"
 license = "MIT"
@@ -14,4 +14,5 @@ doctest = false
 indexmap = "2"
 
 [dependencies]
+carina-aws-types = { git = "https://github.com/carina-rs/carina-provider-aws", rev = "0883f60174b189eaef3b31256ae8bb9e0454a2fe" }
 carina-core = { git = "https://github.com/carina-rs/carina", rev = "31f62d0140e754fcf6867b67d7c1e1aab008acf7" }

--- a/carina-awscc-types/src/lib.rs
+++ b/carina-awscc-types/src/lib.rs
@@ -1,8 +1,13 @@
-//! Shared AWS type definitions and validators
+//! AWSCC-specific type definitions and validators
 //!
-//! This module contains type validators shared between `carina-provider-aws`
-//! and `carina-provider-awscc`. Provider-specific types (region with namespace,
-//! schema config structs) remain in their respective crates.
+//! This crate holds CloudControl/awscc-specific types (region with namespace,
+//! schema config structs, AWSCC-only validators).
+//!
+//! Canonical AWS identities that AWS treats as a single global concept
+//! (`aws_account_id`, `iam_role_arn`, `iam_policy_arn`,
+//! `iam_oidc_provider_arn`) are re-exported from `carina-aws-types`
+//! (carina-provider-aws) so awscc emits the same TypeIdentity as the aws
+//! provider — see carina#3413.
 
 use carina_core::resource::{ConcreteValue, Value};
 #[cfg(test)]
@@ -10,6 +15,8 @@ use carina_core::schema::RawShape;
 use carina_core::schema::{
     AttributeType, CompletionValue, StructField, TypeIdentity, legacy_validator,
 };
+
+pub use carina_aws_types::{aws_account_id, iam_oidc_provider_arn, iam_policy_arn, iam_role_arn};
 
 const PROVIDER_NAME: &str = "awscc";
 
@@ -805,25 +812,6 @@ pub fn validate_aws_account_id(id: &str) -> Result<(), String> {
         return Err("must contain only digits".to_string());
     }
     Ok(())
-}
-
-/// AWS Account ID type (12-digit numeric string, e.g., "123456789012")
-pub fn aws_account_id() -> AttributeType {
-    AttributeType::custom(
-        Some(provider_bare_type(&[], "AccountId")),
-        AttributeType::string(),
-        None,
-        None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                validate_aws_account_id(s)
-                    .map_err(|reason| format!("Invalid AWS Account ID '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
-        None,
-    )
 }
 
 // ========== SSO / Identity Center helpers ==========
@@ -1890,10 +1878,11 @@ mod tests {
     }
 
     #[test]
-    fn carina_aws_types_no_longer_exports_resource_arn_helpers() {
+    fn carina_awscc_types_no_longer_exports_resource_arn_helpers() {
         let source =
             std::fs::read_to_string(format!("{}/src/lib.rs", env!("CARGO_MANIFEST_DIR"))).unwrap();
         for helper in [
+            "aws_account_id",
             "iam_role_arn",
             "iam_policy_arn",
             "iam_oidc_provider_arn",

--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -24,7 +24,8 @@ native = []
 
 [dependencies]
 carina-core = { git = "https://github.com/carina-rs/carina", rev = "31f62d0140e754fcf6867b67d7c1e1aab008acf7" }
-carina-aws-types = { path = "../carina-aws-types" }
+carina-awscc-types = { path = "../carina-awscc-types" }
+carina-aws-types = { git = "https://github.com/carina-rs/carina-provider-aws", rev = "0883f60174b189eaef3b31256ae8bb9e0454a2fe" }
 carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "31f62d0140e754fcf6867b67d7c1e1aab008acf7" }
 carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "31f62d0140e754fcf6867b67d7c1e1aab008acf7" }
 indexmap = "2"

--- a/carina-provider-awscc/scripts/generate-schemas.sh
+++ b/carina-provider-awscc/scripts/generate-schemas.sh
@@ -125,25 +125,10 @@ emit_virtual_helper_modules() {
 //!
 //! DO NOT EDIT MANUALLY - regenerate with carina-codegen
 
-use carina_core::resource::{ConcreteValue, Value};
-use carina_core::schema::{AttributeType, legacy_validator};
+use carina_core::schema::AttributeType;
 
 pub fn arn() -> AttributeType {
-    AttributeType::custom(
-        Some(super::provider_type("iam", "Policy", "Arn")),
-        super::arn(),
-        Some("^arn:(aws|aws-cn|aws-us-gov):iam::[^:]*:policy/.+$".to_string()),
-        None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                super::validate_iam_arn(s, "policy/")
-                    .map_err(|reason| format!("Invalid IAM Policy ARN '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
-        None,
-    )
+    super::iam_policy_arn()
 }
 EOF
 }

--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -405,6 +405,15 @@ fn arn_validator_expression(choice: ArnEmitChoice) -> String {
 }
 
 fn emit_arn_helper(service: &str, resource: &str, choice: ArnEmitChoice) -> String {
+    if let Some(canonical_type) = match (service, resource) {
+        ("iam", "Role") => Some("super::iam_role_arn()"),
+        ("iam", "Policy") => Some("super::iam_policy_arn()"),
+        ("iam", "OidcProvider") => Some("super::iam_oidc_provider_arn()"),
+        _ => None,
+    } {
+        return format!("pub fn arn() -> AttributeType {{\n    {canonical_type}\n}}\n\n");
+    }
+
     if matches!(choice, ArnEmitChoice::Generic) {
         return "pub fn arn() -> AttributeType {\n    super::arn()\n}\n\n".to_string();
     }
@@ -1040,6 +1049,8 @@ fn infer_string_type_display(prop_name: &str, resource_type: &str) -> String {
         "AvailabilityZoneId".to_string()
     } else if prop_lower.ends_with("region") || prop_lower == "regionname" {
         "Region".to_string()
+    } else if let Some(override_type) = iam_canonical_arn_override(resource_type, singular_name) {
+        override_type_to_display_name(override_type).to_string()
     } else if prop_lower.ends_with("arn")
         || prop_lower.ends_with("arns")
         || prop_lower.contains("_arn")
@@ -4333,12 +4344,17 @@ fn resource_type_overrides() -> &'static HashMap<(&'static str, &'static str), T
             // IAM Role's Arn is always an IAM Role ARN
             m.insert(
                 ("AWS::IAM::Role", "Arn"),
-                TypeOverride::StringType("super::super::iam::role::arn()"),
+                TypeOverride::StringType("super::iam_role_arn()"),
+            );
+            // IAM Policy's Arn is always an IAM Policy ARN
+            m.insert(
+                ("AWS::IAM::Policy", "Arn"),
+                TypeOverride::StringType("super::iam_policy_arn()"),
             );
             // IAM OIDCProvider's Arn is always an IAM OIDC Provider ARN
             m.insert(
                 ("AWS::IAM::OIDCProvider", "Arn"),
-                TypeOverride::StringType("super::super::iam::oidc_provider::arn()"),
+                TypeOverride::StringType("super::iam_oidc_provider_arn()"),
             );
             // IAM Role's RoleId uses AROA prefix pattern
             m.insert(
@@ -4805,6 +4821,12 @@ fn infer_string_type(prop_name: &str, resource_type: &str) -> Option<String> {
         return Some("super::awscc_region()".to_string());
     }
 
+    // Canonical IAM ARN identities. These are explicit resource-type matches
+    // because generic ARN naming does not identify the IAM resource kind.
+    if let Some(override_type) = iam_canonical_arn_override(resource_type, singular_name) {
+        return Some(override_type.to_string());
+    }
+
     // Check ARN pattern
     if prop_lower.ends_with("arn") || prop_lower.ends_with("arns") || prop_lower.contains("_arn") {
         return Some("super::arn()".to_string());
@@ -4834,6 +4856,19 @@ fn infer_string_type(prop_name: &str, resource_type: &str) -> Option<String> {
     }
 
     None
+}
+
+fn iam_canonical_arn_override(resource_type: &str, prop_name: &str) -> Option<&'static str> {
+    if !prop_name.eq_ignore_ascii_case("Arn") {
+        return None;
+    }
+
+    match resource_type {
+        "AWS::IAM::Role" => Some("super::iam_role_arn()"),
+        "AWS::IAM::Policy" => Some("super::iam_policy_arn()"),
+        "AWS::IAM::OIDCProvider" => Some("super::iam_oidc_provider_arn()"),
+        _ => None,
+    }
 }
 
 /// Check if a property name represents an email address.
@@ -8380,6 +8415,23 @@ mod tests {
     }
 
     #[test]
+    fn generated_iam_arn_helpers_delegate_to_canonical_helpers() {
+        let role_schema = cfn_schema_for_codegen_tests("AWS::IAM::Role");
+        let generated_role =
+            generate_schema_code(&role_schema, "AWS::IAM::Role").expect("generate iam role");
+        assert!(generated_role.contains("pub fn arn() -> AttributeType"));
+        assert!(generated_role.contains("super::iam_role_arn()"));
+        assert!(!generated_role.contains("provider_type(\"iam\", \"Role\", \"Arn\")"));
+
+        let oidc_schema = cfn_schema_for_codegen_tests("AWS::IAM::OIDCProvider");
+        let generated_oidc = generate_schema_code(&oidc_schema, "AWS::IAM::OIDCProvider")
+            .expect("generate iam oidc provider");
+        assert!(generated_oidc.contains("pub fn arn() -> AttributeType"));
+        assert!(generated_oidc.contains("super::iam_oidc_provider_arn()"));
+        assert!(!generated_oidc.contains("provider_type(\"iam\", \"OidcProvider\", \"Arn\")"));
+    }
+
+    #[test]
     fn generated_organizations_account_gets_service_prefix_arn_helper() {
         let schema = cfn_schema_for_codegen_tests("AWS::Organizations::Account");
         let generated = generate_schema_code(&schema, "AWS::Organizations::Account")
@@ -9002,7 +9054,7 @@ mod tests {
         // IAM Role's Arn should use the schema-owned Role ARN helper, not generic arn
         assert_eq!(
             infer_string_type("Arn", "AWS::IAM::Role"),
-            Some("super::super::iam::role::arn()".to_string())
+            Some("super::iam_role_arn()".to_string())
         );
         // Other resources' Arn should use generic arn
         assert_eq!(
@@ -9189,11 +9241,35 @@ mod tests {
     }
 
     #[test]
+    fn test_iam_role_arn_override() {
+        assert_eq!(
+            infer_string_type("Arn", "AWS::IAM::Role"),
+            Some("super::iam_role_arn()".to_string())
+        );
+        assert_eq!(
+            infer_string_type_display("Arn", "AWS::IAM::Role"),
+            "IamRoleArn"
+        );
+    }
+
+    #[test]
+    fn test_iam_policy_arn_override() {
+        assert_eq!(
+            infer_string_type("Arn", "AWS::IAM::Policy"),
+            Some("super::iam_policy_arn()".to_string())
+        );
+        assert_eq!(
+            infer_string_type_display("Arn", "AWS::IAM::Policy"),
+            "IamPolicyArn"
+        );
+    }
+
+    #[test]
     fn test_iam_oidc_provider_arn_override() {
         // IAM OIDCProvider's Arn should use the schema-owned OIDC Provider ARN helper.
         assert_eq!(
             infer_string_type("Arn", "AWS::IAM::OIDCProvider"),
-            Some("super::super::iam::oidc_provider::arn()".to_string())
+            Some("super::iam_oidc_provider_arn()".to_string())
         );
         assert_eq!(
             infer_string_type_display("Arn", "AWS::IAM::OIDCProvider"),

--- a/carina-provider-awscc/src/lib.rs
+++ b/carina-provider-awscc/src/lib.rs
@@ -105,12 +105,12 @@ impl ProviderFactory for AwsccProviderFactory {
             AttributeType::enum_(
                 carina_core::schema::enum_identity("Region", Some("awscc")),
                 Some(
-                    carina_aws_types::REGIONS
+                    carina_awscc_types::REGIONS
                         .iter()
                         .map(|(code, _)| code.to_string())
                         .collect(),
                 ),
-                carina_aws_types::region_dsl_aliases(),
+                carina_awscc_types::region_dsl_aliases(),
                 None,
                 None,
             ),
@@ -208,7 +208,7 @@ impl ProviderFactory for AwsccProviderFactory {
     ) -> std::collections::HashMap<String, Vec<carina_core::schema::CompletionValue>> {
         std::collections::HashMap::from([(
             "region".to_string(),
-            carina_aws_types::region_completions("awscc"),
+            carina_awscc_types::region_completions("awscc"),
         )])
     }
 

--- a/carina-provider-awscc/src/main.rs
+++ b/carina-provider-awscc/src/main.rs
@@ -87,7 +87,7 @@ impl CarinaProvider for AwsccProcessProvider {
             "region".to_string(),
             proto::AttributeType::StringEnum {
                 name: "Region".to_string(),
-                values: carina_aws_types::REGIONS
+                values: carina_awscc_types::REGIONS
                     .iter()
                     .map(|(code, _)| code.to_string())
                     .collect(),
@@ -99,7 +99,7 @@ impl CarinaProvider for AwsccProcessProvider {
                 // but the DSL spelling uses underscores. Materialize
                 // the alias pairs as data; a `fn` pointer would not
                 // cross the WASM boundary (carina#2831).
-                dsl_aliases: carina_aws_types::region_dsl_aliases(),
+                dsl_aliases: carina_awscc_types::region_dsl_aliases(),
             },
         );
         types.insert(
@@ -165,7 +165,7 @@ impl CarinaProvider for AwsccProcessProvider {
     fn config_completions(&self) -> HashMap<String, Vec<proto::CompletionValue>> {
         HashMap::from([(
             "region".to_string(),
-            carina_aws_types::region_completions("awscc")
+            carina_awscc_types::region_completions("awscc")
                 .into_iter()
                 .map(|c| proto::CompletionValue {
                     value: c.value,

--- a/carina-provider-awscc/src/provider/conversion.rs
+++ b/carina-provider-awscc/src/provider/conversion.rs
@@ -155,7 +155,7 @@ pub(crate) fn aws_value_to_dsl_with_defs(
                     );
                 }
                 let key = if is_condition {
-                    carina_aws_types::condition_operator_to_snake(k).unwrap_or_else(|| k.clone())
+                    carina_awscc_types::condition_operator_to_snake(k).unwrap_or_else(|| k.clone())
                 } else {
                     k.clone()
                 };
@@ -386,7 +386,7 @@ pub(crate) fn dsl_value_to_aws_with_defs(
                     );
                 }
                 let key = if is_condition {
-                    carina_aws_types::condition_operator_to_aws(k).unwrap_or_else(|| k.clone())
+                    carina_awscc_types::condition_operator_to_aws(k).unwrap_or_else(|| k.clone())
                 } else {
                     k.clone()
                 };
@@ -854,7 +854,7 @@ mod tests {
     #[test]
     fn test_dsl_value_to_aws_converts_underscores_for_region() {
         let attr_type = AttributeType::enum_(
-            carina_aws_types::provider_bare_type(&[], "Region"),
+            carina_awscc_types::provider_bare_type(&[], "Region"),
             None,
             vec![],
             Some(legacy_validator(|_| Ok(()))),
@@ -1165,7 +1165,7 @@ mod tests {
 
     #[test]
     fn test_dsl_value_to_aws_iam_policy_document_uses_pascal_case() {
-        use carina_aws_types::iam_policy_document;
+        use carina_awscc_types::iam_policy_document;
 
         let attr_type = iam_policy_document();
         let value = Value::Concrete(ConcreteValue::Map(
@@ -1265,7 +1265,7 @@ mod tests {
     /// (`"2012-10-17"`, `"Allow"`).
     #[test]
     fn test_dsl_value_to_aws_iam_policy_document_canonicalizes_namespaced_and_alias_enums() {
-        use carina_aws_types::iam_policy_document;
+        use carina_awscc_types::iam_policy_document;
 
         let attr_type = iam_policy_document();
         let value = Value::Concrete(ConcreteValue::Map(
@@ -1338,7 +1338,7 @@ mod tests {
 
     #[test]
     fn test_aws_value_to_dsl_iam_policy_document_uses_snake_case() {
-        use carina_aws_types::iam_policy_document;
+        use carina_awscc_types::iam_policy_document;
 
         let attr_type = iam_policy_document();
         let aws_json = json!({
@@ -1419,7 +1419,7 @@ mod tests {
     /// contract.
     #[test]
     fn test_aws313_iam_policy_doc_read_is_api_canonical_and_lifts() {
-        use carina_aws_types::iam_policy_document;
+        use carina_awscc_types::iam_policy_document;
 
         let attr_type = iam_policy_document();
 

--- a/carina-provider-awscc/src/schemas/awscc_types.rs
+++ b/carina-provider-awscc/src/schemas/awscc_types.rs
@@ -1,10 +1,10 @@
 //! AWS Cloud Control type definitions and validators
 //!
-//! This module re-exports shared AWS type validators from `carina-aws-types`
+//! This module re-exports shared AWS type validators from `carina-awscc-types`
 //! and defines provider-specific types (region, availability zone, schema config,
 //! IAM policy document).
 
-pub use carina_aws_types::*;
+pub use carina_awscc_types::*;
 
 use std::collections::HashMap;
 
@@ -51,7 +51,7 @@ macro_rules! register_validators {
 /// Return all AWSCC type validators for registration in ProviderContext.
 ///
 /// These validators are keyed by type name (matching the names used in fn/module
-/// type annotations) and wrap the validation functions from `carina-aws-types`.
+/// type annotations) and wrap the validation functions from `carina-awscc-types`.
 pub fn awscc_validators() -> HashMap<String, ValidatorFn> {
     register_validators! {
         simple {
@@ -144,12 +144,12 @@ pub(crate) fn validate_namespaced_enum(
 /// - Shorthand: ap_northeast_1
 pub fn awscc_region() -> AttributeType {
     AttributeType::enum_(
-        carina_aws_types::provider_bare_type(&[], "Region"),
+        carina_awscc_types::provider_bare_type(&[], "Region"),
         None,
         vec![],
         Some(legacy_validator(|value| {
             if let Value::Concrete(ConcreteValue::String(s)) = value {
-                let id = carina_aws_types::provider_bare_type(&[], "Region");
+                let id = carina_awscc_types::provider_bare_type(&[], "Region");
                 validate_enum_namespace(s, &id)
                     .map_err(|reason| format!("Invalid region '{}': {}", s, reason))?;
                 let normalized = extract_enum_value(s).replace('_', "-");
@@ -174,12 +174,12 @@ pub fn awscc_region() -> AttributeType {
 /// Validates format: region + single letter zone identifier
 pub fn availability_zone() -> AttributeType {
     AttributeType::enum_(
-        carina_aws_types::provider_bare_type(&["AvailabilityZone"], "ZoneName"),
+        carina_awscc_types::provider_bare_type(&["AvailabilityZone"], "ZoneName"),
         None,
         vec![],
         Some(legacy_validator(|value| {
             if let Value::Concrete(ConcreteValue::String(s)) = value {
-                let id = carina_aws_types::provider_bare_type(&["AvailabilityZone"], "ZoneName");
+                let id = carina_awscc_types::provider_bare_type(&["AvailabilityZone"], "ZoneName");
                 validate_enum_namespace(s, &id)
                     .map_err(|reason| format!("Invalid availability zone '{}': {}", s, reason))?;
                 let extracted = extract_enum_value(s);
@@ -195,7 +195,7 @@ pub fn availability_zone() -> AttributeType {
 }
 
 // iam_policy_document() and validate_iam_policy_document() are provided by
-// `pub use carina_aws_types::*` above
+// `pub use carina_awscc_types::*` above
 
 #[cfg(test)]
 mod tests {

--- a/carina-provider-awscc/src/schemas/generated/iam/oidc_provider.rs
+++ b/carina-provider-awscc/src/schemas/generated/iam/oidc_provider.rs
@@ -12,21 +12,7 @@ use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, legacy
 use regex::Regex;
 
 pub fn arn() -> AttributeType {
-    AttributeType::custom(
-        Some(super::provider_type("iam", "OidcProvider", "Arn")),
-        super::arn(),
-        Some("^arn:(aws|aws-cn|aws-us-gov):iam::[^:]*:oidc-provider/.+$".to_string()),
-        None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                super::validate_iam_arn(s, "oidc-provider/")
-                    .map_err(|reason| format!("Invalid IAM OIDC Provider ARN '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
-        None,
-    )
+    super::iam_oidc_provider_arn()
 }
 
 #[allow(dead_code)]

--- a/carina-provider-awscc/src/schemas/generated/iam/policy.rs
+++ b/carina-provider-awscc/src/schemas/generated/iam/policy.rs
@@ -2,23 +2,8 @@
 //!
 //! DO NOT EDIT MANUALLY - regenerate with carina-codegen
 
-use carina_core::resource::{ConcreteValue, Value};
-use carina_core::schema::{AttributeType, legacy_validator};
+use carina_core::schema::AttributeType;
 
 pub fn arn() -> AttributeType {
-    AttributeType::custom(
-        Some(super::provider_type("iam", "Policy", "Arn")),
-        super::arn(),
-        Some("^arn:(aws|aws-cn|aws-us-gov):iam::[^:]*:policy/.+$".to_string()),
-        None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                super::validate_iam_arn(s, "policy/")
-                    .map_err(|reason| format!("Invalid IAM Policy ARN '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
-        None,
-    )
+    super::iam_policy_arn()
 }

--- a/carina-provider-awscc/src/schemas/generated/iam/role.rs
+++ b/carina-provider-awscc/src/schemas/generated/iam/role.rs
@@ -13,21 +13,7 @@ use carina_core::schema::{
 };
 
 pub fn arn() -> AttributeType {
-    AttributeType::custom(
-        Some(super::provider_type("iam", "Role", "Arn")),
-        super::arn(),
-        Some("^arn:(aws|aws-cn|aws-us-gov):iam::[^:]*:role/.+$".to_string()),
-        None,
-        legacy_validator(|value| {
-            if let Value::Concrete(ConcreteValue::String(s)) = value {
-                super::validate_iam_arn(s, "role/")
-                    .map_err(|reason| format!("Invalid IAM Role ARN '{}': {}", s, reason))
-            } else {
-                Err("Expected string".to_string())
-            }
-        }),
-        None,
-    )
+    super::iam_role_arn()
 }
 
 fn validate_max_session_duration_range(value: &Value) -> Result<(), String> {

--- a/carina-provider-awscc/tests/iam_oidc_provider_arn.rs
+++ b/carina-provider-awscc/tests/iam_oidc_provider_arn.rs
@@ -6,7 +6,7 @@ use carina_core::resource::{ConcreteValue, Value};
 fn arn_identity_is_provider_scoped() {
     common::assert_arn_identity(
         carina_provider_awscc::schemas::generated::iam::oidc_provider::arn(),
-        "awscc.iam.OidcProvider.Arn",
+        "aws.iam.OidcProvider.Arn",
     );
 }
 

--- a/carina-provider-awscc/tests/iam_policy_arn.rs
+++ b/carina-provider-awscc/tests/iam_policy_arn.rs
@@ -3,7 +3,7 @@ mod common;
 #[test]
 fn arn_identity_is_provider_scoped() {
     common::assert_arn_identity(
-        carina_provider_awscc::schemas::generated::iam::role::arn(),
-        "aws.iam.Role.Arn",
+        carina_provider_awscc::schemas::generated::iam::policy::arn(),
+        "aws.iam.Policy.Arn",
     );
 }

--- a/scripts/check-carina-pin.sh
+++ b/scripts/check-carina-pin.sh
@@ -6,10 +6,13 @@
 # Two recurring failure modes this catches:
 #
 #   1. INCONSISTENT pin — different revs across the workspace's
-#      Cargo.toml files. carina-aws-types and carina-provider-awscc
-#      must pin the SAME carina-core rev; a mismatch links two
+#      Cargo.toml files. Local workspace crates (`carina-awscc-types`
+#      and `carina-provider-awscc`) must pin the SAME carina-core rev;
+#      a mismatch links two
 #      carina-core crates and silently breaks type identity
 #      (documented hazard, awscc#255). Always a bug. Hard-fail.
+#      The upstream `carina-aws-types` dependency has its own pin in
+#      carina-provider-aws; this script does not inspect that repo.
 #
 #   2. STALE pin — the pinned rev predates a carina-core fix this
 #      provider's correctness now depends on. `.carina-core-min-rev`


### PR DESCRIPTION
## Summary

PR3 of the carina#3413 implementation chain. Per the design doc (carina#3418, https://github.com/carina-rs/carina/blob/main/notes/specs/2026-06-07-cross-namespace-identity-types-design.md), this PR has awscc share the canonical AWS identities (`AccountId`, `iam.Role.Arn`, `iam.Policy.Arn`, `iam.OidcProvider.Arn`) from carina-provider-aws's `carina-aws-types` so awscc and aws emit the same `TypeIdentity` for those values.

## Changes

### Crate rename

- Local `carina-aws-types` → `carina-awscc-types` (awscc-specific types only).
- Workspace / dependency / `use` references updated everywhere. Git rename detection preserves history.

### Add the upstream `carina-aws-types` git dependency

- `carina-provider-awscc/Cargo.toml` and `carina-awscc-types/Cargo.toml` both depend on `carina-aws-types` from carina-provider-aws (pin: `0883f60174b189eaef3b31256ae8bb9e0454a2fe` = carina-rs/carina-provider-aws#415 merge commit).
- `carina-awscc-types/src/lib.rs` re-exports the four canonical identities via `pub use carina_aws_types::{aws_account_id, iam_role_arn, iam_policy_arn, iam_oidc_provider_arn}`. The local `aws_account_id()` constructor is deleted.

### Explicit codegen override

- `carina-provider-awscc/src/bin/codegen.rs` gains an `iam_canonical_arn_override` helper. For `AWS::IAM::Role` / `AWS::IAM::Policy` / `AWS::IAM::OIDCProvider` with property name `Arn` (case-insensitive), the generated `arn()` delegates to the corresponding canonical helper (`super::iam_role_arn()` etc.).
- Detection is by explicit resource-type match, not naming-convention matching, per the design doc.
- Generated `carina-provider-awscc/src/schemas/generated/iam/{role,policy,oidc_provider}.rs::arn()` collapses to a one-line call to the canonical helper.

### TypeIdentity effect

- Before: awscc emitted `awscc.AccountId` / `awscc.iam.Role.Arn` (provider = `"awscc"`).
- After: those four identities all emit the `aws.*` form (provider = `"aws"`).
- `aws.sts.CallerIdentity.account_id` → `awscc.sso.Assignment.target_id` now type-checks via plain `TypeIdentity` equality. No change to carina-core.

### Out of scope

- Resource types themselves (e.g. `aws.iam.Role` vs `awscc.iam.Role`) stay distinct.
- Region/account-scoped Arns (e.g. `s3.Bucket.Arn`) stay distinct (provenance meaning preserved).

## Regression tests

`carina-provider-awscc/tests/iam_role_arn.rs`, `iam_policy_arn.rs`, `iam_oidc_provider_arn.rs` each assert that the generated `arn()` returns `aws.iam.<Resource>.Arn`.

## Verify

- `cargo nextest run --workspace --all-features`: 553/553 pass
- `cargo test --workspace --doc`: pass
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `CARINA_CORE_DIR=... bash scripts/check-carina-pin.sh`: pass
- `bash scripts/check-docs-drift.sh`: pass
- Grep over generated output: `awscc.AccountId` / `awscc.iam.*.Arn` occurrences are 0.

## Related

- carina-rs/carina#3413 (issue)
- carina-rs/carina#3418 (design doc, merged)
- carina-rs/carina-provider-aws#415 (PR2, merged)

Closes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)