### PR TITLE
Acceptance tests: switch awscc.* enum identifiers to aws.* (carina#3413)

### DIFF
--- a/acceptance-tests/attribute_removal/ec2_vpc_endpoint_step1.crn
+++ b/acceptance-tests/attribute_removal/ec2_vpc_endpoint_step1.crn
@@ -21,7 +21,7 @@ awscc.ec2.VpcEndpoint {
   route_table_ids   = [rt.route_table_id]
 
   policy_document = {
-    version = awscc.iam.PolicyDocument.Version.2012_10_17
+    version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
       effect    = 'Allow'
       principal = '*'

--- a/acceptance-tests/create_before_destroy/iam_role_step1.crn
+++ b/acceptance-tests/create_before_destroy/iam_role_step1.crn
@@ -13,9 +13,9 @@ awscc.iam.Role {
   path      = '/'
 
   assume_role_policy_document = {
-    version = awscc.iam.PolicyDocument.Version.2012_10_17
+    version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = awscc.iam.PolicyDocument.Statement.Effect.allow
+      effect = aws.iam.PolicyDocument.Statement.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/create_before_destroy/iam_role_step2.crn
+++ b/acceptance-tests/create_before_destroy/iam_role_step2.crn
@@ -20,9 +20,9 @@ awscc.iam.Role {
   }
 
   assume_role_policy_document = {
-    version = awscc.iam.PolicyDocument.Version.2012_10_17
+    version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = awscc.iam.PolicyDocument.Statement.Effect.allow
+      effect = aws.iam.PolicyDocument.Statement.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/ec2_flow_log/cloudwatch.crn
+++ b/acceptance-tests/ec2_flow_log/cloudwatch.crn
@@ -20,9 +20,9 @@ let flow_log_role = awscc.iam.Role {
   role_name = 'acceptance-test-flow-log-role'
 
   assume_role_policy_document = {
-    version = awscc.iam.PolicyDocument.Version.2012_10_17
+    version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = awscc.iam.PolicyDocument.Statement.Effect.allow
+      effect = aws.iam.PolicyDocument.Statement.Effect.allow
 
       principal = {
         service = 'vpc-flow-logs.amazonaws.com'
@@ -35,7 +35,7 @@ let flow_log_role = awscc.iam.Role {
 
 awscc.ec2.FlowLog {
   resource_id                 = vpc.vpc_id
-  resource_type               = awscc.ec2.FlowLog.ResourceType.vpc
+  resource_type               = aws.ec2.FlowLog.ResourceType.vpc
   traffic_type                = all
   log_destination_type        = cloud_watch_logs
   log_group_name              = log_group.log_group_name

--- a/acceptance-tests/ec2_flow_log/s3.crn
+++ b/acceptance-tests/ec2_flow_log/s3.crn
@@ -19,7 +19,7 @@ let bucket = awscc.s3.Bucket {
 
 awscc.ec2.FlowLog {
   resource_id          = vpc.vpc_id
-  resource_type        = awscc.ec2.FlowLog.ResourceType.vpc
+  resource_type        = aws.ec2.FlowLog.ResourceType.vpc
   traffic_type         = all
   log_destination_type = s3
   log_destination      = bucket.arn

--- a/acceptance-tests/ec2_nat_gateway/public.crn
+++ b/acceptance-tests/ec2_nat_gateway/public.crn
@@ -27,7 +27,7 @@ let public_subnet = awscc.ec2.Subnet {
 }
 
 let eip = awscc.ec2.Eip {
-  domain = awscc.ec2.Eip.Domain.vpc
+  domain = aws.ec2.Eip.Domain.vpc
 }
 
 awscc.ec2.NatGateway {

--- a/acceptance-tests/ec2_route/nat_gateway.crn
+++ b/acceptance-tests/ec2_route/nat_gateway.crn
@@ -27,7 +27,7 @@ let public_subnet = awscc.ec2.Subnet {
 }
 
 let eip = awscc.ec2.Eip {
-  domain = awscc.ec2.Eip.Domain.vpc
+  domain = aws.ec2.Eip.Domain.vpc
 }
 
 let nat_gw = awscc.ec2.NatGateway {

--- a/acceptance-tests/ec2_vpc_endpoint/gateway.crn
+++ b/acceptance-tests/ec2_vpc_endpoint/gateway.crn
@@ -21,9 +21,9 @@ awscc.ec2.VpcEndpoint {
   route_table_ids   = [rt.route_table_id]
 
   policy_document = {
-    version = awscc.iam.PolicyDocument.Version.2012_10_17
+    version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect    = awscc.iam.PolicyDocument.Statement.Effect.allow
+      effect    = aws.iam.PolicyDocument.Statement.Effect.allow
       principal = '*'
       action    = 's3:GetObject'
       resource  = 'arn:aws:s3:::*'

--- a/acceptance-tests/ec2_vpc_gateway_attachment/vpn.crn
+++ b/acceptance-tests/ec2_vpc_gateway_attachment/vpn.crn
@@ -12,7 +12,7 @@ let vpc = awscc.ec2.Vpc {
 }
 
 let vpn_gw = awscc.ec2.VpnGateway {
-  type = awscc.ec2.VpnGateway.Type.ipsec_1
+  type = aws.ec2.VpnGateway.Type.ipsec_1
 }
 
 awscc.ec2.VpcGatewayAttachment {

--- a/acceptance-tests/ec2_vpn_gateway/basic.crn
+++ b/acceptance-tests/ec2_vpn_gateway/basic.crn
@@ -7,7 +7,7 @@ provider awscc {
 }
 
 awscc.ec2.VpnGateway {
-  type = awscc.ec2.VpnGateway.Type.ipsec_1
+  type = aws.ec2.VpnGateway.Type.ipsec_1
 
   tags = {
     Environment = 'acceptance-test'

--- a/acceptance-tests/iam_role/managed_policy.crn
+++ b/acceptance-tests/iam_role/managed_policy.crn
@@ -10,9 +10,9 @@ awscc.iam.Role {
   role_name_prefix = 'carina-acc-test-'
 
   assume_role_policy_document = {
-    version = awscc.iam.PolicyDocument.Version.2012_10_17
+    version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = awscc.iam.PolicyDocument.Statement.Effect.allow
+      effect = aws.iam.PolicyDocument.Statement.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/iam_role/prefix.crn
+++ b/acceptance-tests/iam_role/prefix.crn
@@ -12,9 +12,9 @@ awscc.iam.Role {
   role_name_prefix = 'carina-acc-test-'
 
   assume_role_policy_document = {
-    version = awscc.iam.PolicyDocument.Version.2012_10_17
+    version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = awscc.iam.PolicyDocument.Statement.Effect.allow
+      effect = aws.iam.PolicyDocument.Statement.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/iam_role/with_path.crn
+++ b/acceptance-tests/iam_role/with_path.crn
@@ -11,9 +11,9 @@ awscc.iam.Role {
   path             = '/carina/acceptance-test/'
 
   assume_role_policy_document = {
-    version = awscc.iam.PolicyDocument.Version.2012_10_17
+    version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = awscc.iam.PolicyDocument.Statement.Effect.allow
+      effect = aws.iam.PolicyDocument.Statement.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/iam_role/with_policy.crn
+++ b/acceptance-tests/iam_role/with_policy.crn
@@ -13,9 +13,9 @@ awscc.iam.Role {
   max_session_duration = 7200
 
   assume_role_policy_document = {
-    version = awscc.iam.PolicyDocument.Version.2012_10_17
+    version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = awscc.iam.PolicyDocument.Statement.Effect.allow
+      effect = aws.iam.PolicyDocument.Statement.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'
@@ -29,9 +29,9 @@ awscc.iam.Role {
     policy_name = 'test-policy'
 
     policy_document = {
-      version = awscc.iam.PolicyDocument.Version.2012_10_17
+      version = aws.iam.PolicyDocument.Version.2012_10_17
       statement {
-        effect   = awscc.iam.PolicyDocument.Statement.Effect.allow
+        effect   = aws.iam.PolicyDocument.Statement.Effect.allow
         action   = 'logs:CreateLogGroup'
         resource = '*'
       }

--- a/acceptance-tests/in_place_update/ec2_flow_log_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_flow_log_step1.crn
@@ -19,9 +19,9 @@ let flow_log_role = awscc.iam.Role {
   role_name = 'carina-acc-test-update-flow-log-role'
 
   assume_role_policy_document = {
-    version = awscc.iam.PolicyDocument.Version.2012_10_17
+    version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = awscc.iam.PolicyDocument.Statement.Effect.allow
+      effect = aws.iam.PolicyDocument.Statement.Effect.allow
 
       principal = {
         service = 'vpc-flow-logs.amazonaws.com'

--- a/acceptance-tests/in_place_update/ec2_flow_log_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_flow_log_step2.crn
@@ -19,9 +19,9 @@ let flow_log_role = awscc.iam.Role {
   role_name = 'carina-acc-test-update-flow-log-role'
 
   assume_role_policy_document = {
-    version = awscc.iam.PolicyDocument.Version.2012_10_17
+    version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = awscc.iam.PolicyDocument.Statement.Effect.allow
+      effect = aws.iam.PolicyDocument.Statement.Effect.allow
 
       principal = {
         service = 'vpc-flow-logs.amazonaws.com'

--- a/acceptance-tests/in_place_update/ec2_nat_gateway_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_nat_gateway_step1.crn
@@ -27,7 +27,7 @@ let public_subnet = awscc.ec2.Subnet {
 }
 
 let eip = awscc.ec2.Eip {
-  domain = awscc.ec2.Eip.Domain.vpc
+  domain = aws.ec2.Eip.Domain.vpc
 }
 
 awscc.ec2.NatGateway {

--- a/acceptance-tests/in_place_update/ec2_nat_gateway_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_nat_gateway_step2.crn
@@ -27,7 +27,7 @@ let public_subnet = awscc.ec2.Subnet {
 }
 
 let eip = awscc.ec2.Eip {
-  domain = awscc.ec2.Eip.Domain.vpc
+  domain = aws.ec2.Eip.Domain.vpc
 }
 
 awscc.ec2.NatGateway {

--- a/acceptance-tests/in_place_update/ec2_route_step1.crn
+++ b/acceptance-tests/in_place_update/ec2_route_step1.crn
@@ -27,7 +27,7 @@ let public_subnet = awscc.ec2.Subnet {
 }
 
 let eip = awscc.ec2.Eip {
-  domain = awscc.ec2.Eip.Domain.vpc
+  domain = aws.ec2.Eip.Domain.vpc
 }
 
 awscc.ec2.NatGateway {

--- a/acceptance-tests/in_place_update/ec2_route_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_route_step2.crn
@@ -27,7 +27,7 @@ let public_subnet = awscc.ec2.Subnet {
 }
 
 let eip = awscc.ec2.Eip {
-  domain = awscc.ec2.Eip.Domain.vpc
+  domain = aws.ec2.Eip.Domain.vpc
 }
 
 let nat_gw = awscc.ec2.NatGateway {

--- a/acceptance-tests/in_place_update/ec2_vpc_endpoint_step2.crn
+++ b/acceptance-tests/in_place_update/ec2_vpc_endpoint_step2.crn
@@ -21,7 +21,7 @@ awscc.ec2.VpcEndpoint {
   route_table_ids   = [rt.route_table_id]
 
   policy_document = {
-    version = awscc.iam.PolicyDocument.Version.2012_10_17
+    version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
       effect    = 'Allow'
       principal = '*'

--- a/acceptance-tests/in_place_update/iam_role_step1.crn
+++ b/acceptance-tests/in_place_update/iam_role_step1.crn
@@ -10,9 +10,9 @@ awscc.iam.Role {
   role_name_prefix = 'carina-acc-test-update-'
 
   assume_role_policy_document = {
-    version = awscc.iam.PolicyDocument.Version.2012_10_17
+    version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = awscc.iam.PolicyDocument.Statement.Effect.allow
+      effect = aws.iam.PolicyDocument.Statement.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/in_place_update/iam_role_step2.crn
+++ b/acceptance-tests/in_place_update/iam_role_step2.crn
@@ -10,9 +10,9 @@ awscc.iam.Role {
   role_name_prefix = 'carina-acc-test-update-'
 
   assume_role_policy_document = {
-    version = awscc.iam.PolicyDocument.Version.2012_10_17
+    version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = awscc.iam.PolicyDocument.Statement.Effect.allow
+      effect = aws.iam.PolicyDocument.Statement.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/in_place_update/s3_bucket_step1.crn
+++ b/acceptance-tests/in_place_update/s3_bucket_step1.crn
@@ -10,7 +10,7 @@ awscc.s3.Bucket {
   bucket_name_prefix = 'carina-acc-test-update-'
 
   versioning_configuration = {
-    status = awscc.s3.Bucket.VersioningConfiguration.Status.enabled
+    status = aws.s3.Bucket.VersioningConfiguration.Status.enabled
   }
 
   directives {

--- a/acceptance-tests/in_place_update/s3_bucket_step2.crn
+++ b/acceptance-tests/in_place_update/s3_bucket_step2.crn
@@ -10,7 +10,7 @@ awscc.s3.Bucket {
   bucket_name_prefix = 'carina-acc-test-update-'
 
   versioning_configuration = {
-    status = awscc.s3.Bucket.VersioningConfiguration.Status.suspended
+    status = aws.s3.Bucket.VersioningConfiguration.Status.suspended
   }
 
   directives {

--- a/acceptance-tests/logs_log_group/infrequent_access.crn
+++ b/acceptance-tests/logs_log_group/infrequent_access.crn
@@ -8,6 +8,6 @@ provider awscc {
 
 awscc.logs.LogGroup {
   log_group_name_prefix = '/carina/acc-test-'
-  log_group_class       = awscc.logs.LogGroup.LogGroupClass.infrequent_access
+  log_group_class       = aws.logs.LogGroup.LogGroupClass.infrequent_access
   retention_in_days     = 1
 }

--- a/acceptance-tests/s3_bucket/lifecycle.crn
+++ b/acceptance-tests/s3_bucket/lifecycle.crn
@@ -16,14 +16,14 @@ awscc.s3.Bucket {
   lifecycle_configuration = {
     rule {
       id                 = 'expire-old-objects'
-      status             = awscc.s3.Bucket.LifecycleConfiguration.Rule.Status.enabled
+      status             = aws.s3.Bucket.LifecycleConfiguration.Rule.Status.enabled
       expiration_in_days = 90
     }
     rule {
       id     = 'transition-to-glacier'
-      status = awscc.s3.Bucket.LifecycleConfiguration.Rule.Status.enabled
+      status = aws.s3.Bucket.LifecycleConfiguration.Rule.Status.enabled
       transitions = [{
-        storage_class      = awscc.s3.Bucket.LifecycleConfiguration.Rule.Transition.StorageClass.glacier
+        storage_class      = aws.s3.Bucket.LifecycleConfiguration.Rule.Transition.StorageClass.glacier
         transition_in_days = 30
       }]
     }

--- a/acceptance-tests/s3_bucket/versioning.crn
+++ b/acceptance-tests/s3_bucket/versioning.crn
@@ -12,7 +12,7 @@ awscc.s3.Bucket {
   bucket_name_prefix = 'carina-acc-test-'
 
   versioning_configuration = {
-    status = awscc.s3.Bucket.VersioningConfiguration.Status.enabled
+    status = aws.s3.Bucket.VersioningConfiguration.Status.enabled
   }
 
   directives {

--- a/acceptance-tests/simhash_update/ec2_ipam_step1.crn
+++ b/acceptance-tests/simhash_update/ec2_ipam_step1.crn
@@ -9,7 +9,7 @@ provider awscc {
 
 awscc.ec2.Ipam {
   description = 'simhash acceptance test'
-  tier        = awscc.ec2.Ipam.Tier.free
+  tier        = aws.ec2.Ipam.Tier.free
 
   tags = {
     Environment = 'acceptance-test'

--- a/acceptance-tests/simhash_update/ec2_ipam_step2.crn
+++ b/acceptance-tests/simhash_update/ec2_ipam_step2.crn
@@ -9,7 +9,7 @@ provider awscc {
 
 awscc.ec2.Ipam {
   description = 'simhash acceptance test updated'
-  tier        = awscc.ec2.Ipam.Tier.free
+  tier        = aws.ec2.Ipam.Tier.free
 
   tags = {
     Environment = 'acceptance-test'

--- a/acceptance-tests/tag_deletion/ec2_nat_gateway_step1.crn
+++ b/acceptance-tests/tag_deletion/ec2_nat_gateway_step1.crn
@@ -29,7 +29,7 @@ let public_subnet = awscc.ec2.Subnet {
 }
 
 let eip = awscc.ec2.Eip {
-  domain = awscc.ec2.Eip.Domain.vpc
+  domain = aws.ec2.Eip.Domain.vpc
 }
 
 awscc.ec2.NatGateway {

--- a/acceptance-tests/tag_deletion/ec2_nat_gateway_step2.crn
+++ b/acceptance-tests/tag_deletion/ec2_nat_gateway_step2.crn
@@ -29,7 +29,7 @@ let public_subnet = awscc.ec2.Subnet {
 }
 
 let eip = awscc.ec2.Eip {
-  domain = awscc.ec2.Eip.Domain.vpc
+  domain = aws.ec2.Eip.Domain.vpc
 }
 
 awscc.ec2.NatGateway {

--- a/acceptance-tests/tag_deletion/ec2_nat_gateway_step3.crn
+++ b/acceptance-tests/tag_deletion/ec2_nat_gateway_step3.crn
@@ -29,7 +29,7 @@ let public_subnet = awscc.ec2.Subnet {
 }
 
 let eip = awscc.ec2.Eip {
-  domain = awscc.ec2.Eip.Domain.vpc
+  domain = aws.ec2.Eip.Domain.vpc
 }
 
 awscc.ec2.NatGateway {

--- a/acceptance-tests/tag_deletion/iam_role_step1.crn
+++ b/acceptance-tests/tag_deletion/iam_role_step1.crn
@@ -11,9 +11,9 @@ awscc.iam.Role {
   role_name_prefix = 'carina-acc-test-tag-del-'
 
   assume_role_policy_document = {
-    version = awscc.iam.PolicyDocument.Version.2012_10_17
+    version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = awscc.iam.PolicyDocument.Statement.Effect.allow
+      effect = aws.iam.PolicyDocument.Statement.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/tag_deletion/iam_role_step2.crn
+++ b/acceptance-tests/tag_deletion/iam_role_step2.crn
@@ -12,9 +12,9 @@ awscc.iam.Role {
   role_name_prefix = 'carina-acc-test-tag-del-'
 
   assume_role_policy_document = {
-    version = awscc.iam.PolicyDocument.Version.2012_10_17
+    version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = awscc.iam.PolicyDocument.Statement.Effect.allow
+      effect = aws.iam.PolicyDocument.Statement.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/tag_deletion/iam_role_step3.crn
+++ b/acceptance-tests/tag_deletion/iam_role_step3.crn
@@ -12,9 +12,9 @@ awscc.iam.Role {
   role_name_prefix = 'carina-acc-test-tag-del-'
 
   assume_role_policy_document = {
-    version = awscc.iam.PolicyDocument.Version.2012_10_17
+    version = aws.iam.PolicyDocument.Version.2012_10_17
     statement {
-      effect = awscc.iam.PolicyDocument.Statement.Effect.allow
+      effect = aws.iam.PolicyDocument.Statement.Effect.allow
 
       principal = {
         service = 'lambda.amazonaws.com'

--- a/acceptance-tests/vpc_full/basic.crn
+++ b/acceptance-tests/vpc_full/basic.crn
@@ -109,7 +109,7 @@ awscc.ec2.SubnetRouteTableAssociation {
 # --- Elastic IPs and NAT Gateways ---
 
 let eip_1a = awscc.ec2.Eip {
-  domain = awscc.ec2.Eip.Domain.vpc
+  domain = aws.ec2.Eip.Domain.vpc
 
   tags = {
     Name = 'nat-gw-ap-northeast-1a'
@@ -117,7 +117,7 @@ let eip_1a = awscc.ec2.Eip {
 }
 
 let eip_1c = awscc.ec2.Eip {
-  domain = awscc.ec2.Eip.Domain.vpc
+  domain = aws.ec2.Eip.Domain.vpc
 
   tags = {
     Name = 'nat-gw-ap-northeast-1c'
@@ -125,7 +125,7 @@ let eip_1c = awscc.ec2.Eip {
 }
 
 let eip_1d = awscc.ec2.Eip {
-  domain = awscc.ec2.Eip.Domain.vpc
+  domain = aws.ec2.Eip.Domain.vpc
 
   tags = {
     Name = 'nat-gw-ap-northeast-1d'

--- a/acceptance-tests/write_only_attrs/step1_create.crn
+++ b/acceptance-tests/write_only_attrs/step1_create.crn
@@ -33,7 +33,7 @@ awscc.ec2.VpcGatewayAttachment {
 }
 
 let eip = awscc.ec2.Eip {
-  domain = awscc.ec2.Eip.Domain.vpc
+  domain = aws.ec2.Eip.Domain.vpc
 
   tags = {
     Name = 'write-only-test'

--- a/acceptance-tests/write_only_attrs/step2_change.crn
+++ b/acceptance-tests/write_only_attrs/step2_change.crn
@@ -33,7 +33,7 @@ awscc.ec2.VpcGatewayAttachment {
 }
 
 let eip = awscc.ec2.Eip {
-  domain = awscc.ec2.Eip.Domain.vpc
+  domain = aws.ec2.Eip.Domain.vpc
 
   tags = {
     Name = 'write-only-test'

--- a/acceptance-tests/write_only_attrs/step3_remove.crn
+++ b/acceptance-tests/write_only_attrs/step3_remove.crn
@@ -33,7 +33,7 @@ awscc.ec2.VpcGatewayAttachment {
 }
 
 let eip = awscc.ec2.Eip {
-  domain = awscc.ec2.Eip.Domain.vpc
+  domain = aws.ec2.Eip.Domain.vpc
 
   tags = {
     Name = 'write-only-test'


### PR DESCRIPTION
## Summary

Follow-up to carina-rs/carina-provider-awscc#339. That PR rewrote ``awscc.Region`` and ``awscc.AvailabilityZone`` only, missing the broader class of bug: every enum identifier in the ``awscc.*`` namespace is now invalid because carina-rs/carina-provider-awscc#338 unified the underlying TypeIdentity to ``aws.*``.

## Changes

Rewrote all remaining ``awscc.*`` enum identifiers across acceptance test fixtures:

- ``awscc.iam.PolicyDocument.Statement.Effect.allow`` → ``aws.iam.PolicyDocument.Statement.Effect.allow``
- ``awscc.iam.PolicyDocument.Version.2012_10_17`` → ``aws.iam.PolicyDocument.Version.2012_10_17``
- ``awscc.ec2.VpnGateway.Type.ipsec_1`` → ``aws.ec2.VpnGateway.Type.ipsec_1``
- ``awscc.ec2.Eip.Domain.vpc`` → ``aws.ec2.Eip.Domain.vpc``
- ``awscc.ec2.FlowLog.ResourceType.vpc`` → ``aws.ec2.FlowLog.ResourceType.vpc``
- ``awscc.ec2.Ipam.Tier.free`` → ``aws.ec2.Ipam.Tier.free``
- ``awscc.s3.Bucket.LifecycleConfiguration.Rule.Status.enabled`` → ``aws.s3...``
- ``awscc.s3.Bucket.LifecycleConfiguration.Rule.Transition.StorageClass.glacier`` → ``aws.s3...``
- ``awscc.s3.Bucket.VersioningConfiguration.Status.enabled / suspended`` → ``aws.s3...``
- ``awscc.logs.LogGroup.LogGroupClass.infrequent_access`` → ``aws.logs...``

Resource type references (e.g. ``awscc.s3.Bucket``, ``awscc.ec2.NatGateway``) stay intact — the DSL keeps the per-provider namespace for resources. Only enum value identifiers move to ``aws.*``.

40 files changed, 62 insertions, 62 deletions.

## Verify

Ran ``./acceptance-tests/run-tests.sh full`` locally against 10 test accounts:

Before this PR: 40 passed, 14 failed (of 54).
After this PR: 53 passed, 1 failed (of 54).

The 1 remaining failure is unrelated to this PR's scope and concerns a separate ``aws.s3.Bucket.Arn`` → ``aws.Arn`` (specific → generic) assignment regression in ``ec2_flow_log/s3.crn``. Tracked separately.

Refs carina-rs/carina#3413.

🤖 Generated with [Claude Code](https://claude.com/claude-code)