### PR TITLE
refactor: rename id.name to id.identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,7 +680,7 @@ dependencies = [
 [[package]]
 name = "carina-aws-types"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina-provider-aws?rev=c5ee472b694f6ab4a4819d52fd8fdc253907ddf4#c5ee472b694f6ab4a4819d52fd8fdc253907ddf4"
+source = "git+https://github.com/carina-rs/carina-provider-aws?rev=3d34ada#3d34ada9dc0eca87ff2e3167fb38050e98d79729"
 dependencies = [
  "carina-core",
  "heck",
@@ -689,7 +689,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=dc9e6cab88799d64c2d5972eee099f5b6a468ab8#dc9e6cab88799d64c2d5972eee099f5b6a468ab8"
+source = "git+https://github.com/carina-rs/carina?rev=eaf06412#eaf06412d7facebaef9007bb24b8f642e36a4e2d"
 dependencies = [
  "argon2",
  "carina-provider-protocol",
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=dc9e6cab88799d64c2d5972eee099f5b6a468ab8#dc9e6cab88799d64c2d5972eee099f5b6a468ab8"
+source = "git+https://github.com/carina-rs/carina?rev=eaf06412#eaf06412d7facebaef9007bb24b8f642e36a4e2d"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -759,7 +759,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=dc9e6cab88799d64c2d5972eee099f5b6a468ab8#dc9e6cab88799d64c2d5972eee099f5b6a468ab8"
+source = "git+https://github.com/carina-rs/carina?rev=eaf06412#eaf06412d7facebaef9007bb24b8f642e36a4e2d"
 dependencies = [
  "serde",
  "serde_json",
@@ -1008,7 +1008,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1561,12 +1561,13 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.102"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -2481,9 +2482,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.125"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2494,9 +2495,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.125"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2504,9 +2505,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.125"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2517,9 +2518,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.125"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]

--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -23,10 +23,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "dc9e6cab88799d64c2d5972eee099f5b6a468ab8" }
-carina-aws-types = { git = "https://github.com/carina-rs/carina-provider-aws", rev = "c5ee472b694f6ab4a4819d52fd8fdc253907ddf4" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "dc9e6cab88799d64c2d5972eee099f5b6a468ab8" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "dc9e6cab88799d64c2d5972eee099f5b6a468ab8" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "eaf06412" }
+carina-aws-types = { git = "https://github.com/carina-rs/carina-provider-aws", rev = "3d34ada" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "eaf06412" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "eaf06412" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }

--- a/carina-provider-awscc/src/bin/codegen.rs
+++ b/carina-provider-awscc/src/bin/codegen.rs
@@ -2916,7 +2916,7 @@ pub fn {}() -> AwsccSchemaConfig {{
         ));
     }
 
-    // Determine name_attribute from primaryIdentifier:
+    // Determine unique_name_attribute from primaryIdentifier:
     // If the primary identifier points to a single user-settable (non-read-only) string property,
     // it's the name attribute used for unique name generation during create-before-destroy.
     if let Some(primary_ids) = &schema.primary_identifier
@@ -2935,7 +2935,7 @@ pub fn {}() -> AwsccSchemaConfig {{
             if is_string {
                 let attr_name = prop_path.to_snake_case();
                 body.push_str(&format!(
-                    "        .with_name_attribute(\"{}\")\n", // rust-lit-guard: allow (snake_case output cannot contain " or \\)
+                    "        .with_unique_name_attribute(\"{}\")\n", // rust-lit-guard: allow (snake_case output cannot contain " or \\)
                     attr_name
                 ));
             }

--- a/carina-provider-awscc/src/convert.rs
+++ b/carina-provider-awscc/src/convert.rs
@@ -37,12 +37,12 @@ pub fn core_to_proto_resource_id(id: &CoreResourceId) -> ProtoResourceId {
     ProtoResourceId {
         provider: id.provider.clone(),
         resource_type: id.resource_type.clone(),
-        name: id.name.to_string(),
+        identity: id.identity_or_empty().to_string(),
     }
 }
 
 pub fn proto_to_core_resource_id(id: &ProtoResourceId) -> CoreResourceId {
-    CoreResourceId::with_provider(&id.provider, &id.resource_type, &id.name, None)
+    CoreResourceId::with_provider_name_compat(&id.provider, &id.resource_type, &id.identity, None)
 }
 
 // -- Value --
@@ -222,7 +222,7 @@ pub fn core_to_proto_directives(l: &CoreDirectives) -> ProtoDirectives {
 
 pub fn proto_to_core_resource(r: &ProtoResource) -> CoreResource {
     let mut resource =
-        CoreResource::with_provider(&r.id.provider, &r.id.resource_type, &r.id.name, None);
+        CoreResource::with_provider(&r.id.provider, &r.id.resource_type, &r.id.identity, None);
     resource.attributes = r
         .attributes
         .iter()
@@ -244,7 +244,7 @@ pub fn proto_to_core_resource(r: &ProtoResource) -> CoreResource {
 /// projection (carina#3181).
 pub fn proto_to_core_data_source(r: &ProtoResource) -> CoreDataSource {
     let mut data_source =
-        CoreDataSource::with_provider(&r.id.provider, &r.id.resource_type, &r.id.name, None);
+        CoreDataSource::with_provider(&r.id.provider, &r.id.resource_type, &r.id.identity, None);
     data_source.attributes = r
         .attributes
         .iter()
@@ -470,7 +470,7 @@ pub fn proto_to_core_schema(s: &ProtoResourceSchema) -> CoreResourceSchema {
         description: s.description.clone(),
         validator: None,
         kind,
-        name_attribute: s.name_attribute.clone(),
+        unique_name_attribute: s.unique_name_attribute.clone(),
         operation_config: s.operation_config.as_ref().map(|c| {
             carina_core::schema::OperationConfig {
                 delete_timeout_secs: c.delete_timeout_secs,
@@ -629,7 +629,7 @@ pub fn core_to_proto_schema(s: &CoreResourceSchema) -> ProtoResourceSchema {
             .collect(),
         description: s.description.clone(),
         kind,
-        name_attribute: s.name_attribute.clone(),
+        unique_name_attribute: s.unique_name_attribute.clone(),
         operation_config: s.operation_config.as_ref().map(|c| {
             carina_provider_protocol::OperationConfig {
                 delete_timeout_secs: c.delete_timeout_secs,

--- a/carina-provider-awscc/src/lib.rs
+++ b/carina-provider-awscc/src/lib.rs
@@ -312,8 +312,12 @@ impl Provider for AwsccProvider {
         let id = id.clone();
         let identifier = identifier.map(|s| s.to_string());
         Box::pin(async move {
-            self.read_resource(&id.resource_type, id.name_str(), identifier.as_deref())
-                .await
+            self.read_resource(
+                &id.resource_type,
+                id.identity_or_empty(),
+                identifier.as_deref(),
+            )
+            .await
         })
     }
 
@@ -329,7 +333,7 @@ impl Provider for AwsccProvider {
         }
         let id = resource.id.clone();
         Box::pin(async move {
-            self.read_resource(&id.resource_type, id.name_str(), None)
+            self.read_resource(&id.resource_type, id.identity_or_empty(), None)
                 .await
         })
     }
@@ -528,8 +532,12 @@ mod tests {
     #[tokio::test]
     async fn required_permissions_returns_cfn_handler_actions_for_known_resource() {
         let provider = provider_for_required_permissions_tests().await;
-        let id =
-            ResourceId::with_provider("awscc", "elasticloadbalancingv2.LoadBalancer", "test", None);
+        let id = ResourceId::with_provider_identity(
+            "awscc",
+            "elasticloadbalancingv2.LoadBalancer",
+            "test",
+            None,
+        );
 
         let permissions = Provider::required_permissions(&provider, &id, PlanOp::Create);
 
@@ -547,7 +555,7 @@ mod tests {
     #[tokio::test]
     async fn required_permissions_returns_empty_vec_for_unknown_resource() {
         let provider = provider_for_required_permissions_tests().await;
-        let id = ResourceId::with_provider("awscc", "example.Unknown", "test", None);
+        let id = ResourceId::with_provider_identity("awscc", "example.Unknown", "test", None);
 
         let permissions = Provider::required_permissions(&provider, &id, PlanOp::Create);
 

--- a/carina-provider-awscc/src/provider/normalizer.rs
+++ b/carina-provider-awscc/src/provider/normalizer.rs
@@ -154,7 +154,8 @@ mod tests {
 
     #[tokio::test]
     async fn normalize_state_keeps_api_enum_spellings_out_of_dsl_string_form() {
-        let id = ResourceId::with_provider("awscc", "ec2.SecurityGroupEgress", "test", None);
+        let id =
+            ResourceId::with_provider_identity("awscc", "ec2.SecurityGroupEgress", "test", None);
         let attrs = HashMap::from([(
             "ip_protocol".to_string(),
             Value::Concrete(ConcreteValue::String("-1".to_string())),
@@ -201,7 +202,8 @@ mod tests {
         )
         .expect("host should lift ip_protocol to CanonicalEnum");
 
-        let id = ResourceId::with_provider("awscc", "ec2.SecurityGroupEgress", "test", None);
+        let id =
+            ResourceId::with_provider_identity("awscc", "ec2.SecurityGroupEgress", "test", None);
         let attrs = HashMap::from([("ip_protocol".to_string(), canonical.clone())]);
         let mut current_states = HashMap::from([(id.clone(), State::existing(id.clone(), attrs))]);
 
@@ -218,7 +220,7 @@ mod tests {
 
     #[test]
     fn test_restore_unreturned_attrs_impl_create_only() {
-        let id = ResourceId::with_provider("awscc", "ec2.NatGateway", "test", None);
+        let id = ResourceId::with_provider_identity("awscc", "ec2.NatGateway", "test", None);
         let mut state = State::existing(id.clone(), HashMap::new());
         state.attributes.insert(
             "nat_gateway_id".to_string(),
@@ -248,7 +250,7 @@ mod tests {
 
     #[test]
     fn test_restore_unreturned_attrs_skips_non_awscc() {
-        let id = ResourceId::with_provider("aws", "s3.Bucket", "test", None);
+        let id = ResourceId::with_provider_identity("aws", "s3.Bucket", "test", None);
         let state = State::existing(id.clone(), HashMap::new());
 
         let mut current_states = HashMap::new();
@@ -269,7 +271,7 @@ mod tests {
 
     #[test]
     fn test_restore_unreturned_attrs_skips_already_present() {
-        let id = ResourceId::with_provider("awscc", "ec2.NatGateway", "test", None);
+        let id = ResourceId::with_provider_identity("awscc", "ec2.NatGateway", "test", None);
         let mut attrs = HashMap::new();
         attrs.insert(
             "subnet_id".to_string(),
@@ -300,7 +302,8 @@ mod tests {
 
     #[test]
     fn test_restore_unreturned_attrs_impl_non_create_only() {
-        let id = ResourceId::with_provider("awscc", "ec2.SecurityGroupEgress", "test", None);
+        let id =
+            ResourceId::with_provider_identity("awscc", "ec2.SecurityGroupEgress", "test", None);
         let mut state = State::existing(id.clone(), HashMap::new());
         state.attributes.insert(
             "ip_protocol".to_string(),
@@ -514,14 +517,8 @@ mod tests {
         name: &str,
         attrs: Vec<(&str, Value)>,
     ) -> (ResourceId, State) {
-        use carina_core::resource::ResourceName;
         use std::collections::BTreeSet;
-        let id = ResourceId {
-            provider: provider.to_string(),
-            resource_type: resource_type.to_string(),
-            name: ResourceName::Bound(name.to_string()),
-            provider_instance: None,
-        };
+        let id = ResourceId::with_provider_name_compat(provider, resource_type, name, None);
         let mut attributes = HashMap::new();
         for (k, v) in attrs {
             attributes.insert(k.to_string(), v);

--- a/carina-provider-awscc/src/provider/operations.rs
+++ b/carina-provider-awscc/src/provider/operations.rs
@@ -29,7 +29,7 @@ impl AwsccProvider {
         name: &str,
         identifier: Option<&str>,
     ) -> ProviderResult<State> {
-        let id = ResourceId::with_provider("awscc", resource_type, name, None);
+        let id = ResourceId::with_provider_name_compat("awscc", resource_type, name, None);
 
         let config = get_schema_config(resource_type).ok_or_else(|| {
             ProviderError::internal(format!("Unknown resource type: {}", resource_type))
@@ -147,7 +147,7 @@ impl AwsccProvider {
                 match self
                     .read_resource(
                         &resource.id.resource_type,
-                        resource.id.name_str(),
+                        resource.id.identity_or_empty(),
                         Some(&identifier),
                     )
                     .await
@@ -229,7 +229,7 @@ impl AwsccProvider {
         let state = self
             .read_resource(
                 &resource.id.resource_type,
-                resource.id.name_str(),
+                resource.id.identity_or_empty(),
                 Some(&identifier),
             )
             .await?;
@@ -313,7 +313,7 @@ impl AwsccProvider {
         match outcome {
             WaitOutcome::Success { identifier } => {
                 let state = self
-                    .read_resource(&id.resource_type, id.name_str(), Some(&identifier))
+                    .read_resource(&id.resource_type, id.identity_or_empty(), Some(&identifier))
                     .await?;
                 let state = merge_update_desired_attributes(state, &desired, config);
                 Ok(UpdateOutcome::Success { state })
@@ -323,7 +323,7 @@ impl AwsccProvider {
                 status_message,
             } => {
                 match self
-                    .read_resource(&id.resource_type, id.name_str(), Some(&identifier))
+                    .read_resource(&id.resource_type, id.identity_or_empty(), Some(&identifier))
                     .await
                 {
                     Ok(state) => {
@@ -955,7 +955,7 @@ mod tests {
 
     fn partial_update_bucket_state() -> State {
         State::existing(
-            ResourceId::with_provider("awscc", "s3.Bucket", "partial_bucket", None),
+            ResourceId::with_provider_identity("awscc", "s3.Bucket", "partial_bucket", None),
             HashMap::from([(
                 "bucket_name".to_string(),
                 Value::Concrete(ConcreteValue::String("partial-bucket".to_string())),

--- a/carina-provider-awscc/src/schemas/generated/dynamodb/table.rs
+++ b/carina-provider-awscc/src/schemas/generated/dynamodb/table.rs
@@ -272,7 +272,7 @@ pub fn dynamodb_table_config() -> AwsccSchemaConfig {
                 .with_description("Represents the warm throughput (in read units per second and write units per second) for creating a table.")
                 .with_provider_name("WarmThroughput"),
         )
-        .with_name_attribute("table_name")
+        .with_unique_name_attribute("table_name")
         .with_validator(|attrs| {
             let mut errors = Vec::new();
             if let Err(mut e) = carina_aws_types::validate_tags_map(attrs) {

--- a/carina-provider-awscc/src/schemas/generated/ecs/cluster.rs
+++ b/carina-provider-awscc/src/schemas/generated/ecs/cluster.rs
@@ -97,7 +97,7 @@ pub fn ecs_cluster_config() -> AwsccSchemaConfig {
                 .with_provider_name("Tags")
                 .with_block_name("tag"),
         )
-        .with_name_attribute("cluster_name")
+        .with_unique_name_attribute("cluster_name")
         .with_validator(|attrs| {
             let mut errors = Vec::new();
             if let Err(mut e) = carina_aws_types::validate_tags_map(attrs) {

--- a/carina-provider-awscc/src/schemas/generated/iam/role.rs
+++ b/carina-provider-awscc/src/schemas/generated/iam/role.rs
@@ -113,7 +113,7 @@ pub fn iam_role_config() -> AwsccSchemaConfig {
                 .with_provider_name("Tags")
                 .with_block_name("tag"),
         )
-        .with_name_attribute("role_name")
+        .with_unique_name_attribute("role_name")
         .with_validator(|attrs| {
             let mut errors = Vec::new();
             if let Err(mut e) = carina_aws_types::validate_tags_map(attrs) {

--- a/carina-provider-awscc/src/schemas/generated/logs/log_group.rs
+++ b/carina-provider-awscc/src/schemas/generated/logs/log_group.rs
@@ -111,7 +111,7 @@ pub fn logs_log_group_config() -> AwsccSchemaConfig {
                 .with_provider_name("Tags")
                 .with_block_name("tag"),
         )
-        .with_name_attribute("log_group_name")
+        .with_unique_name_attribute("log_group_name")
         .with_validator(|attrs| {
             let mut errors = Vec::new();
             if let Err(mut e) = carina_aws_types::validate_tags_map(attrs) {

--- a/carina-provider-awscc/src/schemas/generated/s3/bucket.rs
+++ b/carina-provider-awscc/src/schemas/generated/s3/bucket.rs
@@ -488,7 +488,7 @@ pub fn s3_bucket_config() -> AwsccSchemaConfig {
                 .with_description(" (read-only)")
                 .with_provider_name("WebsiteURL"),
         )
-        .with_name_attribute("bucket_name")
+        .with_unique_name_attribute("bucket_name")
         .with_validator(|attrs| {
             let mut errors = Vec::new();
             if let Err(mut e) = carina_aws_types::validate_tags_map(attrs) {

--- a/carina-provider-awscc/src/schemas/generated/s3/bucket_policy.rs
+++ b/carina-provider-awscc/src/schemas/generated/s3/bucket_policy.rs
@@ -29,7 +29,7 @@ pub fn s3_bucket_policy_config() -> AwsccSchemaConfig {
                 .with_description("A policy document containing permissions to add to the specified bucket. In IAM, you must provide policy documents in JSON format. However, in CloudFormation you can provide the policy in JSON or YAML format because CloudFormation converts YAML to JSON before submitting it to IAM. For more information, see the AWS::IAM::Policy [PolicyDocument](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html#cfn-iam-policy-policydocument) resource description in this guide and [Access Policy Language Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/access-policy-language-overview.html) in the *Amazon S3 User Guide*.")
                 .with_provider_name("PolicyDocument"),
         )
-        .with_name_attribute("bucket")
+        .with_unique_name_attribute("bucket")
     }
 }
 

--- a/carina-provider-awscc/src/schemas/mod.rs
+++ b/carina-provider-awscc/src/schemas/mod.rs
@@ -41,7 +41,8 @@ mod tests {
 
     fn assert_tag_change_plans_update(schema: ResourceSchema) {
         let resource_type = schema.resource_type.clone();
-        let resource_id = ResourceId::with_provider("awscc", resource_type.clone(), "test", None);
+        let resource_id =
+            ResourceId::with_provider_identity("awscc", resource_type.clone(), "test", None);
         let resources = vec![
             Resource::with_provider("awscc", resource_type, "test", None)
                 .with_attribute("tags", tags_value("new-name")),

--- a/carina-provider-awscc/tests/ec2_vpc_endpoint_policy_document_read.rs
+++ b/carina-provider-awscc/tests/ec2_vpc_endpoint_policy_document_read.rs
@@ -104,7 +104,7 @@ async fn read_vpc_endpoint(
     policy_document: serde_json::Value,
 ) -> indexmap::IndexMap<String, Value> {
     let provider = provider_with_mock(policy_document).await;
-    let id = ResourceId::with_provider("awscc", "ec2.VpcEndpoint", "gateway", None);
+    let id = ResourceId::with_provider_identity("awscc", "ec2.VpcEndpoint", "gateway", None);
 
     let read = Provider::read(&provider, &id, Some(VPC_ENDPOINT_ID), ReadRequest)
         .await


### PR DESCRIPTION
## Summary

- Rename `id.name` → `id.identity` across all protocol/WIT ResourceId references
- Bump carina rev to eaf06412, carina-provider-aws rev to 3d34ada
- Update carina-plugin-wit submodule

Counterpart to carina-rs/carina#3638 and carina-rs/carina#3644.

🤖 Generated with [Claude Code](https://claude.com/claude-code)