### PR TITLE
Acceptance tests: switch awscc.Region to aws.Region (carina#3413)

### DIFF
--- a/acceptance-tests/allowed_account_ids_guard/basic.crn
+++ b/acceptance-tests/allowed_account_ids_guard/basic.crn
@@ -7,7 +7,7 @@
 # error naming both the expected list and the actual account ID.
 
 provider awscc {
-  region              = awscc.Region.ap_northeast_1
+  region              = aws.Region.ap_northeast_1
   allowed_account_ids = ['000000000000']
 }
 

--- a/acceptance-tests/attribute_removal/ec2_vpc_endpoint_step1.crn
+++ b/acceptance-tests/attribute_removal/ec2_vpc_endpoint_step1.crn
@@ -3,7 +3,7 @@
 # Tests: create gateway endpoint with policy_document set
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/attribute_removal/ec2_vpc_endpoint_step2.crn
+++ b/acceptance-tests/attribute_removal/ec2_vpc_endpoint_step2.crn
@@ -3,7 +3,7 @@
 # Tests: remove policy_document entirely (attribute removal)
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/attribute_removal/logs_log_group_step1.crn
+++ b/acceptance-tests/attribute_removal/logs_log_group_step1.crn
@@ -3,7 +3,7 @@
 # Tests: create log group with retention_in_days set
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.logs.LogGroup {

--- a/acceptance-tests/attribute_removal/logs_log_group_step2.crn
+++ b/acceptance-tests/attribute_removal/logs_log_group_step2.crn
@@ -3,7 +3,7 @@
 # Tests: remove retention_in_days entirely (revert to never-expire default)
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.logs.LogGroup {

--- a/acceptance-tests/builtin_functions/cidr_subnet.crn
+++ b/acceptance-tests/builtin_functions/cidr_subnet.crn
@@ -1,5 +1,5 @@
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let base_cidr = '10.0.0.0/16'

--- a/acceptance-tests/builtin_functions/concat.crn
+++ b/acceptance-tests/builtin_functions/concat.crn
@@ -1,5 +1,5 @@
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let parts1 = ['web', 'test']

--- a/acceptance-tests/builtin_functions/flatten.crn
+++ b/acceptance-tests/builtin_functions/flatten.crn
@@ -1,5 +1,5 @@
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let parts = [['flat', 'test'], ['vpc']]

--- a/acceptance-tests/builtin_functions/join.crn
+++ b/acceptance-tests/builtin_functions/join.crn
@@ -1,5 +1,5 @@
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let env = 'test'

--- a/acceptance-tests/builtin_functions/keys_values.crn
+++ b/acceptance-tests/builtin_functions/keys_values.crn
@@ -1,5 +1,5 @@
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let config = {

--- a/acceptance-tests/builtin_functions/length.crn
+++ b/acceptance-tests/builtin_functions/length.crn
@@ -1,5 +1,5 @@
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let items = ['a', 'b', 'c']

--- a/acceptance-tests/builtin_functions/local_let.crn
+++ b/acceptance-tests/builtin_functions/local_let.crn
@@ -1,5 +1,5 @@
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.ec2.Vpc {

--- a/acceptance-tests/builtin_functions/lookup.crn
+++ b/acceptance-tests/builtin_functions/lookup.crn
@@ -1,5 +1,5 @@
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let env_names = {

--- a/acceptance-tests/builtin_functions/min_max.crn
+++ b/acceptance-tests/builtin_functions/min_max.crn
@@ -1,5 +1,5 @@
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.ec2.Vpc {

--- a/acceptance-tests/builtin_functions/replace.crn
+++ b/acceptance-tests/builtin_functions/replace.crn
@@ -1,5 +1,5 @@
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let name = replace('-', '_', 'web-test-vpc')

--- a/acceptance-tests/builtin_functions/split.crn
+++ b/acceptance-tests/builtin_functions/split.crn
@@ -1,5 +1,5 @@
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let parts = split('-', 'web-test-vpc')

--- a/acceptance-tests/builtin_functions/trim.crn
+++ b/acceptance-tests/builtin_functions/trim.crn
@@ -1,5 +1,5 @@
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.ec2.Vpc {

--- a/acceptance-tests/builtin_functions/upper_lower.crn
+++ b/acceptance-tests/builtin_functions/upper_lower.crn
@@ -1,5 +1,5 @@
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let env = 'Production'

--- a/acceptance-tests/cascade_without_cbd/step1.crn
+++ b/acceptance-tests/cascade_without_cbd/step1.crn
@@ -5,7 +5,7 @@
 # vpc_id, so it should appear as a cascading update in the plan.
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/cascade_without_cbd/step2.crn
+++ b/acceptance-tests/cascade_without_cbd/step2.crn
@@ -5,7 +5,7 @@
 # vpc.vpc_id, so the plan should show it as a cascading update.
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/create_before_destroy/ec2_transit_gateway_attachment_step1.crn
+++ b/acceptance-tests/create_before_destroy/ec2_transit_gateway_attachment_step1.crn
@@ -5,7 +5,7 @@
 # replacement because transit_gateway_id is a create-only property.
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/create_before_destroy/ec2_transit_gateway_attachment_step2.crn
+++ b/acceptance-tests/create_before_destroy/ec2_transit_gateway_attachment_step2.crn
@@ -6,7 +6,7 @@
 # created before the old one (to tgw_a) is deleted.
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/create_before_destroy/ec2_vpc_step1.crn
+++ b/acceptance-tests/create_before_destroy/ec2_vpc_step1.crn
@@ -4,7 +4,7 @@
 # proceed without temporary name generation.
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.ec2.Vpc {

--- a/acceptance-tests/create_before_destroy/ec2_vpc_step2.crn
+++ b/acceptance-tests/create_before_destroy/ec2_vpc_step2.crn
@@ -5,7 +5,7 @@
 # This tests that replacement works correctly without the temp name feature.
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.ec2.Vpc {

--- a/acceptance-tests/create_before_destroy/iam_role_step1.crn
+++ b/acceptance-tests/create_before_destroy/iam_role_step1.crn
@@ -5,7 +5,7 @@
 # triggering replacement with automatic temporary name generation.
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.iam.Role {

--- a/acceptance-tests/create_before_destroy/iam_role_step2.crn
+++ b/acceptance-tests/create_before_destroy/iam_role_step2.crn
@@ -8,7 +8,7 @@
 #    (role_name is create-only so rename may not be possible via update)
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.iam.Role {

--- a/acceptance-tests/ec2_egress_only_internet_gateway/basic.crn
+++ b/acceptance-tests/ec2_egress_only_internet_gateway/basic.crn
@@ -3,7 +3,7 @@
 # Tests: vpc_id, tags
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/ec2_eip/basic.crn
+++ b/acceptance-tests/ec2_eip/basic.crn
@@ -3,7 +3,7 @@
 # Tests: domain, tags
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.ec2.Eip {

--- a/acceptance-tests/ec2_flow_log/cloudwatch.crn
+++ b/acceptance-tests/ec2_flow_log/cloudwatch.crn
@@ -4,7 +4,7 @@
 #        deliver_logs_permission_arn, IAM role with nested policy document
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/ec2_flow_log/s3.crn
+++ b/acceptance-tests/ec2_flow_log/s3.crn
@@ -4,7 +4,7 @@
 #        log_destination, destination_options (Struct)
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/ec2_internet_gateway/basic.crn
+++ b/acceptance-tests/ec2_internet_gateway/basic.crn
@@ -3,7 +3,7 @@
 # Tests: tags
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.ec2.InternetGateway {

--- a/acceptance-tests/ec2_ipam/basic.crn
+++ b/acceptance-tests/ec2_ipam/basic.crn
@@ -3,7 +3,7 @@
 # Tests: tier, operating_regions, description, tags
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.ec2.Ipam {

--- a/acceptance-tests/ec2_ipam_pool/basic.crn
+++ b/acceptance-tests/ec2_ipam_pool/basic.crn
@@ -4,7 +4,7 @@
 #        provisioned_cidrs (List<Struct>), tags
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let ipam = awscc.ec2.Ipam {

--- a/acceptance-tests/ec2_nat_gateway/private.crn
+++ b/acceptance-tests/ec2_nat_gateway/private.crn
@@ -3,7 +3,7 @@
 # Tests: connectivity_type=private, private_ip_address
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/ec2_nat_gateway/public.crn
+++ b/acceptance-tests/ec2_nat_gateway/public.crn
@@ -3,7 +3,7 @@
 # Tests: allocation_id, subnet_id, connectivity_type (public implied), tags
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/ec2_route/igw.crn
+++ b/acceptance-tests/ec2_route/igw.crn
@@ -3,7 +3,7 @@
 # Tests: gateway_id, destination_cidr_block, route_table_id
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/ec2_route/ipv6.crn
+++ b/acceptance-tests/ec2_route/ipv6.crn
@@ -4,7 +4,7 @@
 # Requires: Egress Only Internet Gateway
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/ec2_route/nat_gateway.crn
+++ b/acceptance-tests/ec2_route/nat_gateway.crn
@@ -3,7 +3,7 @@
 # Tests: nat_gateway_id, destination_cidr_block
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/ec2_route/transit_gateway.crn
+++ b/acceptance-tests/ec2_route/transit_gateway.crn
@@ -4,7 +4,7 @@
 # Requires: Transit Gateway, TransitGatewayAttachment, Subnet
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/ec2_route/vpc_peering.crn
+++ b/acceptance-tests/ec2_route/vpc_peering.crn
@@ -4,7 +4,7 @@
 # Requires: VPC Peering Connection
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc1 = awscc.ec2.Vpc {

--- a/acceptance-tests/ec2_route_table/basic.crn
+++ b/acceptance-tests/ec2_route_table/basic.crn
@@ -3,7 +3,7 @@
 # Tests: vpc_id, tags
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/ec2_security_group/ipv6_rules.crn
+++ b/acceptance-tests/ec2_security_group/ipv6_rules.crn
@@ -3,7 +3,7 @@
 # Tests: security_group_ingress with cidr_ipv6, security_group_egress with cidr_ipv6
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/ec2_security_group/prefix.crn
+++ b/acceptance-tests/ec2_security_group/prefix.crn
@@ -5,7 +5,7 @@
 #        destroy cleans up the prefixed resource.
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/ec2_security_group/with_egress.crn
+++ b/acceptance-tests/ec2_security_group/with_egress.crn
@@ -3,7 +3,7 @@
 # Tests: security_group_egress (List<Struct>) with IPv4 cidr_ip
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/ec2_security_group/with_ingress.crn
+++ b/acceptance-tests/ec2_security_group/with_ingress.crn
@@ -3,7 +3,7 @@
 # Tests: security_group_ingress (List<Struct>) with IPv4 cidr_ip
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/ec2_security_group_egress/basic.crn
+++ b/acceptance-tests/ec2_security_group_egress/basic.crn
@@ -3,7 +3,7 @@
 # Tests: cidr_ip, from_port, to_port, ip_protocol, description
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/ec2_security_group_egress/dest_sg.crn
+++ b/acceptance-tests/ec2_security_group_egress/dest_sg.crn
@@ -3,7 +3,7 @@
 # Tests: destination_security_group_id
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/ec2_security_group_egress/ipv6.crn
+++ b/acceptance-tests/ec2_security_group_egress/ipv6.crn
@@ -3,7 +3,7 @@
 # Tests: cidr_ipv6
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/ec2_security_group_ingress/basic.crn
+++ b/acceptance-tests/ec2_security_group_ingress/basic.crn
@@ -3,7 +3,7 @@
 # Tests: cidr_ip, from_port, to_port, ip_protocol, description
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/ec2_security_group_ingress/ipv6.crn
+++ b/acceptance-tests/ec2_security_group_ingress/ipv6.crn
@@ -3,7 +3,7 @@
 # Tests: cidr_ipv6
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/ec2_security_group_ingress/source_sg.crn
+++ b/acceptance-tests/ec2_security_group_ingress/source_sg.crn
@@ -3,7 +3,7 @@
 # Tests: source_security_group_id
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/ec2_subnet/basic.crn
+++ b/acceptance-tests/ec2_subnet/basic.crn
@@ -3,7 +3,7 @@
 # Tests: cidr_block, availability_zone, map_public_ip_on_launch, tags
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/ec2_subnet/ipv6.crn
+++ b/acceptance-tests/ec2_subnet/ipv6.crn
@@ -3,7 +3,7 @@
 # Tests: ipv6_native, assign_ipv6_address_on_creation
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/ec2_subnet/with_dns_options.crn
+++ b/acceptance-tests/ec2_subnet/with_dns_options.crn
@@ -3,7 +3,7 @@
 # Tests: private_dns_name_options_on_launch (Struct type)
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/ec2_subnet/with_ipam.crn
+++ b/acceptance-tests/ec2_subnet/with_ipam.crn
@@ -15,7 +15,7 @@
 # - IPAM Pool deletion times out via CloudControl API.
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 provider aws {

--- a/acceptance-tests/ec2_subnet_route_table_association/basic.crn
+++ b/acceptance-tests/ec2_subnet_route_table_association/basic.crn
@@ -3,7 +3,7 @@
 # Tests: subnet_id, route_table_id
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/ec2_transit_gateway/basic.crn
+++ b/acceptance-tests/ec2_transit_gateway/basic.crn
@@ -3,7 +3,7 @@
 # Tests: description, tags
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.ec2.TransitGateway {

--- a/acceptance-tests/ec2_transit_gateway_attachment/basic.crn
+++ b/acceptance-tests/ec2_transit_gateway_attachment/basic.crn
@@ -3,7 +3,7 @@
 # Tests: subnet_ids, transit_gateway_id, vpc_id
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/ec2_vpc/basic.crn
+++ b/acceptance-tests/ec2_vpc/basic.crn
@@ -3,7 +3,7 @@
 # Tests: cidr_block, enable_dns_support, enable_dns_hostnames, instance_tenancy, tags
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.ec2.Vpc {

--- a/acceptance-tests/ec2_vpc_endpoint/gateway.crn
+++ b/acceptance-tests/ec2_vpc_endpoint/gateway.crn
@@ -3,7 +3,7 @@
 # Tests: vpc_endpoint_type=Gateway, service_name, route_table_ids, policy_document
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/ec2_vpc_endpoint/interface.crn
+++ b/acceptance-tests/ec2_vpc_endpoint/interface.crn
@@ -4,7 +4,7 @@
 #        private_dns_enabled
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/ec2_vpc_gateway_attachment/igw.crn
+++ b/acceptance-tests/ec2_vpc_gateway_attachment/igw.crn
@@ -3,7 +3,7 @@
 # Tests: internet_gateway_id, vpc_id
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/ec2_vpc_gateway_attachment/vpn.crn
+++ b/acceptance-tests/ec2_vpc_gateway_attachment/vpn.crn
@@ -4,7 +4,7 @@
 # Requires: VPN Gateway
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/ec2_vpc_peering_connection/basic.crn
+++ b/acceptance-tests/ec2_vpc_peering_connection/basic.crn
@@ -3,7 +3,7 @@
 # Tests: vpc_id, peer_vpc_id, tags
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc1 = awscc.ec2.Vpc {

--- a/acceptance-tests/ec2_vpn_gateway/basic.crn
+++ b/acceptance-tests/ec2_vpn_gateway/basic.crn
@@ -3,7 +3,7 @@
 # Tests: type, tags
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.ec2.VpnGateway {

--- a/acceptance-tests/for_expression/for_list.crn
+++ b/acceptance-tests/for_expression/for_list.crn
@@ -1,5 +1,5 @@
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpcs = for (i, env) in ['dev', 'stg'] {

--- a/acceptance-tests/for_expression/for_map.crn
+++ b/acceptance-tests/for_expression/for_map.crn
@@ -1,5 +1,5 @@
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let cidrs = {

--- a/acceptance-tests/for_expression/for_module.crn
+++ b/acceptance-tests/for_expression/for_module.crn
@@ -1,5 +1,5 @@
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc_mod = use { source = './modules/vpc_only' }

--- a/acceptance-tests/for_expression/for_module_complex.crn
+++ b/acceptance-tests/for_expression/for_module_complex.crn
@@ -1,5 +1,5 @@
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let network = use { source = './modules/network' }

--- a/acceptance-tests/for_expression/index_access.crn
+++ b/acceptance-tests/for_expression/index_access.crn
@@ -1,5 +1,5 @@
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpcs = for env in ['dev', 'stg'] {

--- a/acceptance-tests/iam_role/managed_policy.crn
+++ b/acceptance-tests/iam_role/managed_policy.crn
@@ -3,7 +3,7 @@
 # Tests: role_name_prefix, assume_role_policy_document, managed_policy_arns
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.iam.Role {

--- a/acceptance-tests/iam_role/prefix.crn
+++ b/acceptance-tests/iam_role/prefix.crn
@@ -5,7 +5,7 @@
 #        destroy cleans up the prefixed resource.
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.iam.Role {

--- a/acceptance-tests/iam_role/with_path.crn
+++ b/acceptance-tests/iam_role/with_path.crn
@@ -3,7 +3,7 @@
 # Tests: role_name_prefix, assume_role_policy_document, path (create_only), tags
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.iam.Role {

--- a/acceptance-tests/iam_role/with_policy.crn
+++ b/acceptance-tests/iam_role/with_policy.crn
@@ -4,7 +4,7 @@
 #        max_session_duration, inline policy block
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.iam.Role {

--- a/acceptance-tests/if_expression/if_else_value.crn
+++ b/acceptance-tests/if_expression/if_else_value.crn
@@ -1,5 +1,5 @@
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let is_production = true

--- a/acceptance-tests/if_expression/if_false.crn
+++ b/acceptance-tests/if_expression/if_false.crn
@@ -1,5 +1,5 @@
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let enabled = false

--- a/acceptance-tests/if_expression/if_true.crn
+++ b/acceptance-tests/if_expression/if_true.crn
@@ -1,5 +1,5 @@
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let enabled = true

--- a/acceptance-tests/in_place_update/ec2_egress_only_internet_gateway_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_egress_only_internet_gateway_step1.crn
@@ -3,7 +3,7 @@
 # Tests: create egress only IGW with initial tags
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/in_place_update/ec2_egress_only_internet_gateway_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_egress_only_internet_gateway_step2.crn
@@ -3,7 +3,7 @@
 # Tests: update tags (in-place update)
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/in_place_update/ec2_eip_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_eip_step1.crn
@@ -3,7 +3,7 @@
 # Tests: create EIP with initial tags
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.ec2.Eip {

--- a/acceptance-tests/in_place_update/ec2_eip_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_eip_step2.crn
@@ -3,7 +3,7 @@
 # Tests: update tags (in-place update)
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.ec2.Eip {

--- a/acceptance-tests/in_place_update/ec2_flow_log_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_flow_log_step1.crn
@@ -3,7 +3,7 @@
 # Tests: create flow log with initial tags
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/in_place_update/ec2_flow_log_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_flow_log_step2.crn
@@ -3,7 +3,7 @@
 # Tests: update tags (in-place update)
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/in_place_update/ec2_ipam_pool_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_ipam_pool_step1.crn
@@ -3,7 +3,7 @@
 # Tests: create IPAM and IPAM pool with initial description
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let ipam = awscc.ec2.Ipam {

--- a/acceptance-tests/in_place_update/ec2_ipam_pool_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_ipam_pool_step2.crn
@@ -3,7 +3,7 @@
 # Tests: update description (in-place update)
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let ipam = awscc.ec2.Ipam {

--- a/acceptance-tests/in_place_update/ec2_nat_gateway_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_nat_gateway_step1.crn
@@ -3,7 +3,7 @@
 # Tests: create NAT gateway with initial tags
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/in_place_update/ec2_nat_gateway_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_nat_gateway_step2.crn
@@ -3,7 +3,7 @@
 # Tests: update tags (in-place update)
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/in_place_update/ec2_route_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_route_step1.crn
@@ -3,7 +3,7 @@
 # Tests: create route 10.1.0.0/16 via Internet Gateway
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/in_place_update/ec2_route_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_route_step2.crn
@@ -3,7 +3,7 @@
 # Tests: change route target from IGW to NAT Gateway (in-place update)
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/in_place_update/ec2_route_table_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_route_table_step1.crn
@@ -3,7 +3,7 @@
 # Tests: create route table with initial tags
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/in_place_update/ec2_route_table_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_route_table_step2.crn
@@ -3,7 +3,7 @@
 # Tests: update tags (in-place update)
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/in_place_update/ec2_security_group_egress_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_security_group_egress_step1.crn
@@ -3,7 +3,7 @@
 # Tests: create egress rule with initial description
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/in_place_update/ec2_security_group_egress_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_security_group_egress_step2.crn
@@ -3,7 +3,7 @@
 # Tests: update description (in-place update)
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/in_place_update/ec2_security_group_ingress_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_security_group_ingress_step1.crn
@@ -3,7 +3,7 @@
 # Tests: create ingress rule with initial description
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/in_place_update/ec2_security_group_ingress_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_security_group_ingress_step2.crn
@@ -3,7 +3,7 @@
 # Tests: update description (in-place update)
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/in_place_update/ec2_security_group_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_security_group_step1.crn
@@ -3,7 +3,7 @@
 # Tests: create security group with one ingress rule
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/in_place_update/ec2_security_group_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_security_group_step2.crn
@@ -3,7 +3,7 @@
 # Tests: add HTTPS ingress rule (in-place update)
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/in_place_update/ec2_subnet_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_subnet_step1.crn
@@ -3,7 +3,7 @@
 # Tests: create subnet with map_public_ip_on_launch = false
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/in_place_update/ec2_subnet_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_subnet_step2.crn
@@ -3,7 +3,7 @@
 # Tests: update map_public_ip_on_launch from false to true (in-place update)
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/in_place_update/ec2_transit_gateway_attachment_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_transit_gateway_attachment_step1.crn
@@ -3,7 +3,7 @@
 # Tests: create transit gateway attachment with initial tags
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/in_place_update/ec2_transit_gateway_attachment_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_transit_gateway_attachment_step2.crn
@@ -3,7 +3,7 @@
 # Tests: update tags (in-place update)
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/in_place_update/ec2_transit_gateway_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_transit_gateway_step1.crn
@@ -3,7 +3,7 @@
 # Tests: create transit gateway with initial description
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.ec2.TransitGateway {

--- a/acceptance-tests/in_place_update/ec2_transit_gateway_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_transit_gateway_step2.crn
@@ -3,7 +3,7 @@
 # Tests: update description (in-place update)
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.ec2.TransitGateway {

--- a/acceptance-tests/in_place_update/ec2_vpc_endpoint_interface_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_vpc_endpoint_interface_step1.crn
@@ -3,7 +3,7 @@
 # Tests: create interface endpoint with private_dns_enabled=false
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/in_place_update/ec2_vpc_endpoint_interface_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_vpc_endpoint_interface_step2.crn
@@ -3,7 +3,7 @@
 # Tests: update private_dns_enabled (false -> true)
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/in_place_update/ec2_vpc_endpoint_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_vpc_endpoint_step1.crn
@@ -3,7 +3,7 @@
 # Tests: create gateway endpoint with initial policy
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/in_place_update/ec2_vpc_endpoint_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_vpc_endpoint_step2.crn
@@ -3,7 +3,7 @@
 # Tests: update policy_document (in-place update)
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/in_place_update/ec2_vpc_peering_connection_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_vpc_peering_connection_step1.crn
@@ -3,7 +3,7 @@
 # Tests: create VPC peering connection with initial tags
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc1 = awscc.ec2.Vpc {

--- a/acceptance-tests/in_place_update/ec2_vpc_peering_connection_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_vpc_peering_connection_step2.crn
@@ -3,7 +3,7 @@
 # Tests: update tags (in-place update)
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc1 = awscc.ec2.Vpc {

--- a/acceptance-tests/in_place_update/ec2_vpc_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_vpc_step1.crn
@@ -3,7 +3,7 @@
 # Tests: create VPC with enable_dns_hostnames = false
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.ec2.Vpc {

--- a/acceptance-tests/in_place_update/ec2_vpc_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_vpc_step2.crn
@@ -3,7 +3,7 @@
 # Tests: update enable_dns_hostnames from false to true (in-place update)
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.ec2.Vpc {

--- a/acceptance-tests/in_place_update/iam_role_step1.crn
+++ b/acceptance-tests/in_place_update/iam_role_step1.crn
@@ -3,7 +3,7 @@
 # Tests: create role with max_session_duration = 3600
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.iam.Role {

--- a/acceptance-tests/in_place_update/iam_role_step2.crn
+++ b/acceptance-tests/in_place_update/iam_role_step2.crn
@@ -3,7 +3,7 @@
 # Tests: update max_session_duration from 3600 to 7200 (in-place update)
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.iam.Role {

--- a/acceptance-tests/in_place_update/logs_log_group_step1.crn
+++ b/acceptance-tests/in_place_update/logs_log_group_step1.crn
@@ -3,7 +3,7 @@
 # Tests: create log group with retention_in_days = 7
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.logs.LogGroup {

--- a/acceptance-tests/in_place_update/logs_log_group_step2.crn
+++ b/acceptance-tests/in_place_update/logs_log_group_step2.crn
@@ -3,7 +3,7 @@
 # Tests: update retention_in_days from 7 to 14 (in-place update)
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.logs.LogGroup {

--- a/acceptance-tests/in_place_update/s3_bucket_step1.crn
+++ b/acceptance-tests/in_place_update/s3_bucket_step1.crn
@@ -3,7 +3,7 @@
 # Tests: create bucket with versioning Enabled
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.s3.Bucket {

--- a/acceptance-tests/in_place_update/s3_bucket_step2.crn
+++ b/acceptance-tests/in_place_update/s3_bucket_step2.crn
@@ -3,7 +3,7 @@
 # Tests: update versioning from Enabled to Suspended (in-place update)
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.s3.Bucket {

--- a/acceptance-tests/logs_log_group/infrequent_access.crn
+++ b/acceptance-tests/logs_log_group/infrequent_access.crn
@@ -3,7 +3,7 @@
 # Tests: log_group_name_prefix, log_group_class, retention_in_days
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.logs.LogGroup {

--- a/acceptance-tests/logs_log_group/prefix.crn
+++ b/acceptance-tests/logs_log_group/prefix.crn
@@ -5,7 +5,7 @@
 #        destroy cleans up the prefixed resource.
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.logs.LogGroup {

--- a/acceptance-tests/logs_log_group/retention.crn
+++ b/acceptance-tests/logs_log_group/retention.crn
@@ -3,7 +3,7 @@
 # Tests: log_group_name_prefix, retention_in_days, tags
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.logs.LogGroup {

--- a/acceptance-tests/module/attributes_access.crn
+++ b/acceptance-tests/module/attributes_access.crn
@@ -3,7 +3,7 @@
 # Tests: accessing module attributes from the caller via let binding
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let network = use { source = './modules/network' }

--- a/acceptance-tests/module/basic.crn
+++ b/acceptance-tests/module/basic.crn
@@ -3,7 +3,7 @@
 # Tests: module use, argument passing, intra-module resource references
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let network = use { source = './modules/network' }

--- a/acceptance-tests/module/nested_module.crn
+++ b/acceptance-tests/module/nested_module.crn
@@ -3,7 +3,7 @@
 # Tests: module useing another module (2-level nesting)
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let network_with_rt = use { source = './modules/network_with_rt' }

--- a/acceptance-tests/s3_bucket/encryption.crn
+++ b/acceptance-tests/s3_bucket/encryption.crn
@@ -6,7 +6,7 @@
 #        destroy cleans up the encrypted bucket.
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.s3.Bucket {

--- a/acceptance-tests/s3_bucket/kms_encryption.crn
+++ b/acceptance-tests/s3_bucket/kms_encryption.crn
@@ -7,7 +7,7 @@
 #        destroy cleans up the KMS-encrypted bucket.
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.s3.Bucket {

--- a/acceptance-tests/s3_bucket/lifecycle.crn
+++ b/acceptance-tests/s3_bucket/lifecycle.crn
@@ -7,7 +7,7 @@
 #        destroy cleans up the bucket.
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.s3.Bucket {

--- a/acceptance-tests/s3_bucket/logging.crn
+++ b/acceptance-tests/s3_bucket/logging.crn
@@ -6,7 +6,7 @@
 #        destroy cleans up both buckets.
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let log_bucket = awscc.s3.Bucket {

--- a/acceptance-tests/s3_bucket/prefix.crn
+++ b/acceptance-tests/s3_bucket/prefix.crn
@@ -5,7 +5,7 @@
 #        destroy cleans up the prefixed resource.
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.s3.Bucket {

--- a/acceptance-tests/s3_bucket/public_access_block.crn
+++ b/acceptance-tests/s3_bucket/public_access_block.crn
@@ -5,7 +5,7 @@
 #        destroy cleans up the bucket.
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.s3.Bucket {

--- a/acceptance-tests/s3_bucket/versioning.crn
+++ b/acceptance-tests/s3_bucket/versioning.crn
@@ -5,7 +5,7 @@
 #        destroy cleans up the versioned bucket.
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.s3.Bucket {

--- a/acceptance-tests/s3_bucket/website.crn
+++ b/acceptance-tests/s3_bucket/website.crn
@@ -5,7 +5,7 @@
 #        destroy cleans up the bucket.
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.s3.Bucket {

--- a/acceptance-tests/secret_env/decrypt_tag.crn
+++ b/acceptance-tests/secret_env/decrypt_tag.crn
@@ -1,5 +1,5 @@
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 # KMS-encrypted value (encrypted with alias/carina-test key in carina-test-000 account)

--- a/acceptance-tests/secret_env/env_tag.crn
+++ b/acceptance-tests/secret_env/env_tag.crn
@@ -1,5 +1,5 @@
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.ec2.Vpc {

--- a/acceptance-tests/secret_env/secret_tag.crn
+++ b/acceptance-tests/secret_env/secret_tag.crn
@@ -1,5 +1,5 @@
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.ec2.Vpc {

--- a/acceptance-tests/simhash_update/ec2_eip_step1.crn
+++ b/acceptance-tests/simhash_update/ec2_eip_step1.crn
@@ -4,7 +4,7 @@
 # Case A: schema has create-only properties, but user didn't set any
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.ec2.Eip {

--- a/acceptance-tests/simhash_update/ec2_eip_step2.crn
+++ b/acceptance-tests/simhash_update/ec2_eip_step2.crn
@@ -4,7 +4,7 @@
 # (not delete+create) via SimHash Hamming distance reconciliation
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.ec2.Eip {

--- a/acceptance-tests/simhash_update/ec2_ipam_step1.crn
+++ b/acceptance-tests/simhash_update/ec2_ipam_step1.crn
@@ -4,7 +4,7 @@
 # Case B: schema has no create-only properties at all
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.ec2.Ipam {

--- a/acceptance-tests/simhash_update/ec2_ipam_step2.crn
+++ b/acceptance-tests/simhash_update/ec2_ipam_step2.crn
@@ -4,7 +4,7 @@
 # (not delete+create) via SimHash Hamming distance reconciliation
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.ec2.Ipam {

--- a/acceptance-tests/state_blocks/step1_create.crn
+++ b/acceptance-tests/state_blocks/step1_create.crn
@@ -1,5 +1,5 @@
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.ec2.Vpc {

--- a/acceptance-tests/state_blocks/step2_moved.crn
+++ b/acceptance-tests/state_blocks/step2_moved.crn
@@ -1,5 +1,5 @@
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 moved {

--- a/acceptance-tests/state_blocks/step3_removed.crn
+++ b/acceptance-tests/state_blocks/step3_removed.crn
@@ -1,5 +1,5 @@
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 removed {

--- a/acceptance-tests/state_blocks/step4_import.crn
+++ b/acceptance-tests/state_blocks/step4_import.crn
@@ -1,5 +1,5 @@
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 import {

--- a/acceptance-tests/string_interpolation/basic.crn
+++ b/acceptance-tests/string_interpolation/basic.crn
@@ -1,5 +1,5 @@
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let env = 'test'

--- a/acceptance-tests/tag_deletion/ec2_nat_gateway_step1.crn
+++ b/acceptance-tests/tag_deletion/ec2_nat_gateway_step1.crn
@@ -5,7 +5,7 @@
 # tag to test that CloudControl "remove" patch is used for the removed key.
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/tag_deletion/ec2_nat_gateway_step2.crn
+++ b/acceptance-tests/tag_deletion/ec2_nat_gateway_step2.crn
@@ -5,7 +5,7 @@
 # patch and plan should show no changes (idempotent).
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/tag_deletion/ec2_nat_gateway_step3.crn
+++ b/acceptance-tests/tag_deletion/ec2_nat_gateway_step3.crn
@@ -5,7 +5,7 @@
 # in current state but is absent from desired state.
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/tag_deletion/ec2_vpc_step1.crn
+++ b/acceptance-tests/tag_deletion/ec2_vpc_step1.crn
@@ -4,7 +4,7 @@
 # that CloudControl "remove" patch is used for the removed key.
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.ec2.Vpc {

--- a/acceptance-tests/tag_deletion/ec2_vpc_step2.crn
+++ b/acceptance-tests/tag_deletion/ec2_vpc_step2.crn
@@ -5,7 +5,7 @@
 # patch and plan should show no changes (idempotent).
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.ec2.Vpc {

--- a/acceptance-tests/tag_deletion/ec2_vpc_step3.crn
+++ b/acceptance-tests/tag_deletion/ec2_vpc_step3.crn
@@ -5,7 +5,7 @@
 # in current state but is absent from desired state.
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.ec2.Vpc {

--- a/acceptance-tests/tag_deletion/iam_role_step1.crn
+++ b/acceptance-tests/tag_deletion/iam_role_step1.crn
@@ -4,7 +4,7 @@
 # that CloudControl "remove" patch is used for the removed key.
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.iam.Role {

--- a/acceptance-tests/tag_deletion/iam_role_step2.crn
+++ b/acceptance-tests/tag_deletion/iam_role_step2.crn
@@ -5,7 +5,7 @@
 # patch and plan should show no changes (idempotent).
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.iam.Role {

--- a/acceptance-tests/tag_deletion/iam_role_step3.crn
+++ b/acceptance-tests/tag_deletion/iam_role_step3.crn
@@ -5,7 +5,7 @@
 # in current state but is absent from desired state.
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.iam.Role {

--- a/acceptance-tests/tag_deletion/s3_bucket_step1.crn
+++ b/acceptance-tests/tag_deletion/s3_bucket_step1.crn
@@ -4,7 +4,7 @@
 # that CloudControl "remove" patch is used for the removed key.
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.s3.Bucket {

--- a/acceptance-tests/tag_deletion/s3_bucket_step2.crn
+++ b/acceptance-tests/tag_deletion/s3_bucket_step2.crn
@@ -5,7 +5,7 @@
 # patch and plan should show no changes (idempotent).
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.s3.Bucket {

--- a/acceptance-tests/tag_deletion/s3_bucket_step3.crn
+++ b/acceptance-tests/tag_deletion/s3_bucket_step3.crn
@@ -5,7 +5,7 @@
 # in current state but is absent from desired state.
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 awscc.s3.Bucket {

--- a/acceptance-tests/user_functions/value_fn.crn
+++ b/acceptance-tests/user_functions/value_fn.crn
@@ -1,5 +1,5 @@
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 fn tag_name(env: String, service: String): String {

--- a/acceptance-tests/vpc_full/basic.crn
+++ b/acceptance-tests/vpc_full/basic.crn
@@ -14,7 +14,7 @@
 # - VPC Endpoints (ecr.dkr, ecr.api, s3, logs, ssm, ssmmessages)
 
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 # --- VPC and Internet Gateway ---

--- a/acceptance-tests/write_only_attrs/step1_create.crn
+++ b/acceptance-tests/write_only_attrs/step1_create.crn
@@ -1,5 +1,5 @@
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/write_only_attrs/step2_change.crn
+++ b/acceptance-tests/write_only_attrs/step2_change.crn
@@ -1,5 +1,5 @@
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {

--- a/acceptance-tests/write_only_attrs/step3_remove.crn
+++ b/acceptance-tests/write_only_attrs/step3_remove.crn
@@ -1,5 +1,5 @@
 provider awscc {
-  region = awscc.Region.ap_northeast_1
+  region = aws.Region.ap_northeast_1
 }
 
 let vpc = awscc.ec2.Vpc {


### PR DESCRIPTION
## Summary

Follow-up to carina-rs/carina#3413. The unified TypeIdentity contract removed the ``awscc.Region`` / ``awscc.AvailabilityZone`` DSL forms; only ``aws.Region`` etc. are valid now. 160 acceptance test fixtures in this repo still wrote the old form. This PR updates them mechanically (single-line ``region = awscc.Region.* → region = aws.Region.*`` replacement per fixture).

## Verify

- ``cargo nextest run -p carina-provider-awscc``: 450 tests pass
- This PR does not affect ``cargo`` build or unit tests; it only touches ``.crn`` fixtures consumed by acceptance test runs, which themselves require AWS credentials and are not part of CI.

Refs carina-rs/carina#3413.

🤖 Generated with [Claude Code](https://claude.com/claude-code)