### PR TITLE
fix(acceptance): initialize work dirs via shared seam; align multi-step suites to cwd == target

### DIFF
--- a/acceptance-tests/attribute_removal/run.sh
+++ b/acceptance-tests/attribute_removal/run.sh
@@ -26,15 +26,29 @@ ACTIVE_WORK_DIR=""
 ACTIVE_STEP1=""
 ACTIVE_STEP2=""
 
+# Swap a step config into the single carina target directory.
+# Args: source_crn work_dir
+swap_crn() {
+    local source_crn="$1"
+    local work_dir="$2"
+
+    cp "$source_crn" "$work_dir/main.crn"
+    prepare_work_dir "$work_dir"
+}
+
 signal_cleanup() {
     if [ -n "$ACTIVE_WORK_DIR" ] && [ -d "$ACTIVE_WORK_DIR" ]; then
         set +e
         echo ""
         echo "Interrupted. Cleaning up resources..."
-        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP2" 2>&1
-        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP1" 2>&1
-        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP2" 2>&1
-        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP1" 2>&1
+        swap_crn "$ACTIVE_STEP2" "$ACTIVE_WORK_DIR"
+        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve . 2>&1
+        swap_crn "$ACTIVE_STEP1" "$ACTIVE_WORK_DIR"
+        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve . 2>&1
+        swap_crn "$ACTIVE_STEP2" "$ACTIVE_WORK_DIR"
+        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve . 2>&1
+        swap_crn "$ACTIVE_STEP1" "$ACTIVE_WORK_DIR"
+        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve . 2>&1
         rm -rf "$ACTIVE_WORK_DIR"
         ACTIVE_WORK_DIR=""
     fi
@@ -47,13 +61,14 @@ run_step() {
     local work_dir="$1"
     local description="$2"
     local command="$3"
-    local crn_file="$4"
+    local source_crn="$4"
     local extra_args="${5:-}"
 
     printf "  %-55s " "$description"
+    swap_crn "$source_crn" "$work_dir"
 
     local output
-    if output=$(cd "$work_dir" && "$CARINA_BIN" $command $extra_args "$crn_file" 2>&1); then
+    if output=$(cd "$work_dir" && "$CARINA_BIN" $command $extra_args . 2>&1); then
         echo "OK"
         TOTAL_PASSED=$((TOTAL_PASSED + 1))
         return 0
@@ -68,13 +83,14 @@ run_step() {
 run_plan_verify() {
     local work_dir="$1"
     local description="$2"
-    local crn_file="$3"
+    local source_crn="$3"
 
     printf "  %-55s " "$description"
+    swap_crn "$source_crn" "$work_dir"
 
     local output
     local rc
-    output=$(cd "$work_dir" && "$CARINA_BIN" plan --detailed-exitcode "$crn_file" 2>&1) || rc=$?
+    output=$(cd "$work_dir" && "$CARINA_BIN" plan --detailed-exitcode . 2>&1) || rc=$?
     rc=${rc:-0}
 
     if [ $rc -eq 2 ]; then
@@ -109,17 +125,21 @@ destroy_work_dir() {
     # Disable set -e to ensure all destroy attempts run
     set +e
     echo "  Cleanup: destroying resources..."
-    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1; then
+    swap_crn "$step2" "$work_dir"
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve . 2>&1; then
         any_success=true
     fi
-    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1; then
+    swap_crn "$step1" "$work_dir"
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve . 2>&1; then
         any_success=true
     fi
     # Retry: resources may have dependencies that prevent deletion on first pass
-    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1; then
+    swap_crn "$step2" "$work_dir"
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve . 2>&1; then
         any_success=true
     fi
-    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1; then
+    swap_crn "$step1" "$work_dir"
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve . 2>&1; then
         any_success=true
     fi
     set -e
@@ -146,10 +166,6 @@ run_test() {
     local work_dir
     work_dir=$(mktemp -d)
 
-    # Inject provider source into .crn files
-    step1=$(inject_provider_source "$step1")
-    step2=$(inject_provider_source "$step2")
-
     # Register for signal cleanup
     ACTIVE_WORK_DIR="$work_dir"
     ACTIVE_STEP1="$step1"
@@ -162,7 +178,6 @@ run_test() {
     if ! run_step "$work_dir" "step1: apply initial (with attribute)" "apply" "$step1" "--auto-approve"; then
         destroy_work_dir "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -171,7 +186,6 @@ run_test() {
     if ! run_plan_verify "$work_dir" "step1: plan-verify initial" "$step1"; then
         destroy_work_dir "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -180,7 +194,6 @@ run_test() {
     if ! run_step "$work_dir" "step2: apply attribute removal" "apply" "$step2" "--auto-approve"; then
         destroy_work_dir "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -189,7 +202,6 @@ run_test() {
     if ! run_plan_verify "$work_dir" "step3: plan-verify after attribute removal" "$step2"; then
         destroy_work_dir "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -199,14 +211,12 @@ run_test() {
         echo "  WARNING: All destroy attempts failed. Preserving work dir for debugging:"
         echo "    $work_dir"
         TOTAL_FAILED=$((TOTAL_FAILED + 1))
-        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         echo ""
         return 1
     fi
 
     rm -rf "$work_dir"
-    rm -rf "$step1" "$step2"
     ACTIVE_WORK_DIR=""
     echo ""
 }

--- a/acceptance-tests/cascade_without_cbd/run.sh
+++ b/acceptance-tests/cascade_without_cbd/run.sh
@@ -10,33 +10,69 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
-CARINA="cargo run --bin carina --"
-
-# Build provider binaries (not built by cargo run --bin carina since Phase 4)
-cargo build -p carina-provider-awscc --bin carina-provider-awscc --quiet 2>/dev/null || cargo build -p carina-provider-awscc --bin carina-provider-awscc
-cargo build -p carina-provider-aws --bin carina-provider-aws --quiet 2>/dev/null || cargo build -p carina-provider-aws --bin carina-provider-aws
 
 source "$SCRIPT_DIR/../shared/_helpers.sh"
 
-STEP1=$(inject_provider_source "$SCRIPT_DIR/step1.crn")
-STEP2=$(inject_provider_source "$SCRIPT_DIR/step2.crn")
-trap "rm -rf $STEP1 $STEP2" EXIT
+STEP1="$SCRIPT_DIR/step1.crn"
+STEP2="$SCRIPT_DIR/step2.crn"
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
 
 PASS=0
 FAIL=0
 
+swap_crn() {
+    local source_crn="$1"
+    local work_dir="$2"
+
+    cp "$source_crn" "$work_dir/main.crn"
+    prepare_work_dir "$work_dir"
+}
+
 run_step() {
     local description="$1"
-    local command="$2"
+    local source_crn="$2"
     shift 2
 
     echo "── $description ──"
-    if eval "$command" "$@"; then
+    swap_crn "$source_crn" "$WORK_DIR"
+    if (cd "$WORK_DIR" && "$CARINA_BIN" "$@" .); then
         echo "  ✓ $description"
         PASS=$((PASS + 1))
     else
         echo "  ✗ $description"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+destroy_work_dir() {
+    local any_success=false
+
+    set +e
+    echo "── destroy (cleanup) ──"
+    swap_crn "$STEP2" "$WORK_DIR"
+    if (cd "$WORK_DIR" && "$CARINA_BIN" destroy --auto-approve . 2>&1); then
+        any_success=true
+    fi
+    swap_crn "$STEP1" "$WORK_DIR"
+    if (cd "$WORK_DIR" && "$CARINA_BIN" destroy --auto-approve . 2>&1); then
+        any_success=true
+    fi
+    swap_crn "$STEP2" "$WORK_DIR"
+    if (cd "$WORK_DIR" && "$CARINA_BIN" destroy --auto-approve . 2>&1); then
+        any_success=true
+    fi
+    swap_crn "$STEP1" "$WORK_DIR"
+    if (cd "$WORK_DIR" && "$CARINA_BIN" destroy --auto-approve . 2>&1); then
+        any_success=true
+    fi
+    set -e
+
+    if [ "$any_success" = true ]; then
+        echo "  ✓ destroy (cleanup)"
+        PASS=$((PASS + 1))
+    else
+        echo "  ✗ destroy (cleanup)"
         FAIL=$((FAIL + 1))
     fi
 }
@@ -48,7 +84,7 @@ echo "════════════════════════�
 echo ""
 
 # Step 1: Apply initial state (VPC + SG + Ingress)
-run_step "apply step1 (create VPC + subnet)" "$CARINA apply --auto-approve $STEP1"
+run_step "apply step1 (create VPC + subnet)" "$STEP1" apply --auto-approve
 
 # Step 2: Plan with changed group_description
 # The plan should show:
@@ -56,7 +92,8 @@ run_step "apply step1 (create VPC + subnet)" "$CARINA apply --auto-approve $STEP
 #   ~ ingress rule (cascading update)
 echo ""
 echo "── plan step2 (expect cascade) ──"
-PLAN_OUTPUT=$($CARINA plan "$STEP2" 2>&1) || true
+swap_crn "$STEP2" "$WORK_DIR"
+PLAN_OUTPUT=$(cd "$WORK_DIR" && "$CARINA_BIN" plan . 2>&1) || true
 echo "$PLAN_OUTPUT"
 
 if echo "$PLAN_OUTPUT" | grep -q "create before destroy"; then
@@ -68,12 +105,13 @@ else
 fi
 
 # Step 2: Apply (VPC CBD replace + subnet replace)
-run_step "apply step2 (replace VPC + subnet)" "$CARINA apply --auto-approve $STEP2"
+run_step "apply step2 (replace VPC + subnet)" "$STEP2" apply --auto-approve
 
 # Step 2: Plan verify (should show no changes after apply)
 echo ""
 echo "── plan-verify step2 ──"
-VERIFY_OUTPUT=$($CARINA plan "$STEP2" 2>&1) || true
+swap_crn "$STEP2" "$WORK_DIR"
+VERIFY_OUTPUT=$(cd "$WORK_DIR" && "$CARINA_BIN" plan . 2>&1) || true
 echo "$VERIFY_OUTPUT"
 
 if echo "$VERIFY_OUTPUT" | grep -q "No changes"; then
@@ -85,7 +123,7 @@ else
 fi
 
 # Cleanup: destroy
-run_step "destroy (cleanup)" "$CARINA destroy --auto-approve $STEP2"
+destroy_work_dir
 
 echo ""
 echo "════════════════════════════════════════"

--- a/acceptance-tests/in_place_update/run.sh
+++ b/acceptance-tests/in_place_update/run.sh
@@ -44,15 +44,29 @@ ACTIVE_WORK_DIR=""
 ACTIVE_STEP1=""
 ACTIVE_STEP2=""
 
+# Swap a step config into the single carina target directory.
+# Args: source_crn work_dir
+swap_crn() {
+    local source_crn="$1"
+    local work_dir="$2"
+
+    cp "$source_crn" "$work_dir/main.crn"
+    prepare_work_dir "$work_dir"
+}
+
 signal_cleanup() {
     if [ -n "$ACTIVE_WORK_DIR" ] && [ -d "$ACTIVE_WORK_DIR" ]; then
         set +e
         echo ""
         echo "Interrupted. Cleaning up resources..."
-        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP2" 2>&1
-        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP1" 2>&1
-        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP2" 2>&1
-        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP1" 2>&1
+        swap_crn "$ACTIVE_STEP2" "$ACTIVE_WORK_DIR"
+        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve . 2>&1
+        swap_crn "$ACTIVE_STEP1" "$ACTIVE_WORK_DIR"
+        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve . 2>&1
+        swap_crn "$ACTIVE_STEP2" "$ACTIVE_WORK_DIR"
+        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve . 2>&1
+        swap_crn "$ACTIVE_STEP1" "$ACTIVE_WORK_DIR"
+        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve . 2>&1
         rm -rf "$ACTIVE_WORK_DIR"
         ACTIVE_WORK_DIR=""
     fi
@@ -65,13 +79,14 @@ run_step() {
     local work_dir="$1"
     local description="$2"
     local command="$3"
-    local crn_file="$4"
+    local source_crn="$4"
     local extra_args="${5:-}"
 
     printf "  %-55s " "$description"
+    swap_crn "$source_crn" "$work_dir"
 
     local output
-    if output=$(cd "$work_dir" && "$CARINA_BIN" $command $extra_args "$crn_file" 2>&1); then
+    if output=$(cd "$work_dir" && "$CARINA_BIN" $command $extra_args . 2>&1); then
         echo "OK"
         TOTAL_PASSED=$((TOTAL_PASSED + 1))
         return 0
@@ -138,13 +153,14 @@ assert_identifiers() {
 run_plan_verify() {
     local work_dir="$1"
     local description="$2"
-    local crn_file="$3"
+    local source_crn="$3"
 
     printf "  %-55s " "$description"
+    swap_crn "$source_crn" "$work_dir"
 
     local output
     local rc
-    output=$(cd "$work_dir" && "$CARINA_BIN" plan --detailed-exitcode "$crn_file" 2>&1) || rc=$?
+    output=$(cd "$work_dir" && "$CARINA_BIN" plan --detailed-exitcode . 2>&1) || rc=$?
     rc=${rc:-0}
 
     if [ $rc -eq 2 ]; then
@@ -179,17 +195,21 @@ destroy_work_dir() {
     # Disable set -e to ensure all destroy attempts run
     set +e
     echo "  Cleanup: destroying resources..."
-    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1; then
+    swap_crn "$step2" "$work_dir"
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve . 2>&1; then
         any_success=true
     fi
-    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1; then
+    swap_crn "$step1" "$work_dir"
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve . 2>&1; then
         any_success=true
     fi
     # Retry: resources may have dependencies that prevent deletion on first pass
-    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1; then
+    swap_crn "$step2" "$work_dir"
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve . 2>&1; then
         any_success=true
     fi
-    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1; then
+    swap_crn "$step1" "$work_dir"
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve . 2>&1; then
         any_success=true
     fi
     set -e
@@ -216,10 +236,6 @@ run_test() {
     local work_dir
     work_dir=$(mktemp -d)
 
-    # Inject provider source into .crn files
-    step1=$(inject_provider_source "$step1")
-    step2=$(inject_provider_source "$step2")
-
     # Register for signal cleanup
     ACTIVE_WORK_DIR="$work_dir"
     ACTIVE_STEP1="$step1"
@@ -232,7 +248,6 @@ run_test() {
     if ! run_step "$work_dir" "step1: apply initial" "apply" "$step1" "--auto-approve"; then
         destroy_work_dir "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -241,7 +256,6 @@ run_test() {
     if ! run_plan_verify "$work_dir" "step1: plan-verify initial" "$step1"; then
         destroy_work_dir "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -254,7 +268,6 @@ run_test() {
     if ! run_step "$work_dir" "step2: apply in-place update" "apply" "$step2" "--auto-approve"; then
         destroy_work_dir "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -267,7 +280,6 @@ run_test() {
     if ! assert_identifiers "assert: identifiers preserved after update" "$ids_after_step1" "$ids_after_step2" "equal"; then
         destroy_work_dir "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -276,7 +288,6 @@ run_test() {
     if ! run_plan_verify "$work_dir" "step3: plan-verify after update" "$step2"; then
         destroy_work_dir "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -286,14 +297,12 @@ run_test() {
         echo "  WARNING: All destroy attempts failed. Preserving work dir for debugging:"
         echo "    $work_dir"
         TOTAL_FAILED=$((TOTAL_FAILED + 1))
-        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         echo ""
         return 1
     fi
 
     rm -rf "$work_dir"
-    rm -rf "$step1" "$step2"
     ACTIVE_WORK_DIR=""
     echo ""
 }

--- a/acceptance-tests/shared/_helpers.sh
+++ b/acceptance-tests/shared/_helpers.sh
@@ -77,11 +77,26 @@ inject_provider_source_dir() {
 TEST_PASSED=0
 TEST_FAILED=0
 
-# prepare_work_dir: Inject provider source into all .crn files in a work directory.
+# work_dir_initialized: Return 0 if carina init already prepared the work dir.
+# Args: work_dir
+work_dir_initialized() {
+    local work_dir="$1"
+    [ -d "$work_dir/.carina/providers" ] || [ -f "$work_dir/carina-backend.lock" ]
+}
+
+# prepare_work_dir: Inject provider source into all .crn files in a work directory
+# and initialize the work dir if needed.
 # Call this after copying .crn files to the work dir but before running carina commands.
 # Args: work_dir
 prepare_work_dir() {
-    inject_provider_source_dir "$1"
+    local work_dir="$1"
+
+    inject_provider_source_dir "$work_dir"
+    if work_dir_initialized "$work_dir"; then
+        return 0
+    fi
+
+    (cd "$work_dir" && "$CARINA_BIN" init . >/dev/null)
 }
 
 ACTIVE_WORK_DIR=""
@@ -92,7 +107,7 @@ cleanup() {
         cd "$ACTIVE_WORK_DIR"
         "$CARINA_BIN" destroy --auto-approve . 2>/dev/null || true
         "$CARINA_BIN" destroy --auto-approve . 2>/dev/null || true
-        rm -f carina.state.json carina.state.lock
+        rm -f carina.state.json carina-backend.lock carina-providers.lock
     fi
 }
 trap cleanup EXIT

--- a/acceptance-tests/simhash_update/run.sh
+++ b/acceptance-tests/simhash_update/run.sh
@@ -30,15 +30,29 @@ ACTIVE_WORK_DIR=""
 ACTIVE_STEP1=""
 ACTIVE_STEP2=""
 
+# Swap a step config into the single carina target directory.
+# Args: source_crn work_dir
+swap_crn() {
+    local source_crn="$1"
+    local work_dir="$2"
+
+    cp "$source_crn" "$work_dir/main.crn"
+    prepare_work_dir "$work_dir"
+}
+
 signal_cleanup() {
     if [ -n "$ACTIVE_WORK_DIR" ] && [ -d "$ACTIVE_WORK_DIR" ]; then
         set +e
         echo ""
         echo "Interrupted. Cleaning up resources..."
-        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP2" 2>&1
-        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP1" 2>&1
-        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP2" 2>&1
-        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve "$ACTIVE_STEP1" 2>&1
+        swap_crn "$ACTIVE_STEP2" "$ACTIVE_WORK_DIR"
+        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve . 2>&1
+        swap_crn "$ACTIVE_STEP1" "$ACTIVE_WORK_DIR"
+        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve . 2>&1
+        swap_crn "$ACTIVE_STEP2" "$ACTIVE_WORK_DIR"
+        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve . 2>&1
+        swap_crn "$ACTIVE_STEP1" "$ACTIVE_WORK_DIR"
+        cd "$ACTIVE_WORK_DIR" && "$CARINA_BIN" destroy --auto-approve . 2>&1
         rm -rf "$ACTIVE_WORK_DIR"
         ACTIVE_WORK_DIR=""
     fi
@@ -51,13 +65,14 @@ run_step() {
     local work_dir="$1"
     local description="$2"
     local command="$3"
-    local crn_file="$4"
+    local source_crn="$4"
     local extra_args="${5:-}"
 
     printf "  %-55s " "$description"
+    swap_crn "$source_crn" "$work_dir"
 
     local output
-    if output=$(cd "$work_dir" && "$CARINA_BIN" $command $extra_args "$crn_file" 2>&1); then
+    if output=$(cd "$work_dir" && "$CARINA_BIN" $command $extra_args . 2>&1); then
         echo "OK"
         TOTAL_PASSED=$((TOTAL_PASSED + 1))
         return 0
@@ -124,13 +139,14 @@ assert_identifiers() {
 run_plan_verify() {
     local work_dir="$1"
     local description="$2"
-    local crn_file="$3"
+    local source_crn="$3"
 
     printf "  %-55s " "$description"
+    swap_crn "$source_crn" "$work_dir"
 
     local output
     local rc
-    output=$(cd "$work_dir" && "$CARINA_BIN" plan --detailed-exitcode "$crn_file" 2>&1) || rc=$?
+    output=$(cd "$work_dir" && "$CARINA_BIN" plan --detailed-exitcode . 2>&1) || rc=$?
     rc=${rc:-0}
 
     if [ $rc -eq 2 ]; then
@@ -165,17 +181,21 @@ destroy_work_dir() {
     # Disable set -e to ensure all destroy attempts run
     set +e
     echo "  Cleanup: destroying resources..."
-    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1; then
+    swap_crn "$step2" "$work_dir"
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve . 2>&1; then
         any_success=true
     fi
-    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1; then
+    swap_crn "$step1" "$work_dir"
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve . 2>&1; then
         any_success=true
     fi
     # Retry: resources may have dependencies that prevent deletion on first pass
-    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step2" 2>&1; then
+    swap_crn "$step2" "$work_dir"
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve . 2>&1; then
         any_success=true
     fi
-    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$step1" 2>&1; then
+    swap_crn "$step1" "$work_dir"
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve . 2>&1; then
         any_success=true
     fi
     set -e
@@ -202,10 +222,6 @@ run_test() {
     local work_dir
     work_dir=$(mktemp -d)
 
-    # Inject provider source into .crn files
-    step1=$(inject_provider_source "$step1")
-    step2=$(inject_provider_source "$step2")
-
     # Register for signal cleanup
     ACTIVE_WORK_DIR="$work_dir"
     ACTIVE_STEP1="$step1"
@@ -218,7 +234,6 @@ run_test() {
     if ! run_step "$work_dir" "step1: apply initial" "apply" "$step1" "--auto-approve"; then
         destroy_work_dir "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -227,7 +242,6 @@ run_test() {
     if ! run_plan_verify "$work_dir" "step1: plan-verify initial" "$step1"; then
         destroy_work_dir "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -240,7 +254,6 @@ run_test() {
     if ! run_step "$work_dir" "step2: apply update (simhash reconcile)" "apply" "$step2" "--auto-approve"; then
         destroy_work_dir "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -253,7 +266,6 @@ run_test() {
     if ! assert_identifiers "assert: identifiers preserved after update" "$ids_after_step1" "$ids_after_step2" "equal"; then
         destroy_work_dir "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -262,7 +274,6 @@ run_test() {
     if ! run_plan_verify "$work_dir" "step3: plan-verify after update" "$step2"; then
         destroy_work_dir "$work_dir" "$step2" "$step1"
         rm -rf "$work_dir"
-        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         return 1
     fi
@@ -272,14 +283,12 @@ run_test() {
         echo "  WARNING: All destroy attempts failed. Preserving work dir for debugging:"
         echo "    $work_dir"
         TOTAL_FAILED=$((TOTAL_FAILED + 1))
-        rm -rf "$step1" "$step2"
         ACTIVE_WORK_DIR=""
         echo ""
         return 1
     fi
 
     rm -rf "$work_dir"
-    rm -rf "$step1" "$step2"
     ACTIVE_WORK_DIR=""
     echo ""
 }
@@ -288,15 +297,17 @@ run_test() {
 # Returns 0 if at least one destroy succeeded, 1 if ALL failed
 cleanup_single() {
     local work_dir="$1"
-    local crn_file="$2"
+    local source_crn="$2"
     local any_success=false
 
     set +e
     echo "  Cleanup: destroying resources..."
-    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$crn_file" 2>&1; then
+    swap_crn "$source_crn" "$work_dir"
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve . 2>&1; then
         any_success=true
     fi
-    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve "$crn_file" 2>&1; then
+    swap_crn "$source_crn" "$work_dir"
+    if cd "$work_dir" && "$CARINA_BIN" destroy --auto-approve . 2>&1; then
         any_success=true
     fi
     set -e
@@ -308,10 +319,10 @@ cleanup_single() {
 }
 
 # Run a single-step test (apply + plan-verify + destroy, no update)
-# Args: test_name crn_file description
+# Args: test_name source_crn description
 run_test_single() {
     local test_name="$1"
-    local crn_file="$2"
+    local source_crn="$2"
     local desc="$3"
 
     # Apply filter
@@ -322,48 +333,41 @@ run_test_single() {
     local work_dir
     work_dir=$(mktemp -d)
 
-    # Inject provider source into .crn file
-    crn_file=$(inject_provider_source "$crn_file")
-
     # Register for signal cleanup
     ACTIVE_WORK_DIR="$work_dir"
-    ACTIVE_STEP1="$crn_file"
-    ACTIVE_STEP2="$crn_file"
+    ACTIVE_STEP1="$source_crn"
+    ACTIVE_STEP2="$source_crn"
 
     echo "$desc"
     echo ""
 
     # Step 1: Apply
-    if ! run_step "$work_dir" "step1: apply" "apply" "$crn_file" "--auto-approve"; then
-        cleanup_single "$work_dir" "$crn_file"
+    if ! run_step "$work_dir" "step1: apply" "apply" "$source_crn" "--auto-approve"; then
+        cleanup_single "$work_dir" "$source_crn"
         rm -rf "$work_dir"
-        rm -rf "$crn_file"
         ACTIVE_WORK_DIR=""
         return 1
     fi
 
     # Step 2: Plan-verify (idempotency check)
-    if ! run_plan_verify "$work_dir" "step2: plan-verify" "$crn_file"; then
-        cleanup_single "$work_dir" "$crn_file"
+    if ! run_plan_verify "$work_dir" "step2: plan-verify" "$source_crn"; then
+        cleanup_single "$work_dir" "$source_crn"
         rm -rf "$work_dir"
-        rm -rf "$crn_file"
         ACTIVE_WORK_DIR=""
         return 1
     fi
 
     # Step 3: Destroy
-    if ! cleanup_single "$work_dir" "$crn_file"; then
+    if ! cleanup_single "$work_dir" "$source_crn"; then
         echo "  WARNING: All destroy attempts failed. Preserving work dir for debugging:"
         echo "    $work_dir"
         TOTAL_FAILED=$((TOTAL_FAILED + 1))
-        rm -rf "$crn_file"
         ACTIVE_WORK_DIR=""
         echo ""
         return 1
     fi
 
     rm -rf "$work_dir"
-    rm -rf "$crn_file"
     ACTIVE_WORK_DIR=""
     echo ""
 }


### PR DESCRIPTION
## Summary

12 of the 16 multi-step acceptance suites never ran `carina init` and failed their first apply with "Provider 'awscc' not installed" — carina requires init since carina-rs/carina@f6ef9be4 (2026-04-14).

Two layers, one invariant ("the work dir a suite runs carina in has been initialized, and carina always runs with cwd == target"):

1. **Shared seam**: `prepare_work_dir` (shared/_helpers.sh) now injects provider sources and runs a guarded `carina init .`, so every suite — current and future — inherits init. Guard checks the real artifacts (`.carina/providers` / `carina-backend.lock`); the old cleanup() referenced a nonexistent `carina.state.lock` and now removes `carina-backend.lock` + `carina-providers.lock`.
2. **Topology**: the four split-dir suites (attribute_removal, in_place_update, simhash_update, cascade_without_cbd) ran `cd work_dir && carina apply $step_dir`. init/apply/destroy place all artifacts in the *target* dir and `plan` currently reads state from *cwd* (carina-rs/carina#3676), so that topology splits state across step dirs and always fails plan-verify with a phantom `+ add`. They are reshaped to the healthy suites' pattern: one work dir, step configs swapped in as `main.crn`, every command `cd work_dir && carina <cmd> .`. Test semantics unchanged.

Also removes cascade_without_cbd's obsolete native `cargo build --bin` prelude: `-p carina-provider-aws` names a package not in this workspace, so under `set -e` the suite died before running (the WASM file:// source is what the tests actually consume).

## Verification (real AWS, carina-test accounts)

| Suite | Result |
|---|---|
| builtin_functions (trim) | pass |
| simhash_update (ec2_eip) | pass |
| attribute_removal (logs_log_group) | pass |
| in_place_update (logs_log_group) | pass |
| cascade_without_cbd | apply step1 / plan step2 (cascade shown) pass; **apply step2 fails on carina-rs/carina#3677** (cascading replace resolves the child's deferred `vpc.vpc_id` to the OLD parent id) — a product bug this suite now surfaces instead of dying at init |

Stub-binary audit over all suites: 225 carina invocations, every one with target `.` and cwd == work dir; exactly one init per work dir, always before the first apply.

Same seam fix in carina-provider-aws: carina-rs/carina-provider-aws#483.

Closes #389

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vca7585CbZTp7xYdAMu3YN