### PR TITLE
Bump carina and carina-aws-types pins; drop force_replace mappings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,7 +629,7 @@ dependencies = [
 [[package]]
 name = "carina-aws-types"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina-provider-aws?rev=57a7958bfc1acfab447cbc7b18e43af4c55c38a1#57a7958bfc1acfab447cbc7b18e43af4c55c38a1"
+source = "git+https://github.com/carina-rs/carina-provider-aws?rev=df61a0a65b64ccfefd8de85a185a774a76da5995#df61a0a65b64ccfefd8de85a185a774a76da5995"
 dependencies = [
  "carina-core",
 ]
@@ -637,7 +637,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=1b95cdf201f140933ae1bc881414e6891d280f99#1b95cdf201f140933ae1bc881414e6891d280f99"
+source = "git+https://github.com/carina-rs/carina?rev=0a70d5bfd213d50e1bc5bca22c964f420e51c401#0a70d5bfd213d50e1bc5bca22c964f420e51c401"
 dependencies = [
  "argon2",
  "carina-provider-protocol",
@@ -657,7 +657,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=1b95cdf201f140933ae1bc881414e6891d280f99#1b95cdf201f140933ae1bc881414e6891d280f99"
+source = "git+https://github.com/carina-rs/carina?rev=0a70d5bfd213d50e1bc5bca22c964f420e51c401#0a70d5bfd213d50e1bc5bca22c964f420e51c401"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -705,7 +705,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=1b95cdf201f140933ae1bc881414e6891d280f99#1b95cdf201f140933ae1bc881414e6891d280f99"
+source = "git+https://github.com/carina-rs/carina?rev=0a70d5bfd213d50e1bc5bca22c964f420e51c401#0a70d5bfd213d50e1bc5bca22c964f420e51c401"
 dependencies = [
  "serde",
  "serde_json",
@@ -923,7 +923,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -23,10 +23,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "1b95cdf201f140933ae1bc881414e6891d280f99" }
-carina-aws-types = { git = "https://github.com/carina-rs/carina-provider-aws", rev = "57a7958bfc1acfab447cbc7b18e43af4c55c38a1" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "1b95cdf201f140933ae1bc881414e6891d280f99" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "1b95cdf201f140933ae1bc881414e6891d280f99" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "0a70d5bfd213d50e1bc5bca22c964f420e51c401" }
+carina-aws-types = { git = "https://github.com/carina-rs/carina-provider-aws", rev = "df61a0a65b64ccfefd8de85a185a774a76da5995" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "0a70d5bfd213d50e1bc5bca22c964f420e51c401" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "0a70d5bfd213d50e1bc5bca22c964f420e51c401" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }

--- a/carina-provider-awscc/src/convert.rs
+++ b/carina-provider-awscc/src/convert.rs
@@ -430,7 +430,6 @@ pub fn proto_to_core_schema(s: &ProtoResourceSchema) -> CoreResourceSchema {
         validator: None,
         kind,
         name_attribute: s.name_attribute.clone(),
-        force_replace: s.force_replace,
         operation_config: s.operation_config.as_ref().map(|c| {
             carina_core::schema::OperationConfig {
                 delete_timeout_secs: c.delete_timeout_secs,
@@ -590,7 +589,6 @@ pub fn core_to_proto_schema(s: &CoreResourceSchema) -> ProtoResourceSchema {
         description: s.description.clone(),
         kind,
         name_attribute: s.name_attribute.clone(),
-        force_replace: s.force_replace,
         operation_config: s.operation_config.as_ref().map(|c| {
             carina_provider_protocol::OperationConfig {
                 delete_timeout_secs: c.delete_timeout_secs,


### PR DESCRIPTION
Bumps the carina git-dependency pin from `1b95cdf2` to `0a70d5bf` (carina#3452–#3474) and the `carina-aws-types` pin (from carina-provider-aws) from `57a7958b` to `df61a0a6` (carina-provider-aws#432, which itself ships the matching carina bump), then removes the now-invalid `force_replace: s.force_replace,` mappings in `convert.rs` — the field was deleted from `carina_provider_protocol::ResourceSchema` by carina#3473.

Both pins must move together: carina-aws-types pulls carina-core through carina-provider-aws, so a single-sided bump leaves two versions of carina-core in the dependency graph (TypeIdentity values are then incompatible across providers, observable as `expected TypeIdentity, found a different TypeIdentity`).

This provider never set force_replace; behavior is unchanged. Awscc#347 already removed the only setters in the generated schemas.

## Verification

- `cargo test`: all pass
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo fmt --check`: clean
- `CARINA_CORE_DIR=... ./scripts/check-carina-pin.sh`: OK
- `./scripts/check-docs-drift.sh`: schemas and docs in sync (44 resources)
- `./carina-provider-awscc/scripts/generate-schemas.sh --from-cache-only`: idempotent
- `./scripts/generate-docs.sh --from-cache-only`: idempotent
- `cargo build -p carina-provider-awscc --target wasm32-wasip2 --release`: OK (48.57s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
