### PR TITLE
Constrain ELBv2 Listener Action.Type to its closed value set

### DIFF
--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -4599,6 +4599,29 @@ fn resource_type_overrides() -> &'static HashMap<(&'static str, &'static str), T
                 ]),
             );
 
+            // ELBv2 Listener Action.Type (awscc#359). The CFN description
+            // is literally "The type of action." with no value list, but
+            // the sibling fields' descriptions enumerate the closed set
+            // ("Specify only when ``Type`` is ``forward``" etc.). Real AWS
+            // values: forward, authenticate-oidc, authenticate-cognito,
+            // redirect, fixed-response, jwt-validation.
+            //
+            // Resource-scoped for the same reason as TargetGroup.Protocol:
+            // `Type` is a generic field name (it also shows up on
+            // VPNGateway with a different value set), so a field-name-only
+            // entry would silently clobber sibling resources.
+            m.insert(
+                ("AWS::ElasticLoadBalancingV2::Listener", "Action.Type"),
+                TypeOverride::Enum(vec![
+                    "forward",
+                    "authenticate-oidc",
+                    "authenticate-cognito",
+                    "redirect",
+                    "fixed-response",
+                    "jwt-validation",
+                ]),
+            );
+
             // CloudFront Distribution: fields the CFN schema leaves as plain
             // strings but are documented as a closed value set (awscc#246).
             // Keys use "DefName.FieldName" composite form so the lookup hits
@@ -6598,6 +6621,42 @@ mod tests {
                 ))
                 .is_none(),
             "RedirectConfig.Protocol must not inherit TargetGroup.Protocol's value list"
+        );
+    }
+
+    #[test]
+    fn test_resource_type_overrides_listener_action_type() {
+        // awscc#359: Listener Action.Type carries no value list in its CFN
+        // description ("The type of action."), but the legal set is closed
+        // and small. Keep the canonical values resource-scoped — `Type` is
+        // a field name shared with `VPNGateway.Type` (= `vec!["ipsec.1"]`),
+        // so a field-name-only override would clobber it.
+        let overrides = resource_type_overrides();
+        assert_eq!(
+            overrides.get(&("AWS::ElasticLoadBalancingV2::Listener", "Action.Type")),
+            Some(&TypeOverride::Enum(vec![
+                "forward",
+                "authenticate-oidc",
+                "authenticate-cognito",
+                "redirect",
+                "fixed-response",
+                "jwt-validation",
+            ]))
+        );
+    }
+
+    #[test]
+    fn test_resource_type_overrides_listener_top_level_type_not_scoped() {
+        // awscc#359: ensure the Action.Type override does NOT leak into a
+        // hypothetical top-level `Type` lookup on the listener. The schema
+        // has no top-level `Type` on Listener today, but a field-name-only
+        // override would collide with VPNGateway.Type if one ever appeared.
+        let overrides = resource_type_overrides();
+        assert!(
+            overrides
+                .get(&("AWS::ElasticLoadBalancingV2::Listener", "Type"))
+                .is_none(),
+            "Listener.Type (top-level) must not inherit Action.Type's value list"
         );
     }
 

--- a/carina-provider-awscc/src/schemas/generated/elasticloadbalancingv2/listener.rs
+++ b/carina-provider-awscc/src/schemas/generated/elasticloadbalancingv2/listener.rs
@@ -7,6 +7,15 @@
 use crate::schemas::config::AwsccSchemaConfig;
 use carina_core::schema::{AttributeSchema, AttributeType, ResourceSchema, StructField};
 
+const VALID_ACTION_TYPE: &[&str] = &[
+    "forward",
+    "authenticate-oidc",
+    "authenticate-cognito",
+    "redirect",
+    "fixed-response",
+    "jwt-validation",
+];
+
 const VALID_FIXED_RESPONSE_CONFIG_CONTENT_TYPE: &[&str] = &[
     "text/plain",
     "text/css",
@@ -77,7 +86,7 @@ pub fn elasticloadbalancingv2_listener_config() -> AwsccSchemaConfig {
                     StructField::new("query", AttributeType::string()).with_description("The query parameters, URL-encoded when necessary, but not percent-encoded. Do not include the leading \"?\", as it is automatically added. You can specify any of the reserved keywords.").with_provider_name("Query"),
                     StructField::new("status_code", AttributeType::string()).required().with_description("The HTTP redirect code. The redirect is either permanent (HTTP 301) or temporary (HTTP 302).").with_provider_name("StatusCode")])).with_description("[Application Load Balancer] Information for creating a redirect action. Specify only when ``Type`` is ``redirect``.").with_provider_name("RedirectConfig"),
                     StructField::new("target_group_arn", carina_aws_types::arn()).with_description("The Amazon Resource Name (ARN) of the target group. Specify only when ``Type`` is ``forward`` and you want to route to a single target group. To route to multiple target groups, you must use ``ForwardConfig`` instead.").with_provider_name("TargetGroupArn"),
-                    StructField::new("type", AttributeType::string()).required().with_description("The type of action.").with_provider_name("Type")])))
+                    StructField::new("type", AttributeType::enum_(carina_core::schema::enum_identity("Type", Some("aws.elasticloadbalancingv2.Listener.Action")), Some(vec!["forward".to_string(), "authenticate-oidc".to_string(), "authenticate-cognito".to_string(), "redirect".to_string(), "fixed-response".to_string(), "jwt-validation".to_string()]), vec![("forward".to_string(), "forward".to_string()), ("authenticate-oidc".to_string(), "authenticate_oidc".to_string()), ("authenticate-cognito".to_string(), "authenticate_cognito".to_string()), ("redirect".to_string(), "redirect".to_string()), ("fixed-response".to_string(), "fixed_response".to_string()), ("jwt-validation".to_string(), "jwt_validation".to_string())], None, None)).required().with_description("The type of action.").with_provider_name("Type")])))
                 .required()
                 .with_description("The actions for the default rule. You cannot define a condition for a default rule. To create additional rules for an Application Load Balancer, use [AWS::ElasticLoadBalancingV2::ListenerRule](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-listenerrule.html).")
                 .with_provider_name("DefaultActions")
@@ -181,6 +190,7 @@ pub fn enum_valid_values() -> (
     (
         "elasticloadbalancingv2.Listener",
         &[
+            ("type", VALID_ACTION_TYPE),
             ("content_type", VALID_FIXED_RESPONSE_CONFIG_CONTENT_TYPE),
             ("mode", VALID_MUTUAL_AUTHENTICATION_MODE),
         ],

--- a/generated-docs/awscc/elasticloadbalancingv2/listener.md
+++ b/generated-docs/awscc/elasticloadbalancingv2/listener.md
@@ -95,6 +95,19 @@ The protocol for connections from clients to the load balancer. For Application 
 
 ## Enum Values
 
+### type (Type)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `forward` | `aws.elasticloadbalancingv2.Listener.Action.Type.forward` |
+| `authenticate-oidc` | `aws.elasticloadbalancingv2.Listener.Action.Type.authenticate_oidc` |
+| `authenticate-cognito` | `aws.elasticloadbalancingv2.Listener.Action.Type.authenticate_cognito` |
+| `redirect` | `aws.elasticloadbalancingv2.Listener.Action.Type.redirect` |
+| `fixed-response` | `aws.elasticloadbalancingv2.Listener.Action.Type.fixed_response` |
+| `jwt-validation` | `aws.elasticloadbalancingv2.Listener.Action.Type.jwt_validation` |
+
+Shorthand formats: `forward` or `Type.forward`
+
 ### content_type (ContentType)
 
 | Value | DSL Identifier |
@@ -131,7 +144,7 @@ Shorthand formats: `off` or `Mode.off`
 | `order` | Int | No | The order for the action. This value is required for rules with multiple actions. The action with the lowest value for order is performed first. |
 | `redirect_config` | [Struct(RedirectConfig)](#redirectconfig) | No | [Application Load Balancer] Information for creating a redirect action. Specify only when ``Type`` is ``redirect``. |
 | `target_group_arn` | Arn | No | The Amazon Resource Name (ARN) of the target group. Specify only when ``Type`` is ``forward`` and you want to route to a single target group. To route to multiple target groups, you must use ``ForwardConfig`` instead. |
-| `type` | String | Yes | The type of action. |
+| `type` | [Enum (Type)](#type-type) | Yes | The type of action. |
 
 ### AuthenticateCognitoConfig
 


### PR DESCRIPTION
## Summary

`awscc.elasticloadbalancingv2.Listener` exposes `default_action.type`
as the discriminant selecting which sub-config (`ForwardConfig`,
`RedirectConfig`, `FixedResponseConfig`, …) is meaningful. The CFN
schema types it as a bare `string` with no `enum` and a description
that carries no value list ("The type of action."), so validate
accepts typos that only fail at apply-time inside CloudControl.

Add the closed value set (derived from sibling fields' `Specify only
when ``Type`` is ``X``` mentions + AWS docs) to the resource-scoped
`resource_type_overrides()` overlay:

```rust
("AWS::ElasticLoadBalancingV2::Listener", "Action.Type") => Enum([
    "forward", "authenticate-oidc", "authenticate-cognito",
    "redirect", "fixed-response", "jwt-validation",
])
```

Same seam as awscc#358's `TargetGroup.{TargetType, Protocol}`. **Not**
the field-name-only `known_enum_overrides` table — `Type` is a generic
field name and `VPNGateway.Type` already owns it with a different
value set. The negative test
`test_resource_type_overrides_listener_top_level_type_not_scoped`
freezes this contract.

## Test plan

- [x] `cargo nextest run -p carina-provider-awscc --all-features` — 447/447
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --doc`
- [x] `bash scripts/check-carina-pin.sh && bash scripts/check-docs-drift.sh`
- [x] Regen via `--from-cache-only`; only `listener.rs` and `listener.md` change

Closes #359