### PR TITLE
test(acceptance): restore object-level statement in s3_bucket_policy

### DIFF
--- a/acceptance-tests/s3_bucket_policy/basic.crn
+++ b/acceptance-tests/s3_bucket_policy/basic.crn
@@ -47,9 +47,8 @@ awscc.s3.BucketPolicy {
         aws = reader_role.arn
       }
 
-      # Object-level '${bucket.arn}/*' is blocked on carina-rs/carina#3665; restore it when fixed.
-      action   = 's3:ListBucket'
-      resource = bucket.arn
+      action   = 's3:GetObject'
+      resource = "${bucket.arn}/*"
     }
   }
 }


### PR DESCRIPTION
## What

Restores the `s3:GetObject` / `resource = "${bucket.arn}/*"` object-level statement in the `s3_bucket_policy` fixture, replacing the interim `s3:ListBucket` workaround from #386.

The original failure was not a carina bug: the statement was written with **single quotes** (`'${bucket.arn}/*'`), and carina single-quoted strings are literal-only by design — the literal text reached S3. carina-rs/carina#3665 was closed accordingly; carina-rs/carina#3668 tracks a validate/LSP warning so the footgun is caught at validate time.

## Verification

Real-AWS full cycle (apply → plan-verify → destroy):

```
OK   s3_bucket_policy/basic.crn
Total: 1 passed, 0 failed (of 1)
```

`run-tests.sh validate`: 1 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)