### PR TITLE
Trust host enum canonicalization; remove desired-side re-derivation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,7 +629,7 @@ dependencies = [
 [[package]]
 name = "carina-aws-types"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina-provider-aws?rev=57367357e94fc91b9d3e7b1551481cf3727d6088#57367357e94fc91b9d3e7b1551481cf3727d6088"
+source = "git+https://github.com/carina-rs/carina-provider-aws?rev=1baf75502897de8ac2f37786897c35b4b0e3fee6#1baf75502897de8ac2f37786897c35b4b0e3fee6"
 dependencies = [
  "carina-core",
 ]
@@ -637,7 +637,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=ad91ed00f2c5b3f0345570a48835977dacfc145b#ad91ed00f2c5b3f0345570a48835977dacfc145b"
+source = "git+https://github.com/carina-rs/carina?rev=1b95cdf201f140933ae1bc881414e6891d280f99#1b95cdf201f140933ae1bc881414e6891d280f99"
 dependencies = [
  "argon2",
  "carina-provider-protocol",
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=ad91ed00f2c5b3f0345570a48835977dacfc145b#ad91ed00f2c5b3f0345570a48835977dacfc145b"
+source = "git+https://github.com/carina-rs/carina?rev=1b95cdf201f140933ae1bc881414e6891d280f99#1b95cdf201f140933ae1bc881414e6891d280f99"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -705,7 +705,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=ad91ed00f2c5b3f0345570a48835977dacfc145b#ad91ed00f2c5b3f0345570a48835977dacfc145b"
+source = "git+https://github.com/carina-rs/carina?rev=1b95cdf201f140933ae1bc881414e6891d280f99#1b95cdf201f140933ae1bc881414e6891d280f99"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -23,10 +23,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "ad91ed00f2c5b3f0345570a48835977dacfc145b" }
-carina-aws-types = { git = "https://github.com/carina-rs/carina-provider-aws", rev = "57367357e94fc91b9d3e7b1551481cf3727d6088" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "ad91ed00f2c5b3f0345570a48835977dacfc145b" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "ad91ed00f2c5b3f0345570a48835977dacfc145b" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "1b95cdf201f140933ae1bc881414e6891d280f99" }
+carina-aws-types = { git = "https://github.com/carina-rs/carina-provider-aws", rev = "1baf75502897de8ac2f37786897c35b4b0e3fee6" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "1b95cdf201f140933ae1bc881414e6891d280f99" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "1b95cdf201f140933ae1bc881414e6891d280f99" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }

--- a/carina-provider-awscc/src/lib.rs
+++ b/carina-provider-awscc/src/lib.rs
@@ -22,7 +22,7 @@ use indexmap::IndexMap;
 use carina_core::provider::{
     BoxFuture, CreateRequest, DeleteRequest, Provider, ProviderError, ProviderFactory,
     ProviderNormalizer, ProviderResult, ReadRequest, SavedAttrs, UpdateRequest,
-    merge_default_tags_for_provider,
+    merge_default_tags_for_provider, ready_noop,
 };
 use carina_core::resource::{ConcreteValue, DataSource, Resource, ResourceId, State, Value};
 use carina_core::schema::SchemaRegistry;
@@ -31,20 +31,16 @@ use crate::provider::AwsccProviderConfig;
 
 /// Schema extension for the AWSCC provider.
 ///
-/// Handles plan-time normalization of enum identifiers and hydration of
-/// unreturned attributes from saved state.
+/// Handles provider-local state normalization and hydration of unreturned
+/// attributes from saved state.
 pub struct AwsccNormalizer;
 
 impl ProviderNormalizer for AwsccNormalizer {
-    // The trait is async (carina#3112) only so the WASM host impl can
-    // `.await` the guest directly. These bodies are pure (enum
-    // resolution, state canonicalization, attr hydration, tag merge —
-    // no I/O), so wrapping the existing sync logic in a ready future is
-    // sufficient; no logic change.
-    fn normalize_desired<'a>(&'a self, resources: &'a mut [Resource]) -> BoxFuture<'a, ()> {
-        Box::pin(async move {
-            crate::provider::resolve_enum_identifiers_impl(resources);
-        })
+    // Desired-side enum canonicalization is owned by the host. Keeping
+    // provider-side enum re-derivation here can re-namespace host-canonical
+    // open-enum API values and leak DSL strings to AWS.
+    fn normalize_desired<'a>(&'a self, _resources: &'a mut [Resource]) -> BoxFuture<'a, ()> {
+        ready_noop()
     }
 
     fn normalize_state<'a>(

--- a/carina-provider-awscc/src/provider/conversion.rs
+++ b/carina-provider-awscc/src/provider/conversion.rs
@@ -11,7 +11,7 @@ use carina_core::schema::{AttributeType, ResourceSchema, Shape, ShapeWalkBudget,
 use serde_json::json;
 
 use carina_aws_types::canonicalize_enum_value;
-use carina_core::utils::{convert_enum_value, extract_enum_value_with_values};
+use carina_core::utils::canonicalize_enum_to_api;
 
 fn struct_fields_for<'a>(
     schema: &'a ResourceSchema,
@@ -257,20 +257,12 @@ pub(crate) fn dsl_value_to_aws_with_defs(
     let is_namespaced_enum = matches!(shape, Shape::Enum { identity: _, .. });
     if is_namespaced_enum {
         match value {
-            // Phase 3 of carina#2986 routes DSL-source enum values to
-            // `EnumIdentifier`; the same text payload also still arrives
-            // as `String` from state-loader / aws_value_to_dsl paths
-            // that haven't been promoted yet. Accept both — the
-            // namespace-strip / `api_for` lookup below is text-based
-            // and shape-agnostic.
+            // Listed enum `String` values can arrive from read/state JSON
+            // conversion or older saved state. Keep schema-aware
+            // canonicalization for those closed enums. Validator-only enums
+            // have no positional fallback after host canonicalization; pass
+            // strings through unchanged so schema desync stays visible.
             Value::Concrete(ConcreteValue::String(s)) => {
-                // For value-listed enums: extract the trailing segment (handling
-                // dotted values like the legacy `ipsec.1` shape that may
-                // still arrive from older state) and look up the
-                // API-canonical spelling via `DslMap::api_for`. The
-                // alias table is now exhaustive (carina-rs/carina#2980 /
-                // awscc#222) so every DSL spelling — including identity
-                // rows — round-trips through this single lookup.
                 let resolved = if let Shape::Enum {
                     values: Some(values),
                     dsl_aliases,
@@ -278,24 +270,17 @@ pub(crate) fn dsl_value_to_aws_with_defs(
                 } = shape
                 {
                     let valid: Vec<&str> = values.iter().map(String::as_str).collect();
-                    let raw_extracted = extract_enum_value_with_values(s, &valid);
-                    carina_core::schema::DslMap::new(dsl_aliases, None).api_for(raw_extracted)
+                    canonicalize_enum_to_api(
+                        s,
+                        &valid,
+                        &carina_core::schema::DslMap::new(dsl_aliases, None),
+                    )
                 } else {
-                    // Validator-only enum shorthands (e.g. Region)
-                    // use a closure-shaped DslMap; the convention there is
-                    // underscores in DSL, hyphens in the AWS API.
-                    convert_enum_value(s).replace('_', "-")
+                    s.clone()
                 };
                 Some(json!(resolved))
             }
             Value::Concrete(ConcreteValue::EnumIdentifier(s)) => {
-                // For value-listed enums: extract the trailing segment (handling
-                // dotted values like the legacy `ipsec.1` shape that may
-                // still arrive from older state) and look up the
-                // API-canonical spelling via `DslMap::api_for`. The
-                // alias table is now exhaustive (carina-rs/carina#2980 /
-                // awscc#222) so every DSL spelling — including identity
-                // rows — round-trips through this single lookup.
                 let resolved = if let Shape::Enum {
                     values: Some(values),
                     dsl_aliases,
@@ -303,13 +288,17 @@ pub(crate) fn dsl_value_to_aws_with_defs(
                 } = shape
                 {
                     let valid: Vec<&str> = values.iter().map(String::as_str).collect();
-                    let raw_extracted = extract_enum_value_with_values(s.as_str(), &valid);
-                    carina_core::schema::DslMap::new(dsl_aliases, None).api_for(raw_extracted)
+                    canonicalize_enum_to_api(
+                        s.as_str(),
+                        &valid,
+                        &carina_core::schema::DslMap::new(dsl_aliases, None),
+                    )
                 } else {
-                    // Validator-only enum shorthands (e.g. Region)
-                    // use a closure-shaped DslMap; the convention there is
-                    // underscores in DSL, hyphens in the AWS API.
-                    convert_enum_value(s.as_str()).replace('_', "-")
+                    // Raw EnumIdentifier at a validator-only enum position
+                    // means the host did not canonicalize it; pass it through
+                    // so AWS-side rejection is visible instead of silently
+                    // mis-splitting.
+                    s.as_str().to_string()
                 };
                 Some(json!(resolved))
             }
@@ -804,39 +793,7 @@ mod tests {
         let config = crate::schemas::generated::ec2::vpc_endpoint::ec2_vpc_endpoint_config();
         let attr_schema = config.schema.attributes.get("vpc_endpoint_type").unwrap();
 
-        // 1. DSL side: resolve_enum_identifiers_impl converts bare `Gateway` ident
-        let mut resource = carina_core::resource::Resource::with_provider(
-            "awscc",
-            "ec2.VpcEndpoint",
-            "test",
-            None,
-        );
-        resource.set_attr(
-            "vpc_id".to_string(),
-            Value::Concrete(ConcreteValue::String("vpc-123".to_string())),
-        );
-        resource.set_attr(
-            "vpc_endpoint_type".to_string(),
-            Value::Concrete(ConcreteValue::String("Gateway".to_string())),
-        );
-
-        let mut resources = vec![resource];
-        crate::provider::resolve_enum_identifiers_impl(&mut resources);
-
-        let dsl_resolved = resources[0].attributes["vpc_endpoint_type"].clone();
-        // Per naming-conventions design D7 / issue #199, the DSL spelling is
-        // snake_case; the bare ident `Gateway` is accepted (transition
-        // convenience) but resolves to the snake_case namespaced form, since
-        // `resolve_enum_identifiers_impl` runs `to_dsl` on the input.
-        assert_eq!(
-            dsl_resolved,
-            Value::Concrete(ConcreteValue::String(
-                "aws.ec2.VpcEndpoint.VpcEndpointType.gateway".to_string()
-            )),
-            "DSL bare ident `Gateway` should resolve to snake_case namespaced form"
-        );
-
-        // 2. AWS read-back side.
+        // AWS read-back side.
         let aws_json = serde_json::json!("Gateway");
         let aws_dsl = aws_value_to_dsl_with_defs(
             "vpc_endpoint_type",
@@ -853,7 +810,7 @@ mod tests {
             "AWS read-back must persist the API-canonical value"
         );
 
-        // 3. No false diff: reconciliation now happens in carina-core
+        // No false diff: reconciliation happens in carina-core
         // (state-lift + differ), not by the provider emitting identical
         // strings on both sides. Assert the awscc-owned half — the
         // persisted API value lifts to the canonical fully-qualified identifier.
@@ -892,7 +849,7 @@ mod tests {
     }
 
     #[test]
-    fn test_dsl_value_to_aws_converts_underscores_for_region() {
+    fn test_dsl_value_to_aws_passes_through_validator_only_string() {
         let attr_type = AttributeType::enum_(
             carina_aws_types::provider_bare_type(&[], "Region"),
             None,
@@ -911,7 +868,29 @@ mod tests {
             &std::collections::BTreeMap::new(),
         );
 
-        assert_eq!(result, Some(json!("ap-northeast-1")));
+        assert_eq!(result, Some(json!("aws.Region.ap_northeast_1")));
+    }
+
+    #[test]
+    fn test_dsl_value_to_aws_raw_enum_identifier_passes_through_verbatim() {
+        let attr_type = AttributeType::enum_(
+            carina_aws_types::provider_bare_type(&[], "Region"),
+            None,
+            vec![],
+            Some(legacy_validator(|_| Ok(()))),
+            None,
+        );
+        let raw = "aws.Region.ap_northeast_1";
+        let value = Value::Concrete(ConcreteValue::enum_identifier(raw));
+        let result = dsl_value_to_aws_with_defs(
+            &value,
+            &attr_type,
+            "logs.LogGroup",
+            "region",
+            &std::collections::BTreeMap::new(),
+        );
+
+        assert_eq!(result, Some(json!(raw)));
     }
 
     #[test]
@@ -1298,9 +1277,9 @@ mod tests {
     /// the **same `EnumIdentifier` shape** (namespaced for `version`, bare
     /// alias for `effect`) to prove awscc has no parallel gap:
     /// `dsl_value_to_aws` accepts both `String | EnumIdentifier` at the
-    /// StringEnum branch and resolves via `DslMap::api_for`, so the Cloud
-    /// Control `desired_state` payload still gets the AWS wire form
-    /// (`"2012-10-17"`, `"Allow"`).
+    /// StringEnum branch and resolves via `canonicalize_enum_to_api`, so
+    /// the Cloud Control `desired_state` payload still gets the AWS wire
+    /// form (`"2012-10-17"`, `"Allow"`).
     #[test]
     fn test_dsl_value_to_aws_iam_policy_document_canonicalizes_namespaced_and_alias_enums() {
         use carina_aws_types::iam_policy_document;

--- a/carina-provider-awscc/src/provider/mod.rs
+++ b/carina-provider-awscc/src/provider/mod.rs
@@ -7,7 +7,7 @@
 //!
 //! - `cloudcontrol` - Low-level Cloud Control API methods and retry/error handling
 //! - `conversion` - Value conversion between DSL and AWS JSON formats
-//! - `normalizer` - Plan-time enum resolution and state hydration
+//! - `normalizer` - State normalization and hydration
 //! - `operations` - High-level resource operations (read, create, update, delete)
 //! - `s3` - S3-specific operations (empty bucket for force_delete)
 //! - `special_cases` - Resource-type-specific attribute handling
@@ -37,7 +37,7 @@ use crate::schemas::config::AwsccSchemaConfig;
 // Re-export public API
 pub use normalizer::{
     canonicalize_string_or_list_states_impl, normalize_state_enums_impl,
-    resolve_enum_identifiers_impl, restore_unreturned_attrs_impl,
+    restore_unreturned_attrs_impl,
 };
 pub(crate) use update::parse_resource_properties;
 

--- a/carina-provider-awscc/src/provider/normalizer.rs
+++ b/carina-provider-awscc/src/provider/normalizer.rs
@@ -1,67 +1,15 @@
-//! Plan-time normalization of enum identifiers and state hydration.
+//! State normalization and state hydration.
 //!
-//! This module contains standalone functions used by `ProviderNormalizer` to resolve
-//! enum identifiers in resources and restore unreturned attributes from saved state.
+//! This module contains standalone functions used by `ProviderNormalizer` to normalize
+//! read state and restore unreturned attributes from saved state.
 
 use indexmap::IndexMap;
 use std::collections::HashMap;
 
-use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
+use carina_core::resource::{ConcreteValue, ResourceId, State, Value};
 use carina_core::schema::{
     AttributeType, RawShape, ResourceSchema, Shape, ShapeWalkBudget, StructField,
 };
-
-/// Resolve enum identifiers in resources to their fully-qualified DSL format.
-///
-/// For each awscc resource, looks up the schema and resolves bare identifiers
-/// (e.g., `advanced`) or TypeName.value identifiers (e.g., `Tier.advanced`)
-/// into fully-qualified namespaced strings (e.g., `awscc.ec2.Ipam.Tier.advanced`).
-pub fn resolve_enum_identifiers_impl(resources: &mut [Resource]) {
-    for resource in resources.iter_mut() {
-        // Only handle awscc resources
-        if resource.id.provider != "awscc" {
-            continue;
-        }
-
-        // Find the matching schema config via cached O(1) lookup
-        let config = match crate::schemas::generated::get_config_by_type(&resource.id.resource_type)
-        {
-            Some(c) => c,
-            None => continue,
-        };
-
-        // Resolve enum attributes
-        let mut resolved_attrs = HashMap::new();
-        for (key, value) in &resource.attributes {
-            if let Some(attr_schema) = config.schema.attributes.get(key.as_str())
-                && let Some(parts) = attr_schema.attr_type.enum_parts()
-            {
-                if let Some(resolved) = carina_core::utils::resolve_enum_value(value, &parts) {
-                    resolved_attrs.insert(key.clone(), resolved);
-                } else {
-                    resolved_attrs.insert(key.clone(), value.clone());
-                }
-                continue;
-            }
-
-            // Handle struct fields containing schema-level string enums.
-            if let Some(attr_schema) = config.schema.attributes.get(key.as_str()) {
-                let struct_fields = struct_fields_for(&attr_schema.attr_type, &config.schema);
-
-                if let Some(fields) = struct_fields {
-                    let resolved = resolve_struct_enum_values(value, fields, &config.schema);
-                    resolved_attrs.insert(key.clone(), resolved);
-                    continue;
-                }
-            }
-
-            resolved_attrs.insert(key.clone(), value.clone());
-        }
-        for (key, value) in resolved_attrs {
-            resource.set_attr(key, value);
-        }
-    }
-}
 
 /// Extract the struct-field slice an attribute type advertises, looking
 /// through a single `List` wrapper. Returns `None` for any other shape.
@@ -161,10 +109,9 @@ fn resolve_struct_enum_values(
 /// Normalize enum values in current states to their fully-qualified DSL format.
 ///
 /// State files store raw AWS values (e.g., `"ap-northeast-1a"`, `"default"`).
-/// After `normalize_desired()` converts desired values to DSL enum format
-/// (e.g., `"awscc.ec2.Subnet.AvailabilityZone.ap_northeast_1a"`), the differ
-/// would see a false diff. This function normalizes state values the same way
-/// so that both sides use the same representation.
+/// The host owns desired/state enum canonicalization for schema-known enum
+/// positions, but this provider still applies awscc-specific read/state
+/// transforms and legacy state normalization here.
 pub fn normalize_state_enums_impl(current_states: &mut HashMap<ResourceId, State>) {
     for (resource_id, state) in current_states.iter_mut() {
         if !state.exists || resource_id.provider != "awscc" {
@@ -312,176 +259,34 @@ pub fn restore_unreturned_attrs_impl(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use carina_core::provider::ProviderNormalizer;
+    use carina_core::resource::Resource;
     use carina_core::schema::legacy_validator;
 
     fn test_resource_schema() -> ResourceSchema {
         ResourceSchema::new("test.Resource")
     }
 
-    #[test]
-    fn test_resolve_enum_identifiers_bare_ident() {
-        let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "test", None);
+    #[tokio::test]
+    async fn normalize_desired_preserves_host_canonical_enum_strings() {
+        let mut resource = Resource::with_provider("awscc", "ec2.Subnet", "test", None);
         resource.set_attr(
-            "instance_tenancy".to_string(),
-            Value::Concrete(ConcreteValue::String("dedicated".to_string())),
+            "availability_zone".to_string(),
+            Value::Concrete(ConcreteValue::String("ap-northeast-1a".to_string())),
         );
-
         let mut resources = vec![resource];
-        resolve_enum_identifiers_impl(&mut resources);
-        match resources[0].get_attr("instance_tenancy").unwrap() {
-            Value::Concrete(ConcreteValue::String(s)) => assert!(
-                s.contains("InstanceTenancy") && s.contains("dedicated"),
-                "Expected namespaced enum, got: {}",
-                s
-            ),
-            other => panic!("Expected String, got: {:?}", other),
-        }
-    }
 
-    #[test]
-    fn test_resolve_enum_identifiers_typename_value() {
-        let mut resource = Resource::with_provider("awscc", "ec2.Vpc", "test", None);
-        resource.set_attr(
-            "instance_tenancy".to_string(),
-            Value::Concrete(ConcreteValue::String(
-                "InstanceTenancy.dedicated".to_string(),
-            )),
-        );
+        crate::AwsccNormalizer
+            .normalize_desired(&mut resources)
+            .await;
 
-        let mut resources = vec![resource];
-        resolve_enum_identifiers_impl(&mut resources);
-        match resources[0].get_attr("instance_tenancy").unwrap() {
-            Value::Concrete(ConcreteValue::String(s)) => assert!(
-                s.contains("InstanceTenancy") && s.contains("dedicated"),
-                "Expected namespaced enum, got: {}",
-                s
-            ),
-            other => panic!("Expected String, got: {:?}", other),
-        }
-    }
-
-    #[test]
-    fn test_resolve_enum_identifiers_skips_non_awscc() {
-        let mut resource = Resource::with_provider("aws", "s3.Bucket", "test", None);
-        resource.set_attr(
-            "instance_tenancy".to_string(),
-            Value::Concrete(ConcreteValue::String("dedicated".to_string())),
-        );
-
-        let mut resources = vec![resource];
-        resolve_enum_identifiers_impl(&mut resources);
-        assert!(matches!(
-            resources[0].get_attr("instance_tenancy").unwrap(),
-            Value::Concrete(ConcreteValue::String(_))
-        ));
-    }
-
-    /// aws#313 bare-`effect` path: the issue notes `effect` is
-    /// typically written bare (`effect = allow`) — the parser emits
-    /// `ConcreteValue::EnumIdentifier("allow")`, which exercises
-    /// `resolve_enum_value` Case 1 (no dots), a different branch than
-    /// the already-fully-qualified `version` path. The desired side
-    /// must resolve to the same fully-qualified DSL form that the
-    /// AWS-read side produces from raw `"Allow"`
-    /// (`aws.iam.PolicyDocument.Statement.Effect.allow`), or the differ diverges.
-    #[test]
-    fn test_aws313_bare_effect_desired_resolves_to_namespaced() {
-        use indexmap::IndexMap;
-
-        let mut stmt = IndexMap::new();
-        stmt.insert(
-            "effect".to_string(),
-            Value::Concrete(ConcreteValue::enum_identifier("allow")),
-        );
-        stmt.insert(
-            "action".to_string(),
-            Value::Concrete(ConcreteValue::String("sts:AssumeRole".to_string())),
-        );
-        let mut policy = IndexMap::new();
-        policy.insert(
-            "version".to_string(),
-            Value::Concrete(ConcreteValue::String(
-                "aws.iam.PolicyDocument.Version.2012_10_17".to_string(),
-            )),
-        );
-        policy.insert(
-            "statement".to_string(),
-            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
-                ConcreteValue::Map(stmt),
-            )])),
-        );
-        let mut resource = Resource::with_provider("awscc", "iam.Role", "rd-role", None);
-        resource.set_attr(
-            "assume_role_policy_document".to_string(),
-            Value::Concrete(ConcreteValue::Map(policy)),
-        );
-
-        let mut resources = vec![resource];
-        resolve_enum_identifiers_impl(&mut resources);
-
-        let Some(Value::Concrete(ConcreteValue::Map(doc))) =
-            resources[0].get_attr("assume_role_policy_document")
-        else {
-            panic!("expected assume_role_policy_document Map");
-        };
-        let Some(Value::Concrete(ConcreteValue::List(stmts))) = doc.get("statement") else {
-            panic!("expected statement List");
-        };
-        let Some(Value::Concrete(ConcreteValue::Map(s0))) = stmts.first() else {
-            panic!("expected statement[0] Map");
-        };
         assert_eq!(
-            s0.get("effect"),
+            resources[0].get_attr("availability_zone"),
             Some(&Value::Concrete(ConcreteValue::String(
-                "aws.iam.PolicyDocument.Statement.Effect.allow".to_string()
+                "ap-northeast-1a".to_string()
             ))),
-            "bare `effect = allow` desired must resolve to the same \
-             fully-qualified form the read side produces from \"Allow\""
+            "host-canonical open-enum API values must not be re-namespaced"
         );
-    }
-
-    #[test]
-    fn test_resolve_enum_identifiers_hyphen_to_underscore() {
-        let mut resource = Resource::with_provider("awscc", "ec2.FlowLog", "test", None);
-        resource.set_attr(
-            "log_destination_type".to_string(),
-            Value::Concrete(ConcreteValue::String("cloud_watch_logs".to_string())),
-        );
-
-        let mut resources = vec![resource];
-        resolve_enum_identifiers_impl(&mut resources);
-        match resources[0].get_attr("log_destination_type").unwrap() {
-            Value::Concrete(ConcreteValue::String(s)) => {
-                assert_eq!(
-                    s, "aws.ec2.FlowLog.LogDestinationType.cloud_watch_logs",
-                    "Expected underscored namespaced enum, got: {}",
-                    s
-                );
-            }
-            other => panic!("Expected String, got: {:?}", other),
-        }
-    }
-
-    #[test]
-    fn test_resolve_enum_identifiers_hyphen_string_to_underscore() {
-        let mut resource = Resource::with_provider("awscc", "ec2.FlowLog", "test", None);
-        resource.set_attr(
-            "log_destination_type".to_string(),
-            Value::Concrete(ConcreteValue::String("cloud-watch-logs".to_string())),
-        );
-
-        let mut resources = vec![resource];
-        resolve_enum_identifiers_impl(&mut resources);
-        match resources[0].get_attr("log_destination_type").unwrap() {
-            Value::Concrete(ConcreteValue::String(s)) => {
-                assert_eq!(
-                    s, "aws.ec2.FlowLog.LogDestinationType.cloud_watch_logs",
-                    "Hyphenated string should be converted to underscore form, got: {}",
-                    s
-                );
-            }
-            other => panic!("Expected String, got: {:?}", other),
-        }
     }
 
     #[test]
@@ -636,52 +441,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_resolve_enum_identifiers_ip_protocol_all_alias() {
-        let mut resource =
-            Resource::with_provider("awscc", "ec2.SecurityGroupEgress", "test", None);
-        resource.set_attr(
-            "ip_protocol".to_string(),
-            Value::Concrete(ConcreteValue::String("all".to_string())),
-        );
-
-        let mut resources = vec![resource];
-        resolve_enum_identifiers_impl(&mut resources);
-        match resources[0].get_attr("ip_protocol").unwrap() {
-            Value::Concrete(ConcreteValue::String(s)) => {
-                assert_eq!(
-                    s, "aws.ec2.SecurityGroupEgress.IpProtocol.all",
-                    "Expected namespaced IpProtocol.all, got: {}",
-                    s
-                );
-            }
-            other => panic!("Expected String, got: {:?}", other),
-        }
-    }
-
-    #[test]
-    fn test_resolve_enum_identifiers_ip_protocol_tcp() {
-        let mut resource =
-            Resource::with_provider("awscc", "ec2.SecurityGroupEgress", "test", None);
-        resource.set_attr(
-            "ip_protocol".to_string(),
-            Value::Concrete(ConcreteValue::String("tcp".to_string())),
-        );
-
-        let mut resources = vec![resource];
-        resolve_enum_identifiers_impl(&mut resources);
-        match resources[0].get_attr("ip_protocol").unwrap() {
-            Value::Concrete(ConcreteValue::String(s)) => {
-                assert_eq!(
-                    s, "aws.ec2.SecurityGroupEgress.IpProtocol.tcp",
-                    "Expected namespaced IpProtocol.tcp, got: {}",
-                    s
-                );
-            }
-            other => panic!("Expected String, got: {:?}", other),
-        }
-    }
-
     /// Helper to create struct fields with an enum type for testing
     fn test_ip_protocol_fields() -> Vec<StructField> {
         vec![
@@ -802,58 +561,6 @@ mod tests {
             }
         } else {
             panic!("Expected List");
-        }
-    }
-
-    #[test]
-    fn test_resolve_enum_identifiers_impl_struct_field() {
-        let mut resource = Resource::with_provider("awscc", "ec2.SecurityGroup", "test-sg", None);
-        resource.set_attr(
-            "group_description".to_string(),
-            Value::Concrete(ConcreteValue::String("test".to_string())),
-        );
-        let mut egress_map = IndexMap::new();
-        egress_map.insert(
-            "ip_protocol".to_string(),
-            Value::Concrete(ConcreteValue::String("all".to_string())),
-        );
-        egress_map.insert(
-            "cidr_ip".to_string(),
-            Value::Concrete(ConcreteValue::String("0.0.0.0/0".to_string())),
-        );
-        resource.set_attr(
-            "security_group_egress".to_string(),
-            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
-                ConcreteValue::Map(egress_map),
-            )])),
-        );
-
-        let mut resources = vec![resource];
-        resolve_enum_identifiers_impl(&mut resources);
-
-        if let Value::Concrete(ConcreteValue::List(items)) =
-            resources[0].get_attr("security_group_egress").unwrap()
-        {
-            if let Value::Concrete(ConcreteValue::Map(m)) = &items[0] {
-                match &m["ip_protocol"] {
-                    Value::Concrete(ConcreteValue::String(s)) => {
-                        assert_eq!(
-                            s, "aws.ec2.SecurityGroup.Egress.IpProtocol.all",
-                            "Expected namespaced Egress.IpProtocol.all in struct field, got: {}",
-                            s
-                        );
-                    }
-                    other => panic!("Expected String for ip_protocol, got: {:?}", other),
-                }
-                match &m["cidr_ip"] {
-                    Value::Concrete(ConcreteValue::String(s)) => assert_eq!(s, "0.0.0.0/0"),
-                    other => panic!("Expected String for cidr_ip, got: {:?}", other),
-                }
-            } else {
-                panic!("Expected Map in egress list");
-            }
-        } else {
-            panic!("Expected List for security_group_egress");
         }
     }
 
@@ -1297,8 +1004,6 @@ mod tests {
         // A WebACL rule carrying `captcha_config`, a `Ref("CaptchaConfig")`
         // field of the generated `Rule` struct (awscc#286). The recursion
         // must peel this `Ref` against the WebACL's `defs` map.
-        let mut resource = Resource::with_provider("awscc", "wafv2.WebAcl", "test-acl", None);
-
         let mut immunity = IndexMap::new();
         immunity.insert(
             "immunity_time".to_string(),
@@ -1320,20 +1025,17 @@ mod tests {
             Value::Concrete(ConcreteValue::Map(captcha_config)),
         );
 
-        resource.set_attr(
-            "rules".to_string(),
-            Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
-                ConcreteValue::Map(rule),
-            )])),
-        );
-
-        let mut resources = vec![resource];
+        let value = Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+            ConcreteValue::Map(rule),
+        )]));
+        let config = crate::schemas::generated::wafv2::web_acl::wafv2_web_acl_config();
+        let attr_schema = config.schema.attributes.get("rules").unwrap();
+        let fields = struct_fields_for(&attr_schema.attr_type, &config.schema).unwrap();
         // Before the fix this panics: the recursion peels the
         // `Ref("CaptchaConfig")` field against an empty definition map.
-        resolve_enum_identifiers_impl(&mut resources);
+        let resolved = resolve_struct_enum_values(&value, fields, &config.schema);
 
-        let Value::Concrete(ConcreteValue::List(rules)) = resources[0].get_attr("rules").unwrap()
-        else {
+        let Value::Concrete(ConcreteValue::List(rules)) = &resolved else {
             panic!("expected rules list");
         };
         let Value::Concrete(ConcreteValue::Map(rule)) = &rules[0] else {


### PR DESCRIPTION
## Summary

Final PR of the carina-provider-aws#423 chain (design carina-rs/carina#3436 → core carina-rs/carina#3451 → provider-aws carina-rs/carina-provider-aws#425). Bumps both pins and removes awscc's dependence on the deleted schema-free extraction API — including the same desired-side enum re-derivation defect class that PR #425 uncovered in provider-aws.

## Pins

- carina: `ad91ed00` → `1b95cdf2` (`check-carina-pin.sh` green, ancestry verified)
- carina-aws-types: → provider-aws `1baf7550` (PR #425 merge commit)

## Changes

- **`normalize_desired` is now a no-op.** `resolve_enum_identifiers_impl` re-derived enum spellings over host-canonical desired values (re-namespacing bare canonical open-enum values into DSL form) — the same class that sent `aws.AvailabilityZone.ZoneName.ap_northeast_1a` to EC2 in the provider-aws sweep. Post-carina#3438 the host owns desired/state canonicalization; the provider pass was at best a wasteful round-trip and at worst destructive. Read/state-side normalization is untouched — that seam is owned by carina#3409 (follow-up filed: #343).
- **`conversion.rs` enum arms**: values-listed enums use the still-pub schema-aware `canonicalize_enum_to_api` (replacing the now-`pub(crate)` `extract_enum_value_with_values` composition); validator-only enums (`values: None`) pass through unchanged — the deleted positional fallback (`convert_enum_value` + `_`→`-`) is not re-implemented, because an un-canonicalized value reaching the CloudControl JSON is a schema desync and the AWS-side rejection is the visible failure surface. `CanonicalEnum` arm unchanged.
- Tests: no-mutation regression for `normalize_desired` (host-canonical open-enum value survives), validator-only pass-through for both String and EnumIdentifier shapes, IAM policy document EnumIdentifier canonicalization e2e restored.

## Verify

- `cargo check --workspace --all-targets` / `cargo nextest run` (445/445) / clippy `-D warnings` / `cargo fmt --check` ✓
- `scripts/check-carina-pin.sh` / `scripts/check-docs-drift.sh` ✓
- **Real AWS acceptance: full suite 54/54.**

Review: adversarial finder pass (traced the validator-only desired path safe via the host resolver; flagged the state-side sibling → #343), 2 Codex rounds (round 2 fixed an over-broad EnumIdentifier verbatim arm that the existing object-ownership round-trip test caught).

Refs carina-rs/carina-provider-aws#423

🤖 Generated with [Claude Code](https://claude.com/claude-code)
