### PR TITLE
Bump carina past #3480 and adapt CreateRequest typestate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,7 +629,7 @@ dependencies = [
 [[package]]
 name = "carina-aws-types"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina-provider-aws?rev=9579178faa260db6b1464394d722dd4f3c72c070#9579178faa260db6b1464394d722dd4f3c72c070"
+source = "git+https://github.com/carina-rs/carina-provider-aws?rev=078b4373c855949f2418a5d6690bbed81f510a52#078b4373c855949f2418a5d6690bbed81f510a52"
 dependencies = [
  "carina-core",
  "heck",
@@ -638,7 +638,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=0a70d5bfd213d50e1bc5bca22c964f420e51c401#0a70d5bfd213d50e1bc5bca22c964f420e51c401"
+source = "git+https://github.com/carina-rs/carina?rev=d8947f40a6674a393cad6e96c6c32e4ce905f7f0#d8947f40a6674a393cad6e96c6c32e4ce905f7f0"
 dependencies = [
  "argon2",
  "carina-provider-protocol",
@@ -658,7 +658,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=0a70d5bfd213d50e1bc5bca22c964f420e51c401#0a70d5bfd213d50e1bc5bca22c964f420e51c401"
+source = "git+https://github.com/carina-rs/carina?rev=d8947f40a6674a393cad6e96c6c32e4ce905f7f0#d8947f40a6674a393cad6e96c6c32e4ce905f7f0"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -706,7 +706,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=0a70d5bfd213d50e1bc5bca22c964f420e51c401#0a70d5bfd213d50e1bc5bca22c964f420e51c401"
+source = "git+https://github.com/carina-rs/carina?rev=d8947f40a6674a393cad6e96c6c32e4ce905f7f0#d8947f40a6674a393cad6e96c6c32e4ce905f7f0"
 dependencies = [
  "serde",
  "serde_json",

--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -23,10 +23,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "0a70d5bfd213d50e1bc5bca22c964f420e51c401" }
-carina-aws-types = { git = "https://github.com/carina-rs/carina-provider-aws", rev = "9579178faa260db6b1464394d722dd4f3c72c070" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "0a70d5bfd213d50e1bc5bca22c964f420e51c401" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "0a70d5bfd213d50e1bc5bca22c964f420e51c401" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "d8947f40a6674a393cad6e96c6c32e4ce905f7f0" }
+carina-aws-types = { git = "https://github.com/carina-rs/carina-provider-aws", rev = "078b4373c855949f2418a5d6690bbed81f510a52" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "d8947f40a6674a393cad6e96c6c32e4ce905f7f0" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "d8947f40a6674a393cad6e96c6c32e4ce905f7f0" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }

--- a/carina-provider-awscc/src/lib.rs
+++ b/carina-provider-awscc/src/lib.rs
@@ -333,15 +333,14 @@ impl Provider for AwsccProvider {
     ) -> BoxFuture<'_, ProviderResult<State>> {
         if let Some(err) = self.init_error() {
             let err = err.to_string();
-            let id = request.resource.id.clone();
+            let id = request.resource.as_resource().id.clone();
             return Box::pin(async move {
                 Err(ProviderError::invalid_input(err)
                     .for_provider("awscc")
                     .for_resource(id))
             });
         }
-        let resource = request.resource;
-        Box::pin(async move { self.create_resource(resource).await })
+        Box::pin(async move { self.create_resource(request.resource.as_resource()).await })
     }
 
     fn update(

--- a/carina-provider-awscc/src/main.rs
+++ b/carina-provider-awscc/src/main.rs
@@ -246,10 +246,23 @@ impl CarinaProvider for AwsccProcessProvider {
     ) -> Result<proto::State, proto::ProviderError> {
         let core_id = convert::proto_to_core_resource_id(id);
         let core_resource = convert::proto_to_core_resource(&request.resource);
+        let mut registry = carina_core::schema::SchemaRegistry::new();
+        for config in schemas::generated::configs() {
+            registry.insert("awscc", config.schema.clone());
+        }
+        let normalized_resource = self.runtime.block_on(
+            carina_core::executor::normalized::apply_desired_normalization(
+                core_resource,
+                &[],
+                &self.normalizer,
+                &[],
+                &registry,
+            ),
+        );
         let result = self.runtime.block_on(self.provider().create(
             &core_id,
             CoreCreateRequest {
-                resource: core_resource,
+                resource: normalized_resource,
             },
         ));
         match result {

--- a/carina-provider-awscc/src/provider/operations.rs
+++ b/carina-provider-awscc/src/provider/operations.rs
@@ -76,7 +76,7 @@ impl AwsccProvider {
     }
 
     /// Create a resource using its configuration
-    pub async fn create_resource(&self, resource: Resource) -> ProviderResult<State> {
+    pub async fn create_resource(&self, resource: &Resource) -> ProviderResult<State> {
         let config = get_schema_config(&resource.id.resource_type).ok_or_else(|| {
             ProviderError::internal(format!(
                 "Unknown resource type: {}",
@@ -110,7 +110,7 @@ impl AwsccProvider {
         }
 
         // Handle special cases for create
-        self.create_special_attributes(&resource, &mut desired_state);
+        self.create_special_attributes(resource, &mut desired_state);
 
         // Handle tags
         if config.has_tags {

--- a/carina-provider-awscc/tests/common/mod.rs
+++ b/carina-provider-awscc/tests/common/mod.rs
@@ -1,8 +1,18 @@
+use carina_core::executor::normalized::{NormalizedResource, apply_desired_normalization};
+use carina_core::resource::Resource;
 use carina_core::schema::AttributeType;
+use carina_core::schema::SchemaRegistry;
+use carina_provider_awscc::AwsccNormalizer;
 
+#[allow(dead_code)]
 pub fn assert_arn_identity(t: AttributeType, expected: &str) {
     let carina_core::schema::RawShape::String { identity, .. } = t.raw_shape() else {
         panic!("arn() should be a refined string");
     };
     assert_eq!(identity.map(|id| id.to_string()).as_deref(), Some(expected));
+}
+
+#[allow(dead_code)]
+pub async fn normalize_resource(resource: Resource) -> NormalizedResource {
+    apply_desired_normalization(resource, &[], &AwsccNormalizer, &[], &SchemaRegistry::new()).await
 }

--- a/carina-provider-awscc/tests/dynamodb_table_cloudcontrol_roundtrip.rs
+++ b/carina-provider-awscc/tests/dynamodb_table_cloudcontrol_roundtrip.rs
@@ -11,6 +11,8 @@
 //! resolution, survives the real apply path as a structured list of maps instead
 //! of being flattened into a string.
 
+mod common;
+
 use aws_config::{BehaviorVersion, Region};
 use carina_core::provider::{CreateRequest, Provider, ReadRequest};
 use carina_core::resource::{ConcreteValue, Resource, Value};
@@ -101,6 +103,7 @@ async fn dynamodb_table_create_then_read_round_trips_list_of_struct_fields() {
     let provider = winterbaume_provider().await;
     let resource = dynamodb_table_resource();
     let id = resource.id.clone();
+    let resource = common::normalize_resource(resource).await;
 
     let created = Provider::create(&provider, &id, CreateRequest { resource })
         .await

--- a/carina-provider-awscc/tests/ecs_cluster_cloudcontrol_roundtrip.rs
+++ b/carina-provider-awscc/tests/ecs_cluster_cloudcontrol_roundtrip.rs
@@ -11,6 +11,8 @@
 //! `cluster_settings` survives as a list of maps instead of being flattened into
 //! a string.
 
+mod common;
+
 use aws_config::{BehaviorVersion, Region};
 use carina_core::provider::{CreateRequest, Provider, ReadRequest};
 use carina_core::resource::{ConcreteValue, Resource, Value};
@@ -87,6 +89,7 @@ async fn ecs_cluster_create_then_read_round_trips_structured_list_fields() {
     let provider = winterbaume_provider().await;
     let resource = ecs_cluster_resource();
     let id = resource.id.clone();
+    let resource = common::normalize_resource(resource).await;
 
     let created = Provider::create(&provider, &id, CreateRequest { resource })
         .await

--- a/carina-provider-awscc/tests/elasticloadbalancingv2_listener_cloudcontrol_roundtrip.rs
+++ b/carina-provider-awscc/tests/elasticloadbalancingv2_listener_cloudcontrol_roundtrip.rs
@@ -9,6 +9,8 @@
 //! full CFN-schema-shaped read state round-trips through the awscc provider's
 //! serialization and conversion.
 
+mod common;
+
 use aws_config::{BehaviorVersion, Region};
 use carina_core::provider::{CreateRequest, Provider, ReadRequest};
 use carina_core::resource::{ConcreteValue, Resource, Value};
@@ -167,6 +169,7 @@ async fn listener_create_then_read_round_trips_full_shaped_state() {
     let provider = winterbaume_provider().await;
     let resource = listener_resource();
     let id = resource.id.clone();
+    let resource = common::normalize_resource(resource).await;
 
     let created = Provider::create(&provider, &id, CreateRequest { resource })
         .await

--- a/carina-provider-awscc/tests/elasticloadbalancingv2_load_balancer_cloudcontrol_roundtrip.rs
+++ b/carina-provider-awscc/tests/elasticloadbalancingv2_load_balancer_cloudcontrol_roundtrip.rs
@@ -9,6 +9,8 @@
 //! the full CFN-schema-shaped read state round-trips through the awscc
 //! provider's serialization and conversion.
 
+mod common;
+
 use aws_config::{BehaviorVersion, Region};
 use carina_core::provider::{CreateRequest, Provider, ReadRequest};
 use carina_core::resource::{ConcreteValue, Resource, Value};
@@ -138,6 +140,7 @@ async fn load_balancer_create_then_read_round_trips_full_shaped_state() {
     let provider = winterbaume_provider().await;
     let resource = load_balancer_resource();
     let id = resource.id.clone();
+    let resource = common::normalize_resource(resource).await;
 
     let created = Provider::create(&provider, &id, CreateRequest { resource })
         .await

--- a/carina-provider-awscc/tests/elasticloadbalancingv2_target_group_cloudcontrol_roundtrip.rs
+++ b/carina-provider-awscc/tests/elasticloadbalancingv2_target_group_cloudcontrol_roundtrip.rs
@@ -8,6 +8,8 @@
 //! one create request and asserts the full CFN-schema-shaped read state
 //! round-trips through the awscc provider's serialization and conversion.
 
+mod common;
+
 use aws_config::{BehaviorVersion, Region};
 use carina_core::provider::{CreateRequest, Provider, ReadRequest};
 use carina_core::resource::{ConcreteValue, Resource, Value};
@@ -147,6 +149,7 @@ async fn target_group_create_then_read_round_trips_full_shaped_state() {
     let provider = winterbaume_provider().await;
     let resource = target_group_resource();
     let id = resource.id.clone();
+    let resource = common::normalize_resource(resource).await;
 
     let created = Provider::create(&provider, &id, CreateRequest { resource })
         .await

--- a/carina-provider-awscc/tests/kms_key_cloudcontrol_roundtrip.rs
+++ b/carina-provider-awscc/tests/kms_key_cloudcontrol_roundtrip.rs
@@ -10,6 +10,8 @@
 //! In particular, `key_policy` survives as a structured policy document, which
 //! is PR #313's core `key_policy` = `iam_policy_document` design.
 
+mod common;
+
 use aws_config::{BehaviorVersion, Region};
 use carina_core::provider::{CreateRequest, Provider, ReadRequest};
 use carina_core::resource::{ConcreteValue, Resource, Value};
@@ -123,6 +125,7 @@ async fn kms_key_create_then_read_round_trips_structured_key_policy() {
     let provider = winterbaume_provider().await;
     let resource = kms_key_resource();
     let id = resource.id.clone();
+    let resource = common::normalize_resource(resource).await;
 
     let created = Provider::create(&provider, &id, CreateRequest { resource })
         .await


### PR DESCRIPTION
## Summary

Bump `carina-core` / `carina-plugin-sdk` / `carina-provider-protocol` past `carina-rs/carina#3482` and `carina-aws-types` past `carina-rs/carina-provider-aws#434`. Adapts `Provider::create` to the new `NormalizedResource` typestate on `CreateRequest.resource`.

Closes `carina-rs/carina-provider-awscc#351` (the original symptom report — CloudControl in-place updates dropping provider `default_tags`). The root-cause fix landed on the carina side in #3482; this PR is the provider pin bump that activates it.

## Changes

- `Provider::create` now reads the typestate via `request.resource.as_resource()` once and dispatches `&Resource` to `AwsccProvider::create_resource`.
- `AwsccProvider::create_resource` takes `&Resource` (no ownership needed — the CloudControl payload builder only reads).
- Process/WASM adapter in `src/main.rs` runs `apply_desired_normalization` on the proto-side resource before constructing `CoreCreateRequest`.
- Test fixtures that constructed `CreateRequest { resource: ... }` now obtain a `NormalizedResource` via a shared `common::normalize_resource` helper.

## Test plan

- [x] `cargo build`
- [x] `cargo nextest run` — 435 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo build -p carina-provider-awscc --target wasm32-wasip2 --release`

Closes carina-rs/carina-provider-awscc#351.
