### PR TITLE
fix: reject exists=false post-create reads, preserve StringList (carina#3582/#3583/#3584)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.136.0"
+version = "1.137.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbd03e531a7d981fba45114c5813a7565dd470a1bd3ef1188ca98c98ebdfc668"
+checksum = "c2dd7213994e2ff9382ff100403b78c30d1b74cdfcd8fa9d0d1dc3a94a5c4874"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -680,7 +680,7 @@ dependencies = [
 [[package]]
 name = "carina-aws-types"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina-provider-aws?rev=aeefd2f656666ecde4d9c8feed542e55d51a29e7#aeefd2f656666ecde4d9c8feed542e55d51a29e7"
+source = "git+https://github.com/carina-rs/carina-provider-aws?rev=c5ee472b694f6ab4a4819d52fd8fdc253907ddf4#c5ee472b694f6ab4a4819d52fd8fdc253907ddf4"
 dependencies = [
  "carina-core",
  "heck",
@@ -689,7 +689,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=9c91c5f89753338b6e41ef8256be6c4cb77059bf#9c91c5f89753338b6e41ef8256be6c4cb77059bf"
+source = "git+https://github.com/carina-rs/carina?rev=dc9e6cab88799d64c2d5972eee099f5b6a468ab8#dc9e6cab88799d64c2d5972eee099f5b6a468ab8"
 dependencies = [
  "argon2",
  "carina-provider-protocol",
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=9c91c5f89753338b6e41ef8256be6c4cb77059bf#9c91c5f89753338b6e41ef8256be6c4cb77059bf"
+source = "git+https://github.com/carina-rs/carina?rev=dc9e6cab88799d64c2d5972eee099f5b6a468ab8#dc9e6cab88799d64c2d5972eee099f5b6a468ab8"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -759,7 +759,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=9c91c5f89753338b6e41ef8256be6c4cb77059bf#9c91c5f89753338b6e41ef8256be6c4cb77059bf"
+source = "git+https://github.com/carina-rs/carina?rev=dc9e6cab88799d64c2d5972eee099f5b6a468ab8#dc9e6cab88799d64c2d5972eee099f5b6a468ab8"
 dependencies = [
  "serde",
  "serde_json",
@@ -2164,9 +2164,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -23,10 +23,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "9c91c5f89753338b6e41ef8256be6c4cb77059bf" }
-carina-aws-types = { git = "https://github.com/carina-rs/carina-provider-aws", rev = "aeefd2f656666ecde4d9c8feed542e55d51a29e7" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "9c91c5f89753338b6e41ef8256be6c4cb77059bf" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "9c91c5f89753338b6e41ef8256be6c4cb77059bf" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "dc9e6cab88799d64c2d5972eee099f5b6a468ab8" }
+carina-aws-types = { git = "https://github.com/carina-rs/carina-provider-aws", rev = "c5ee472b694f6ab4a4819d52fd8fdc253907ddf4" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "dc9e6cab88799d64c2d5972eee099f5b6a468ab8" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "dc9e6cab88799d64c2d5972eee099f5b6a468ab8" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }

--- a/carina-provider-awscc/src/convert.rs
+++ b/carina-provider-awscc/src/convert.rs
@@ -70,12 +70,9 @@ pub fn core_to_proto_value(v: &CoreValue) -> ProtoValue {
         CoreValue::Concrete(ConcreteValue::List(l)) => {
             ProtoValue::List(l.iter().map(core_to_proto_value).collect())
         }
-        CoreValue::Concrete(ConcreteValue::StringList(items)) => ProtoValue::List(
-            items
-                .iter()
-                .map(|s| ProtoValue::String(s.clone()))
-                .collect(),
-        ),
+        CoreValue::Concrete(ConcreteValue::StringList(items)) => {
+            ProtoValue::StringList(items.clone())
+        }
         CoreValue::Concrete(ConcreteValue::Map(m)) => ProtoValue::Map(
             m.iter()
                 .map(|(k, v)| (k.clone(), core_to_proto_value(v)))
@@ -116,6 +113,9 @@ pub fn proto_to_core_value(v: &ProtoValue) -> CoreValue {
         ProtoValue::List(l) => CoreValue::Concrete(ConcreteValue::List(
             l.iter().map(proto_to_core_value).collect(),
         )),
+        ProtoValue::StringList(items) => {
+            CoreValue::Concrete(ConcreteValue::StringList(items.clone()))
+        }
         ProtoValue::Map(m) => CoreValue::Concrete(ConcreteValue::Map(
             m.iter()
                 .map(|(k, v)| (k.clone(), proto_to_core_value(v)))

--- a/carina-provider-awscc/src/provider/operations.rs
+++ b/carina-provider-awscc/src/provider/operations.rs
@@ -153,6 +153,15 @@ impl AwsccProvider {
                     .await
                 {
                     Ok(state) => {
+                        if !state.exists {
+                            return Ok(create_read_not_found_outcome(
+                                state,
+                                format!(
+                                    "handler failed: {}; read-back returned not_found",
+                                    status_message
+                                ),
+                            ));
+                        }
                         let mut state = merge_desired_attributes(state, resource, config);
                         let Some(canonical_identifier) =
                             canonicalize_identifier_from_read(config, &state)
@@ -225,6 +234,12 @@ impl AwsccProvider {
             )
             .await?;
 
+        if !state.exists {
+            return Ok(create_read_not_found_outcome(
+                state,
+                "read-back returned not_found",
+            ));
+        }
         let mut state = merge_desired_attributes(state, resource, config);
         let Some(canonical_identifier) = canonicalize_identifier_from_read(config, &state) else {
             let missing_attributes = missing_primary_identifier_attributes(config, &state);
@@ -528,6 +543,10 @@ fn map_aws_props_to_attributes(
     attributes
 }
 
+fn create_read_not_found_outcome(state: State, diagnostic: impl Into<String>) -> CreateOutcome {
+    CreateOutcome::partial_success(state, diagnostic.into(), vec!["state".to_string()])
+}
+
 /// Reconstruct the post-update desired-state attribute map: take the
 /// current provider-side `from` state and apply each patch op on top.
 ///
@@ -659,17 +678,35 @@ mod tests {
         AwsccProvider::from_sdk_config(config, &super::super::AwsccProviderConfig::default()).await
     }
 
+    #[derive(Clone, Copy, Debug)]
+    enum IamRoleReadMode {
+        WithRoleName,
+        WithoutRoleName,
+        NotFound,
+    }
+
     #[derive(Debug)]
     struct IamRoleCreateCloudControlService {
-        include_role_name_in_read: bool,
+        read_mode: IamRoleReadMode,
+        wait_succeeds: bool,
         saw_create_resource: AtomicBool,
         saw_get_resource: AtomicBool,
     }
 
     impl IamRoleCreateCloudControlService {
         fn new(include_role_name_in_read: bool) -> Arc<Self> {
+            let read_mode = if include_role_name_in_read {
+                IamRoleReadMode::WithRoleName
+            } else {
+                IamRoleReadMode::WithoutRoleName
+            };
+            Self::with_read_mode(read_mode, true)
+        }
+
+        fn with_read_mode(read_mode: IamRoleReadMode, wait_succeeds: bool) -> Arc<Self> {
             Arc::new(Self {
-                include_role_name_in_read,
+                read_mode,
+                wait_succeeds,
                 saw_create_resource: AtomicBool::new(false),
                 saw_get_resource: AtomicBool::new(false),
             })
@@ -707,16 +744,29 @@ mod tests {
                             r#"{"ProgressEvent":{"RequestToken":"iam-role-token"}}"#,
                         )
                     }
-                    "GetResourceRequestStatus" => MockResponse::json(
+                    "GetResourceRequestStatus" if self.wait_succeeds => MockResponse::json(
                         200,
                         r#"{"ProgressEvent":{"RequestToken":"iam-role-token","OperationStatus":"SUCCESS","Identifier":"flow-log-role"}}"#,
                     ),
+                    "GetResourceRequestStatus" => MockResponse::json(
+                        200,
+                        r#"{"ProgressEvent":{"RequestToken":"iam-role-token","OperationStatus":"FAILED","Identifier":"flow-log-role","StatusMessage":"post-create validation failed"}}"#,
+                    ),
                     "GetResource" => {
                         self.saw_get_resource.store(true, Ordering::SeqCst);
-                        let properties = if self.include_role_name_in_read {
-                            r#"{"Path":"/service-role/","RoleName":"flow-log-role","RoleId":"AROATESTROLEID"}"#
-                        } else {
-                            r#"{"Path":"/service-role/","RoleId":"AROATESTROLEID"}"#
+                        let properties = match self.read_mode {
+                            IamRoleReadMode::WithRoleName => {
+                                r#"{"Path":"/service-role/","RoleName":"flow-log-role","RoleId":"AROATESTROLEID"}"#
+                            }
+                            IamRoleReadMode::WithoutRoleName => {
+                                r#"{"Path":"/service-role/","RoleId":"AROATESTROLEID"}"#
+                            }
+                            IamRoleReadMode::NotFound => {
+                                return MockResponse::json(
+                                    404,
+                                    r#"{"__type":"ResourceNotFoundException","message":"role not found"}"#,
+                                );
+                            }
                         };
                         MockResponse::json(
                             200,
@@ -1194,6 +1244,67 @@ mod tests {
             Some(&Value::Concrete(ConcreteValue::String(
                 "arn:aws-us-gov:iam::123456789012:role/service-role/flow-log-role".to_string()
             )))
+        );
+    }
+
+    #[tokio::test]
+    async fn create_iam_role_returns_partial_success_when_post_create_read_is_not_found() {
+        let cloudcontrol =
+            IamRoleCreateCloudControlService::with_read_mode(IamRoleReadMode::NotFound, true);
+        let sts = CallerIdentityService::new();
+        let provider =
+            provider_with_iam_role_create_service(cloudcontrol.clone(), sts.clone()).await;
+
+        let outcome = provider
+            .create_resource(&iam_role_resource(true))
+            .await
+            .expect("IAM role create should report partial success");
+
+        let CreateOutcome::PartialSuccess { state, diagnostic } = outcome else {
+            panic!("expected partial success when post-create read returns not_found");
+        };
+        assert!(cloudcontrol.saw_create_resource.load(Ordering::SeqCst));
+        assert!(cloudcontrol.saw_get_resource.load(Ordering::SeqCst));
+        assert!(!state.exists);
+        assert_eq!(state.identifier.as_deref(), None);
+        assert!(state.attributes.is_empty());
+        assert_eq!(diagnostic.reason(), "read-back returned not_found");
+        assert_eq!(diagnostic.missing_attributes(), &["state".to_string()]);
+        assert!(
+            !sts.saw_get_caller_identity.load(Ordering::SeqCst),
+            "not_found read-back must stop before ARN synthesis"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_iam_role_returns_partial_success_when_failed_create_read_back_is_not_found() {
+        let cloudcontrol =
+            IamRoleCreateCloudControlService::with_read_mode(IamRoleReadMode::NotFound, false);
+        let sts = CallerIdentityService::new();
+        let provider =
+            provider_with_iam_role_create_service(cloudcontrol.clone(), sts.clone()).await;
+
+        let outcome = provider
+            .create_resource(&iam_role_resource(true))
+            .await
+            .expect("IAM role create should report partial success");
+
+        let CreateOutcome::PartialSuccess { state, diagnostic } = outcome else {
+            panic!("expected partial success when failed-create read-back returns not_found");
+        };
+        assert!(cloudcontrol.saw_create_resource.load(Ordering::SeqCst));
+        assert!(cloudcontrol.saw_get_resource.load(Ordering::SeqCst));
+        assert!(!state.exists);
+        assert_eq!(state.identifier.as_deref(), None);
+        assert!(state.attributes.is_empty());
+        assert_eq!(
+            diagnostic.reason(),
+            "handler failed: post-create validation failed; read-back returned not_found"
+        );
+        assert_eq!(diagnostic.missing_attributes(), &["state".to_string()]);
+        assert!(
+            !sts.saw_get_caller_identity.load(Ordering::SeqCst),
+            "not_found read-back must stop before ARN synthesis"
         );
     }
 


### PR DESCRIPTION
## Summary

Three changes that together close the long tail of carina-rs/carina#3582, #3583, and #3584:

1. **Rev bumps.** carina pin → `dc9e6cab` (after carina-rs/carina#3587), `carina-aws-types` pin → `c5ee472` (after carina-rs/carina-provider-aws#461), `carina-plugin-wit` submodule → `facd597`.

2. **Preserve `StringList` across the WIT boundary** (`provider/convert.rs`). The carina-core differ now compares `StringList` and `List<String>` as distinct shapes; the previous protocol conversion collapsed `ConcreteValue::StringList` to `ProtoValue::List` of strings, dropping the tag at the boundary and defeating the read-side normalization awscc#377 introduced for carina#3584.

3. **Reject `exists == false` post-create reads** (`provider/operations.rs::create_resource`). Both the normal create-success read-back path and the partial/failed-create read-recovery path short-circuit to `CreateOutcome::PartialSuccess` with a `"read-back returned not_found"` diagnostic before the merge / canonicalize / synthesis stages. This was the carina#3582 and carina#3583 root cause: when a post-create read returned `not_found` (Cloud Control eventual consistency, identifier mismatch, etc.), the previous code merged desired attributes onto the empty state and returned `Success { state }` with `state.exists == false`. The host's `wit_to_core_state` then discarded `identifier` and `attributes`, leaving the saved state file with `identifier: null, attributes: {}` — exactly the "binding not published" and "post-apply role replanned as Create" symptoms.

A small helper `create_read_not_found_outcome` deduplicates the `PartialSuccess { state, "read-back returned not_found", ["state"] }` construction across the two call sites.

## Why this PR closes the long tail

The previous rounds (#373/#374/#375/#376/#377) all fixed real provider-side problems, but the acceptance test kept failing because the host was silently dropping populated state when `exists == false` and the differ was silently dropping the `StringList` tag. Both of those upstream seams are now closed: the Carina-side `#3587` carries the `StringList` tag through the WIT round-trip, and this PR refuses to mark a Create as `Success` when the read couldn't actually see the resource.

## Test plan

- [x] `cargo update -p carina-core -p carina-plugin-sdk -p carina-provider-protocol -p carina-aws-types` — clean lockfile bump (full rebuild from scratch because the short-rev / full-rev mix needed lock regen).
- [x] `cargo check` — passes.
- [x] `cargo test` — passes; two new tests cover the post-create `not_found` path on both code arms.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — passes.
- [x] `cargo build --target wasm32-wasip2 -p carina-provider-awscc --release` — passes.
- [x] `./carina-provider-awscc/scripts/generate-schemas.sh --from-cache-only` — no drift.
- [x] `./scripts/generate-docs.sh --from-cache-only` — no drift.
- [ ] Re-run acceptance test for `iam_role/*` (carina#3583) and `ec2_vpc_endpoint/gateway` (carina#3584) after merge to confirm green.

Refs carina-rs/carina#3582, #3583, #3584.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
