### PR TITLE
fix(iam): synthesize iam.Role.arn at read-back so downstream bindings resolve (carina#3582)

### DIFF
--- a/carina-provider-awscc/src/provider/arn_synthesis.rs
+++ b/carina-provider-awscc/src/provider/arn_synthesis.rs
@@ -16,11 +16,50 @@ use carina_core::resource::{ConcreteValue, Value};
 
 use super::AwsccProvider;
 
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum SynthesisStatus {
+    Complete,
+    Missing { attributes: Vec<String> },
+}
+
+impl SynthesisStatus {
+    pub(crate) fn missing_attributes(self) -> Option<Vec<String>> {
+        match self {
+            Self::Complete => None,
+            Self::Missing { attributes } => Some(attributes),
+        }
+    }
+}
+
 /// Build the ARN for `AWS::CloudFront::Distribution`.
 ///
 /// CloudFront is a global service: the region segment is empty.
-pub(crate) fn cloudfront_distribution_arn(account_id: &str, distribution_id: &str) -> String {
-    format!("arn:aws:cloudfront::{account_id}:distribution/{distribution_id}")
+pub(crate) fn cloudfront_distribution_arn(
+    partition: &str,
+    account_id: &str,
+    distribution_id: &str,
+) -> String {
+    format!("arn:{partition}:cloudfront::{account_id}:distribution/{distribution_id}")
+}
+
+/// Build the ARN for `AWS::IAM::Role`.
+///
+/// IAM is a global service: the region segment is empty.
+pub(crate) fn iam_role_arn(
+    partition: &str,
+    account_id: &str,
+    path: &str,
+    role_name: &str,
+) -> String {
+    format!("arn:{partition}:iam::{account_id}:role{path}{role_name}")
+}
+
+pub(crate) fn partition_for_region(region: Option<&str>) -> &'static str {
+    match region {
+        Some(region) if region.starts_with("cn-") => "aws-cn",
+        Some(region) if region.starts_with("us-gov-") => "aws-us-gov",
+        _ => "aws",
+    }
 }
 
 /// If `attributes` is missing the `arn` slot for a
@@ -32,6 +71,7 @@ pub(crate) fn cloudfront_distribution_arn(account_id: &str, distribution_id: &st
 pub(crate) fn pending_cloudfront_distribution_arn(
     resource_type: &str,
     attributes: &HashMap<String, Value>,
+    partition: &str,
     account_id: &str,
 ) -> Option<Value> {
     if resource_type != "cloudfront.Distribution" {
@@ -44,8 +84,53 @@ pub(crate) fn pending_cloudfront_distribution_arn(
         return None;
     };
     Some(Value::Concrete(ConcreteValue::String(
-        cloudfront_distribution_arn(account_id, id),
+        cloudfront_distribution_arn(partition, account_id, id),
     )))
+}
+
+/// If `attributes` is missing the `arn` slot for an `iam.Role` read-back
+/// but `role_name` is present, return the synthesized ARN value to insert.
+/// The caller separately treats an absent role name as a missing synthesized
+/// attribute so create can return `PartialSuccess` instead of publishing an
+/// incomplete success state.
+pub(crate) fn pending_iam_role_arn(
+    resource_type: &str,
+    attributes: &HashMap<String, Value>,
+    partition: &str,
+    account_id: &str,
+) -> Option<Value> {
+    if resource_type != "iam.Role" {
+        return None;
+    }
+    if attributes.contains_key("arn") {
+        return None;
+    }
+    let role_name = string_attr(attributes, "role_name")?;
+    let path = string_attr(attributes, "path").unwrap_or("/");
+    Some(Value::Concrete(ConcreteValue::String(iam_role_arn(
+        partition, account_id, path, role_name,
+    ))))
+}
+
+pub(crate) fn missing_synthesized_attributes(
+    resource_type: &str,
+    attributes: &HashMap<String, Value>,
+) -> Vec<String> {
+    if resource_type == "iam.Role"
+        && !attributes.contains_key("arn")
+        && string_attr(attributes, "role_name").is_none()
+    {
+        vec!["arn".to_string()]
+    } else {
+        Vec::new()
+    }
+}
+
+fn string_attr<'a>(attributes: &'a HashMap<String, Value>, name: &str) -> Option<&'a str> {
+    match attributes.get(name) {
+        Some(Value::Concrete(ConcreteValue::String(value))) => Some(value),
+        _ => None,
+    }
 }
 
 /// Whether `synthesize_read_attributes` would mutate `attributes` for this
@@ -53,34 +138,49 @@ pub(crate) fn pending_cloudfront_distribution_arn(
 /// "non-distribution reads — and distribution reads with no id — never call
 /// STS" invariant can be unit-tested without instantiating a real provider.
 pub(crate) fn needs_synthesis(resource_type: &str, attributes: &HashMap<String, Value>) -> bool {
-    resource_type == "cloudfront.Distribution"
-        && !attributes.contains_key("arn")
-        && matches!(
+    if attributes.contains_key("arn") {
+        return false;
+    }
+    match resource_type {
+        "cloudfront.Distribution" => matches!(
             attributes.get("id"),
             Some(Value::Concrete(ConcreteValue::String(_)))
-        )
+        ),
+        "iam.Role" => string_attr(attributes, "role_name").is_some(),
+        _ => false,
+    }
 }
 
 impl AwsccProvider {
     /// Populate read-side attributes whose value is not returned by Cloud
-    /// Control but is derivable from data we already have. Today this is
-    /// just `cloudfront.Distribution.arn`; the function is a switch on
-    /// resource type so adding the next case stays a few lines.
+    /// Control but is derivable from data we already have.
     pub(crate) async fn synthesize_read_attributes(
         &self,
         resource_type: &str,
         attributes: &mut HashMap<String, Value>,
-    ) -> ProviderResult<()> {
+    ) -> ProviderResult<SynthesisStatus> {
+        let missing = missing_synthesized_attributes(resource_type, attributes);
+        if !missing.is_empty() {
+            return Ok(SynthesisStatus::Missing {
+                attributes: missing,
+            });
+        }
         if !needs_synthesis(resource_type, attributes) {
-            return Ok(());
+            return Ok(SynthesisStatus::Complete);
         }
         let account_id = self.account_id().await?;
+        let partition =
+            partition_for_region(self.aws_config.region().map(|region| region.as_ref()));
         if let Some(value) =
-            pending_cloudfront_distribution_arn(resource_type, attributes, account_id)
+            pending_cloudfront_distribution_arn(resource_type, attributes, partition, account_id)
         {
             attributes.insert("arn".to_string(), value);
         }
-        Ok(())
+        if let Some(value) = pending_iam_role_arn(resource_type, attributes, partition, account_id)
+        {
+            attributes.insert("arn".to_string(), value);
+        }
+        Ok(SynthesisStatus::Complete)
     }
 }
 
@@ -91,11 +191,29 @@ mod tests {
 
     #[test]
     fn cloudfront_distribution_arn_uses_empty_region_segment() {
-        let arn = cloudfront_distribution_arn("123456789012", "E1U5RQF7T870K0");
+        let arn = cloudfront_distribution_arn("aws", "123456789012", "E1U5RQF7T870K0");
         assert_eq!(
             arn,
             "arn:aws:cloudfront::123456789012:distribution/E1U5RQF7T870K0"
         );
+    }
+
+    #[test]
+    fn iam_role_arn_uses_empty_region_segment_and_path() {
+        let arn = iam_role_arn("aws-us-gov", "123456789012", "/service-role/", "flow-log");
+        assert_eq!(
+            arn,
+            "arn:aws-us-gov:iam::123456789012:role/service-role/flow-log"
+        );
+    }
+
+    #[test]
+    fn partition_for_region_uses_aws_partition_by_region_family() {
+        assert_eq!(partition_for_region(Some("us-east-1")), "aws");
+        assert_eq!(partition_for_region(Some("ap-northeast-1")), "aws");
+        assert_eq!(partition_for_region(Some("us-gov-west-1")), "aws-us-gov");
+        assert_eq!(partition_for_region(Some("cn-north-1")), "aws-cn");
+        assert_eq!(partition_for_region(None), "aws");
     }
 
     /// `AWS::CloudFront::Distribution`'s CFN schema does not expose `Arn`,
@@ -132,9 +250,13 @@ mod tests {
     #[test]
     fn pending_arn_builds_value_when_id_present_and_arn_missing() {
         let attrs = attrs_with_id("E1U5RQF7T870K0");
-        let v =
-            pending_cloudfront_distribution_arn("cloudfront.Distribution", &attrs, "123456789012")
-                .expect("ARN must be synthesizable when id is present");
+        let v = pending_cloudfront_distribution_arn(
+            "cloudfront.Distribution",
+            &attrs,
+            "aws",
+            "123456789012",
+        )
+        .expect("ARN must be synthesizable when id is present");
         match v {
             Value::Concrete(ConcreteValue::String(s)) => assert_eq!(
                 s,
@@ -152,8 +274,13 @@ mod tests {
             Value::Concrete(ConcreteValue::String("preexisting".to_string())),
         );
         assert!(
-            pending_cloudfront_distribution_arn("cloudfront.Distribution", &attrs, "123456789012",)
-                .is_none()
+            pending_cloudfront_distribution_arn(
+                "cloudfront.Distribution",
+                &attrs,
+                "aws",
+                "123456789012",
+            )
+            .is_none()
         );
     }
 
@@ -161,8 +288,13 @@ mod tests {
     fn pending_arn_returns_none_when_id_missing() {
         let attrs = HashMap::new();
         assert!(
-            pending_cloudfront_distribution_arn("cloudfront.Distribution", &attrs, "123456789012",)
-                .is_none()
+            pending_cloudfront_distribution_arn(
+                "cloudfront.Distribution",
+                &attrs,
+                "aws",
+                "123456789012",
+            )
+            .is_none()
         );
     }
 
@@ -170,8 +302,66 @@ mod tests {
     fn pending_arn_returns_none_for_unrelated_resource_type() {
         let attrs = attrs_with_id("E1U5RQF7T870K0");
         assert!(
-            pending_cloudfront_distribution_arn("cloudfront.OriginAccessControl", &attrs, "123",)
-                .is_none()
+            pending_cloudfront_distribution_arn(
+                "cloudfront.OriginAccessControl",
+                &attrs,
+                "aws",
+                "123",
+            )
+            .is_none()
+        );
+    }
+
+    fn attrs_with_role(path: Option<&str>, role_name: Option<&str>) -> HashMap<String, Value> {
+        let mut attrs = HashMap::new();
+        if let Some(path) = path {
+            attrs.insert(
+                "path".to_string(),
+                Value::Concrete(ConcreteValue::String(path.to_string())),
+            );
+        }
+        if let Some(role_name) = role_name {
+            attrs.insert(
+                "role_name".to_string(),
+                Value::Concrete(ConcreteValue::String(role_name.to_string())),
+            );
+        }
+        attrs
+    }
+
+    #[test]
+    fn pending_iam_role_arn_builds_value_when_role_name_present() {
+        let attrs = attrs_with_role(Some("/service-role/"), Some("flow-log-role"));
+        let v = pending_iam_role_arn("iam.Role", &attrs, "aws-cn", "123456789012")
+            .expect("ARN must be synthesizable when role_name is present");
+        match v {
+            Value::Concrete(ConcreteValue::String(s)) => assert_eq!(
+                s,
+                "arn:aws-cn:iam::123456789012:role/service-role/flow-log-role"
+            ),
+            other => panic!("expected concrete string ARN, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn pending_iam_role_arn_defaults_path_to_slash() {
+        let attrs = attrs_with_role(None, Some("flow-log-role"));
+        let v = pending_iam_role_arn("iam.Role", &attrs, "aws", "123456789012")
+            .expect("ARN must be synthesizable when role_name is present");
+        match v {
+            Value::Concrete(ConcreteValue::String(s)) => {
+                assert_eq!(s, "arn:aws:iam::123456789012:role/flow-log-role");
+            }
+            other => panic!("expected concrete string ARN, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn missing_synthesized_attributes_reports_iam_role_arn_without_role_name() {
+        let attrs = attrs_with_role(Some("/"), None);
+        assert_eq!(
+            missing_synthesized_attributes("iam.Role", &attrs),
+            vec!["arn".to_string()]
         );
     }
 

--- a/carina-provider-awscc/src/provider/operations.rs
+++ b/carina-provider-awscc/src/provider/operations.rs
@@ -17,6 +17,7 @@ use serde_json::json;
 use super::conversion::{aws_value_to_dsl_with_defs, dsl_value_to_aws_with_defs};
 use super::update::build_update_patches;
 use super::{AwsccProvider, get_schema_config};
+use crate::provider::arn_synthesis::SynthesisStatus;
 use crate::provider::cloudcontrol::WaitOutcome;
 
 impl AwsccProvider {
@@ -72,7 +73,8 @@ impl AwsccProvider {
 
         // Synthesize attributes the Cloud Control read does not return
         // (e.g. cloudfront.Distribution.arn). Reads STS once, then caches.
-        self.synthesize_read_attributes(resource_type, &mut attributes)
+        let _ = self
+            .synthesize_read_attributes(resource_type, &mut attributes)
             .await?;
 
         Ok(State::existing(id, attributes).with_identifier(identifier))
@@ -150,7 +152,26 @@ impl AwsccProvider {
                     .await
                 {
                     Ok(state) => {
-                        let state = merge_desired_attributes(state, resource, config);
+                        let mut state = merge_desired_attributes(state, resource, config);
+                        if let Some(missing_attributes) = self
+                            .synthesize_read_attributes(
+                                &resource.id.resource_type,
+                                &mut state.attributes,
+                            )
+                            .await?
+                            .missing_attributes()
+                        {
+                            let reason = format!(
+                                "handler failed: {}; read-back missing synthesized attributes: {}",
+                                status_message,
+                                missing_attributes.join(", ")
+                            );
+                            return Ok(CreateOutcome::partial_success(
+                                state,
+                                reason,
+                                missing_attributes,
+                            ));
+                        }
                         return Ok(CreateOutcome::Success { state });
                     }
                     Err(read_err) => {
@@ -186,9 +207,22 @@ impl AwsccProvider {
             )
             .await?;
 
-        let state = merge_desired_attributes(state, resource, config);
+        let mut state = merge_desired_attributes(state, resource, config);
 
-        Ok(CreateOutcome::Success { state })
+        match self
+            .synthesize_read_attributes(&resource.id.resource_type, &mut state.attributes)
+            .await?
+        {
+            SynthesisStatus::Complete => Ok(CreateOutcome::Success { state }),
+            SynthesisStatus::Missing { attributes } => Ok(CreateOutcome::partial_success(
+                state,
+                format!(
+                    "read-back missing synthesized attributes: {}",
+                    attributes.join(", ")
+                ),
+                attributes,
+            )),
+        }
     }
 
     /// Update a resource by applying an [`UpdatePatch`] to its
@@ -549,6 +583,151 @@ mod tests {
     }
 
     #[derive(Debug)]
+    struct IamRoleCreateCloudControlService {
+        include_role_name_in_read: bool,
+        saw_create_resource: AtomicBool,
+        saw_get_resource: AtomicBool,
+    }
+
+    impl IamRoleCreateCloudControlService {
+        fn new(include_role_name_in_read: bool) -> Arc<Self> {
+            Arc::new(Self {
+                include_role_name_in_read,
+                saw_create_resource: AtomicBool::new(false),
+                saw_get_resource: AtomicBool::new(false),
+            })
+        }
+    }
+
+    impl MockService for IamRoleCreateCloudControlService {
+        fn service_name(&self) -> &str {
+            "cloudcontrolapi"
+        }
+
+        fn url_patterns(&self) -> Vec<&str> {
+            vec![
+                r"https?://cloudcontrolapi\..*\.amazonaws\.com",
+                r"https?://cloudcontrolapi\.amazonaws\.com",
+            ]
+        }
+
+        fn handle(
+            &self,
+            request: MockRequest,
+        ) -> Pin<Box<dyn Future<Output = MockResponse> + Send + '_>> {
+            Box::pin(async move {
+                let action = request
+                    .headers
+                    .get("x-amz-target")
+                    .and_then(|v| v.to_str().ok())
+                    .and_then(|v| v.split('.').next_back())
+                    .unwrap_or_default();
+                match action {
+                    "CreateResource" => {
+                        self.saw_create_resource.store(true, Ordering::SeqCst);
+                        MockResponse::json(
+                            200,
+                            r#"{"ProgressEvent":{"RequestToken":"iam-role-token"}}"#,
+                        )
+                    }
+                    "GetResourceRequestStatus" => MockResponse::json(
+                        200,
+                        r#"{"ProgressEvent":{"RequestToken":"iam-role-token","OperationStatus":"SUCCESS","Identifier":"flow-log-role"}}"#,
+                    ),
+                    "GetResource" => {
+                        self.saw_get_resource.store(true, Ordering::SeqCst);
+                        let properties = if self.include_role_name_in_read {
+                            r#"{"Path":"/service-role/","RoleName":"flow-log-role","RoleId":"AROATESTROLEID"}"#
+                        } else {
+                            r#"{"Path":"/service-role/","RoleId":"AROATESTROLEID"}"#
+                        };
+                        MockResponse::json(
+                            200,
+                            format!(
+                                r#"{{"TypeName":"AWS::IAM::Role","ResourceDescription":{{"Identifier":"flow-log-role","Properties":{properties:?}}}}}"#
+                            ),
+                        )
+                    }
+                    _ => MockResponse::json(
+                        400,
+                        format!(
+                            r#"{{"__type":"InvalidAction","message":"unexpected action {action}"}}"#
+                        ),
+                    ),
+                }
+            })
+        }
+    }
+
+    #[derive(Debug)]
+    struct CallerIdentityService {
+        saw_get_caller_identity: AtomicBool,
+    }
+
+    impl CallerIdentityService {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                saw_get_caller_identity: AtomicBool::new(false),
+            })
+        }
+    }
+
+    impl MockService for CallerIdentityService {
+        fn service_name(&self) -> &str {
+            "sts"
+        }
+
+        fn url_patterns(&self) -> Vec<&str> {
+            vec![
+                r"https?://sts\..*\.amazonaws\.com",
+                r"https?://sts\.amazonaws\.com",
+            ]
+        }
+
+        fn handle(
+            &self,
+            _request: MockRequest,
+        ) -> Pin<Box<dyn Future<Output = MockResponse> + Send + '_>> {
+            Box::pin(async move {
+                self.saw_get_caller_identity.store(true, Ordering::SeqCst);
+                MockResponse::xml(
+                    200,
+                    r#"<GetCallerIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <GetCallerIdentityResult>
+    <Arn>arn:aws-us-gov:iam::123456789012:user/test</Arn>
+    <UserId>AIDATESTUSER</UserId>
+    <Account>123456789012</Account>
+  </GetCallerIdentityResult>
+  <ResponseMetadata>
+    <RequestId>00000000-0000-0000-0000-000000000000</RequestId>
+  </ResponseMetadata>
+</GetCallerIdentityResponse>"#,
+                )
+            })
+        }
+    }
+
+    async fn provider_with_iam_role_create_service(
+        cloudcontrol: Arc<IamRoleCreateCloudControlService>,
+        sts: Arc<CallerIdentityService>,
+    ) -> AwsccProvider {
+        use aws_config::{BehaviorVersion, Region};
+
+        let mock = MockAws::builder()
+            .with_service(cloudcontrol)
+            .with_service(sts)
+            .build();
+        let config = aws_config::defaults(BehaviorVersion::latest())
+            .http_client(mock.http_client())
+            .credentials_provider(mock.credentials_provider())
+            .region(Region::new("us-gov-west-1"))
+            .load()
+            .await;
+
+        AwsccProvider::from_sdk_config(config, &super::super::AwsccProviderConfig::default()).await
+    }
+
+    #[derive(Debug)]
     struct PartialUpdateCloudControlService {
         wait_succeeds: bool,
         read_succeeds: bool,
@@ -781,6 +960,53 @@ mod tests {
         )
     }
 
+    fn assume_role_policy_document() -> Value {
+        let mut statement = indexmap::IndexMap::new();
+        statement.insert(
+            "Effect".to_string(),
+            Value::Concrete(ConcreteValue::String("Allow".to_string())),
+        );
+        statement.insert(
+            "Action".to_string(),
+            Value::Concrete(ConcreteValue::String("sts:AssumeRole".to_string())),
+        );
+        statement.insert(
+            "Principal".to_string(),
+            Value::Concrete(ConcreteValue::Map(indexmap::IndexMap::from([(
+                "Service".to_string(),
+                Value::Concrete(ConcreteValue::String(
+                    "vpc-flow-logs.amazonaws.com".to_string(),
+                )),
+            )]))),
+        );
+
+        Value::Concrete(ConcreteValue::Map(indexmap::IndexMap::from([
+            (
+                "Version".to_string(),
+                Value::Concrete(ConcreteValue::String("2012-10-17".to_string())),
+            ),
+            (
+                "Statement".to_string(),
+                Value::Concrete(ConcreteValue::List(vec![Value::Concrete(
+                    ConcreteValue::Map(statement),
+                )])),
+            ),
+        ])))
+    }
+
+    fn iam_role_resource(include_role_name: bool) -> Resource {
+        let resource = Resource::with_provider("awscc", "iam.Role", "flow_log_role", None)
+            .with_attribute("assume_role_policy_document", assume_role_policy_document());
+        if include_role_name {
+            resource.with_attribute(
+                "role_name",
+                Value::Concrete(ConcreteValue::String("flow-log-role".to_string())),
+            )
+        } else {
+            resource
+        }
+    }
+
     #[tokio::test]
     async fn create_resource_returns_partial_success_when_failed_identifier_read_fails() {
         let service = PartialCreateCloudControlService::new(false);
@@ -835,6 +1061,93 @@ mod tests {
             Some(&Value::Concrete(ConcreteValue::String(
                 "partial-bucket".to_string()
             )))
+        );
+    }
+
+    #[tokio::test]
+    async fn create_iam_role_synthesizes_arn_when_cloudcontrol_omits_arn() {
+        let cloudcontrol = IamRoleCreateCloudControlService::new(false);
+        let sts = CallerIdentityService::new();
+        let provider =
+            provider_with_iam_role_create_service(cloudcontrol.clone(), sts.clone()).await;
+
+        let outcome = provider
+            .create_resource(&iam_role_resource(true))
+            .await
+            .expect("IAM role create should succeed");
+
+        let CreateOutcome::Success { state } = outcome else {
+            panic!("expected full success when role_name can be carried forward");
+        };
+        assert!(cloudcontrol.saw_create_resource.load(Ordering::SeqCst));
+        assert!(cloudcontrol.saw_get_resource.load(Ordering::SeqCst));
+        assert!(
+            sts.saw_get_caller_identity.load(Ordering::SeqCst),
+            "ARN synthesis must use the existing account lookup"
+        );
+        assert_eq!(
+            state.attributes.get("arn"),
+            Some(&Value::Concrete(ConcreteValue::String(
+                "arn:aws-us-gov:iam::123456789012:role/service-role/flow-log-role".to_string()
+            ))),
+            "synthesis must derive the partition from the provider region instead of hardcoding aws"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_iam_role_synthesizes_arn_from_cloudcontrol_role_name() {
+        let cloudcontrol = IamRoleCreateCloudControlService::new(true);
+        let sts = CallerIdentityService::new();
+        let provider = provider_with_iam_role_create_service(cloudcontrol, sts.clone()).await;
+
+        let outcome = provider
+            .create_resource(&iam_role_resource(false))
+            .await
+            .expect("IAM role create should succeed when read-back includes RoleName");
+
+        let CreateOutcome::Success { state } = outcome else {
+            panic!("expected full success when CloudControl returns RoleName");
+        };
+        assert!(
+            sts.saw_get_caller_identity.load(Ordering::SeqCst),
+            "ARN synthesis must use the existing account lookup"
+        );
+        assert_eq!(
+            state.attributes.get("arn"),
+            Some(&Value::Concrete(ConcreteValue::String(
+                "arn:aws-us-gov:iam::123456789012:role/service-role/flow-log-role".to_string()
+            )))
+        );
+    }
+
+    #[tokio::test]
+    async fn create_iam_role_returns_partial_success_when_role_name_is_unknown() {
+        let cloudcontrol = IamRoleCreateCloudControlService::new(false);
+        let sts = CallerIdentityService::new();
+        let provider = provider_with_iam_role_create_service(cloudcontrol, sts.clone()).await;
+
+        let outcome = provider
+            .create_resource(&iam_role_resource(false))
+            .await
+            .expect("IAM role create should report partial success");
+
+        let CreateOutcome::PartialSuccess { state, diagnostic } = outcome else {
+            panic!("expected partial success when ARN cannot be synthesized");
+        };
+        assert!(state.exists);
+        assert_eq!(state.identifier.as_deref(), Some("flow-log-role"));
+        assert!(
+            !state.attributes.contains_key("arn"),
+            "unknown ARN must not be published as a successful attribute"
+        );
+        assert_eq!(diagnostic.missing_attributes(), &["arn".to_string()]);
+        assert_eq!(
+            diagnostic.reason(),
+            "read-back missing synthesized attributes: arn"
+        );
+        assert!(
+            !sts.saw_get_caller_identity.load(Ordering::SeqCst),
+            "missing role_name should not call STS because the ARN is not synthesizable"
         );
     }
 


### PR DESCRIPTION
## Summary

Fix carina-rs/carina#3582 — Cloud Control's `GetResource` for `AWS::IAM::Role` does not include `Arn` in its scalar props payload, so the previous create path returned `CreateOutcome::Success { state }` with `state.attributes["arn"]` unset. carina-core publishes whatever the provider returns into the binding view, so downstream resources referencing `<role>.arn` failed with `binding has not been published yet`.

The aws-side `ec2_flow_log/basic` works because it consumes a real `aws.iam.Role.arn` from the native SDK provider (which always populates it). The awscc-side `ec2_flow_log/cloudwatch` fails because it depends on `awscc.iam.Role.arn`, which Cloud Control omits.

## What this PR does

1. Extends the existing `provider/arn_synthesis.rs` seam (which already covers `cloudfront.Distribution`) to also synthesize `iam.Role.arn` at read-back. ARN format: `arn:<partition>:iam::<account>:role<path><role_name>`, with `path` defaulting to `/`.
2. Adds `partition_for_region` to derive partition from the provider's region (`cn-*` → `aws-cn`, `us-gov-*` → `aws-us-gov`, else `aws`). The existing `cloudfront_distribution_arn` helper takes the same partition argument so the seam is uniform.
3. Adds `SynthesisStatus { Complete, Missing { attributes } }` so the synthesis call site can route to `CreateOutcome::PartialSuccess { state, diagnostic }` instead of publishing an incomplete success when `role_name` is unknown.
4. Threads `Missing` through both the normal create-success path and the post-failure read-recovery path in `operations.rs`.

## Why type-state for the missing-attributes case

`Success { state }` with `arn` silently absent is exactly the broken state the original symptom hit. Making "we synthesized everything we needed" structurally distinguishable from "we couldn't fill an attribute we promised" prevents the next consumer from rediscovering the bug by adding another synthesis case and forgetting the fallback. The runtime side (carina#3567's `partial_success`) is the right channel for that signal.

## Out of scope

- `iam.OidcProvider` also declares `arn`; Cloud Control may have the same gap, but real-AWS behavior cannot be confirmed from code alone. Follow-up if acceptance ever covers it.
- carina-core's binding publisher is unchanged. The contract "provider returns state, runtime publishes it" is correct; the bug was the provider returning an incomplete Success.

## Test plan

- [x] `cargo check` — passes.
- [x] `cargo test` — passes; 8 new tests across `arn_synthesis::tests` and `operations::tests` cover: empty region segment, partition selection, synthesis when role_name comes from desired carry-forward, synthesis when role_name comes from Cloud Control's response, default `/` path, `Missing` reporting for absent role_name, and the end-to-end create paths (Success vs PartialSuccess).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — passes.
- [x] `cargo fmt --check` — passes.
- [x] `cargo build --target wasm32-wasip2 -p carina-provider-awscc --release` — passes.
- [ ] Re-run awscc acceptance `ec2_flow_log/cloudwatch` after merge to confirm the binding-publish gap is closed.

Refs carina-rs/carina#3582.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
