### PR TITLE
Derive ELBv2 Listener Protocol / RedirectConfig.{Protocol,StatusCode} enums

### DIFF
--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -3476,17 +3476,28 @@ fn extract_enum_from_description(description: &str) -> Option<Vec<String>> {
 
     // Strategy 4: Look for prose lists like
     // "The possible values are A, B, and C" without backticks or a colon.
-    if let (Ok(possible_values_re), Ok(connector_re)) = (
-        Regex::new(r"(?i)(?:possible|valid) values?\s+(?:are|is)\s+([^\n.]+)"),
+    //
+    // The head noun is gated to a small allowlist
+    // (values / protocols / modes / policies). Plain `supported X are ...`
+    // without one of those nouns is too generic and false-positives on
+    // sentences like "supported features are described in the docs".
+    //
+    // Multiple matching sentences are *unioned* — `Listener.Protocol`
+    // carries two "supported protocols are ..." clauses (ALB vs NLB), and
+    // the legal enum value set is the union over load-balancer types.
+    if let (Ok(prose_values_re), Ok(connector_re)) = (
+        Regex::new(
+            r"(?i)(?:possible|valid|supported)\s+(?:values?|protocols?|modes?|policies)\s+(?:are|is)\s+([^\n.]+)",
+        ),
         Regex::new(r"(?i)\s+(?:and|or)\s+"),
-    ) && let Some(cap) = possible_values_re.captures(description)
-    {
-        let clause = cap[1].trim();
+    ) {
         let mut candidates: Vec<String> = vec![];
-
-        for comma_part in clause.split(',') {
-            for part in connector_re.split(comma_part) {
-                candidates.push(part.trim().to_string());
+        for cap in prose_values_re.captures_iter(description) {
+            let clause = cap[1].trim();
+            for comma_part in clause.split(',') {
+                for part in connector_re.split(comma_part) {
+                    candidates.push(part.trim().to_string());
+                }
             }
         }
 
@@ -4620,6 +4631,37 @@ fn resource_type_overrides() -> &'static HashMap<(&'static str, &'static str), T
                     "fixed-response",
                     "jwt-validation",
                 ]),
+            );
+
+            // ELBv2 Listener RedirectConfig.Protocol (awscc#360). The
+            // description ("You can specify HTTP, HTTPS, or #{protocol}.")
+            // mixes two literal values with a `#{protocol}` placeholder
+            // that lets a redirect inherit the listener's incoming
+            // protocol. The placeholder is NOT an enum identifier — it
+            // does not satisfy `looks_like_enum_value` and would pollute
+            // the generated DSL identifier set — so the static enum
+            // covers the two literal values only. Authoring redirects
+            // with `#{protocol}` is tracked as the remaining open
+            // question in awscc#360 (carina-core placeholder handling).
+            m.insert(
+                (
+                    "AWS::ElasticLoadBalancingV2::Listener",
+                    "RedirectConfig.Protocol",
+                ),
+                TypeOverride::Enum(vec!["HTTP", "HTTPS"]),
+            );
+            // ELBv2 Listener RedirectConfig.StatusCode (awscc#360). The
+            // description ("either permanent (HTTP 301) or temporary
+            // (HTTP 302)") names the values in prose but the CFN string
+            // form uses the underscored variants `HTTP_301` / `HTTP_302`.
+            // No existing matcher recovers this mapping; pin the two
+            // canonical values.
+            m.insert(
+                (
+                    "AWS::ElasticLoadBalancingV2::Listener",
+                    "RedirectConfig.StatusCode",
+                ),
+                TypeOverride::Enum(vec!["HTTP_301", "HTTP_302"]),
             );
 
             // CloudFront Distribution: fields the CFN schema leaves as plain
@@ -6601,26 +6643,98 @@ mod tests {
     }
 
     #[test]
-    fn test_resource_type_overrides_listener_protocol_not_scoped() {
-        // awscc#357: ensure the TargetGroup.Protocol override does NOT leak
-        // to Listener.Protocol via field-name lookup. The listener allows a
-        // wider union including `QUIC` and `TCP_QUIC`, and field-name-only
-        // overrides would silently reject those.
+    fn test_resource_type_overrides_listener_top_level_protocol_listed_via_prose() {
+        // awscc#360: Listener.Protocol is now enum-derived via the
+        // description-scraping path ("supported protocols are HTTP and
+        // HTTPS. ... supported protocols are TCP, TLS, UDP, TCP_UDP, QUIC,
+        // and TCP_QUIC."). The static list is the UNION across all
+        // load-balancer types — apply-time CloudControl enforces the
+        // contextual subset. The resource_type_overrides() table itself
+        // intentionally still does NOT have a top-level Listener.Protocol
+        // entry: the prose matcher carries this case, leaving the overlay
+        // table free to express the negative contract "this is not a
+        // field-name leak from TargetGroup.Protocol".
         let overrides = resource_type_overrides();
         assert!(
             overrides
                 .get(&("AWS::ElasticLoadBalancingV2::Listener", "Protocol"))
                 .is_none(),
-            "Listener.Protocol must not inherit TargetGroup.Protocol's value list"
+            "Listener.Protocol must not be in resource_type_overrides — it is derived from description prose, not the overlay"
         );
+    }
+
+    #[test]
+    fn test_resource_type_overrides_listener_redirect_config_protocol() {
+        // awscc#360: RedirectConfig.Protocol description is
+        // "You can specify HTTP, HTTPS, or #{protocol}." The static enum
+        // covers the two literal values; `#{protocol}` is a redirect
+        // placeholder, not an enum identifier, and stays out of the
+        // static set (a separate axis tracked in awscc#360).
+        let overrides = resource_type_overrides();
+        assert_eq!(
+            overrides.get(&(
+                "AWS::ElasticLoadBalancingV2::Listener",
+                "RedirectConfig.Protocol",
+            )),
+            Some(&TypeOverride::Enum(vec!["HTTP", "HTTPS"]))
+        );
+    }
+
+    #[test]
+    fn test_resource_type_overrides_listener_redirect_config_status_code() {
+        // awscc#360: RedirectConfig.StatusCode description is
+        // "either permanent (HTTP 301) or temporary (HTTP 302)". The CFN
+        // string form uses underscores (`HTTP_301`, `HTTP_302`); no
+        // existing matcher recovers this without a curated mapping.
+        let overrides = resource_type_overrides();
+        assert_eq!(
+            overrides.get(&(
+                "AWS::ElasticLoadBalancingV2::Listener",
+                "RedirectConfig.StatusCode",
+            )),
+            Some(&TypeOverride::Enum(vec!["HTTP_301", "HTTP_302"]))
+        );
+    }
+
+    #[test]
+    fn test_extract_enum_from_description_supported_protocols_are_union() {
+        // awscc#360: Listener.Protocol CFN description verbatim. Two
+        // "supported protocols are" sentences — the matcher must union
+        // both, not return the first only.
+        let description = "The protocol for connections from clients to the load balancer. \
+            For Application Load Balancers, the supported protocols are HTTP and HTTPS. \
+            For Network Load Balancers, the supported protocols are TCP, TLS, UDP, TCP_UDP, QUIC, and TCP_QUIC. \
+            You can't specify the UDP, TCP_UDP, QUIC, or TCP_QUIC protocol if dual-stack mode is enabled. \
+            You can't specify a protocol for a Gateway Load Balancer.";
+        let result = extract_enum_from_description(description);
         assert!(
-            overrides
-                .get(&(
-                    "AWS::ElasticLoadBalancingV2::Listener",
-                    "RedirectConfig.Protocol",
-                ))
-                .is_none(),
-            "RedirectConfig.Protocol must not inherit TargetGroup.Protocol's value list"
+            result.is_some(),
+            "Listener.Protocol prose should be matched"
+        );
+        let values = result.unwrap();
+        // Order: ALB sentence first (HTTP, HTTPS), then NLB sentence
+        // (TCP, TLS, UDP, TCP_UDP, QUIC, TCP_QUIC). Deduplication preserves
+        // first occurrence order.
+        assert_eq!(
+            values,
+            vec![
+                "HTTP", "HTTPS", "TCP", "TLS", "UDP", "TCP_UDP", "QUIC", "TCP_QUIC"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_extract_enum_from_description_supported_values_oxford_comma() {
+        // Same Strategy-5 path, common sibling phrasing.
+        let description =
+            "The block mode. The supported values are off, block-bidirectional, and block-ingress.";
+        assert_eq!(
+            extract_enum_from_description(description),
+            Some(vec![
+                "off".to_string(),
+                "block-bidirectional".to_string(),
+                "block-ingress".to_string()
+            ])
         );
     }
 

--- a/carina-provider-awscc/src/schemas/generated/elasticloadbalancingv2/listener.rs
+++ b/carina-provider-awscc/src/schemas/generated/elasticloadbalancingv2/listener.rs
@@ -26,6 +26,14 @@ const VALID_FIXED_RESPONSE_CONFIG_CONTENT_TYPE: &[&str] = &[
 
 const VALID_MUTUAL_AUTHENTICATION_MODE: &[&str] = &["off", "passthrough", "verify"];
 
+const VALID_PROTOCOL: &[&str] = &[
+    "HTTP", "HTTPS", "TCP", "TLS", "UDP", "TCP_UDP", "QUIC", "TCP_QUIC",
+];
+
+const VALID_REDIRECT_CONFIG_PROTOCOL: &[&str] = &["HTTP", "HTTPS"];
+
+const VALID_REDIRECT_CONFIG_STATUS_CODE: &[&str] = &["HTTP_301", "HTTP_302"];
+
 /// Returns the schema config for elasticloadbalancingv2_listener (AWS::ElasticLoadBalancingV2::Listener)
 pub fn elasticloadbalancingv2_listener_config() -> AwsccSchemaConfig {
     AwsccSchemaConfig {
@@ -82,9 +90,9 @@ pub fn elasticloadbalancingv2_listener_config() -> AwsccSchemaConfig {
                     StructField::new("redirect_config", AttributeType::struct_("RedirectConfig".to_string(), vec![StructField::new("host", AttributeType::string()).with_description("The hostname. This component is not percent-encoded. The hostname can contain #{host}.").with_provider_name("Host"),
                     StructField::new("path", AttributeType::string()).with_description("The absolute path, starting with the leading \"/\". This component is not percent-encoded. The path can contain #{host}, #{path}, and #{port}.").with_provider_name("Path"),
                     StructField::new("port", AttributeType::string()).with_description("The port. You can specify a value from 1 to 65535 or #{port}.").with_provider_name("Port"),
-                    StructField::new("protocol", AttributeType::string()).with_description("The protocol. You can specify HTTP, HTTPS, or #{protocol}. You can redirect HTTP to HTTP, HTTP to HTTPS, and HTTPS to HTTPS. You can't redirect HTTPS to HTTP.").with_provider_name("Protocol"),
+                    StructField::new("protocol", AttributeType::enum_(carina_core::schema::enum_identity("Protocol", Some("aws.elasticloadbalancingv2.Listener.Action.RedirectConfig")), Some(vec!["HTTP".to_string(), "HTTPS".to_string()]), vec![("HTTP".to_string(), "http".to_string()), ("HTTPS".to_string(), "https".to_string())], None, None)).with_description("The protocol. You can specify HTTP, HTTPS, or #{protocol}. You can redirect HTTP to HTTP, HTTP to HTTPS, and HTTPS to HTTPS. You can't redirect HTTPS to HTTP.").with_provider_name("Protocol"),
                     StructField::new("query", AttributeType::string()).with_description("The query parameters, URL-encoded when necessary, but not percent-encoded. Do not include the leading \"?\", as it is automatically added. You can specify any of the reserved keywords.").with_provider_name("Query"),
-                    StructField::new("status_code", AttributeType::string()).required().with_description("The HTTP redirect code. The redirect is either permanent (HTTP 301) or temporary (HTTP 302).").with_provider_name("StatusCode")])).with_description("[Application Load Balancer] Information for creating a redirect action. Specify only when ``Type`` is ``redirect``.").with_provider_name("RedirectConfig"),
+                    StructField::new("status_code", AttributeType::enum_(carina_core::schema::enum_identity("StatusCode", Some("aws.elasticloadbalancingv2.Listener.Action.RedirectConfig")), Some(vec!["HTTP_301".to_string(), "HTTP_302".to_string()]), vec![("HTTP_301".to_string(), "http_301".to_string()), ("HTTP_302".to_string(), "http_302".to_string())], None, None)).required().with_description("The HTTP redirect code. The redirect is either permanent (HTTP 301) or temporary (HTTP 302).").with_provider_name("StatusCode")])).with_description("[Application Load Balancer] Information for creating a redirect action. Specify only when ``Type`` is ``redirect``.").with_provider_name("RedirectConfig"),
                     StructField::new("target_group_arn", carina_aws_types::arn()).with_description("The Amazon Resource Name (ARN) of the target group. Specify only when ``Type`` is ``forward`` and you want to route to a single target group. To route to multiple target groups, you must use ``ForwardConfig`` instead.").with_provider_name("TargetGroupArn"),
                     StructField::new("type", AttributeType::enum_(carina_core::schema::enum_identity("Type", Some("aws.elasticloadbalancingv2.Listener.Action")), Some(vec!["forward".to_string(), "authenticate-oidc".to_string(), "authenticate-cognito".to_string(), "redirect".to_string(), "fixed-response".to_string(), "jwt-validation".to_string()]), vec![("forward".to_string(), "forward".to_string()), ("authenticate-oidc".to_string(), "authenticate_oidc".to_string()), ("authenticate-cognito".to_string(), "authenticate_cognito".to_string()), ("redirect".to_string(), "redirect".to_string()), ("fixed-response".to_string(), "fixed_response".to_string()), ("jwt-validation".to_string(), "jwt_validation".to_string())], None, None)).required().with_description("The type of action.").with_provider_name("Type")])))
                 .required()
@@ -126,7 +134,7 @@ pub fn elasticloadbalancingv2_listener_config() -> AwsccSchemaConfig {
                 .with_provider_name("Port"),
         )
         .attribute(
-            AttributeSchema::new("protocol", AttributeType::string())
+            AttributeSchema::new("protocol", AttributeType::enum_(carina_core::schema::enum_identity("Protocol", Some("aws.elasticloadbalancingv2.Listener")), Some(vec!["HTTP".to_string(), "HTTPS".to_string(), "TCP".to_string(), "TLS".to_string(), "UDP".to_string(), "TCP_UDP".to_string(), "QUIC".to_string(), "TCP_QUIC".to_string()]), vec![("HTTP".to_string(), "http".to_string()), ("HTTPS".to_string(), "https".to_string()), ("TCP".to_string(), "tcp".to_string()), ("TLS".to_string(), "tls".to_string()), ("UDP".to_string(), "udp".to_string()), ("TCP_UDP".to_string(), "tcp_udp".to_string()), ("QUIC".to_string(), "quic".to_string()), ("TCP_QUIC".to_string(), "tcp_quic".to_string())], None, None))
                 .with_description("The protocol for connections from clients to the load balancer. For Application Load Balancers, the supported protocols are HTTP and HTTPS. For Network Load Balancers, the supported protocols are TCP, TLS, UDP, TCP_UDP, QUIC, and TCP_QUIC. You can’t specify the UDP, TCP_UDP, QUIC, or TCP_QUIC protocol if dual-stack mode is enabled. You can't specify a protocol for a Gateway Load Balancer.")
                 .with_provider_name("Protocol"),
         )
@@ -174,9 +182,9 @@ pub fn elasticloadbalancingv2_listener_config() -> AwsccSchemaConfig {
         .with_def("RedirectConfig", AttributeType::struct_("RedirectConfig".to_string(), vec![StructField::new("host", AttributeType::string()).with_description("The hostname. This component is not percent-encoded. The hostname can contain #{host}.").with_provider_name("Host"),
                     StructField::new("path", AttributeType::string()).with_description("The absolute path, starting with the leading \"/\". This component is not percent-encoded. The path can contain #{host}, #{path}, and #{port}.").with_provider_name("Path"),
                     StructField::new("port", AttributeType::string()).with_description("The port. You can specify a value from 1 to 65535 or #{port}.").with_provider_name("Port"),
-                    StructField::new("protocol", AttributeType::string()).with_description("The protocol. You can specify HTTP, HTTPS, or #{protocol}. You can redirect HTTP to HTTP, HTTP to HTTPS, and HTTPS to HTTPS. You can't redirect HTTPS to HTTP.").with_provider_name("Protocol"),
+                    StructField::new("protocol", AttributeType::enum_(carina_core::schema::enum_identity("Protocol", Some("aws.elasticloadbalancingv2.Listener.Action.RedirectConfig")), Some(vec!["HTTP".to_string(), "HTTPS".to_string()]), vec![("HTTP".to_string(), "http".to_string()), ("HTTPS".to_string(), "https".to_string())], None, None)).with_description("The protocol. You can specify HTTP, HTTPS, or #{protocol}. You can redirect HTTP to HTTP, HTTP to HTTPS, and HTTPS to HTTPS. You can't redirect HTTPS to HTTP.").with_provider_name("Protocol"),
                     StructField::new("query", AttributeType::string()).with_description("The query parameters, URL-encoded when necessary, but not percent-encoded. Do not include the leading \"?\", as it is automatically added. You can specify any of the reserved keywords.").with_provider_name("Query"),
-                    StructField::new("status_code", AttributeType::string()).required().with_description("The HTTP redirect code. The redirect is either permanent (HTTP 301) or temporary (HTTP 302).").with_provider_name("StatusCode")]))
+                    StructField::new("status_code", AttributeType::enum_(carina_core::schema::enum_identity("StatusCode", Some("aws.elasticloadbalancingv2.Listener.Action.RedirectConfig")), Some(vec!["HTTP_301".to_string(), "HTTP_302".to_string()]), vec![("HTTP_301".to_string(), "http_301".to_string()), ("HTTP_302".to_string(), "http_302".to_string())], None, None)).required().with_description("The HTTP redirect code. The redirect is either permanent (HTTP 301) or temporary (HTTP 302).").with_provider_name("StatusCode")]))
         .with_def("TargetGroupStickinessConfig", AttributeType::struct_("TargetGroupStickinessConfig".to_string(), vec![StructField::new("duration_seconds", AttributeType::int()).with_description("[Application Load Balancers] The time period, in seconds, during which requests from a client should be routed to the same target group. The range is 1-604800 seconds (7 days). You must specify this value when enabling target group stickiness.").with_provider_name("DurationSeconds"),
                     StructField::new("enabled", AttributeType::bool()).with_description("Indicates whether target group stickiness is enabled.").with_provider_name("Enabled")]))
     }
@@ -193,6 +201,9 @@ pub fn enum_valid_values() -> (
             ("type", VALID_ACTION_TYPE),
             ("content_type", VALID_FIXED_RESPONSE_CONFIG_CONTENT_TYPE),
             ("mode", VALID_MUTUAL_AUTHENTICATION_MODE),
+            ("protocol", VALID_PROTOCOL),
+            ("protocol", VALID_REDIRECT_CONFIG_PROTOCOL),
+            ("status_code", VALID_REDIRECT_CONFIG_STATUS_CODE),
         ],
     )
 }

--- a/generated-docs/awscc/elasticloadbalancingv2/listener.md
+++ b/generated-docs/awscc/elasticloadbalancingv2/listener.md
@@ -81,7 +81,7 @@ The port on which the load balancer is listening. You can't specify a port for a
 
 ### `protocol`
 
-- **Type:** String
+- **Type:** [Enum (Protocol)](#protocol-protocol)
 - **Required:** No
 
 The protocol for connections from clients to the load balancer. For Application Load Balancers, the supported protocols are HTTP and HTTPS. For Network Load Balancers, the supported protocols are TCP, TLS, UDP, TCP_UDP, QUIC, and TCP_QUIC. You can’t specify the UDP, TCP_UDP, QUIC, or TCP_QUIC protocol if dual-stack mode is enabled. You can't specify a protocol for a Gateway Load Balancer.
@@ -129,6 +129,39 @@ Shorthand formats: `text_plain` or `ContentType.text_plain`
 | `verify` | `aws.elasticloadbalancingv2.Listener.MutualAuthentication.Mode.verify` |
 
 Shorthand formats: `off` or `Mode.off`
+
+### protocol (Protocol)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `HTTP` | `aws.elasticloadbalancingv2.Listener.Protocol.http` |
+| `HTTPS` | `aws.elasticloadbalancingv2.Listener.Protocol.https` |
+| `TCP` | `aws.elasticloadbalancingv2.Listener.Protocol.tcp` |
+| `TLS` | `aws.elasticloadbalancingv2.Listener.Protocol.tls` |
+| `UDP` | `aws.elasticloadbalancingv2.Listener.Protocol.udp` |
+| `TCP_UDP` | `aws.elasticloadbalancingv2.Listener.Protocol.tcp_udp` |
+| `QUIC` | `aws.elasticloadbalancingv2.Listener.Protocol.quic` |
+| `TCP_QUIC` | `aws.elasticloadbalancingv2.Listener.Protocol.tcp_quic` |
+
+Shorthand formats: `http` or `Protocol.http`
+
+### protocol (Protocol)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `HTTP` | `aws.elasticloadbalancingv2.Listener.Action.RedirectConfig.Protocol.http` |
+| `HTTPS` | `aws.elasticloadbalancingv2.Listener.Action.RedirectConfig.Protocol.https` |
+
+Shorthand formats: `http` or `Protocol.http`
+
+### status_code (StatusCode)
+
+| Value | DSL Identifier |
+|-------|----------------|
+| `HTTP_301` | `aws.elasticloadbalancingv2.Listener.Action.RedirectConfig.StatusCode.http_301` |
+| `HTTP_302` | `aws.elasticloadbalancingv2.Listener.Action.RedirectConfig.StatusCode.http_302` |
+
+Shorthand formats: `http_301` or `StatusCode.http_301`
 
 ## Struct Definitions
 
@@ -236,9 +269,9 @@ Shorthand formats: `off` or `Mode.off`
 | `host` | String | No | The hostname. This component is not percent-encoded. The hostname can contain #{host}. |
 | `path` | String | No | The absolute path, starting with the leading "/". This component is not percent-encoded. The path can contain #{host}, #{path}, and #{port}. |
 | `port` | String | No | The port. You can specify a value from 1 to 65535 or #{port}. |
-| `protocol` | String | No | The protocol. You can specify HTTP, HTTPS, or #{protocol}. You can redirect HTTP to HTTP, HTTP to HTTPS, and HTTPS to HTTPS. You can't redirect HTTPS to HTTP. |
+| `protocol` | [Enum (Protocol)](#protocol-protocol) | No | The protocol. You can specify HTTP, HTTPS, or #{protocol}. You can redirect HTTP to HTTP, HTTP to HTTPS, and HTTPS to HTTPS. You can't redirect HTTPS to HTTP. |
 | `query` | String | No | The query parameters, URL-encoded when necessary, but not percent-encoded. Do not include the leading "?", as it is automatically added. You can specify any of the reserved keywords. |
-| `status_code` | String | Yes | The HTTP redirect code. The redirect is either permanent (HTTP 301) or temporary (HTTP 302). |
+| `status_code` | [Enum (StatusCode)](#status_code-statuscode) | Yes | The HTTP redirect code. The redirect is either permanent (HTTP 301) or temporary (HTTP 302). |
 
 ### TargetGroupStickinessConfig
 


### PR DESCRIPTION
## Summary

Closes the awscc#357 → #358 → #361 series on the ELBv2 Listener side.
After this PR every enum-shaped string field on `Listener` that the
CFN schema leaves as `type: string` is rescued at validate time.

### 1. Strategy 4 head-noun allowlist + multi-sentence union

`extract_enum_from_description` now matches
`(possible|valid|supported) (values|protocols|modes|policies) (are|is) ...`
— the head noun is gated to a small allowlist so a generic sentence
like \"supported features are described in the docs\" cannot
false-positive. The matcher uses `captures_iter` so multiple sentences
in the same description are *unioned*. `Listener.Protocol` carries two
\"supported protocols are ...\" clauses (ALB vs NLB); the legal static
enum is the union, apply-time CloudControl enforces the contextual
subset (same stance as awscc#357's `TargetGroup.Protocol`).

### 2. RedirectConfig.Protocol curated overlay = [HTTP, HTTPS]

The description names a third token `#{protocol}` — a redirect
placeholder that lets a redirect inherit the listener's incoming
protocol. It is *not* a real enum identifier (does not satisfy
`looks_like_enum_value`, would not survive DSL identifier generation),
so the static enum covers the two literal values only. Authoring
redirects with `#{protocol}` remains the open question on awscc#360
(carina-core-side placeholder handling — separate axis).

### 3. RedirectConfig.StatusCode curated overlay = [HTTP_301, HTTP_302]

The description mentions the values only in prose
(`(HTTP 301)` / `(HTTP 302)`); the CFN string form uses underscores
(`HTTP_301`, `HTTP_302`) so no matcher recovers them without a curated
mapping. Same shape as `FixedResponseConfig.StatusCode` from
awscc#356.

## Resulting state of ELBv2 Listener enum fields

| Field | After this PR | Path |
|---|---|---|
| `Action.Type` | enum | awscc#361 overlay |
| `default_action.fixed_response_config.content_type` | enum | existing Strategy 2 |
| `default_action.mutual_authentication.mode` | enum | existing Strategy 3 |
| `default_action.redirect_config.protocol` | enum | **this PR** overlay |
| `default_action.redirect_config.status_code` | enum | **this PR** overlay |
| `default_action.fixed_response_config.status_code` | http_response_status_code | awscc#356 |
| `protocol` | enum | **this PR** prose union |
| `alpn_policy` / `ssl_policy` | string | out of scope (no overlay; values churn) |

## Test plan

- [x] `cargo nextest run -p carina-provider-awscc --all-features` — 451/451
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --doc`
- [x] `bash scripts/check-carina-pin.sh && bash scripts/check-docs-drift.sh`
- [x] Regen via `--from-cache-only`; only `listener.rs` and `listener.md` change (no false-positive ripple to other resources from the `supported` head noun)

Closes #360