### PR TITLE
Derive ELBv2 TargetGroup enum fields (TargetType, Protocol, IpAddressType, ProtocolVersion)

### DIFF
--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -1374,6 +1374,20 @@ fn generate_markdown(schema: &CfnSchema, type_name: &str) -> Result<String> {
         if is_deprecated_property(prop) {
             continue;
         }
+        // Apply resource-scoped enum overlay (awscc#357) for top-level
+        // properties. The nested-struct loop below already does the same
+        // thing for `Struct.Field` keys (awscc#246); without this branch a
+        // top-level Enum override (e.g. `TargetGroup.Protocol`) was
+        // recorded in the schema (`generate_schema_code`) but never
+        // mirrored into the markdown — `cfn_type_to_carina_type_with_enum`
+        // does not consult `resource_type_overrides` itself.
+        if let Some(TypeOverride::Enum(values) | TypeOverride::EnumUnordered(values)) =
+            resource_type_overrides().get(&(type_name, prop_name.as_str()))
+        {
+            enums.insert(prop_name.clone(), enum_info_for_override(prop_name, values));
+            collect_struct_defs(prop, prop_name, schema, &[], &mut struct_defs);
+            continue;
+        }
         let (_, enum_info) =
             cfn_type_to_carina_type_with_enum(prop, prop_name, schema, &namespace, &enums);
         if let Some(info) = enum_info {
@@ -3460,6 +3474,37 @@ fn extract_enum_from_description(description: &str) -> Option<Vec<String>> {
         }
     }
 
+    // Strategy 4: Look for prose lists like
+    // "The possible values are A, B, and C" without backticks or a colon.
+    if let (Ok(possible_values_re), Ok(connector_re)) = (
+        Regex::new(r"(?i)(?:possible|valid) values?\s+(?:are|is)\s+([^\n.]+)"),
+        Regex::new(r"(?i)\s+(?:and|or)\s+"),
+    ) && let Some(cap) = possible_values_re.captures(description)
+    {
+        let clause = cap[1].trim();
+        let mut candidates: Vec<String> = vec![];
+
+        for comma_part in clause.split(',') {
+            for part in connector_re.split(comma_part) {
+                candidates.push(part.trim().to_string());
+            }
+        }
+
+        values = candidates
+            .into_iter()
+            .filter(|v| {
+                !v.is_empty()
+                    && !v.contains(' ')
+                    && looks_like_enum_value(v)
+                    && !looks_like_property_name(v)
+            })
+            .collect();
+
+        if values.len() >= 2 {
+            return deduplicate_enum_values(values);
+        }
+    }
+
     None
 }
 
@@ -4531,6 +4576,27 @@ fn resource_type_overrides() -> &'static HashMap<(&'static str, &'static str), T
             m.insert(
                 ("AWS::EC2::VPNGateway", "Type"),
                 TypeOverride::Enum(vec!["ipsec.1"]),
+            );
+
+            // ELBv2 TargetGroup TargetType / Protocol (awscc#357). The CFN
+            // descriptions carry no value list, so the description-scraping
+            // heuristic in `extract_enum_from_description` returns nothing
+            // and the type would otherwise stay a free-form string.
+            //
+            // Scope these by resource type — `Protocol` is a field name
+            // shared with `Listener.Protocol` and the listener uses a
+            // different value union (it adds `QUIC`/`TCP_QUIC`), so we must
+            // NOT let a field-name-only override (`known_enum_overrides`)
+            // leak this list across resources.
+            m.insert(
+                ("AWS::ElasticLoadBalancingV2::TargetGroup", "TargetType"),
+                TypeOverride::Enum(vec!["instance", "ip", "lambda", "alb"]),
+            );
+            m.insert(
+                ("AWS::ElasticLoadBalancingV2::TargetGroup", "Protocol"),
+                TypeOverride::Enum(vec![
+                    "HTTP", "HTTPS", "TCP", "TLS", "UDP", "TCP_UDP", "GENEVE",
+                ]),
             );
 
             // CloudFront Distribution: fields the CFN schema leaves as plain
@@ -6429,6 +6495,110 @@ mod tests {
         assert!(result.is_some());
         let values = result.unwrap();
         assert_eq!(values, vec!["enabled", "disabled"]);
+    }
+
+    #[test]
+    fn test_extract_enum_from_description_possible_values_are_two_values() {
+        // awscc#357 motivating case: ELBv2 TargetGroup.IpAddressType
+        // description (verbatim from the CFN schema).
+        let description = "The type of IP address used for this target group. The possible values are ipv4 and ipv6.";
+        assert_eq!(
+            extract_enum_from_description(description),
+            Some(vec!["ipv4".to_string(), "ipv6".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_extract_enum_from_description_possible_values_are_oxford_comma() {
+        // awscc#357 motivating case: ELBv2 TargetGroup.ProtocolVersion
+        // description (verbatim from the CFN schema).
+        let description = "[HTTP/HTTPS protocol] The protocol version. The possible values are GRPC, HTTP1, and HTTP2.";
+        assert_eq!(
+            extract_enum_from_description(description),
+            Some(vec![
+                "GRPC".to_string(),
+                "HTTP1".to_string(),
+                "HTTP2".to_string()
+            ])
+        );
+    }
+
+    #[test]
+    fn test_extract_enum_from_description_possible_values_are_no_oxford() {
+        // Same prose shape without the Oxford comma — common variant.
+        let description = "Some flag. The possible values are foo, bar and baz.";
+        assert_eq!(
+            extract_enum_from_description(description),
+            Some(vec![
+                "foo".to_string(),
+                "bar".to_string(),
+                "baz".to_string()
+            ])
+        );
+    }
+
+    #[test]
+    fn test_extract_enum_from_description_possible_values_are_rejects_prose() {
+        // "The possible values are ..." followed by a sentence-shaped clause
+        // (multi-word tokens, no enum-shaped identifiers) must NOT yield an enum.
+        let description = "The mode. The possible values are described in the AWS documentation.";
+        assert_eq!(extract_enum_from_description(description), None);
+    }
+
+    #[test]
+    fn test_resource_type_overrides_target_group_target_type() {
+        // awscc#357: TargetGroup.TargetType has no value list in its CFN
+        // description, so the legal values are kept in the resource-scoped
+        // curated overlay (NOT the field-name-only `known_enum_overrides`
+        // table — `TargetType` collides nowhere today but would the moment
+        // any other resource grows a field of the same name).
+        let overrides = resource_type_overrides();
+        assert_eq!(
+            overrides.get(&("AWS::ElasticLoadBalancingV2::TargetGroup", "TargetType")),
+            Some(&TypeOverride::Enum(vec!["instance", "ip", "lambda", "alb"]))
+        );
+    }
+
+    #[test]
+    fn test_resource_type_overrides_target_group_protocol() {
+        // awscc#357: TargetGroup.Protocol has no value list in its CFN
+        // description. Use the union of all TargetType-dependent values.
+        //
+        // This MUST be resource-scoped, not field-name-scoped:
+        // `Listener.Protocol` shares the name but allows a different value
+        // union (adds `QUIC`/`TCP_QUIC`), so a field-name-only override
+        // would silently reject those at validate.
+        let overrides = resource_type_overrides();
+        assert_eq!(
+            overrides.get(&("AWS::ElasticLoadBalancingV2::TargetGroup", "Protocol")),
+            Some(&TypeOverride::Enum(vec![
+                "HTTP", "HTTPS", "TCP", "TLS", "UDP", "TCP_UDP", "GENEVE"
+            ]))
+        );
+    }
+
+    #[test]
+    fn test_resource_type_overrides_listener_protocol_not_scoped() {
+        // awscc#357: ensure the TargetGroup.Protocol override does NOT leak
+        // to Listener.Protocol via field-name lookup. The listener allows a
+        // wider union including `QUIC` and `TCP_QUIC`, and field-name-only
+        // overrides would silently reject those.
+        let overrides = resource_type_overrides();
+        assert!(
+            overrides
+                .get(&("AWS::ElasticLoadBalancingV2::Listener", "Protocol"))
+                .is_none(),
+            "Listener.Protocol must not inherit TargetGroup.Protocol's value list"
+        );
+        assert!(
+            overrides
+                .get(&(
+                    "AWS::ElasticLoadBalancingV2::Listener",
+                    "RedirectConfig.Protocol",
+                ))
+                .is_none(),
+            "RedirectConfig.Protocol must not inherit TargetGroup.Protocol's value list"
+        );
     }
 
     #[test]
@@ -10835,6 +11005,59 @@ mod tests {
         assert!(
             !generated.contains(".with_default("),
             "Should not emit scalar JSON defaults for structured policy documents: {generated}"
+        );
+    }
+
+    #[test]
+    fn test_generate_markdown_top_level_enum_override_renders_table() {
+        // awscc#357: top-level `Enum` entries in `resource_type_overrides`
+        // must show up in the markdown's `## Enum Values` section. Before
+        // this fix the nested-struct loop consulted `resource_type_overrides`
+        // but the top-level attribute loop did not, so `VPNGateway.Type`
+        // (and the new `TargetGroup.{Protocol,TargetType}`) were silently
+        // rendered as plain `String` even though the generated schema
+        // correctly typed them as enums.
+        let mut properties = BTreeMap::new();
+        properties.insert(
+            "Type".to_string(),
+            CfnProperty {
+                prop_type: Some(TypeValue::Single("string".to_string())),
+                description: Some(
+                    "The type of VPN connection the virtual private gateway supports.".to_string(),
+                ),
+                ..Default::default()
+            },
+        );
+
+        let schema = CfnSchema {
+            type_name: "AWS::EC2::VPNGateway".to_string(),
+            description: None,
+            properties,
+            required: vec!["Type".to_string()],
+            read_only_properties: vec![],
+            create_only_properties: vec!["/properties/Type".to_string()],
+            write_only_properties: vec![],
+            primary_identifier: None,
+            definitions: None,
+            tagging: None,
+            one_of: vec![],
+            any_of: vec![],
+            handlers: BTreeMap::new(),
+        };
+
+        let md = generate_markdown(&schema, "AWS::EC2::VPNGateway").unwrap();
+
+        assert!(
+            md.contains("[Enum (Type)](#type-type)"),
+            "top-level enum override should render as an Enum link, not String: {md}"
+        );
+        assert!(
+            md.contains("## Enum Values"),
+            "top-level enum override should add an Enum Values section: {md}"
+        );
+        assert!(
+            md.contains("`ipsec.1`"),
+            "the enum value list should be rendered: {md}"
         );
     }
 

--- a/carina-provider-awscc/src/schemas/generated/elasticloadbalancingv2/target_group.rs
+++ b/carina-provider-awscc/src/schemas/generated/elasticloadbalancingv2/target_group.rs
@@ -7,6 +7,14 @@
 use crate::schemas::config::AwsccSchemaConfig;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
 
+const VALID_IP_ADDRESS_TYPE: &[&str] = &["ipv4", "ipv6"];
+
+const VALID_PROTOCOL: &[&str] = &["HTTP", "HTTPS", "TCP", "TLS", "UDP", "TCP_UDP", "GENEVE"];
+
+const VALID_PROTOCOL_VERSION: &[&str] = &["GRPC", "HTTP1", "HTTP2"];
+
+const VALID_TARGET_TYPE: &[&str] = &["instance", "ip", "lambda", "alb"];
+
 /// Returns the schema config for elasticloadbalancingv2_target_group (AWS::ElasticLoadBalancingV2::TargetGroup)
 pub fn elasticloadbalancingv2_target_group_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
@@ -51,7 +59,7 @@ pub fn elasticloadbalancingv2_target_group_config() -> AwsccSchemaConfig {
                 .with_provider_name("HealthyThresholdCount"),
         )
         .attribute(
-            AttributeSchema::new("ip_address_type", AttributeType::string())
+            AttributeSchema::new("ip_address_type", AttributeType::enum_(carina_core::schema::enum_identity("IpAddressType", Some("aws.elasticloadbalancingv2.TargetGroup")), Some(vec!["ipv4".to_string(), "ipv6".to_string()]), vec![("ipv4".to_string(), "ipv4".to_string()), ("ipv6".to_string(), "ipv6".to_string())], None, None))
                 .create_only()
                 .with_description("The type of IP address used for this target group. The possible values are ipv4 and ipv6. ")
                 .with_provider_name("IpAddressType"),
@@ -81,13 +89,13 @@ pub fn elasticloadbalancingv2_target_group_config() -> AwsccSchemaConfig {
                 .with_provider_name("Port"),
         )
         .attribute(
-            AttributeSchema::new("protocol", AttributeType::string())
+            AttributeSchema::new("protocol", AttributeType::enum_(carina_core::schema::enum_identity("Protocol", Some("aws.elasticloadbalancingv2.TargetGroup")), Some(vec!["HTTP".to_string(), "HTTPS".to_string(), "TCP".to_string(), "TLS".to_string(), "UDP".to_string(), "TCP_UDP".to_string(), "GENEVE".to_string()]), vec![("HTTP".to_string(), "http".to_string()), ("HTTPS".to_string(), "https".to_string()), ("TCP".to_string(), "tcp".to_string()), ("TLS".to_string(), "tls".to_string()), ("UDP".to_string(), "udp".to_string()), ("TCP_UDP".to_string(), "tcp_udp".to_string()), ("GENEVE".to_string(), "geneve".to_string())], None, None))
                 .create_only()
                 .with_description("The protocol to use for routing traffic to the targets.")
                 .with_provider_name("Protocol"),
         )
         .attribute(
-            AttributeSchema::new("protocol_version", AttributeType::string())
+            AttributeSchema::new("protocol_version", AttributeType::enum_(carina_core::schema::enum_identity("ProtocolVersion", Some("aws.elasticloadbalancingv2.TargetGroup")), Some(vec!["GRPC".to_string(), "HTTP1".to_string(), "HTTP2".to_string()]), vec![("GRPC".to_string(), "grpc".to_string()), ("HTTP1".to_string(), "http1".to_string()), ("HTTP2".to_string(), "http2".to_string())], None, None))
                 .create_only()
                 .with_description("[HTTP/HTTPS protocol] The protocol version. The possible values are GRPC, HTTP1, and HTTP2.")
                 .with_provider_name("ProtocolVersion"),
@@ -129,7 +137,7 @@ pub fn elasticloadbalancingv2_target_group_config() -> AwsccSchemaConfig {
                 .with_provider_name("TargetGroupName"),
         )
         .attribute(
-            AttributeSchema::new("target_type", AttributeType::string())
+            AttributeSchema::new("target_type", AttributeType::enum_(carina_core::schema::enum_identity("TargetType", Some("aws.elasticloadbalancingv2.TargetGroup")), Some(vec!["instance".to_string(), "ip".to_string(), "lambda".to_string(), "alb".to_string()]), vec![("instance".to_string(), "instance".to_string()), ("ip".to_string(), "ip".to_string()), ("lambda".to_string(), "lambda".to_string()), ("alb".to_string(), "alb".to_string())], None, None))
                 .create_only()
                 .with_description("The type of target that you must specify when registering targets with this target group. You can't specify targets for a target group using more than one target type.")
                 .with_provider_name("TargetType"),
@@ -171,5 +179,13 @@ pub fn enum_valid_values() -> (
     &'static str,
     &'static [(&'static str, &'static [&'static str])],
 ) {
-    ("elasticloadbalancingv2.TargetGroup", &[])
+    (
+        "elasticloadbalancingv2.TargetGroup",
+        &[
+            ("ip_address_type", VALID_IP_ADDRESS_TYPE),
+            ("protocol", VALID_PROTOCOL),
+            ("protocol_version", VALID_PROTOCOL_VERSION),
+            ("target_type", VALID_TARGET_TYPE),
+        ],
+    )
 }

--- a/generated-docs/awscc/ec2/vpn_gateway.md
+++ b/generated-docs/awscc/ec2/vpn_gateway.md
@@ -40,11 +40,21 @@ Any tags assigned to the virtual private gateway.
 
 ### `type`
 
-- **Type:** String
+- **Type:** [Enum (Type)](#type-type)
 - **Required:** Yes
 - **Create-only:** Yes
 
 The type of VPN connection the virtual private gateway supports.
+
+## Enum Values
+
+### type (Type)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `ipsec.1` | `aws.ec2.VpnGateway.Type.ipsec_1` |
+
+Shorthand formats: `ipsec_1` or `Type.ipsec_1`
 
 ## Attribute Reference
 

--- a/generated-docs/awscc/elasticloadbalancingv2/target_group.md
+++ b/generated-docs/awscc/elasticloadbalancingv2/target_group.md
@@ -84,7 +84,7 @@ The number of consecutive health checks successes required before considering an
 
 ### `ip_address_type`
 
-- **Type:** String
+- **Type:** [Enum (IpAddressType)](#ip_address_type-ipaddresstype)
 - **Required:** No
 - **Create-only:** Yes
 
@@ -115,7 +115,7 @@ The port on which the targets receive traffic. This port is used unless you spec
 
 ### `protocol`
 
-- **Type:** String
+- **Type:** [Enum (Protocol)](#protocol-protocol)
 - **Required:** No
 - **Create-only:** Yes
 
@@ -123,7 +123,7 @@ The protocol to use for routing traffic to the targets.
 
 ### `protocol_version`
 
-- **Type:** String
+- **Type:** [Enum (ProtocolVersion)](#protocol_version-protocolversion)
 - **Required:** No
 - **Create-only:** Yes
 
@@ -152,7 +152,7 @@ The attributes.
 
 ### `target_type`
 
-- **Type:** String
+- **Type:** [Enum (TargetType)](#target_type-targettype)
 - **Required:** No
 - **Create-only:** Yes
 
@@ -179,6 +179,52 @@ The number of consecutive health check failures required before considering a ta
 - **Create-only:** Yes
 
 The identifier of the virtual private cloud (VPC). If the target is a Lambda function, this parameter does not apply.
+
+## Enum Values
+
+### ip_address_type (IpAddressType)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `ipv4` | `aws.elasticloadbalancingv2.TargetGroup.IpAddressType.ipv4` |
+| `ipv6` | `aws.elasticloadbalancingv2.TargetGroup.IpAddressType.ipv6` |
+
+Shorthand formats: `ipv4` or `IpAddressType.ipv4`
+
+### protocol (Protocol)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `HTTP` | `aws.elasticloadbalancingv2.TargetGroup.Protocol.http` |
+| `HTTPS` | `aws.elasticloadbalancingv2.TargetGroup.Protocol.https` |
+| `TCP` | `aws.elasticloadbalancingv2.TargetGroup.Protocol.tcp` |
+| `TLS` | `aws.elasticloadbalancingv2.TargetGroup.Protocol.tls` |
+| `UDP` | `aws.elasticloadbalancingv2.TargetGroup.Protocol.udp` |
+| `TCP_UDP` | `aws.elasticloadbalancingv2.TargetGroup.Protocol.tcp_udp` |
+| `GENEVE` | `aws.elasticloadbalancingv2.TargetGroup.Protocol.geneve` |
+
+Shorthand formats: `http` or `Protocol.http`
+
+### protocol_version (ProtocolVersion)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `GRPC` | `aws.elasticloadbalancingv2.TargetGroup.ProtocolVersion.grpc` |
+| `HTTP1` | `aws.elasticloadbalancingv2.TargetGroup.ProtocolVersion.http1` |
+| `HTTP2` | `aws.elasticloadbalancingv2.TargetGroup.ProtocolVersion.http2` |
+
+Shorthand formats: `grpc` or `ProtocolVersion.grpc`
+
+### target_type (TargetType)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `instance` | `aws.elasticloadbalancingv2.TargetGroup.TargetType.instance` |
+| `ip` | `aws.elasticloadbalancingv2.TargetGroup.TargetType.ip` |
+| `lambda` | `aws.elasticloadbalancingv2.TargetGroup.TargetType.lambda` |
+| `alb` | `aws.elasticloadbalancingv2.TargetGroup.TargetType.alb` |
+
+Shorthand formats: `instance` or `TargetType.instance`
 
 ## Struct Definitions
 


### PR DESCRIPTION
## Summary

The CFN schema leaves `TargetGroup.{TargetType, Protocol, IpAddressType,
ProtocolVersion}` typed as plain strings, so `carina validate` accepts
arbitrary input and bad values only fail at apply-time inside
CloudControl. This PR brings all four fields into the DSL enum system.

Two complementary fixes:

1. **New `extract_enum_from_description` strategy** for the
   `The possible values are A, B(, and C)` / `valid values are X and Y`
   prose forms — backtick-less, colon-less. `IpAddressType` and
   `ProtocolVersion` use this shape, as do many sibling fields across
   services. `include` is deliberately not matched: it does not promise
   a closed value set and would false-reject legitimate apply-time
   values.

2. **Resource-scoped curated overlay** for `TargetType` and `Protocol`,
   whose descriptions carry no value list at all. Added to
   `resource_type_overrides()` keyed by `("AWS::ElasticLoadBalancingV2::TargetGroup", "...")`
   — **not** the field-name-only `known_enum_overrides` table. `Listener`
   has its own `Protocol` field that allows a wider union (it adds
   `QUIC` and `TCP_QUIC`), so a field-name-only entry would silently
   reject those values; the regression is covered by
   `test_resource_type_overrides_listener_protocol_not_scoped`.

Also fixes a latent docs-generator bug: the markdown generator's
top-level attribute loop did not consult `resource_type_overrides`, so
any top-level `TypeOverride::Enum` (`VPNGateway.Type`, and now the
TargetGroup additions) was recorded in the schema but rendered as plain
`String` in the docs. The nested-struct loop already did the right
thing (awscc#246); this PR mirrors the same lookup at the top level so
docs and code stay in sync. The `vpn_gateway.md` change is the docs
catching up to a schema state that has been correct since the original
`VPNGateway.Type` override landed.

## Notes / out of scope

- `LoadBalancer.IpAddressType` uses a different `[Application Load Balancers] The possible values are` ``ipv4`` (IPv4 addresses), ``dualstack`` ...` shape mixing backticks with parenthetical annotations. Strategy 4's `looks_like_enum_value` filter drops the annotated tokens, so this PR does not derive an enum for it. Different failure mode, separate issue.
- `known_enum_overrides` still holds several field-name-only entries (`IpProtocol`, `ConnectivityType`, `Domain`, …) that would benefit from the same `resource_type_overrides` migration the new `Protocol` entry uses. Not done here to keep the diff scoped.

## Test plan

- [x] `cargo nextest run -p carina-provider-awscc --all-features` — 445 / 445
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --doc`
- [x] `bash scripts/check-carina-pin.sh && bash scripts/check-docs-drift.sh`
- [x] Schemas + docs regenerated via `--from-cache-only`; only `TargetGroup` rs/md and `vpn_gateway.md` change (the latter is the related docs-bug fix)

Closes #357