### PR TITLE
feat(provider): emit partial-update state when CloudControl handler fails post-Identifier (#371)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,7 +629,7 @@ dependencies = [
 [[package]]
 name = "carina-aws-types"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina-provider-aws?rev=f076689a1a6ce55a58d53e0b0a0e8e3fb7437a48#f076689a1a6ce55a58d53e0b0a0e8e3fb7437a48"
+source = "git+https://github.com/carina-rs/carina-provider-aws?rev=21c5e25c2fd7b2df200ced89a21986d3ff4963c1#21c5e25c2fd7b2df200ced89a21986d3ff4963c1"
 dependencies = [
  "carina-core",
  "heck",
@@ -638,7 +638,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=474ce867#474ce867c1a0d8d8044bc472380cd145b620d0ea"
+source = "git+https://github.com/carina-rs/carina?rev=c5231c06#c5231c061d93ebbfaeb16a91d528d17a2edba65d"
 dependencies = [
  "argon2",
  "carina-provider-protocol",
@@ -660,7 +660,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=474ce867#474ce867c1a0d8d8044bc472380cd145b620d0ea"
+source = "git+https://github.com/carina-rs/carina?rev=c5231c06#c5231c061d93ebbfaeb16a91d528d17a2edba65d"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -708,7 +708,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=474ce867#474ce867c1a0d8d8044bc472380cd145b620d0ea"
+source = "git+https://github.com/carina-rs/carina?rev=c5231c06#c5231c061d93ebbfaeb16a91d528d17a2edba65d"
 dependencies = [
  "serde",
  "serde_json",
@@ -926,7 +926,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -23,10 +23,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "474ce867" }
-carina-aws-types = { git = "https://github.com/carina-rs/carina-provider-aws", rev = "f076689a1a6ce55a58d53e0b0a0e8e3fb7437a48" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "474ce867" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "474ce867" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "c5231c06" }
+carina-aws-types = { git = "https://github.com/carina-rs/carina-provider-aws", rev = "21c5e25c2fd7b2df200ced89a21986d3ff4963c1" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "c5231c06" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "c5231c06" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }

--- a/carina-provider-awscc/src/convert.rs
+++ b/carina-provider-awscc/src/convert.rs
@@ -8,7 +8,8 @@ use std::collections::HashMap;
 
 use carina_core::provider::{
     CreateOutcome as CoreCreateOutcome, PatchOp as CorePatchOp, PatchOpKind as CorePatchOpKind,
-    ProviderError as CoreProviderError, UpdatePatch as CoreUpdatePatch,
+    ProviderError as CoreProviderError, UpdateOutcome as CoreUpdateOutcome,
+    UpdatePatch as CoreUpdatePatch,
 };
 use carina_core::resource::{
     ConcreteValue, DataSource as CoreDataSource, DeferredValue, Directives as CoreDirectives,
@@ -22,11 +23,12 @@ use carina_core::schema::{
 use carina_provider_protocol::types::{
     AttributeSchema as ProtoAttributeSchema, AttributeType as ProtoAttributeType,
     CreateOutcome as ProtoCreateOutcome, Directives as ProtoDirectives,
-    PartialCreateDiagnostic as ProtoPartialCreateDiagnostic, PatchOp as ProtoPatchOp,
+    PartialReadDiagnostic as ProtoPartialReadDiagnostic, PatchOp as ProtoPatchOp,
     PatchOpKind as ProtoPatchOpKind, ProviderError as ProtoProviderError,
     ProviderErrorKind as ProtoProviderErrorKind, Resource as ProtoResource,
     ResourceId as ProtoResourceId, ResourceSchema as ProtoResourceSchema, State as ProtoState,
-    StructField as ProtoStructField, UpdatePatch as ProtoUpdatePatch, Value as ProtoValue,
+    StructField as ProtoStructField, UpdateOutcome as ProtoUpdateOutcome,
+    UpdatePatch as ProtoUpdatePatch, Value as ProtoValue,
 };
 
 // -- ResourceId --
@@ -168,7 +170,26 @@ pub fn core_to_proto_create_outcome(outcome: CoreCreateOutcome) -> ProtoCreateOu
         CoreCreateOutcome::PartialSuccess { state, diagnostic } => {
             ProtoCreateOutcome::PartialSuccess {
                 state: core_to_proto_state(&state),
-                diagnostic: ProtoPartialCreateDiagnostic {
+                diagnostic: ProtoPartialReadDiagnostic {
+                    reason: diagnostic.reason().to_string(),
+                    missing_attributes: diagnostic.missing_attributes().to_vec(),
+                },
+            }
+        }
+    }
+}
+
+// -- UpdateOutcome --
+
+pub fn core_to_proto_update_outcome(outcome: CoreUpdateOutcome) -> ProtoUpdateOutcome {
+    match outcome {
+        CoreUpdateOutcome::Success { state } => ProtoUpdateOutcome::Success {
+            state: core_to_proto_state(&state),
+        },
+        CoreUpdateOutcome::PartialSuccess { state, diagnostic } => {
+            ProtoUpdateOutcome::PartialSuccess {
+                state: core_to_proto_state(&state),
+                diagnostic: ProtoPartialReadDiagnostic {
                     reason: diagnostic.reason().to_string(),
                     missing_attributes: diagnostic.missing_attributes().to_vec(),
                 },

--- a/carina-provider-awscc/src/lib.rs
+++ b/carina-provider-awscc/src/lib.rs
@@ -22,8 +22,8 @@ use indexmap::IndexMap;
 use carina_core::effect::PlanOp;
 use carina_core::provider::{
     BoxFuture, CreateOutcome, CreateRequest, DeleteRequest, Provider, ProviderError,
-    ProviderFactory, ProviderNormalizer, ProviderResult, ReadRequest, SavedAttrs, UpdateRequest,
-    merge_default_tags_for_provider, ready_noop,
+    ProviderFactory, ProviderNormalizer, ProviderResult, ReadRequest, SavedAttrs, UpdateOutcome,
+    UpdateRequest, merge_default_tags_for_provider, ready_noop,
 };
 use carina_core::resource::{ConcreteValue, DataSource, Resource, ResourceId, State, Value};
 use carina_core::schema::SchemaRegistry;
@@ -356,7 +356,7 @@ impl Provider for AwsccProvider {
         id: &ResourceId,
         identifier: &str,
         request: UpdateRequest,
-    ) -> BoxFuture<'_, ProviderResult<State>> {
+    ) -> BoxFuture<'_, ProviderResult<UpdateOutcome>> {
         if let Some(err) = self.init_error() {
             let err = err.to_string();
             let id = id.clone();

--- a/carina-provider-awscc/src/main.rs
+++ b/carina-provider-awscc/src/main.rs
@@ -280,7 +280,7 @@ impl CarinaProvider for AwsccProcessProvider {
         id: &proto::ResourceId,
         identifier: &str,
         request: proto::UpdateRequest,
-    ) -> Result<proto::State, proto::ProviderError> {
+    ) -> Result<proto::UpdateOutcome, proto::ProviderError> {
         let core_id = convert::proto_to_core_resource_id(id);
         let core_from = convert::proto_to_core_state(&request.from);
         let core_patch = convert::proto_to_core_update_patch(&request.patch);
@@ -293,7 +293,7 @@ impl CarinaProvider for AwsccProcessProvider {
             },
         ));
         match result {
-            Ok(state) => Ok(convert::core_to_proto_state(&state)),
+            Ok(outcome) => Ok(convert::core_to_proto_update_outcome(outcome)),
             Err(e) => Err(Self::convert_error(e)),
         }
     }

--- a/carina-provider-awscc/src/provider/cloudcontrol.rs
+++ b/carina-provider-awscc/src/provider/cloudcontrol.rs
@@ -165,9 +165,11 @@ impl AwsccProvider {
         type_name: &str,
         identifier: &str,
         patch_ops: Vec<serde_json::Value>,
-    ) -> ProviderResult<()> {
+    ) -> ProviderResult<WaitOutcome> {
         if patch_ops.is_empty() {
-            return Ok(());
+            return Ok(WaitOutcome::Success {
+                identifier: identifier.to_string(),
+            });
         }
 
         let patch_document = serde_json::to_string(&patch_ops)
@@ -187,10 +189,14 @@ impl AwsccProvider {
             })?;
 
         if let Some(request_token) = result.progress_event().and_then(|p| p.request_token()) {
-            self.wait_for_operation(request_token).await?;
+            return self
+                .wait_for_operation_with_attempts(request_token, 120)
+                .await;
         }
 
-        Ok(())
+        Ok(WaitOutcome::Success {
+            identifier: identifier.to_string(),
+        })
     }
 
     /// Delete a resource using Cloud Control API, with retry logic for retryable errors.
@@ -459,19 +465,6 @@ impl AwsccProvider {
         RETRYABLE_STATUS_PATTERNS
             .iter()
             .any(|pattern| status_message.contains(pattern))
-    }
-
-    /// Wait for a Cloud Control operation to complete
-    pub(crate) async fn wait_for_operation(&self, request_token: &str) -> ProviderResult<String> {
-        match self
-            .wait_for_operation_with_attempts(request_token, 120)
-            .await?
-        {
-            WaitOutcome::Success { identifier } => Ok(identifier),
-            WaitOutcome::PartialOrFailed { status_message, .. } => Err(ProviderError::api_error(
-                format!("Operation failed: {}", status_message),
-            )),
-        }
     }
 
     /// Wait for a Cloud Control operation to complete with a configurable number of attempts

--- a/carina-provider-awscc/src/provider/operations.rs
+++ b/carina-provider-awscc/src/provider/operations.rs
@@ -252,14 +252,18 @@ impl AwsccProvider {
                         Ok(UpdateOutcome::Success { state })
                     }
                     Err(read_err) => {
-                        let state =
-                            State::existing(id.clone(), desired).with_identifier(identifier);
                         let missing_attributes = patch
                             .ops
                             .iter()
                             .filter(|op| config.schema.attributes.contains_key(&op.key))
                             .map(|op| op.key.clone())
-                            .collect();
+                            .collect::<Vec<_>>();
+                        let mut state_attributes = desired;
+                        for attr in &missing_attributes {
+                            state_attributes.remove(attr);
+                        }
+                        let state = State::existing(id.clone(), state_attributes)
+                            .with_identifier(identifier);
                         let reason = format!(
                             "handler failed: {}; read error: {}",
                             status_message,
@@ -729,7 +733,10 @@ mod tests {
                 "partial-bucket".to_string()
             )))
         );
-        assert!(state.attributes.contains_key("tags"));
+        assert!(
+            !state.attributes.contains_key("tags"),
+            "missing authored attributes must be absent so the partial-read marker can materialize them as Unknown"
+        );
         assert_eq!(
             diagnostic.reason(),
             "handler failed: post-update read denied; read error: Failed to get resource: AccessDeniedException: read denied"

--- a/carina-provider-awscc/src/provider/operations.rs
+++ b/carina-provider-awscc/src/provider/operations.rs
@@ -6,7 +6,9 @@
 
 use std::collections::HashMap;
 
-use carina_core::provider::{CreateOutcome, ProviderError, ProviderResult, UpdatePatch};
+use carina_core::provider::{
+    CreateOutcome, ProviderError, ProviderResult, UpdateOutcome, UpdatePatch,
+};
 use carina_core::resource::{ConcreteValue, Directives, Resource, ResourceId, State, Value};
 use carina_core::schema::{AttributeSchema, AttributeType, Schema, Shape};
 use indexmap::IndexMap;
@@ -209,7 +211,7 @@ impl AwsccProvider {
         identifier: &str,
         from: &State,
         patch: &UpdatePatch,
-    ) -> ProviderResult<State> {
+    ) -> ProviderResult<UpdateOutcome> {
         let config = get_schema_config(&id.resource_type).ok_or_else(|| {
             ProviderError::internal(format!("Unknown resource type: {}", id.resource_type))
                 .for_resource(id.clone())
@@ -217,13 +219,10 @@ impl AwsccProvider {
 
         let patch_ops = build_update_patches(config, &id.resource_type, patch);
 
-        self.cc_update_resource(config.aws_type_name, identifier, patch_ops)
+        let outcome = self
+            .cc_update_resource(config.aws_type_name, identifier, patch_ops)
             .await
             .map_err(|e| e.for_resource(id.clone()))?;
-
-        let mut state = self
-            .read_resource(&id.resource_type, id.name_str(), Some(identifier))
-            .await?;
 
         // Reconstruct the post-update desired view (current state + the
         // patch we just applied). This is the source of values to carry
@@ -231,15 +230,50 @@ impl AwsccProvider {
         // same logic as `create_resource` but built without a `to:
         // Resource` (which Level 3 deliberately does not pass through).
         let desired = post_update_attributes(from, patch);
-        for dsl_name in config.schema.attributes.keys() {
-            if !state.attributes.contains_key(dsl_name)
-                && let Some(value) = desired.get(dsl_name)
-            {
-                state.attributes.insert(dsl_name.clone(), value.clone());
+
+        match outcome {
+            WaitOutcome::Success { identifier } => {
+                let state = self
+                    .read_resource(&id.resource_type, id.name_str(), Some(&identifier))
+                    .await?;
+                let state = merge_update_desired_attributes(state, &desired, config);
+                Ok(UpdateOutcome::Success { state })
+            }
+            WaitOutcome::PartialOrFailed {
+                identifier,
+                status_message,
+            } => {
+                match self
+                    .read_resource(&id.resource_type, id.name_str(), Some(&identifier))
+                    .await
+                {
+                    Ok(state) => {
+                        let state = merge_update_desired_attributes(state, &desired, config);
+                        Ok(UpdateOutcome::Success { state })
+                    }
+                    Err(read_err) => {
+                        let state =
+                            State::existing(id.clone(), desired).with_identifier(identifier);
+                        let missing_attributes = patch
+                            .ops
+                            .iter()
+                            .filter(|op| config.schema.attributes.contains_key(&op.key))
+                            .map(|op| op.key.clone())
+                            .collect();
+                        let reason = format!(
+                            "handler failed: {}; read error: {}",
+                            status_message,
+                            read_err.message(),
+                        );
+                        Ok(UpdateOutcome::partial_success(
+                            state,
+                            reason,
+                            missing_attributes,
+                        ))
+                    }
+                }
             }
         }
-
-        Ok(state)
     }
 
     /// Delete a resource
@@ -290,6 +324,21 @@ fn merge_desired_attributes(
             && let Some(value) = resource.get_attr(dsl_name.as_str())
         {
             state.attributes.insert(dsl_name.to_string(), value.clone());
+        }
+    }
+    state
+}
+
+fn merge_update_desired_attributes(
+    mut state: State,
+    desired: &HashMap<String, Value>,
+    config: &crate::schemas::config::AwsccSchemaConfig,
+) -> State {
+    for dsl_name in config.schema.attributes.keys() {
+        if !state.attributes.contains_key(dsl_name)
+            && let Some(value) = desired.get(dsl_name)
+        {
+            state.attributes.insert(dsl_name.clone(), value.clone());
         }
     }
     state
@@ -398,7 +447,7 @@ fn post_update_attributes(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use carina_core::provider::CreateOutcome;
+    use carina_core::provider::{CreateOutcome, PatchOp, PatchOpKind, UpdateOutcome};
     use carina_core::schema::AttributeType;
     use serde_json::json;
     use std::future::Future;
@@ -493,6 +542,229 @@ mod tests {
             .await;
 
         AwsccProvider::from_sdk_config(config, &super::super::AwsccProviderConfig::default()).await
+    }
+
+    #[derive(Debug)]
+    struct PartialUpdateCloudControlService {
+        wait_succeeds: bool,
+        read_succeeds: bool,
+        saw_update_resource: AtomicBool,
+        saw_get_resource: AtomicBool,
+    }
+
+    impl PartialUpdateCloudControlService {
+        fn new(wait_succeeds: bool, read_succeeds: bool) -> Arc<Self> {
+            Arc::new(Self {
+                wait_succeeds,
+                read_succeeds,
+                saw_update_resource: AtomicBool::new(false),
+                saw_get_resource: AtomicBool::new(false),
+            })
+        }
+    }
+
+    impl MockService for PartialUpdateCloudControlService {
+        fn service_name(&self) -> &str {
+            "cloudcontrolapi"
+        }
+
+        fn url_patterns(&self) -> Vec<&str> {
+            vec![
+                r"https?://cloudcontrolapi\..*\.amazonaws\.com",
+                r"https?://cloudcontrolapi\.amazonaws\.com",
+            ]
+        }
+
+        fn handle(
+            &self,
+            request: MockRequest,
+        ) -> Pin<Box<dyn Future<Output = MockResponse> + Send + '_>> {
+            Box::pin(async move {
+                let action = request
+                    .headers
+                    .get("x-amz-target")
+                    .and_then(|v| v.to_str().ok())
+                    .and_then(|v| v.split('.').next_back())
+                    .unwrap_or_default();
+                match action {
+                    "UpdateResource" => {
+                        self.saw_update_resource.store(true, Ordering::SeqCst);
+                        MockResponse::json(
+                            200,
+                            r#"{"ProgressEvent":{"RequestToken":"update-token-1"}}"#,
+                        )
+                    }
+                    "GetResourceRequestStatus" if self.wait_succeeds => MockResponse::json(
+                        200,
+                        r#"{"ProgressEvent":{"RequestToken":"update-token-1","OperationStatus":"SUCCESS","Identifier":"partial-bucket"}}"#,
+                    ),
+                    "GetResourceRequestStatus" => MockResponse::json(
+                        200,
+                        r#"{"ProgressEvent":{"RequestToken":"update-token-1","OperationStatus":"FAILED","Identifier":"partial-bucket","StatusMessage":"post-update read denied"}}"#,
+                    ),
+                    "GetResource" if self.read_succeeds => {
+                        self.saw_get_resource.store(true, Ordering::SeqCst);
+                        MockResponse::json(
+                            200,
+                            r#"{"TypeName":"AWS::S3::Bucket","ResourceDescription":{"Identifier":"partial-bucket","Properties":"{}"}}"#,
+                        )
+                    }
+                    "GetResource" => {
+                        self.saw_get_resource.store(true, Ordering::SeqCst);
+                        MockResponse::json(
+                            403,
+                            r#"{"__type":"AccessDeniedException","message":"read denied"}"#,
+                        )
+                    }
+                    _ => MockResponse::json(
+                        400,
+                        format!(
+                            r#"{{"__type":"InvalidAction","message":"unexpected action {action}"}}"#
+                        ),
+                    ),
+                }
+            })
+        }
+    }
+
+    async fn provider_with_partial_update_service(
+        service: Arc<PartialUpdateCloudControlService>,
+    ) -> AwsccProvider {
+        use aws_config::{BehaviorVersion, Region};
+
+        let mock = MockAws::builder().with_service(service).build();
+        let config = aws_config::defaults(BehaviorVersion::latest())
+            .http_client(mock.http_client())
+            .credentials_provider(mock.credentials_provider())
+            .region(Region::new("us-east-1"))
+            .load()
+            .await;
+
+        AwsccProvider::from_sdk_config(config, &super::super::AwsccProviderConfig::default()).await
+    }
+
+    fn partial_update_bucket_state() -> State {
+        State::existing(
+            ResourceId::with_provider("awscc", "s3.Bucket", "partial_bucket", None),
+            HashMap::from([(
+                "bucket_name".to_string(),
+                Value::Concrete(ConcreteValue::String("partial-bucket".to_string())),
+            )]),
+        )
+        .with_identifier("partial-bucket")
+    }
+
+    fn partial_update_bucket_patch() -> UpdatePatch {
+        let mut tags = indexmap::IndexMap::new();
+        tags.insert(
+            "env".to_string(),
+            Value::Concrete(ConcreteValue::String("prod".to_string())),
+        );
+        UpdatePatch {
+            ops: vec![PatchOp {
+                kind: PatchOpKind::Replace,
+                key: "tags".to_string(),
+                value: Some(Value::Concrete(ConcreteValue::Map(tags))),
+            }],
+        }
+    }
+
+    #[tokio::test]
+    async fn update_resource_returns_success_when_wait_success() {
+        let service = PartialUpdateCloudControlService::new(true, true);
+        let provider = provider_with_partial_update_service(service.clone()).await;
+        let from = partial_update_bucket_state();
+        let patch = partial_update_bucket_patch();
+
+        let outcome = provider
+            .update_resource(
+                from.id.clone(),
+                from.identifier.as_deref().expect("identifier"),
+                &from,
+                &patch,
+            )
+            .await
+            .expect("update should succeed");
+
+        let UpdateOutcome::Success { state } = outcome else {
+            panic!("expected success when wait succeeds");
+        };
+        assert!(service.saw_update_resource.load(Ordering::SeqCst));
+        assert!(service.saw_get_resource.load(Ordering::SeqCst));
+        assert!(state.exists);
+        assert_eq!(state.identifier.as_deref(), Some("partial-bucket"));
+        assert!(state.attributes.contains_key("tags"));
+    }
+
+    #[tokio::test]
+    async fn update_resource_returns_partial_success_when_failed_identifier_read_fails() {
+        let service = PartialUpdateCloudControlService::new(false, false);
+        let provider = provider_with_partial_update_service(service.clone()).await;
+        let from = partial_update_bucket_state();
+        let patch = partial_update_bucket_patch();
+
+        let outcome = provider
+            .update_resource(
+                from.id.clone(),
+                from.identifier.as_deref().expect("identifier"),
+                &from,
+                &patch,
+            )
+            .await
+            .expect("update should return a partial outcome instead of error");
+
+        let UpdateOutcome::PartialSuccess { state, diagnostic } = outcome else {
+            panic!("expected partial success when post-update read fails");
+        };
+        assert!(service.saw_update_resource.load(Ordering::SeqCst));
+        assert!(
+            service.saw_get_resource.load(Ordering::SeqCst),
+            "provider must retry read with the identifier from failed progress"
+        );
+        assert!(state.exists);
+        assert_eq!(state.identifier.as_deref(), Some("partial-bucket"));
+        assert_eq!(
+            state.attributes.get("bucket_name"),
+            Some(&Value::Concrete(ConcreteValue::String(
+                "partial-bucket".to_string()
+            )))
+        );
+        assert!(state.attributes.contains_key("tags"));
+        assert_eq!(
+            diagnostic.reason(),
+            "handler failed: post-update read denied; read error: Failed to get resource: AccessDeniedException: read denied"
+        );
+        assert_eq!(diagnostic.missing_attributes(), &["tags".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn update_resource_returns_success_when_failed_identifier_read_succeeds() {
+        let service = PartialUpdateCloudControlService::new(false, true);
+        let provider = provider_with_partial_update_service(service.clone()).await;
+        let from = partial_update_bucket_state();
+        let patch = partial_update_bucket_patch();
+
+        let outcome = provider
+            .update_resource(
+                from.id.clone(),
+                from.identifier.as_deref().expect("identifier"),
+                &from,
+                &patch,
+            )
+            .await
+            .expect("update should recover when post-update read succeeds");
+
+        let UpdateOutcome::Success { state } = outcome else {
+            panic!("expected full success when post-update read succeeds");
+        };
+        assert!(service.saw_update_resource.load(Ordering::SeqCst));
+        assert!(
+            service.saw_get_resource.load(Ordering::SeqCst),
+            "provider must retry read with the identifier from failed progress"
+        );
+        assert!(state.exists);
+        assert_eq!(state.identifier.as_deref(), Some("partial-bucket"));
+        assert!(state.attributes.contains_key("tags"));
     }
 
     fn partial_create_bucket_resource() -> Resource {

--- a/carina-provider-awscc/src/provider/special_cases.rs
+++ b/carina-provider-awscc/src/provider/special_cases.rs
@@ -11,6 +11,7 @@ use carina_core::resource::{ConcreteValue, Resource, ResourceId, Value};
 use serde_json::json;
 
 use super::AwsccProvider;
+use crate::provider::cloudcontrol::WaitOutcome;
 use crate::schemas::config::AwsccSchemaConfig;
 
 impl AwsccProvider {
@@ -91,7 +92,8 @@ impl AwsccProvider {
                 && !attachments.is_empty()
             {
                 let patch_ops = vec![json!({"op": "remove", "path": "/Attachments"})];
-                self.cc_update_resource(config.aws_type_name, identifier, patch_ops)
+                match self
+                    .cc_update_resource(config.aws_type_name, identifier, patch_ops)
                     .await
                     .map_err(|e| {
                         ProviderError::api_error(
@@ -99,7 +101,16 @@ impl AwsccProvider {
                         )
                         .with_cause(e)
                         .for_resource(id.clone())
-                    })?;
+                    })? {
+                    WaitOutcome::Success { .. } => {}
+                    WaitOutcome::PartialOrFailed { status_message, .. } => {
+                        return Err(ProviderError::api_error(format!(
+                            "Failed to detach Internet Gateway from VPC before deletion: {}",
+                            status_message
+                        ))
+                        .for_resource(id.clone()));
+                    }
+                }
             }
         }
         Ok(())


### PR DESCRIPTION
## Summary

Closes #371.

Completes the chain that started with carina#3571 / #3574 (carina-side
`UpdateOutcome`) by detecting partial-update on the awscc side. When
CloudControl's update handler mutates the resource then fails the
post-update read, `cc_update_resource` no longer folds
`WaitOutcome::PartialOrFailed` back to `Err`. It returns
`UpdateOutcome::PartialSuccess`, carina records the post-mutation
`State` (identifier preserved, patch's desired attributes carried
forward), the apply exits with code 2, and the next plan surfaces the
attributes the handler couldn't observe as
`(known after next apply: post-create read failed — …)`.

## Decision rule (same as awscc#370 for create)

```text
ProgressEvent.OperationStatus = Success
  → WaitOutcome::Success { identifier }

ProgressEvent.OperationStatus = Failed | CancelComplete
├── ProgressEvent.identifier is Some(non-empty)
│     → WaitOutcome::PartialOrFailed { identifier, status_message }
│
└── ProgressEvent.identifier is None or empty
      → Err(ProviderError::api_error)
```

No `HandlerErrorCode` allowlist. The single structural signal is
"did the handler confirm an Identifier before failing?" — same rule
as create-side awscc#370.

For `update_resource`, a `PartialOrFailed` outcome retries one
`read_resource`; success becomes `UpdateOutcome::Success` (with desired
carry-forward), failure becomes
`UpdateOutcome::partial_success(state, reason, missing_attributes)`
with the identifier preserved and `missing_attributes` limited to
attributes the user actually authored.

The previous `wait_for_operation` shim (`Result<String>` wrapper) is
removed — only `cc_update_resource` called it, and the new update
path consumes `WaitOutcome` directly. A pre-delete IGW detach corner
case in `provider/special_cases.rs` now collapses `PartialOrFailed →
Err` explicitly.

## Changes

- `carina-core`, `carina-plugin-sdk`, `carina-provider-protocol`
  bumped to `c5231c06` (carina #3574 merge).
- `carina-aws-types` bumped to `21c5e25c` (aws PR #457 merge).
- `carina-plugin-wit` submodule bumped to `53469e8` (plugin-wit #26).
- `Provider::update` returns `ProviderResult<UpdateOutcome>`.
- `convert.rs` adds `core_to_proto_update_outcome` and follows
  the `PartialCreateDiagnostic` → `PartialReadDiagnostic` rename.

## Test plan

Three new unit tests, symmetric with awscc#370's create tests:

- `update_resource_returns_success_when_wait_success`
- `update_resource_returns_partial_success_when_failed_identifier_read_fails`
- `update_resource_returns_success_when_failed_identifier_read_succeeds`

Verify:
- `cargo nextest run --all-features`: 475 passed.
- `cargo test --workspace --doc`: passed.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `bash scripts/check-carina-pin.sh`: rev `c5231c06` verified.
- `bash scripts/check-docs-drift.sh`: schemas and docs in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
