### PR TITLE
test(acceptance): add fixtures for 13 uncovered resource types

### DIFF
--- a/acceptance-tests/README.md
+++ b/acceptance-tests/README.md
@@ -1,0 +1,23 @@
+# Acceptance Tests
+
+## Known Coverage Gaps
+
+The following generated resource types intentionally do not have acceptance
+fixtures yet:
+
+- `organizations.Organization`: the pooled `carina-test-00X` accounts are
+  already members of the shared organization, and organization management is not
+  safe to exercise from individual pool accounts.
+- `organizations.Account`: creating accounts would add new members to the shared
+  organization, and account closure lingers for 90 days before final deletion.
+- `sso.Instance`: IAM Identity Center instances live in the organization
+  management account, are limited to one instance per organization, and are not
+  creatable from the pool accounts.
+- `sso.PermissionSet`: permission sets require the organization IAM Identity
+  Center instance and identity store that live in the management account.
+- `sso.Assignment`: assignments require the organization IAM Identity Center
+  instance and identity store that live in the management account.
+- `identitystore.Group`: identity store resources live with the organization IAM
+  Identity Center instance in the management account, not in pool accounts.
+- `identitystore.GroupMembership`: group memberships depend on the management
+  account identity store and are not creatable in pool accounts.

--- a/acceptance-tests/cloudfront_distribution/basic.crn
+++ b/acceptance-tests/cloudfront_distribution/basic.crn
@@ -1,0 +1,58 @@
+# CloudFront Distribution - Basic test
+#
+# Tests: disabled minimal distribution with a custom origin and PriceClass_100.
+# This fixture has a custom run.sh because deploy/delete commonly takes 5-15 minutes.
+
+provider awscc {
+  region = aws.Region.ap_northeast_1
+}
+
+awscc.cloudfront.Distribution {
+  distribution_config = {
+    comment         = 'Carina acceptance test distribution'
+    enabled         = false
+    price_class     = price_class_100
+    http_version    = http2
+    ipv6_enabled    = false
+
+    default_cache_behavior = {
+      target_origin_id       = 'example-origin'
+      viewer_protocol_policy = allow_all
+      allowed_methods        = [get, head]
+      cached_methods         = [get, head]
+
+      forwarded_values = {
+        query_string = false
+        cookies = {
+          forward = none
+        }
+      }
+    }
+
+    origin {
+      id          = 'example-origin'
+      domain_name = 'example.com'
+
+      custom_origin_config = {
+        http_port              = 80
+        https_port             = 443
+        origin_protocol_policy = http_only
+        origin_ssl_protocols   = [tlsv1_2]
+      }
+    }
+
+    restrictions = {
+      geo_restriction = {
+        restriction_type = none
+      }
+    }
+
+    viewer_certificate = {
+      cloud_front_default_certificate = true
+    }
+  }
+
+  tags = {
+    Environment = 'acceptance-test'
+  }
+}

--- a/acceptance-tests/cloudfront_distribution/run.sh
+++ b/acceptance-tests/cloudfront_distribution/run.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+# Standalone acceptance test for CloudFront distribution.
+#
+# Usage:
+#   env AWS_PROFILE="<profile>" ./run.sh
+#
+# CloudFront distribution create/delete can take 5-15 minutes, so this suite is
+# intentionally skipped by acceptance-tests/run-tests.sh and must be run alone.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../shared/_helpers.sh"
+
+TOTAL_PASSED=0
+TOTAL_FAILED=0
+ACTIVE_WORK_DIR=""
+
+with_account_creds() {
+    local account="${AWS_PROFILE:-}"
+    if [ -z "$account" ]; then
+        echo "ERROR: AWS_PROFILE is not set; cannot resolve credentials" >&2
+        return 1
+    fi
+    local creds
+    if ! creds=$(aws configure export-credentials --profile "$account" --format env-no-export 2>&1); then
+        echo "ERROR: aws configure export-credentials failed for $account: $creds" >&2
+        return 1
+    fi
+    (
+        set -a
+        eval "$creds"
+        set +a
+        unset AWS_PROFILE
+        "$@"
+    )
+}
+
+run_with_timeout() {
+    local seconds="$1"
+    shift
+
+    if command -v timeout >/dev/null 2>&1; then
+        timeout "$seconds" "$@"
+    elif command -v gtimeout >/dev/null 2>&1; then
+        gtimeout "$seconds" "$@"
+    else
+        "$@"
+    fi
+}
+
+record_step() {
+    local description="$1"
+    shift
+
+    printf "  %-55s " "$description"
+    local output
+    if output=$("$@" 2>&1); then
+        echo "OK"
+        TOTAL_PASSED=$((TOTAL_PASSED + 1))
+        return 0
+    else
+        echo "FAIL"
+        echo "  ERROR: $output"
+        TOTAL_FAILED=$((TOTAL_FAILED + 1))
+        return 1
+    fi
+}
+
+plan_verify() {
+    local work_dir="$1"
+
+    printf "  %-55s " "plan-verify"
+    local output
+    local rc=0
+    output=$(cd "$work_dir" && with_account_creds run_with_timeout 3600 "$CARINA_BIN" plan --detailed-exitcode . 2>&1) || rc=$?
+
+    if [ $rc -eq 0 ]; then
+        echo "OK"
+        TOTAL_PASSED=$((TOTAL_PASSED + 1))
+        return 0
+    fi
+
+    echo "FAIL"
+    if [ $rc -eq 2 ]; then
+        echo "  ERROR: Post-apply plan detected changes:"
+    fi
+    echo "  $output"
+    TOTAL_FAILED=$((TOTAL_FAILED + 1))
+    return 1
+}
+
+apply_distribution() {
+    cd "$ACTIVE_WORK_DIR"
+    with_account_creds run_with_timeout 3600 "$CARINA_BIN" apply --auto-approve .
+}
+
+destroy_distribution() {
+    cd "$ACTIVE_WORK_DIR"
+    with_account_creds run_with_timeout 3600 "$CARINA_BIN" destroy --auto-approve .
+}
+
+cleanup() {
+    if [ -n "$ACTIVE_WORK_DIR" ] && [ -d "$ACTIVE_WORK_DIR" ]; then
+        set +e
+        echo ""
+        echo "  Cleanup: destroying CloudFront distribution resources..."
+        (cd "$ACTIVE_WORK_DIR" && with_account_creds run_with_timeout 3600 "$CARINA_BIN" destroy --auto-approve . 2>&1)
+        (cd "$ACTIVE_WORK_DIR" && with_account_creds run_with_timeout 3600 "$CARINA_BIN" destroy --auto-approve . 2>&1)
+        rm -rf "$ACTIVE_WORK_DIR"
+        ACTIVE_WORK_DIR=""
+    fi
+}
+trap cleanup EXIT
+
+WORK_DIR="$(mktemp -d)"
+ACTIVE_WORK_DIR="$WORK_DIR"
+
+INJECTED_DIR="$(inject_provider_source "$SCRIPT_DIR/basic.crn")"
+cp "$INJECTED_DIR/main.crn" "$WORK_DIR/main.crn"
+rm -rf "$INJECTED_DIR"
+
+echo "Running CloudFront distribution acceptance test with AWS_PROFILE=${AWS_PROFILE:-}"
+echo ""
+
+record_step "init" "$CARINA_BIN" init "$WORK_DIR"
+record_step "apply" apply_distribution
+plan_verify "$WORK_DIR"
+record_step "destroy" destroy_distribution
+
+rm -rf "$WORK_DIR"
+ACTIVE_WORK_DIR=""
+
+echo ""
+echo "Results: $TOTAL_PASSED passed, $TOTAL_FAILED failed"
+if [ "$TOTAL_FAILED" -gt 0 ]; then
+    exit 1
+fi

--- a/acceptance-tests/cloudfront_origin_access_control/basic.crn
+++ b/acceptance-tests/cloudfront_origin_access_control/basic.crn
@@ -1,0 +1,17 @@
+# CloudFront OriginAccessControl - Basic test
+#
+# Tests: required origin access control configuration for S3 origins.
+
+provider awscc {
+  region = aws.Region.ap_northeast_1
+}
+
+awscc.cloudfront.OriginAccessControl {
+  origin_access_control_config = {
+    name                              = 'carina-acc-test-oac'
+    description                       = 'Carina acceptance test origin access control'
+    origin_access_control_origin_type = s3
+    signing_behavior                  = always
+    signing_protocol                  = sigv4
+  }
+}

--- a/acceptance-tests/dynamodb_table/basic.crn
+++ b/acceptance-tests/dynamodb_table/basic.crn
@@ -1,0 +1,26 @@
+# DynamoDB Table - Basic test
+#
+# Tests: on-demand billing, hash key schema, and tags.
+
+provider awscc {
+  region = aws.Region.ap_northeast_1
+}
+
+awscc.dynamodb.Table {
+  table_name   = 'carina-acc-test-table'
+  billing_mode = pay_per_request
+
+  attribute_definition {
+    attribute_name = 'pk'
+    attribute_type = s
+  }
+
+  key_schema {
+    attribute_name = 'pk'
+    key_type       = hash
+  }
+
+  tags = {
+    Environment = 'acceptance-test'
+  }
+}

--- a/acceptance-tests/ecs_cluster/basic.crn
+++ b/acceptance-tests/ecs_cluster/basic.crn
@@ -1,0 +1,20 @@
+# ECS Cluster - Basic test
+#
+# Tests: cluster_name, cluster_settings, and tags.
+
+provider awscc {
+  region = aws.Region.ap_northeast_1
+}
+
+awscc.ecs.Cluster {
+  cluster_name = 'carina-acc-test-cluster'
+
+  cluster_setting {
+    name  = 'containerInsights'
+    value = disabled
+  }
+
+  tags = {
+    Environment = 'acceptance-test'
+  }
+}

--- a/acceptance-tests/elasticloadbalancingv2_listener/basic.crn
+++ b/acceptance-tests/elasticloadbalancingv2_listener/basic.crn
@@ -1,0 +1,98 @@
+# ElasticLoadBalancingV2 Listener - Basic test
+#
+# Tests: VPC, subnets, internal ALB, target group, and forward listener.
+
+provider awscc {
+  region = aws.Region.ap_northeast_1
+}
+
+let vpc = awscc.ec2.Vpc {
+  cidr_block           = '10.22.0.0/16'
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Environment = 'acceptance-test'
+  }
+}
+
+let subnet_a = awscc.ec2.Subnet {
+  vpc_id            = vpc.vpc_id
+  cidr_block        = '10.22.1.0/24'
+  availability_zone = 'ap-northeast-1a'
+
+  tags = {
+    Environment = 'acceptance-test'
+  }
+}
+
+let subnet_c = awscc.ec2.Subnet {
+  vpc_id            = vpc.vpc_id
+  cidr_block        = '10.22.2.0/24'
+  availability_zone = 'ap-northeast-1c'
+
+  tags = {
+    Environment = 'acceptance-test'
+  }
+}
+
+let alb_sg = awscc.ec2.SecurityGroup {
+  vpc_id            = vpc.vpc_id
+  group_description = 'Acceptance test internal ALB listener security group'
+
+  security_group_ingress {
+    ip_protocol = tcp
+    from_port   = 80
+    to_port     = 80
+    cidr_ip     = '10.22.0.0/16'
+    description = 'Allow VPC HTTP'
+  }
+
+  security_group_egress {
+    ip_protocol = all
+    cidr_ip     = '10.22.0.0/16'
+    description = 'Allow VPC egress'
+  }
+
+  tags = {
+    Environment = 'acceptance-test'
+  }
+}
+
+let alb = awscc.elasticloadbalancingv2.LoadBalancer {
+  name            = 'carina-acc-test-listener-alb'
+  type            = application
+  scheme          = internal
+  ip_address_type = ipv4
+  subnets         = [subnet_a.subnet_id, subnet_c.subnet_id]
+  security_groups = [alb_sg.group_id]
+
+  tags = {
+    Environment = 'acceptance-test'
+  }
+}
+
+let target_group = awscc.elasticloadbalancingv2.TargetGroup {
+  name              = 'carina-acc-test-listener-tg'
+  protocol          = http
+  port              = 80
+  target_type       = ip
+  ip_address_type   = ipv4
+  vpc_id            = vpc.vpc_id
+  health_check_path = '/'
+
+  tags = {
+    Environment = 'acceptance-test'
+  }
+}
+
+awscc.elasticloadbalancingv2.Listener {
+  load_balancer_arn = alb.load_balancer_arn
+  port              = 80
+  protocol          = http
+
+  default_action {
+    type             = forward
+    target_group_arn = target_group.target_group_arn
+  }
+}

--- a/acceptance-tests/elasticloadbalancingv2_load_balancer/basic.crn
+++ b/acceptance-tests/elasticloadbalancingv2_load_balancer/basic.crn
@@ -1,0 +1,73 @@
+# ElasticLoadBalancingV2 LoadBalancer - Basic test
+#
+# Tests: internal application load balancer with two subnets in different AZs.
+
+provider awscc {
+  region = aws.Region.ap_northeast_1
+}
+
+let vpc = awscc.ec2.Vpc {
+  cidr_block           = '10.20.0.0/16'
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Environment = 'acceptance-test'
+  }
+}
+
+let subnet_a = awscc.ec2.Subnet {
+  vpc_id            = vpc.vpc_id
+  cidr_block        = '10.20.1.0/24'
+  availability_zone = 'ap-northeast-1a'
+
+  tags = {
+    Environment = 'acceptance-test'
+  }
+}
+
+let subnet_c = awscc.ec2.Subnet {
+  vpc_id            = vpc.vpc_id
+  cidr_block        = '10.20.2.0/24'
+  availability_zone = 'ap-northeast-1c'
+
+  tags = {
+    Environment = 'acceptance-test'
+  }
+}
+
+let alb_sg = awscc.ec2.SecurityGroup {
+  vpc_id            = vpc.vpc_id
+  group_description = 'Acceptance test internal ALB security group'
+
+  security_group_ingress {
+    ip_protocol = tcp
+    from_port   = 80
+    to_port     = 80
+    cidr_ip     = '10.20.0.0/16'
+    description = 'Allow VPC HTTP'
+  }
+
+  security_group_egress {
+    ip_protocol = all
+    cidr_ip     = '10.20.0.0/16'
+    description = 'Allow VPC egress'
+  }
+
+  tags = {
+    Environment = 'acceptance-test'
+  }
+}
+
+awscc.elasticloadbalancingv2.LoadBalancer {
+  name            = 'carina-acc-test-alb'
+  type            = application
+  scheme          = internal
+  ip_address_type = ipv4
+  subnets         = [subnet_a.subnet_id, subnet_c.subnet_id]
+  security_groups = [alb_sg.group_id]
+
+  tags = {
+    Environment = 'acceptance-test'
+  }
+}

--- a/acceptance-tests/elasticloadbalancingv2_target_group/basic.crn
+++ b/acceptance-tests/elasticloadbalancingv2_target_group/basic.crn
@@ -1,0 +1,29 @@
+# ElasticLoadBalancingV2 TargetGroup - Basic test
+#
+# Tests: IP target type target group in a VPC.
+
+provider awscc {
+  region = aws.Region.ap_northeast_1
+}
+
+let vpc = awscc.ec2.Vpc {
+  cidr_block = '10.21.0.0/16'
+
+  tags = {
+    Environment = 'acceptance-test'
+  }
+}
+
+awscc.elasticloadbalancingv2.TargetGroup {
+  name              = 'carina-acc-test-tg'
+  protocol          = http
+  port              = 80
+  target_type       = ip
+  ip_address_type   = ipv4
+  vpc_id            = vpc.vpc_id
+  health_check_path = '/'
+
+  tags = {
+    Environment = 'acceptance-test'
+  }
+}

--- a/acceptance-tests/iam_oidc_provider/basic.crn
+++ b/acceptance-tests/iam_oidc_provider/basic.crn
@@ -1,0 +1,17 @@
+# IAM OIDCProvider - Basic test
+#
+# Tests: URL, client ID list, thumbprint list, and tags.
+
+provider awscc {
+  region = aws.Region.ap_northeast_1
+}
+
+awscc.iam.OidcProvider {
+  url              = 'https://token.actions.githubusercontent.com'
+  client_id_list   = ['sts.amazonaws.com']
+  thumbprint_list  = ['ffffffffffffffffffffffffffffffffffffffff']
+
+  tags = {
+    Environment = 'acceptance-test'
+  }
+}

--- a/acceptance-tests/iam_role_policy/basic.crn
+++ b/acceptance-tests/iam_role_policy/basic.crn
@@ -1,0 +1,42 @@
+# IAM RolePolicy - Basic test
+#
+# Tests: standalone inline role policy attached to a role in the same fixture.
+
+provider awscc {
+  region = aws.Region.ap_northeast_1
+}
+
+let role = awscc.iam.Role {
+  role_name_prefix = 'carina-acc-test-'
+
+  assume_role_policy_document = {
+    version = aws.iam.PolicyDocument.Version.2012_10_17
+    statement {
+      effect = aws.iam.PolicyDocument.Statement.Effect.allow
+
+      principal = {
+        service = 'lambda.amazonaws.com'
+      }
+
+      action = 'sts:AssumeRole'
+    }
+  }
+
+  tags = {
+    Environment = 'acceptance-test'
+  }
+}
+
+awscc.iam.RolePolicy {
+  role_name   = role.role_name
+  policy_name = 'acceptance-test-role-policy'
+
+  policy_document = {
+    version = aws.iam.PolicyDocument.Version.2012_10_17
+    statement {
+      effect   = aws.iam.PolicyDocument.Statement.Effect.allow
+      action   = 'logs:CreateLogGroup'
+      resource = '*'
+    }
+  }
+}

--- a/acceptance-tests/kms_key/basic.crn
+++ b/acceptance-tests/kms_key/basic.crn
@@ -1,0 +1,18 @@
+# KMS Key - Basic test
+#
+# Tests: symmetric key defaults, key rotation flag, minimum deletion window, and tags.
+# After destroy, the KMS key lingers in PendingDeletion for the 7-day minimum window.
+
+provider awscc {
+  region = aws.Region.ap_northeast_1
+}
+
+awscc.kms.Key {
+  description            = 'Carina acceptance test key'
+  enable_key_rotation    = false
+  pending_window_in_days = 7
+
+  tags = {
+    Environment = 'acceptance-test'
+  }
+}

--- a/acceptance-tests/route53_hosted_zone/basic.crn
+++ b/acceptance-tests/route53_hosted_zone/basic.crn
@@ -1,0 +1,20 @@
+# Route53 HostedZone - Basic test
+#
+# Tests: public hosted zone name, config, and hosted zone tags.
+
+provider awscc {
+  region = aws.Region.ap_northeast_1
+}
+
+awscc.route53.HostedZone {
+  name = 'acceptance-test.example.com'
+
+  hosted_zone_config = {
+    comment = 'Carina acceptance test hosted zone'
+  }
+
+  hosted_zone_tag {
+    key   = 'Environment'
+    value = 'acceptance-test'
+  }
+}

--- a/acceptance-tests/run-tests.sh
+++ b/acceptance-tests/run-tests.sh
@@ -247,6 +247,30 @@ deep_cleanup_account() {
     local account="$1"
     local found=0
 
+    # 0. Delete orphaned ELBv2 load balancers and target groups before VPC cleanup
+    local load_balancers
+    load_balancers=$(with_account_creds "$account" aws elbv2 describe-load-balancers \
+        --query 'LoadBalancers[?contains(LoadBalancerName, `acceptance-test`) || contains(LoadBalancerName, `carina-acc`)].LoadBalancerArn' --output text 2>/dev/null)
+    for lb_arn in $load_balancers; do
+        [ -z "$lb_arn" ] && continue
+        found=$((found + 1))
+        echo "  Cleaning ELBv2 load balancer $lb_arn..."
+        with_account_creds "$account" aws elbv2 delete-load-balancer --load-balancer-arn "$lb_arn" 2>/dev/null || true
+    done
+    if [ -n "$load_balancers" ] && [ "$load_balancers" != "None" ]; then
+        sleep 15
+    fi
+
+    local target_groups
+    target_groups=$(with_account_creds "$account" aws elbv2 describe-target-groups \
+        --query 'TargetGroups[?contains(TargetGroupName, `acceptance-test`) || contains(TargetGroupName, `carina-acc`)].TargetGroupArn' --output text 2>/dev/null)
+    for tg_arn in $target_groups; do
+        [ -z "$tg_arn" ] && continue
+        found=$((found + 1))
+        echo "  Cleaning ELBv2 target group $tg_arn..."
+        with_account_creds "$account" aws elbv2 delete-target-group --target-group-arn "$tg_arn" 2>/dev/null || true
+    done
+
     # 1. Delete non-default VPCs and all dependencies
     local vpcs
     vpcs=$(with_account_creds "$account" aws ec2 describe-vpcs \
@@ -359,7 +383,70 @@ deep_cleanup_account() {
         with_account_creds "$account" aws s3 rb "s3://$bucket" --force 2>/dev/null || true
     done
 
-    # 3. Delete orphaned IAM roles
+    # 3. Delete orphaned DynamoDB tables
+    local ddb_tables
+    ddb_tables=$(with_account_creds "$account" aws dynamodb list-tables \
+        --query 'TableNames[?starts_with(@, `carina-acc-test`) || starts_with(@, `acceptance-test`)]' --output text 2>/dev/null)
+    for table in $ddb_tables; do
+        [ -z "$table" ] && continue
+        found=$((found + 1))
+        echo "  Cleaning DynamoDB table $table..."
+        with_account_creds "$account" aws dynamodb delete-table --table-name "$table" 2>/dev/null || true
+    done
+
+    # 4. Delete orphaned ECS clusters
+    local ecs_clusters
+    ecs_clusters=$(with_account_creds "$account" aws ecs list-clusters \
+        --query 'clusterArns[?contains(@, `acceptance-test`) || contains(@, `carina-acc`)]' --output text 2>/dev/null)
+    for cluster_arn in $ecs_clusters; do
+        [ -z "$cluster_arn" ] && continue
+        found=$((found + 1))
+        echo "  Cleaning ECS cluster $cluster_arn..."
+        with_account_creds "$account" aws ecs delete-cluster --cluster "$cluster_arn" 2>/dev/null || true
+    done
+
+    # 5. Delete orphaned Route 53 hosted zones
+    local hosted_zones
+    hosted_zones=$(with_account_creds "$account" aws route53 list-hosted-zones \
+        --query 'HostedZones[?contains(Name, `acceptance-test`) || contains(Name, `carina-acc`)].Id' --output text 2>/dev/null)
+    for zone_id in $hosted_zones; do
+        [ -z "$zone_id" ] && continue
+        found=$((found + 1))
+        echo "  Cleaning Route 53 hosted zone $zone_id..."
+        with_account_creds "$account" aws route53 delete-hosted-zone --id "$zone_id" 2>/dev/null || true
+    done
+
+    # 6. Delete orphaned regional WAFv2 web ACLs
+    local web_acls
+    web_acls=$(with_account_creds "$account" aws wafv2 list-web-acls --scope REGIONAL \
+        --query 'WebACLs[?contains(Name, `acceptance-test`) || contains(Name, `carina-acc`)].[Name,Id,LockToken]' --output text 2>/dev/null)
+    while read -r acl_name acl_id lock_token; do
+        [ -z "$acl_name" ] && continue
+        found=$((found + 1))
+        echo "  Cleaning WAFv2 web ACL $acl_name..."
+        with_account_creds "$account" aws wafv2 delete-web-acl \
+            --name "$acl_name" --scope REGIONAL --id "$acl_id" --lock-token "$lock_token" 2>/dev/null || true
+    done <<< "$web_acls"
+
+    # 7. Delete orphaned IAM OIDC providers tagged by acceptance tests
+    local oidc_providers
+    oidc_providers=$(with_account_creds "$account" aws iam list-open-id-connect-providers \
+        --query 'OpenIDConnectProviderList[*].Arn' --output text 2>/dev/null)
+    for provider_arn in $oidc_providers; do
+        [ -z "$provider_arn" ] && continue
+        local provider_tags
+        provider_tags=$(with_account_creds "$account" aws iam list-open-id-connect-provider-tags \
+            --open-id-connect-provider-arn "$provider_arn" \
+            --query 'Tags[?Key==`Environment` && Value==`acceptance-test`].Key' --output text 2>/dev/null)
+        if [ -z "$provider_tags" ] || [ "$provider_tags" = "None" ]; then
+            continue
+        fi
+        found=$((found + 1))
+        echo "  Cleaning IAM OIDC provider $provider_arn..."
+        with_account_creds "$account" aws iam delete-open-id-connect-provider --open-id-connect-provider-arn "$provider_arn" 2>/dev/null || true
+    done
+
+    # 8. Delete orphaned IAM roles
     local roles
     roles=$(with_account_creds "$account" aws iam list-roles \
         --query 'Roles[?contains(RoleName, `acceptance-test`) || contains(RoleName, `carina-acc`)].RoleName' --output text 2>/dev/null)
@@ -375,10 +462,61 @@ deep_cleanup_account() {
             [ -z "$policy_arn" ] && continue
             with_account_creds "$account" aws iam detach-role-policy --role-name "$role" --policy-arn "$policy_arn" 2>/dev/null || true
         done
+        local inline_policies
+        inline_policies=$(with_account_creds "$account" aws iam list-role-policies --role-name "$role" \
+            --query 'PolicyNames[*]' --output text 2>/dev/null)
+        for policy_name in $inline_policies; do
+            [ -z "$policy_name" ] && continue
+            with_account_creds "$account" aws iam delete-role-policy --role-name "$role" --policy-name "$policy_name" 2>/dev/null || true
+        done
         with_account_creds "$account" aws iam delete-role --role-name "$role" 2>/dev/null || true
     done
 
-    # 4. Delete orphaned log groups
+    # 9. Delete orphaned IAM customer managed policies
+    local iam_policies
+    iam_policies=$(with_account_creds "$account" aws iam list-policies --scope Local \
+        --query 'Policies[?contains(PolicyName, `acceptance-test`) || contains(PolicyName, `carina-acc`)].Arn' --output text 2>/dev/null)
+    for policy_arn in $iam_policies; do
+        [ -z "$policy_arn" ] && continue
+        found=$((found + 1))
+        echo "  Cleaning IAM policy $policy_arn..."
+
+        local attached_roles
+        attached_roles=$(with_account_creds "$account" aws iam list-entities-for-policy --policy-arn "$policy_arn" \
+            --query 'PolicyRoles[*].RoleName' --output text 2>/dev/null)
+        for role_name in $attached_roles; do
+            [ -z "$role_name" ] && continue
+            with_account_creds "$account" aws iam detach-role-policy --role-name "$role_name" --policy-arn "$policy_arn" 2>/dev/null || true
+        done
+
+        local attached_users
+        attached_users=$(with_account_creds "$account" aws iam list-entities-for-policy --policy-arn "$policy_arn" \
+            --query 'PolicyUsers[*].UserName' --output text 2>/dev/null)
+        for user_name in $attached_users; do
+            [ -z "$user_name" ] && continue
+            with_account_creds "$account" aws iam detach-user-policy --user-name "$user_name" --policy-arn "$policy_arn" 2>/dev/null || true
+        done
+
+        local attached_groups
+        attached_groups=$(with_account_creds "$account" aws iam list-entities-for-policy --policy-arn "$policy_arn" \
+            --query 'PolicyGroups[*].GroupName' --output text 2>/dev/null)
+        for group_name in $attached_groups; do
+            [ -z "$group_name" ] && continue
+            with_account_creds "$account" aws iam detach-group-policy --group-name "$group_name" --policy-arn "$policy_arn" 2>/dev/null || true
+        done
+
+        local policy_versions
+        policy_versions=$(with_account_creds "$account" aws iam list-policy-versions --policy-arn "$policy_arn" \
+            --query 'Versions[?IsDefaultVersion==`false`].VersionId' --output text 2>/dev/null)
+        for version_id in $policy_versions; do
+            [ -z "$version_id" ] && continue
+            with_account_creds "$account" aws iam delete-policy-version --policy-arn "$policy_arn" --version-id "$version_id" 2>/dev/null || true
+        done
+
+        with_account_creds "$account" aws iam delete-policy --policy-arn "$policy_arn" 2>/dev/null || true
+    done
+
+    # 10. Delete orphaned log groups
     local log_groups
     log_groups=$(with_account_creds "$account" aws logs describe-log-groups \
         --log-group-name-prefix "/acceptance-test/" \
@@ -390,7 +528,7 @@ deep_cleanup_account() {
         with_account_creds "$account" aws logs delete-log-group --log-group-name "$lg" 2>/dev/null || true
     done
 
-    # 5. Delete transit gateways
+    # 11. Delete transit gateways
     local tgws
     tgws=$(with_account_creds "$account" aws ec2 describe-transit-gateways \
         --filters "Name=state,Values=available,pending" \
@@ -411,7 +549,7 @@ deep_cleanup_account() {
         with_account_creds "$account" aws ec2 delete-transit-gateway --transit-gateway-id "$tgw_id" 2>/dev/null || true
     done
 
-    # 6. Release Elastic IPs not associated with anything
+    # 12. Release Elastic IPs not associated with anything
     local eips
     eips=$(with_account_creds "$account" aws ec2 describe-addresses \
         --query 'Addresses[?AssociationId==null].AllocationId' --output text 2>/dev/null)
@@ -440,7 +578,7 @@ echo ""
 
 # CARINA_BIN can be set externally (e.g., when running from the monorepo).
 # If not set, look for it in common locations.
-if [ -z "$CARINA_BIN" ]; then
+if [ -z "${CARINA_BIN:-}" ]; then
     # Prefer release build (WASM JIT is much faster with release)
     if [ -f "$PROJECT_ROOT/../carina/target/release/carina" ]; then
         CARINA_BIN="$PROJECT_ROOT/../carina/target/release/carina"

--- a/acceptance-tests/s3_bucket_policy/basic.crn
+++ b/acceptance-tests/s3_bucket_policy/basic.crn
@@ -1,0 +1,54 @@
+# S3 BucketPolicy - Basic test
+#
+# Tests: bucket policy attached to a generated S3 bucket.
+
+provider awscc {
+  region = aws.Region.ap_northeast_1
+}
+
+let bucket = awscc.s3.Bucket {
+  bucket_name_prefix = 'carina-acc-test-'
+
+  directives {
+    force_delete = true
+  }
+}
+
+let reader_role = awscc.iam.Role {
+  role_name_prefix = 'carina-acc-test-'
+
+  assume_role_policy_document = {
+    version = aws.iam.PolicyDocument.Version.2012_10_17
+    statement {
+      effect = aws.iam.PolicyDocument.Statement.Effect.allow
+
+      principal = {
+        service = 'lambda.amazonaws.com'
+      }
+
+      action = 'sts:AssumeRole'
+    }
+  }
+
+  tags = {
+    Environment = 'acceptance-test'
+  }
+}
+
+awscc.s3.BucketPolicy {
+  bucket = bucket.bucket_name
+
+  policy_document = {
+    version = aws.iam.PolicyDocument.Version.2012_10_17
+    statement {
+      effect = aws.iam.PolicyDocument.Statement.Effect.allow
+
+      principal = {
+        aws = reader_role.arn
+      }
+
+      action   = 's3:GetObject'
+      resource = '${bucket.arn}/*'
+    }
+  }
+}

--- a/acceptance-tests/shared/_helpers.sh
+++ b/acceptance-tests/shared/_helpers.sh
@@ -15,7 +15,7 @@ fi
 PROJECT_ROOT="$(cd "$HELPERS_DIR/../.." && pwd)"
 
 # CARINA_BIN can be set externally. If not, try common locations.
-if [ -z "$CARINA_BIN" ]; then
+if [ -z "${CARINA_BIN:-}" ]; then
     if [ -f "$PROJECT_ROOT/../carina/target/debug/carina" ]; then
         CARINA_BIN="$PROJECT_ROOT/../carina/target/debug/carina"
     elif command -v carina &>/dev/null; then

--- a/acceptance-tests/wafv2_web_acl/basic.crn
+++ b/acceptance-tests/wafv2_web_acl/basic.crn
@@ -1,0 +1,27 @@
+# WAFv2 WebACL - Basic test
+#
+# Tests: REGIONAL scope, allow default action, visibility config, and tags.
+
+provider awscc {
+  region = aws.Region.ap_northeast_1
+}
+
+awscc.wafv2.WebAcl {
+  name        = 'carina-acc-test-web-acl'
+  description = 'Carina acceptance test web ACL'
+  scope       = regional
+
+  default_action = {
+    allow = {}
+  }
+
+  visibility_config = {
+    cloud_watch_metrics_enabled = false
+    metric_name                 = 'carinaAccTestWebAcl'
+    sampled_requests_enabled    = false
+  }
+
+  tags = {
+    Environment = 'acceptance-test'
+  }
+}


### PR DESCRIPTION
Closes #383

## What

Acceptance test fixtures for the implementable coverage gaps from #383, plus documentation of the intentionally skipped resources.

### New fixtures (all pass `run-tests.sh validate`)

Standalone: `s3_bucket_policy`, `iam_role_policy` (role + inline policy), `iam_oidc_provider`, `dynamodb_table`, `ecs_cluster`, `route53_hosted_zone`, `cloudfront_origin_access_control`, `wafv2_web_acl` (REGIONAL scope, allow default action), `kms_key` (minimum 7-day deletion pending window; header notes the key lingers in `PendingDeletion` after destroy).

ELBv2 trio: `elasticloadbalancingv2_load_balancer` / `_target_group` / `_listener` — internal ALBs composing VPC + two-AZ subnets; the listener fixture exercises the full LB → TG → Listener chain.

`cloudfront_distribution` — disabled minimal distribution with a custom origin (fast deploy) and its own `run.sh`, so the 5–15 minute deploy/delete cycle is excluded from the default sweep (dirs with `run.sh` are skipped by the runner's main loop, same pattern as `create_before_destroy/`).

### Not implementable

`iam.Policy` from the issue checklist is not a resource type — the generated `iam/policy.rs` is an ARN-helper module only (corrected on the issue).

### Documented skips (acceptance-tests/README.md)

`organizations.*` (pool accounts are already org members; account closure lingers 90 days), `sso.Instance` / `sso.PermissionSet` / `sso.Assignment` / `identitystore.Group` / `identitystore.GroupMembership` (IAM Identity Center instance and identity store live in the org management account, one per org).

### Runner changes

- deep-cleanup: new sections for ELBv2 LBs/TGs (before VPC cleanup), DynamoDB tables, ECS clusters, hosted zones, regional web ACLs, `Environment=acceptance-test`-tagged OIDC providers, and inline role policies
- fix: `CARINA_BIN` unset handling under `set -u` (run-tests.sh + shared/_helpers.sh)

## Verification

```
Results: 12 passed, 0 failed (total: 12)   # run-tests.sh validate, all new sweep fixtures
```

`cloudfront_distribution/basic.crn` validated directly via `carina validate` (run.sh dirs are excluded from the sweep by design): 1 resource validated successfully.

Real-AWS full-cycle runs (apply → plan-verify → destroy) follow after merge; failures found there will be filed as issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)