### PR TITLE
chore: bump carina to 1b63267e and aws to 5c2c972

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,7 +629,7 @@ dependencies = [
 [[package]]
 name = "carina-aws-types"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina-provider-aws?rev=da55aa1#da55aa13380f5a3eb1180c3f8f695c698e7a67c8"
+source = "git+https://github.com/carina-rs/carina-provider-aws?rev=5c2c972#5c2c9722d1322bdb1e716e50e263bec76ea2efe3"
 dependencies = [
  "carina-core",
  "heck",
@@ -638,7 +638,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=156b5e2f#156b5e2f4808bb90c49c4ea26a8e05e0cf9f8265"
+source = "git+https://github.com/carina-rs/carina?rev=1b63267e#1b63267ea9ee3e30519bfd4ac4d499a1c1c5ac9c"
 dependencies = [
  "argon2",
  "carina-provider-protocol",
@@ -653,13 +653,14 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-util",
+ "tracing",
  "uuid",
 ]
 
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=156b5e2f#156b5e2f4808bb90c49c4ea26a8e05e0cf9f8265"
+source = "git+https://github.com/carina-rs/carina?rev=1b63267e#1b63267ea9ee3e30519bfd4ac4d499a1c1c5ac9c"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -707,7 +708,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=156b5e2f#156b5e2f4808bb90c49c4ea26a8e05e0cf9f8265"
+source = "git+https://github.com/carina-rs/carina?rev=1b63267e#1b63267ea9ee3e30519bfd4ac4d499a1c1c5ac9c"
 dependencies = [
  "serde",
  "serde_json",
@@ -925,7 +926,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -23,10 +23,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "156b5e2f" }
-carina-aws-types = { git = "https://github.com/carina-rs/carina-provider-aws", rev = "da55aa1" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "156b5e2f" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "156b5e2f" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "1b63267e" }
+carina-aws-types = { git = "https://github.com/carina-rs/carina-provider-aws", rev = "5c2c972" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "1b63267e" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "1b63267e" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }

--- a/carina-provider-awscc/src/schemas/mod.rs
+++ b/carina-provider-awscc/src/schemas/mod.rs
@@ -70,6 +70,7 @@ mod tests {
         let plan = create_plan(
             &resources,
             &[],
+            &carina_core::provider::ProviderRouter::new(),
             &current_states,
             &HashMap::new(),
             &schemas,


### PR DESCRIPTION
## Summary
- carina rev `156b5e2f` → `1b63267e`、carina-provider-aws rev `da55aa1` → `5c2c972` を pick up
- 含まれる主な変更: carina#3496/#3503/#3504/#3505/#3516/#3524 (executor cancellation observation, IAM preflight, satisfier_hint trait method with default impl, apply-cancel persistence)
- `carina-plugin-wit` submodule を `03e4997` に更新 (`satisfier-hint` WIT 型追加)
- `schemas` テストを新しい `create_plan` シグネチャに追従 (`provider` 引数を `current_states` の前に追加)

## Test plan
- [x] `cargo nextest run --workspace`
- [x] `cargo test --workspace --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build -p carina-provider-awscc --target wasm32-wasip2 --release`