### PR TITLE
fix(acceptance): make harness exit status reflect test results only

### DIFF
--- a/acceptance-tests/run-tests.sh
+++ b/acceptance-tests/run-tests.sh
@@ -200,7 +200,7 @@ if [ "$COMMAND" != "validate" ]; then
     if ! acquire_all_account_locks; then
         exit 1
     fi
-    trap 'for p in ${PIDS[@]+"${PIDS[@]}"}; do kill "$p" 2>/dev/null; done; release_account_locks' EXIT
+    trap 'for p in ${PIDS[@]+"${PIDS[@]}"}; do kill "$p" 2>/dev/null || true; done; release_account_locks' EXIT
 fi
 
 # Validate command
@@ -752,7 +752,7 @@ if [ "$COMMAND" = "cleanup" ]; then
     echo ""
 
     WORK_DIR=$(mktemp -d)
-    trap 'for p in ${PIDS[@]+"${PIDS[@]}"}; do kill "$p" 2>/dev/null; done; rm -rf '"$WORK_DIR"'; release_account_locks' EXIT
+    trap 'for p in ${PIDS[@]+"${PIDS[@]}"}; do kill "$p" 2>/dev/null || true; done; rm -rf '"$WORK_DIR"'; release_account_locks' EXIT
 
     # Pre-authenticate accounts
     echo "Pre-authenticating AWS accounts..."
@@ -879,7 +879,7 @@ if [ "$COMMAND" = "full" ]; then
     trap cleanup_main INT TERM
 
     # Clean up temp dir and release locks on normal exit
-    trap 'for p in ${PIDS[@]+"${PIDS[@]}"}; do kill "$p" 2>/dev/null; done; rm -rf '"$WORK_DIR"'; release_account_locks' EXIT
+    trap 'for p in ${PIDS[@]+"${PIDS[@]}"}; do kill "$p" 2>/dev/null || true; done; rm -rf '"$WORK_DIR"'; release_account_locks' EXIT
 
     # Pre-authenticate accounts sequentially to avoid opening
     # multiple SSO browser tabs simultaneously
@@ -1090,7 +1090,7 @@ echo ""
 # (plan/apply/destroy) to prevent cross-contamination between tests (issue #839)
 if [ "$COMMAND" != "validate" ]; then
     WORK_DIR=$(mktemp -d)
-    trap 'for p in ${PIDS[@]+"${PIDS[@]}"}; do kill "$p" 2>/dev/null; done; rm -rf '"$WORK_DIR"'; release_account_locks' EXIT
+    trap 'for p in ${PIDS[@]+"${PIDS[@]}"}; do kill "$p" 2>/dev/null || true; done; rm -rf '"$WORK_DIR"'; release_account_locks' EXIT
 fi
 
 PASSED=0

--- a/acceptance-tests/secret_env/run.sh
+++ b/acceptance-tests/secret_env/run.sh
@@ -32,4 +32,6 @@ echo "════════════════════════�
 echo "Tests run: $TESTS_RUN, $TOTAL_PASSED passed, $TOTAL_FAILED failed"
 echo "════════════════════════════════════════"
 
-[ "$TOTAL_FAILED" -gt 0 ] && exit 1
+if [ "$TOTAL_FAILED" -gt 0 ]; then
+    exit 1
+fi

--- a/acceptance-tests/user_functions/run.sh
+++ b/acceptance-tests/user_functions/run.sh
@@ -25,4 +25,6 @@ echo ""
 echo "════════════════════════════════════════"
 echo "Tests run: $TESTS_RUN, $TOTAL_PASSED passed, $TOTAL_FAILED failed"
 echo "════════════════════════════════════════"
-[ "$TOTAL_FAILED" -gt 0 ] && exit 1
+if [ "$TOTAL_FAILED" -gt 0 ]; then
+    exit 1
+fi

--- a/acceptance-tests/write_only_attrs/run.sh
+++ b/acceptance-tests/write_only_attrs/run.sh
@@ -32,4 +32,6 @@ echo "════════════════════════�
 echo "Tests run: $TESTS_RUN, $TOTAL_PASSED passed, $TOTAL_FAILED failed"
 echo "════════════════════════════════════════"
 
-[ "$TOTAL_FAILED" -gt 0 ] && exit 1
+if [ "$TOTAL_FAILED" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

The acceptance harness exited 1 even when every test passed. Two mechanisms, both fixed:

1. **run-tests.sh EXIT traps**: `kill "$p"` runs on worker PIDs that have already exited; under `set -e` the failing kill aborts the trap and overrides the script's exit status with 1. All four trap sites now use `kill "$p" 2>/dev/null || true`.
2. **Sub-runner trailing `[ "$TOTAL_FAILED" -gt 0 ] && exit 1`** (user_functions, write_only_attrs, secret_env): when `TOTAL_FAILED=0` the test command itself returns 1 and, as the last command, becomes the script's exit status. Replaced with an explicit `if` branch.

## Verification

- `[ ... ] && exit 1` simulation exits 0/1 for `TOTAL_FAILED=0/1` in all three sub-runners.
- `CARINA_BIN=/usr/bin/true ./acceptance-tests/run-tests.sh cleanup ec2_vpc/basic` now exits 0 (was 1); instrumenting the `wait` loop confirmed no worker ever returned nonzero — the trap was the sole source.
- `rg` confirms no instance of either pattern remains under acceptance-tests/.

Closes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vca7585CbZTp7xYdAMu3YN