### PR TITLE
fix(read): canonicalize scalar/list Union to StringList in read deserializer (carina#3584)

### DIFF
--- a/carina-provider-awscc/src/provider/conversion.rs
+++ b/carina-provider-awscc/src/provider/conversion.rs
@@ -27,6 +27,64 @@ fn union_members_for<'a>(
     schema.union_members_with_budget(attr_type, &mut ShapeWalkBudget::new(256))
 }
 
+fn string_or_list_of_strings_from_json(
+    schema: &ResourceSchema,
+    members: &[AttributeType],
+    value: &serde_json::Value,
+) -> Option<Value> {
+    let has_string = members
+        .iter()
+        .any(|member| matches!(schema.shape_of(member), Shape::String { .. }));
+    let has_list_of_strings = members.iter().any(|member| {
+        let Shape::List { element_type, .. } = schema.shape_of(member) else {
+            return false;
+        };
+        matches!(schema.shape_of(element_type), Shape::String { .. })
+    });
+
+    if !has_string || !has_list_of_strings {
+        return None;
+    }
+
+    if let Some(s) = value.as_str() {
+        return Some(Value::Concrete(ConcreteValue::StringList(vec![
+            s.to_string(),
+        ])));
+    }
+
+    let arr = value.as_array()?;
+    let items: Option<Vec<String>> = arr
+        .iter()
+        .map(|item| item.as_str().map(ToString::to_string))
+        .collect();
+    items.map(|items| Value::Concrete(ConcreteValue::StringList(items)))
+}
+
+fn json_matches_shape(
+    schema: &ResourceSchema,
+    attr_type: &AttributeType,
+    value: &serde_json::Value,
+) -> bool {
+    match schema.shape_of(attr_type) {
+        Shape::String { .. } | Shape::Enum { .. } => value.is_string(),
+        Shape::Int { .. } => value.as_i64().is_some(),
+        Shape::Float { .. } => value.is_number(),
+        Shape::Bool => value.is_boolean(),
+        Shape::Duration => value.is_string() || value.is_number(),
+        Shape::List { element_type, .. } => value.as_array().is_some_and(|items| {
+            items
+                .iter()
+                .all(|item| json_matches_shape(schema, element_type, item))
+        }),
+        Shape::Map { .. } | Shape::Struct { .. } => value.is_object(),
+        Shape::Union => union_members_for(schema, attr_type).is_some_and(|members| {
+            members
+                .iter()
+                .any(|member| json_matches_shape(schema, member, value))
+        }),
+    }
+}
+
 /// carina#3340: schema-aware variant that takes the enclosing
 /// [`ResourceSchema::defs`] map so `AttributeType::Ref` chains can be
 /// resolved during the value-tree walk. Callers that hold a resource
@@ -106,7 +164,14 @@ pub(crate) fn aws_value_to_dsl_with_defs(
     if let Shape::Union = shape
         && let Some(members) = union_members_for(&schema, attr_type)
     {
-        for member in members {
+        if let Some(result) = string_or_list_of_strings_from_json(&schema, members, value) {
+            return Some(result);
+        }
+
+        for member in members
+            .iter()
+            .filter(|member| json_matches_shape(&schema, member, value))
+        {
             if let Some(result) =
                 aws_value_to_dsl_with_defs(dsl_name, value, member, resource_type, defs)
             {
@@ -1397,18 +1462,18 @@ mod tests {
                     );
                     assert_eq!(
                         stmt.get("action"),
-                        Some(&Value::Concrete(ConcreteValue::String(
+                        Some(&Value::Concrete(ConcreteValue::StringList(vec![
                             "sts:AssumeRole".to_string()
-                        )))
+                        ])))
                     );
                     if let Some(Value::Concrete(ConcreteValue::Map(principal))) =
                         stmt.get("principal")
                     {
                         assert_eq!(
                             principal.get("service"),
-                            Some(&Value::Concrete(ConcreteValue::String(
+                            Some(&Value::Concrete(ConcreteValue::StringList(vec![
                                 "lambda.amazonaws.com".to_string()
-                            )))
+                            ])))
                         );
                     } else {
                         panic!("Expected principal to be a Map");
@@ -1422,6 +1487,104 @@ mod tests {
         } else {
             panic!("Expected Value::Map, got: {:?}", result);
         }
+    }
+
+    #[test]
+    fn test_aws_value_to_dsl_iam_policy_document_canonicalizes_scalar_action_to_string_list() {
+        use carina_aws_types::iam_policy_document;
+
+        let attr_type = iam_policy_document();
+        let aws_json = json!({
+            "Version": "2012-10-17",
+            "Statement": [{
+                "Effect": "Allow",
+                "Action": "s3:GetObject",
+                "Resource": "arn:aws:s3:::*"
+            }]
+        });
+
+        let result = aws_value_to_dsl_with_defs(
+            "policy_document",
+            &aws_json,
+            &attr_type,
+            "ec2.VpcEndpoint",
+            &std::collections::BTreeMap::new(),
+        )
+        .expect("policy document should convert");
+        let Value::Concrete(ConcreteValue::Map(policy_document)) = result else {
+            panic!("Expected policy document map");
+        };
+        let Some(Value::Concrete(ConcreteValue::List(statements))) =
+            policy_document.get("statement")
+        else {
+            panic!("Expected statement list");
+        };
+        let Some(Value::Concrete(ConcreteValue::Map(statement))) = statements.first() else {
+            panic!("Expected statement map");
+        };
+
+        assert_eq!(
+            statement.get("action"),
+            Some(&Value::Concrete(ConcreteValue::StringList(vec![
+                "s3:GetObject".to_string()
+            ])))
+        );
+        assert_eq!(
+            statement.get("resource"),
+            Some(&Value::Concrete(ConcreteValue::StringList(vec![
+                "arn:aws:s3:::*".to_string()
+            ])))
+        );
+    }
+
+    #[test]
+    fn test_aws_value_to_dsl_iam_policy_document_canonicalizes_list_action_to_string_list() {
+        use carina_aws_types::iam_policy_document;
+
+        let attr_type = iam_policy_document();
+        let aws_json = json!({
+            "Version": "2012-10-17",
+            "Statement": [{
+                "Effect": "Allow",
+                "Action": ["s3:GetObject", "s3:PutObject"],
+                "Resource": ["arn:aws:s3:::*", "arn:aws:s3:::example/*"]
+            }]
+        });
+
+        let result = aws_value_to_dsl_with_defs(
+            "policy_document",
+            &aws_json,
+            &attr_type,
+            "ec2.VpcEndpoint",
+            &std::collections::BTreeMap::new(),
+        )
+        .expect("policy document should convert");
+        let Value::Concrete(ConcreteValue::Map(policy_document)) = result else {
+            panic!("Expected policy document map");
+        };
+        let Some(Value::Concrete(ConcreteValue::List(statements))) =
+            policy_document.get("statement")
+        else {
+            panic!("Expected statement list");
+        };
+        let Some(Value::Concrete(ConcreteValue::Map(statement))) = statements.first() else {
+            panic!("Expected statement map");
+        };
+
+        assert_eq!(
+            statement.get("action"),
+            Some(&Value::Concrete(ConcreteValue::StringList(vec![
+                "s3:GetObject".to_string(),
+                "s3:PutObject".to_string()
+            ])))
+        );
+        assert_eq!(
+            statement.get("resource"),
+            Some(&Value::Concrete(ConcreteValue::StringList(vec![
+                "arn:aws:s3:::*".to_string(),
+                "arn:aws:s3:::example/*".to_string()
+            ])))
+        );
     }
 
     /// Regression for aws#313 + awscc#254. aws#313 made the IAM policy
@@ -1471,9 +1634,9 @@ mod tests {
                                 ),
                                 (
                                     "action".to_string(),
-                                    Value::Concrete(ConcreteValue::String(
+                                    Value::Concrete(ConcreteValue::StringList(vec![
                                         "sts:AssumeRole".to_string(),
-                                    )),
+                                    ])),
                                 ),
                             ]
                             .into_iter()

--- a/carina-provider-awscc/tests/ec2_vpc_endpoint_policy_document_read.rs
+++ b/carina-provider-awscc/tests/ec2_vpc_endpoint_policy_document_read.rs
@@ -1,0 +1,195 @@
+use aws_config::{BehaviorVersion, Region};
+use carina_core::provider::{Provider, ReadRequest};
+use carina_core::resource::{ConcreteValue, ResourceId, Value};
+use carina_provider_awscc::AwsccProvider;
+use carina_provider_awscc::provider::AwsccProviderConfig;
+use serde_json::json;
+use std::future::Future;
+use std::pin::Pin;
+use winterbaume_core::{MockAws, MockRequest, MockResponse, MockService, json_error_response};
+
+const VPC_ENDPOINT_ID: &str = "vpce-0123456789abcdef0";
+
+#[derive(Clone)]
+struct VpcEndpointPolicyCloudControl {
+    policy_document: serde_json::Value,
+}
+
+impl MockService for VpcEndpointPolicyCloudControl {
+    fn service_name(&self) -> &str {
+        "cloudcontrolapi"
+    }
+
+    fn url_patterns(&self) -> Vec<&str> {
+        vec![
+            r"https?://cloudcontrolapi\..*\.amazonaws\.com",
+            r"https?://cloudcontrolapi\.amazonaws\.com",
+        ]
+    }
+
+    fn handle(
+        &self,
+        request: MockRequest,
+    ) -> Pin<Box<dyn Future<Output = MockResponse> + Send + '_>> {
+        Box::pin(async move {
+            let action = request
+                .headers
+                .get("x-amz-target")
+                .and_then(|value| value.to_str().ok())
+                .and_then(|value| value.split('.').next_back())
+                .unwrap_or("");
+            match action {
+                "GetResource" => get_resource_response(&request.body, &self.policy_document),
+                _ => json_error_response(
+                    501,
+                    "NotImplementedError",
+                    &format!("{action} is not implemented in test mock"),
+                ),
+            }
+        })
+    }
+}
+
+fn get_resource_response(body: &[u8], policy_document: &serde_json::Value) -> MockResponse {
+    let input: serde_json::Value = serde_json::from_slice(body).unwrap();
+    let identifier = input
+        .get("Identifier")
+        .and_then(|value| value.as_str())
+        .unwrap_or("");
+    if identifier != VPC_ENDPOINT_ID {
+        return json_error_response(
+            404,
+            "ResourceNotFoundException",
+            &format!("AWS::EC2::VPCEndpoint {identifier} not found"),
+        );
+    }
+
+    let properties = json!({
+        "Id": VPC_ENDPOINT_ID,
+        "VpcId": "vpc-0123456789abcdef0",
+        "ServiceName": "com.amazonaws.us-east-1.s3",
+        "VpcEndpointType": "Gateway",
+        "PolicyDocument": policy_document
+    });
+    let properties = properties.to_string();
+
+    MockResponse::json(
+        200,
+        json!({
+            "TypeName": "AWS::EC2::VPCEndpoint",
+            "ResourceDescription": {
+                "Identifier": VPC_ENDPOINT_ID,
+                "Properties": properties
+            }
+        })
+        .to_string(),
+    )
+}
+
+async fn provider_with_mock(policy_document: serde_json::Value) -> AwsccProvider {
+    let mock = MockAws::builder()
+        .with_service(VpcEndpointPolicyCloudControl { policy_document })
+        .build();
+    let config = aws_config::defaults(BehaviorVersion::latest())
+        .http_client(mock.http_client())
+        .credentials_provider(mock.credentials_provider())
+        .region(Region::new("us-east-1"))
+        .load()
+        .await;
+
+    AwsccProvider::from_sdk_config(config, &AwsccProviderConfig::default()).await
+}
+
+async fn read_vpc_endpoint(
+    policy_document: serde_json::Value,
+) -> indexmap::IndexMap<String, Value> {
+    let provider = provider_with_mock(policy_document).await;
+    let id = ResourceId::with_provider("awscc", "ec2.VpcEndpoint", "gateway", None);
+
+    let read = Provider::read(&provider, &id, Some(VPC_ENDPOINT_ID), ReadRequest)
+        .await
+        .expect("ec2.VpcEndpoint read through Provider::read should succeed");
+
+    assert!(read.exists, "read-back state must exist");
+    assert_eq!(read.identifier.as_deref(), Some(VPC_ENDPOINT_ID));
+
+    first_policy_statement(&read.attributes).clone()
+}
+
+fn first_policy_statement(
+    attributes: &std::collections::HashMap<String, Value>,
+) -> &indexmap::IndexMap<String, Value> {
+    let Some(Value::Concrete(ConcreteValue::Map(policy_document))) =
+        attributes.get("policy_document")
+    else {
+        panic!("policy_document must be a Map: {attributes:?}");
+    };
+    let Some(Value::Concrete(ConcreteValue::List(statements))) = policy_document.get("statement")
+    else {
+        panic!("policy_document.statement must be a List: {policy_document:?}");
+    };
+    let Some(Value::Concrete(ConcreteValue::Map(statement))) = statements.first() else {
+        panic!("policy_document.statement[0] must be a Map: {statements:?}");
+    };
+    statement
+}
+
+#[tokio::test]
+async fn ec2_vpc_endpoint_read_canonicalizes_scalar_policy_action_and_resource() {
+    let statement = read_vpc_endpoint(json!({
+        "Version": "2012-10-17",
+        "Statement": [{
+            "Action": "s3:GetObject",
+            "Resource": "arn:aws:s3:::*",
+            "Effect": "Allow",
+            "Principal": "*"
+        }]
+    }))
+    .await;
+
+    assert_eq!(
+        statement.get("action"),
+        Some(&Value::Concrete(ConcreteValue::StringList(vec![
+            "s3:GetObject".to_string()
+        ]))),
+        "policy_document.statement[0].action must be canonicalized"
+    );
+    assert_eq!(
+        statement.get("resource"),
+        Some(&Value::Concrete(ConcreteValue::StringList(vec![
+            "arn:aws:s3:::*".to_string()
+        ]))),
+        "policy_document.statement[0].resource must be canonicalized"
+    );
+}
+
+#[tokio::test]
+async fn ec2_vpc_endpoint_read_canonicalizes_list_policy_action_and_resource() {
+    let statement = read_vpc_endpoint(json!({
+        "Version": "2012-10-17",
+        "Statement": [{
+            "Action": ["s3:GetObject", "s3:PutObject"],
+            "Resource": ["arn:aws:s3:::*", "arn:aws:s3:::example/*"],
+            "Effect": "Allow",
+            "Principal": "*"
+        }]
+    }))
+    .await;
+
+    assert_eq!(
+        statement.get("action"),
+        Some(&Value::Concrete(ConcreteValue::StringList(vec![
+            "s3:GetObject".to_string(),
+            "s3:PutObject".to_string()
+        ]))),
+        "policy_document.statement[0].action must be canonicalized"
+    );
+    assert_eq!(
+        statement.get("resource"),
+        Some(&Value::Concrete(ConcreteValue::StringList(vec![
+            "arn:aws:s3:::*".to_string(),
+            "arn:aws:s3:::example/*".to_string()
+        ]))),
+        "policy_document.statement[0].resource must be canonicalized"
+    );
+}

--- a/carina-provider-awscc/tests/kms_key_cloudcontrol_roundtrip.rs
+++ b/carina-provider-awscc/tests/kms_key_cloudcontrol_roundtrip.rs
@@ -26,6 +26,12 @@ fn string(value: &str) -> Value {
     Value::Concrete(ConcreteValue::String(value.to_string()))
 }
 
+fn string_list(items: impl IntoIterator<Item = &'static str>) -> Value {
+    Value::Concrete(ConcreteValue::StringList(
+        items.into_iter().map(ToString::to_string).collect(),
+    ))
+}
+
 fn int(value: i64) -> Value {
     Value::Concrete(ConcreteValue::Int(value))
 }
@@ -61,6 +67,25 @@ fn key_policy() -> Value {
                 ),
                 ("action", string("kms:*")),
                 ("resource", string("*")),
+            ])]),
+        ),
+    ])
+}
+
+fn expected_key_policy() -> Value {
+    map([
+        ("version", string("2012-10-17")),
+        (
+            "statement",
+            list([map([
+                ("sid", string("AllowRootAccountAccess")),
+                ("effect", string("Allow")),
+                (
+                    "principal",
+                    map([("aws", string_list(["arn:aws:iam::111122223333:root"]))]),
+                ),
+                ("action", string_list(["kms:*"])),
+                ("resource", string_list(["*"])),
             ])]),
         ),
     ])
@@ -169,7 +194,7 @@ async fn kms_key_create_then_read_round_trips_structured_key_policy() {
         ("enabled", bool_(true)),
         ("multi_region", bool_(false)),
         ("origin", string("AWS_KMS")),
-        ("key_policy", key_policy()),
+        ("key_policy", expected_key_policy()),
         ("tags", map([("Environment", string("test"))])),
         ("key_id", string(key_id)),
         (


### PR DESCRIPTION
## Summary

Fix carina-rs/carina#3584 — `awscc.ec2.VpcEndpoint`'s post-apply plan-verify proposes a `~` change diff that adds `policy_document.statement[*].action` and `.resource`, even though the apply just sent those exact values.

Root cause: `Action` / `Resource` in `iam_policy_document()` are typed as `Union<String, List<String>>`. Apply-time canonicalize converts a single-element DSL `action = 'sts:AssumeRole'` to `ConcreteValue::StringList(["sts:AssumeRole"])`. Cloud Control's `GetResource` echoes the original input shape — for scalar input, it returns `"Action": "s3:GetObject"` (a JSON string). The read-side Union deserializer walks members in declaration order and tries each, selecting the `String` arm for scalar JSON and the `List<String>` arm for array JSON. So `state.attributes["policy_document"].statement[0].action` ends up as `ConcreteValue::String` from read but `ConcreteValue::StringList` from apply, the differ sees the mismatch as a shape change, and plan-verify proposes the addition.

Confirmed against real Cloud Control (mizzy account, 2026-06-16): `aws cloudcontrol get-resource --type-name AWS::EC2::VPCEndpoint` returns `Action` and `Resource` as scalar JSON strings when the original input was scalar:

```json
"Statement": [{
  "Action": "s3:GetObject",
  "Resource": "arn:aws:s3:::*",
  "Effect": "Allow",
  "Principal": "*"
}]
```

## What this PR does

1. Adds `string_or_list_of_strings_from_json` to `provider/conversion.rs`. When a Union has both a `String` member and a `List<String>` member, this helper normalizes either JSON form (scalar string or array of strings) into `ConcreteValue::StringList(vec![...])`. The resulting `Value` shape now matches what apply-time canonicalize produces for the same Union schema.
2. Adds `json_matches_shape` so the generic Union member selection picks the correct member by JSON shape rather than first-match-wins, fixing the indirectly related issue where struct-shaped Unions can pick the wrong member when an early arm happens to accept the same JSON form.

Single upstream seam in the shared read deserializer — no per-resource carve-out. Applies to any future schema that re-uses the same `string_or_list_of_strings` Union shape.

## Test plan

- [x] `cargo check` — passes.
- [x] `cargo test` — passes; four new tests cover scalar/list × VPCEndpoint mock × unit deserializer.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — passes.
- [x] `cargo fmt --check` — passes.
- [x] `cargo build --target wasm32-wasip2 -p carina-provider-awscc --release` — passes.
- [x] `./carina-provider-awscc/scripts/generate-schemas.sh --from-cache-only` — no drift.
- [x] `./scripts/generate-docs.sh --from-cache-only` — no drift.
- [ ] Re-run awscc acceptance `ec2_vpc_endpoint/gateway` after merge.

Refs carina-rs/carina#3584.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
