### PR TITLE
chore: bump carina-core rev + switch to into_plan_input_map (carina#3664)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,7 +680,7 @@ dependencies = [
 [[package]]
 name = "carina-aws-types"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina-provider-aws?rev=3d34ada#3d34ada9dc0eca87ff2e3167fb38050e98d79729"
+source = "git+https://github.com/carina-rs/carina-provider-aws?rev=8ae6b29#8ae6b29e20e60c9b499ebccca3cd3d1f94509bd1"
 dependencies = [
  "carina-core",
  "heck",
@@ -689,7 +689,7 @@ dependencies = [
 [[package]]
 name = "carina-core"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=eaf06412#eaf06412d7facebaef9007bb24b8f642e36a4e2d"
+source = "git+https://github.com/carina-rs/carina?rev=8ebc747a#8ebc747a03fe677d62763920d7bc5ecc9984fb0d"
 dependencies = [
  "argon2",
  "carina-provider-protocol",
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "carina-plugin-sdk"
 version = "0.4.0"
-source = "git+https://github.com/carina-rs/carina?rev=eaf06412#eaf06412d7facebaef9007bb24b8f642e36a4e2d"
+source = "git+https://github.com/carina-rs/carina?rev=8ebc747a#8ebc747a03fe677d62763920d7bc5ecc9984fb0d"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -759,7 +759,7 @@ dependencies = [
 [[package]]
 name = "carina-provider-protocol"
 version = "0.3.0"
-source = "git+https://github.com/carina-rs/carina?rev=eaf06412#eaf06412d7facebaef9007bb24b8f642e36a4e2d"
+source = "git+https://github.com/carina-rs/carina?rev=8ebc747a#8ebc747a03fe677d62763920d7bc5ecc9984fb0d"
 dependencies = [
  "serde",
  "serde_json",
@@ -1008,7 +1008,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/carina-provider-awscc/Cargo.toml
+++ b/carina-provider-awscc/Cargo.toml
@@ -23,10 +23,10 @@ default = ["native"]
 native = []
 
 [dependencies]
-carina-core = { git = "https://github.com/carina-rs/carina", rev = "eaf06412" }
-carina-aws-types = { git = "https://github.com/carina-rs/carina-provider-aws", rev = "3d34ada" }
-carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "eaf06412" }
-carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "eaf06412" }
+carina-core = { git = "https://github.com/carina-rs/carina", rev = "8ebc747a" }
+carina-aws-types = { git = "https://github.com/carina-rs/carina-provider-aws", rev = "8ae6b29" }
+carina-plugin-sdk = { git = "https://github.com/carina-rs/carina", rev = "8ebc747a" }
+carina-provider-protocol = { git = "https://github.com/carina-rs/carina", rev = "8ebc747a" }
 indexmap = "2"
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rt-tokio"] }
 aws-credential-types = { version = "1" }

--- a/carina-provider-awscc/src/schemas/mod.rs
+++ b/carina-provider-awscc/src/schemas/mod.rs
@@ -20,9 +20,7 @@ mod tests {
 
     use carina_core::differ::create_plan;
     use carina_core::effect::Effect;
-    use carina_core::resource::{
-        ConcreteValue, PlanInputState, Resource, ResourceId, State, Value,
-    };
+    use carina_core::resource::{ConcreteValue, Resource, ResourceId, State, Value};
     use carina_core::schema::{AttributeType, RawShape, ResourceSchema, Shape, ShapeWalkBudget};
     use carina_core::schema::{SchemaKind, SchemaRegistry};
     use indexmap::IndexMap;
@@ -48,16 +46,6 @@ mod tests {
                 .with_attribute("tags", tags_value("new-name")),
         ];
 
-        let mut current_states: HashMap<ResourceId, PlanInputState> = HashMap::new();
-        current_states.insert(
-            resource_id.clone(),
-            State::existing(
-                resource_id.clone(),
-                HashMap::from([("tags".to_string(), tags_value("old-name"))]),
-            )
-            .into_plan_input(),
-        );
-
         let mut schemas = SchemaRegistry::new();
         schemas.insert("awscc", schema);
         assert!(
@@ -70,6 +58,16 @@ mod tests {
                 .is_some(),
             "schema must be resolvable under the key the differ uses"
         );
+
+        let raw_states: HashMap<ResourceId, State> = HashMap::from([(
+            resource_id.clone(),
+            State::existing(
+                resource_id.clone(),
+                HashMap::from([("tags".to_string(), tags_value("old-name"))]),
+            ),
+        )]);
+        let current_states =
+            carina_core::resource::into_plan_input_map(raw_states, &schemas, &resources);
 
         let plan = create_plan(
             &resources,


### PR DESCRIPTION
## Summary

Bump carina-core/plugin-sdk/provider-protocol to `8ebc747a` (carina#3664) and
carina-aws-types to `8ae6b29` (aws#465).

carina#3664 made `State::into_plan_input()` `pub(crate)`. The tag-change test
in `schemas/mod.rs` called it directly — switch to `into_plan_input_map` which
canonicalizes and lifts internally.

## Test plan

- [x] `cargo check` passes
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes