### PR TITLE
Remove misdiagnosed FORCE_REPLACE_TYPES; InternetGateway/IPAM update in place

### DIFF
--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -2897,13 +2897,6 @@ pub fn {}() -> AwsccSchemaConfig {{
         }
     }
 
-    // Resource types where CloudControl API rejects updates despite the schema
-    // having an update handler. These must be replaced instead of updated.
-    const FORCE_REPLACE_TYPES: &[&str] = &["AWS::EC2::InternetGateway", "AWS::EC2::IPAM"];
-    if FORCE_REPLACE_TYPES.contains(&type_name) {
-        body.push_str("        .force_replace()\n");
-    }
-
     // Per-resource operational config for resources with slow CloudControl operations.
     let op_config = operation_config_for_type(type_name);
     if let Some(cfg) = op_config {

--- a/carina-provider-awscc/src/provider/operations.rs
+++ b/carina-provider-awscc/src/provider/operations.rs
@@ -181,15 +181,6 @@ impl AwsccProvider {
                 .for_resource(id.clone())
         })?;
 
-        // Reject updates for resource types marked as force_replace in the schema
-        if config.schema.force_replace {
-            return Err(ProviderError::invalid_input(format!(
-                "Update not supported for {}, delete and recreate",
-                id.resource_type
-            ))
-            .for_resource(id));
-        }
-
         let patch_ops = build_update_patches(config, &id.resource_type, patch);
 
         self.cc_update_resource(config.aws_type_name, identifier, patch_ops)

--- a/carina-provider-awscc/src/schemas/generated/ec2/internet_gateway.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/internet_gateway.rs
@@ -27,7 +27,6 @@ pub fn ec2_internet_gateway_config() -> AwsccSchemaConfig {
                 .with_provider_name("Tags")
                 .with_block_name("tag"),
         )
-        .force_replace()
         .with_validator(|attrs| {
             let mut errors = Vec::new();
             if let Err(mut e) = carina_aws_types::validate_tags_map(attrs) {

--- a/carina-provider-awscc/src/schemas/generated/ec2/ipam.rs
+++ b/carina-provider-awscc/src/schemas/generated/ec2/ipam.rs
@@ -152,7 +152,6 @@ pub fn ec2_ipam_config() -> AwsccSchemaConfig {
                 .with_description("The tier of the IPAM.")
                 .with_provider_name("Tier"),
         )
-        .force_replace()
         .with_operation_config(OperationConfig {
             delete_timeout_secs: Some(1800),
             delete_max_retries: None,

--- a/carina-provider-awscc/src/schemas/mod.rs
+++ b/carina-provider-awscc/src/schemas/mod.rs
@@ -16,9 +16,83 @@ pub fn all_schemas() -> Vec<ResourceSchema> {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{BTreeMap, BTreeSet};
+    use std::collections::{BTreeMap, BTreeSet, HashMap};
 
+    use carina_core::differ::create_plan;
+    use carina_core::effect::Effect;
+    use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
     use carina_core::schema::{AttributeType, RawShape, ResourceSchema, Shape, ShapeWalkBudget};
+    use carina_core::schema::{SchemaKind, SchemaRegistry};
+    use indexmap::IndexMap;
+
+    #[test]
+    fn internet_gateway_tag_change_plans_update() {
+        assert_tag_change_plans_update(
+            super::generated::ec2::internet_gateway::ec2_internet_gateway_config().schema,
+        );
+    }
+
+    #[test]
+    fn ipam_tag_change_plans_update() {
+        assert_tag_change_plans_update(super::generated::ec2::ipam::ec2_ipam_config().schema);
+    }
+
+    fn assert_tag_change_plans_update(schema: ResourceSchema) {
+        let resource_type = schema.resource_type.clone();
+        let resource_id = ResourceId::with_provider("awscc", resource_type.clone(), "test", None);
+        let resources = vec![
+            Resource::with_provider("awscc", resource_type, "test", None)
+                .with_attribute("tags", tags_value("new-name")),
+        ];
+
+        let mut current_states = HashMap::new();
+        current_states.insert(
+            resource_id.clone(),
+            State::existing(
+                resource_id.clone(),
+                HashMap::from([("tags".to_string(), tags_value("old-name"))]),
+            ),
+        );
+
+        let mut schemas = SchemaRegistry::new();
+        schemas.insert("awscc", schema);
+        assert!(
+            schemas
+                .get(
+                    &resource_id.provider,
+                    &resource_id.resource_type,
+                    SchemaKind::Resource,
+                )
+                .is_some(),
+            "schema must be resolvable under the key the differ uses"
+        );
+
+        let plan = create_plan(
+            &resources,
+            &[],
+            &current_states,
+            &HashMap::new(),
+            &schemas,
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &[],
+        );
+
+        assert_eq!(plan.effects().len(), 1);
+        assert!(
+            matches!(plan.effects()[0], Effect::Update { .. }),
+            "expected tag-only change to plan Update, got {:?}",
+            plan.effects()[0]
+        );
+    }
+
+    fn tags_value(name: &str) -> Value {
+        Value::Concrete(ConcreteValue::Map(IndexMap::from([(
+            "Name".to_string(),
+            Value::Concrete(ConcreteValue::String(name.to_string())),
+        )])))
+    }
 
     #[test]
     fn generated_s3_lifecycle_rule_omits_deprecated_transition_fields() {


### PR DESCRIPTION
Closes #346

## Problem

Changing only the `Name` tag on `awscc.ec2.InternetGateway` planned `must be replaced (create before destroy)` — with no `(forces replacement)` attribute line — while sibling EC2 resources receiving the same tag edit planned an in-place `~` update. Replacing an IGW detaches/attaches `VpcGatewayAttachment` and rewrites the default route, i.e. a public-egress interruption window for a tag rename.

## Root cause

Codegen's hand-curated list emitted a resource-level `.force_replace()` into two generated schemas:

```rust
const FORCE_REPLACE_TYPES: &[&str] = &["AWS::EC2::InternetGateway", "AWS::EC2::IPAM"];
```

The carina-core differ turns any attribute change on a `force_replace` schema into `Effect::Replace`, with `changed_create_only` empty — which is also why no attribute carried `(forces replacement)` in the plan output.

The list was built on a misdiagnosis. The error quoted in carina#595 — `Update not supported for ec2.internet_gateway, delete and recreate` — did not come from the CloudControl API. It was the provider's own hardcoded VPC-only update check at the time (`if id.resource_type != "ec2.vpc" { return Err(...) }`); carina#601 then propagated the "schemas cannot be trusted" framing from that same self-inflicted error.

Verified on live AWS (ap-northeast-1) that CloudControl `UpdateResource` succeeds for tag changes on both types, consistent with both CFN schemas having `update` handlers and no `createOnlyProperties`:

| Type | Operation | Result |
|---|---|---|
| `AWS::EC2::InternetGateway` | create → update tag → delete | UPDATE `OperationStatus: SUCCESS` |
| `AWS::EC2::IPAM` (free tier) | create → update tag → delete | UPDATE `OperationStatus: SUCCESS` |

## Fix

- Remove `FORCE_REPLACE_TYPES` and the `.force_replace()` emission from codegen.
- Regenerate `ec2/internet_gateway.rs` and `ec2/ipam.rs` from the committed schema cache (diff is exactly the two `.force_replace()` lines; regen verified idempotent).
- Remove the now-unreachable update rejection guard in `update_resource` (no schema in this repo sets `force_replace` anymore).
- Add differ regression tests driving the real generated schemas through carina-core's `create_plan`: a tag-only change must plan `Effect::Update`. Observed failing (`Replace`) before the fix; mutation-checked (re-adding `.force_replace()` makes them fail again). The tests register the schema under the real `awscc` provider key and assert the registry lookup resolves with the same key shape the differ uses, so a future keying change cannot turn them into a vacuous pass (registry miss silently defaults to Update).

The update apply path for these resources is the same tags-projection path (`build_update_patches` → `/Tags` patch) already exercised by `ec2.Vpc` tag updates.

## Follow-up (carina repo)

After this PR nothing in the ecosystem sets `force_replace`; the mechanism itself (schema field, differ branch, protocol field, plugin-host/provider mappings) is dead code and its removal — which also makes an unexplained `must be replaced` (issue expected-2) structurally unrepresentable, since every `Replace` then stems from non-empty `changed_create_only` — is filed as a follow-up in the carina repo.

## Verification

- `cargo test` / `cargo test --all-features`: 446 passed, 0 failed
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean
- `cargo fmt --check`: clean
- `./scripts/check-docs-drift.sh`: OK (44 resources in sync)
- `./scripts/check-carina-pin.sh`: OK (pin ancestry verified)
- `generate-schemas.sh --from-cache-only` + `generate-docs.sh --from-cache-only`: idempotent, no drift
- `cargo build -p carina-provider-awscc --target wasm32-wasip2 --release`: OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)